### PR TITLE
Fix: Storyboard Generation hangs on simple prompt + genre (#68)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "supabase:types:ci": "test -n \"$POSTGRES_URL\" && bunx supabase gen types typescript --db-url \"$POSTGRES_URL\" > src/lib/supabase/gen.types.ts && biome check --write src/lib/supabase/gen.types.ts",
     "qstash:dev": "bunx @upstash/qstash-cli dev",
     "setup:env": "./scripts/setup-env.sh",
+    "bash:setup:env": "bash ./scripts/setup-env.sh",
     "workflow:assign": "./workflow/scripts/workflow-manager.sh assign",
     "workflow:orchestrator": "./workflow/scripts/orchestrator.sh",
     "storybook": "storybook dev -p 6006",

--- a/src/app/actions/frames/index.ts
+++ b/src/app/actions/frames/index.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
+import type { Job } from "@/hooks/use-storyboard-status";
 import { getQStashClient } from "@/lib/qstash/client";
 import { getJobManager } from "@/lib/qstash/job-manager";
 import { createServerClient } from "@/lib/supabase/server";
@@ -467,6 +468,8 @@ export async function generateFramesAction(
         expectedFrameCount: null, // Will be updated after script analysis
         completedFrameCount: 0,
         options: validated.options,
+        error: null,
+        failedAt: null,
       },
     };
 
@@ -710,14 +713,12 @@ export async function generateFramesAction(
       },
     };
 
-    // Set status to draft if thumbnails are still generating, completed if not
-    const newStatus =
-      validated.options?.generateThumbnails !== false ? "draft" : "completed";
-
+    // Always set status back to draft after frame creation (removes "processing" state)
+    // This ensures frontend polling stops even when thumbnails are still generating
     await supabase
       .from("sequences")
       .update({
-        status: newStatus,
+        status: "draft", // Always reset from "processing" to stop infinite polling
         metadata: finalMetadata as Json,
         updated_at: new Date().toISOString(),
       })
@@ -873,25 +874,7 @@ export async function regenerateFrameAction(
  */
 export async function getActiveFrameGenerationJob(sequenceId: string): Promise<{
   success: boolean;
-  job?: {
-    id: string;
-    type: string;
-    status: string;
-    progress?: number;
-    result?: unknown;
-    error?: string;
-    created_at: string;
-    updated_at: string;
-    framesProgress?: {
-      total: number;
-      completed: number;
-      frames: Array<{
-        id: string;
-        order_index: number;
-        thumbnail_url?: string | null;
-      }>;
-    };
-  };
+  job?: Job;
   error?: string;
 }> {
   try {

--- a/src/app/actions/sequence/index.ts
+++ b/src/app/actions/sequence/index.ts
@@ -180,8 +180,55 @@ export async function generateFrames(sequenceId: string): Promise<{
     const { getJobManager } = await import("@/lib/qstash/job-manager");
     const { getQStashClient } = await import("@/lib/qstash/client");
 
-    // Create a job for frame generation
+    // Check for existing active jobs to prevent duplicates
     const jobManager = getJobManager();
+    const existingJobs = await jobManager.getJobsByStatus("running", {
+      teamId: sequence.team_id,
+    });
+
+    // Check for existing frame generation job for this sequence
+    const existingFrameJob = existingJobs.find((job) => {
+      if (job.type !== "frame_generation") return false;
+      const payload = job.payload as { sequenceId?: string };
+      return payload?.sequenceId === sequenceId;
+    });
+
+    if (existingFrameJob) {
+      console.log("[generateFrames] Found existing active job, returning it", {
+        sequenceId,
+        existingJobId: existingFrameJob.id,
+      });
+      return {
+        success: true,
+        jobId: existingFrameJob.id,
+        frames: [],
+      };
+    }
+
+    // Also check for pending jobs
+    const pendingJobs = await jobManager.getJobsByStatus("pending", {
+      teamId: sequence.team_id,
+    });
+
+    const existingPendingJob = pendingJobs.find((job) => {
+      if (job.type !== "frame_generation") return false;
+      const payload = job.payload as { sequenceId?: string };
+      return payload?.sequenceId === sequenceId;
+    });
+
+    if (existingPendingJob) {
+      console.log("[generateFrames] Found existing pending job, returning it", {
+        sequenceId,
+        existingJobId: existingPendingJob.id,
+      });
+      return {
+        success: true,
+        jobId: existingPendingJob.id,
+        frames: [],
+      };
+    }
+
+    // Create a job for frame generation
     const job = await jobManager.createJob({
       type: "frame_generation",
       payload: {

--- a/src/app/api/v1/webhooks/qstash/image/route.ts
+++ b/src/app/api/v1/webhooks/qstash/image/route.ts
@@ -94,6 +94,63 @@ const processImageGeneration: JobProcessor = async (
           frameId: imageData.frameId,
           error: updateError.message,
         });
+        return result;
+      }
+
+      const { data: frameData } = await supabase
+        .from("frames")
+        .select("sequence_id")
+        .eq("id", imageData.frameId)
+        .single();
+
+      if (frameData?.sequence_id) {
+        // Check if all frames for this sequence now have thumbnails
+        const { data: allFrames } = await supabase
+          .from("frames")
+          .select("id, thumbnail_url")
+          .eq("sequence_id", frameData.sequence_id);
+
+        if (allFrames) {
+          const framesWithThumbnails = allFrames.filter(
+            (frame) => frame.thumbnail_url,
+          );
+          const allFramesHaveThumbnails =
+            framesWithThumbnails.length === allFrames.length;
+
+          if (allFramesHaveThumbnails && allFrames.length > 0) {
+            const { data: sequence } = await supabase
+              .from("sequences")
+              .select("metadata")
+              .eq("id", frameData.sequence_id)
+              .single();
+
+            if (sequence) {
+              const existingMetadata =
+                (sequence.metadata as Record<string, unknown>) || {};
+              const frameGeneration =
+                (existingMetadata.frameGeneration as Record<string, unknown>) ||
+                {};
+
+              const updatedMetadata = {
+                ...existingMetadata,
+                frameGeneration: {
+                  ...frameGeneration,
+                  status: "completed",
+                  completedAt: new Date().toISOString(),
+                  thumbnailsGenerating: false,
+                },
+              };
+
+              await supabase
+                .from("sequences")
+                .update({
+                  metadata: updatedMetadata,
+                  updated_at: new Date().toISOString(),
+                })
+                .eq("id", frameData.sequence_id);
+            }
+          }
+        }
       }
     }
 

--- a/src/app/sequences/[id]/storyboard/page.tsx
+++ b/src/app/sequences/[id]/storyboard/page.tsx
@@ -9,20 +9,8 @@ import {
   PageHeader,
   PageHeading,
 } from "@/components/typography";
-import {
-  useActiveFrameGeneration,
-  useFramesBySequence,
-} from "@/hooks/use-frames";
-import { useSequence } from "@/hooks/use-sequences";
+import { useStoryboardStatus } from "@/hooks/use-storyboard-status";
 import { useUser } from "@/hooks/use-user";
-
-interface FrameGenerationMetadata {
-  frameGeneration?: {
-    status?: string;
-    expectedFrameCount?: number;
-    completedFrameCount?: number;
-  };
-}
 
 interface StoryboardPageProps {
   params: Promise<{
@@ -37,31 +25,8 @@ export default function StoryboardPage({ params }: StoryboardPageProps) {
   // Verify session
   useUser();
 
-  // Load sequence to check status
-  const { data: sequence } = useSequence(sequenceId, {
-    refetchInterval: 2000, // Poll sequence status
-  });
-
-  // Check if frames are being generated based on sequence status
-  const metadata = sequence?.metadata as FrameGenerationMetadata | null;
-  const isBackgroundGenerating =
-    sequence?.status === "processing" ||
-    metadata?.frameGeneration?.status === "processing" ||
-    metadata?.frameGeneration?.status === "generating_thumbnails";
-
-  // Check for active frame generation job as fallback
-  const { data: activeJob } = useActiveFrameGeneration(sequenceId);
-  const isJobGenerating =
-    activeJob?.status === "running" || activeJob?.status === "pending";
-
-  // Consider generating if either sequence status or job indicates generation
-  const isGenerating = isBackgroundGenerating || isJobGenerating;
-
-  // Load frames with auto-refresh when generating
-  const { data: frames = [] } = useFramesBySequence(sequenceId, {
-    // Refetch every 2 seconds when frames are being generated
-    refetchInterval: isGenerating ? 2000 : false,
-  });
+  // Use unified storyboard status hook (replaces multiple polling hooks)
+  const { frames } = useStoryboardStatus(sequenceId);
 
   // Completed steps based on what's in the sequence
   const completedSteps = new Set([1]); // Script is always completed to get here

--- a/src/components/sequence-flow/storyboard-step.tsx
+++ b/src/components/sequence-flow/storyboard-step.tsx
@@ -1,5 +1,5 @@
 import type * as React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { generateFrames } from "#actions/sequence";
 import { StoryboardFrameSkeletonWithScript } from "@/components/sequence/storyboard-frame-skeleton-with-script";
 import { StoryboardFrameWithScript } from "@/components/sequence/storyboard-frame-with-script";
@@ -7,21 +7,12 @@ import { SectionHeading } from "@/components/typography";
 import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useFramePreviewStatus } from "@/hooks/use-frames";
 import {
-  useActiveFrameGeneration,
-  useFramePreviewStatus,
-  useFramesBySequence,
-} from "@/hooks/use-frames";
-import { useSequence } from "@/hooks/use-sequences";
+  type FrameGenerationMetadata,
+  useStoryboardStatus,
+} from "@/hooks/use-storyboard-status";
 import type { Frame } from "@/types/database";
-
-interface FrameGenerationMetadata {
-  frameGeneration?: {
-    status?: string;
-    expectedFrameCount?: number;
-    completedFrameCount?: number;
-  };
-}
 
 interface StoryboardStepProps {
   sequenceId: string;
@@ -32,23 +23,19 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
   sequenceId,
   onPrevious,
 }) => {
-  // Load the sequence data with polling
-  const { data: sequence } = useSequence(sequenceId, {
-    refetchInterval: 2000, // Poll sequence status
-  });
-
-  // Check if frames are being generated based on sequence status
-  const metadata = sequence?.metadata as FrameGenerationMetadata | null;
-  const sequenceGenerating = sequence?.status === "processing";
-
-  // Check for active frame generation job as fallback
-  const { data: activeJob } = useActiveFrameGeneration(sequenceId);
-  const jobGenerating =
-    activeJob?.status === "running" || activeJob?.status === "pending";
-
-  const isBackgroundGenerating = sequenceGenerating || jobGenerating;
+  // Use unified storyboard status hook (replaces multiple polling hooks)
+  const {
+    sequence,
+    frames,
+    activeJob,
+    isGenerating: isBackgroundGenerating,
+    hasFrames,
+    canGenerate: canGenerateFromHook,
+    refetch: refetchFrames,
+  } = useStoryboardStatus(sequenceId);
 
   // Get expected frame count from sequence metadata or job
+  const metadata = sequence?.metadata as FrameGenerationMetadata | null;
   const expectedFrameCount =
     metadata?.frameGeneration?.expectedFrameCount ||
     activeJob?.framesProgress?.total ||
@@ -58,14 +45,10 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
     activeJob?.framesProgress?.completed ||
     0;
 
-  // Load frames with auto-refresh when generating
-  const { data: frames = [], refetch: refetchFrames } = useFramesBySequence(
-    sequenceId,
-    {
-      // Refetch every 2 seconds when frames are being generated
-      refetchInterval: isBackgroundGenerating ? 2000 : false,
-    },
-  );
+  // Check for errors in sequence metadata
+  const metadataError = metadata?.frameGeneration?.error;
+  const hasMetadataError =
+    metadataError && metadata?.frameGeneration?.status === "failed";
 
   // Track preview generation status for all frames
   const framePreviewStatus = useFramePreviewStatus(frames);
@@ -73,10 +56,7 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
   // Local state for generation
   const [generationError, setGenerationError] = useState<string | null>(null);
 
-  const hasFrames = frames.length > 0;
-  const styleId = sequence?.style_id;
-
-  // Count frames with motion
+  // Count frames with motion (hasFrames already available from hook)
   const framesWithMotion = frames.filter((frame: Frame) => frame.video_url);
   const totalFrames = frames.length;
   const _hasAnyMotion = framesWithMotion.length > 0;
@@ -84,7 +64,7 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
     totalFrames > 0 && framesWithMotion.length === totalFrames;
 
   const handleGenerateStoryboard = useCallback(async () => {
-    if (!sequence?.script || !styleId) return;
+    if (!canGenerateFromHook) return;
 
     setGenerationError(null);
 
@@ -102,7 +82,7 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
 
       setGenerationError(errorMessage);
     }
-  }, [sequence, styleId, sequenceId]);
+  }, [canGenerateFromHook, sequenceId]);
 
   // Next button - now goes to the next sequence step (removed motion page)
   const handleNext = useCallback(() => {
@@ -120,15 +100,6 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
     },
     [refetchFrames],
   );
-
-  const canGenerate = useMemo(() => {
-    return (
-      sequence?.script &&
-      sequence.script.trim().length >= 10 &&
-      styleId &&
-      !isBackgroundGenerating
-    );
-  }, [sequence?.script, styleId, isBackgroundGenerating]);
 
   const canProceed = hasFrames && !isBackgroundGenerating;
 
@@ -217,7 +188,7 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
               variant="outline"
               size="sm"
               onClick={handleGenerateStoryboard}
-              disabled={!canGenerate || isBackgroundGenerating}
+              disabled={!canGenerateFromHook || isBackgroundGenerating}
               data-testid="regenerate-storyboard-button"
             >
               {isBackgroundGenerating ? "Generating..." : "Regenerate All"}
@@ -235,7 +206,7 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
                   <StoryboardFrameWithScript
                     key={frame.id}
                     frame={frame}
-                    styleId={styleId || undefined}
+                    styleId={sequence?.style_id || undefined}
                     isGeneratingPreview={previewStatus?.isGenerating || false}
                     onFrameUpdate={handleFrameUpdate}
                     onEdit={(frameId) => {
@@ -268,6 +239,25 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
               )}
           </div>
 
+          {/* Show metadata error from sequence */}
+          {hasMetadataError && (
+            <Alert variant="destructive">
+              <div className="space-y-2">
+                <div className="font-medium">Generation Failed</div>
+                <div className="text-sm">{metadataError}</div>
+                {metadata?.frameGeneration?.failedAt && (
+                  <div className="text-xs text-muted-foreground">
+                    Failed at:{" "}
+                    {new Date(
+                      metadata.frameGeneration.failedAt,
+                    ).toLocaleString()}
+                  </div>
+                )}
+              </div>
+            </Alert>
+          )}
+
+          {/* Show local generation error */}
           {generationError && (
             <Alert variant="destructive">
               <div className="space-y-2">
@@ -277,6 +267,22 @@ export const StoryboardStep: React.FC<StoryboardStepProps> = ({
             </Alert>
           )}
         </div>
+      )}
+
+      {/* Show metadata errors even when no frames exist */}
+      {hasMetadataError && !hasFrames && !isBackgroundGenerating && (
+        <Alert variant="destructive" className="w-full flex items-start gap-2">
+          <div className="space-y-2">
+            <div className="font-medium">Generation Failed</div>
+            <div className="text-sm">Reason: {metadataError}</div>
+            {metadata?.frameGeneration?.failedAt && (
+              <div className="text-xs text-muted-foreground">
+                Failed at:{" "}
+                {new Date(metadata.frameGeneration.failedAt).toLocaleString()}
+              </div>
+            )}
+          </div>
+        </Alert>
       )}
 
       {/* Navigation */}

--- a/src/hooks/use-storyboard-status.ts
+++ b/src/hooks/use-storyboard-status.ts
@@ -1,0 +1,190 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+import {
+  getActiveFrameGenerationJob,
+  getFramesBySequence,
+} from "#actions/frames";
+import { getSequence } from "#actions/sequence";
+import type { Frame, Sequence } from "@/types/database";
+import { frameKeys } from "./use-frames";
+import { sequenceKeys } from "./use-sequences";
+
+export interface FrameGenerationMetadata {
+  frameGeneration?: {
+    status?: string;
+    expectedFrameCount?: number;
+    completedFrameCount?: number;
+    error?: string;
+    failedAt?: string;
+  };
+}
+
+export interface Job {
+  id: string;
+  type: string;
+  status: string;
+  progress?: number;
+  result?: unknown;
+  error?: string;
+  created_at: string;
+  updated_at: string;
+  framesProgress?: {
+    total: number;
+    completed: number;
+    frames: Array<{
+      id: string;
+      order_index: number;
+      thumbnail_url?: string | null;
+    }>;
+  };
+}
+
+interface StoryboardStatus {
+  sequence: Sequence | null;
+  frames: Frame[];
+  activeJob?: Job | null;
+  isGenerating: boolean;
+  hasFrames: boolean;
+  canGenerate: boolean;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+/**
+ * Unified hook for managing storyboard status and polling
+ * Consolidates sequence, frames, and job status into a single coordinated query
+ * Follows React rules: minimal React, externalized logic, TanStack Query for data fetching
+ */
+export function useStoryboardStatus(sequenceId: string): StoryboardStatus {
+  const queryClient = useQueryClient();
+
+  const {
+    data,
+    isLoading,
+    error,
+    refetch: refetchQuery,
+  } = useQuery({
+    queryKey: ["storyboard-status", sequenceId],
+    queryFn: async () => {
+      const [sequenceResult, framesResult, activeJobResult] = await Promise.all(
+        [
+          getSequence(sequenceId),
+          getFramesBySequence(sequenceId),
+          getActiveFrameGenerationJob(sequenceId),
+        ],
+      );
+
+      // Extract data from results
+      const sequence = sequenceResult.success ? sequenceResult.sequence : null;
+      const frames = framesResult.success ? framesResult.frames || [] : [];
+      const activeJob = activeJobResult.success ? activeJobResult.job : null;
+
+      return {
+        sequence: sequence as Sequence | null,
+        frames,
+        activeJob,
+      };
+    },
+    enabled: !!sequenceId,
+    staleTime: 1000,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+    refetchInterval: (query) => {
+      if (!query.state.data) return false;
+
+      const { sequence, activeJob } = query.state.data;
+
+      const metadata = sequence?.metadata as FrameGenerationMetadata | null;
+      const sequenceGenerating =
+        sequence?.status === "processing" ||
+        metadata?.frameGeneration?.status === "processing" ||
+        metadata?.frameGeneration?.status === "generating_thumbnails";
+
+      const jobGenerating =
+        activeJob?.status === "running" || activeJob?.status === "pending";
+
+      const isGenerating = sequenceGenerating || jobGenerating;
+      return isGenerating ? 2000 : false;
+    },
+  });
+
+  const refetch = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: sequenceKeys.detail(sequenceId),
+      }),
+      queryClient.invalidateQueries({ queryKey: frameKeys.list(sequenceId) }),
+      queryClient.invalidateQueries({ queryKey: ["active-job", sequenceId] }),
+    ]);
+
+    await refetchQuery();
+  };
+
+  const derivedState = useMemo(() => {
+    if (!data) {
+      return {
+        sequence: null,
+        frames: [],
+        activeJob: null,
+        isGenerating: false,
+        hasFrames: false,
+        canGenerate: false,
+      };
+    }
+
+    const { sequence, frames, activeJob } = data;
+
+    // Check if generation is in progress
+    const metadata = sequence?.metadata as FrameGenerationMetadata | null;
+    const sequenceGenerating =
+      sequence?.status === "processing" ||
+      metadata?.frameGeneration?.status === "processing" ||
+      metadata?.frameGeneration?.status === "generating_thumbnails";
+
+    const jobGenerating =
+      activeJob?.status === "running" || activeJob?.status === "pending";
+
+    const isGenerating = sequenceGenerating || jobGenerating;
+    const hasFrames = frames.length > 0;
+    const styleId = sequence?.style_id;
+
+    // Can generate if we have script, style, and not currently generating
+    const canGenerate = Boolean(
+      sequence?.script &&
+        sequence.script.trim().length >= 10 &&
+        styleId &&
+        !isGenerating,
+    );
+
+    return {
+      sequence,
+      frames,
+      activeJob,
+      isGenerating,
+      hasFrames,
+      canGenerate,
+    };
+  }, [data]);
+
+  return {
+    ...derivedState,
+    isLoading,
+    error: error as Error | null,
+    refetch,
+  };
+}
+
+export function useIsGenerating(sequenceId: string): boolean {
+  const { isGenerating } = useStoryboardStatus(sequenceId);
+  return isGenerating;
+}
+
+export function useStoryboardFrames(sequenceId: string): {
+  frames: Frame[];
+  isLoading: boolean;
+  refetch: () => Promise<void>;
+} {
+  const { frames, isLoading, refetch } = useStoryboardStatus(sequenceId);
+  return { frames, isLoading, refetch };
+}


### PR DESCRIPTION
## Related Issue

Closes #68

## Summary of Changes

- Add sequence status reset after frame generation completion  
- Prevent duplicate job creation with existing job detection
- Add thumbnail completion detection in image webhook
- Consolidate polling logic with unified storyboard status hook
- Clean up redundant error metadata handling
- Fix metadata error display outside conditional blocks

## Risk Assessment

<!-- Assess the risk level of this PR:
- Medium: Potential for some edge cases or indirect effects.
-->

- [x] Medium


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified storyboard status for sequences and frames with smarter auto-refresh.
  - Clearer UI alerts for frame-generation errors.
- Bug Fixes
  - Prevents duplicate frame-generation jobs for the same sequence.
  - Automatically marks sequences as complete when all thumbnails are ready.
- Refactor
  - Replaced multiple polling/data sources with a single status hook for consistency and performance.
  - Simplified post-generation state handling.
- Chores
  - Added a new script alias to run environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->