### PR TITLE
Add tabs for script, image prompt, and motion prompt viewing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@react-email/components": "^0.5.6",
         "@react-email/render": "^1.3.2",
         "@supabase/ssr": "^0.7.0",
@@ -619,6 +620,8 @@
     "@radix-ui/react-select": ["@radix-ui/react-select@2.2.6", "", { "dependencies": { "@radix-ui/number": "1.1.1", "@radix-ui/primitive": "1.1.3", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-previous": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ=="],
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tabs": ["@radix-ui/react-tabs@1.1.13", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A=="],
 
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@react-email/components": "^0.5.6",
     "@react-email/render": "^1.3.2",
     "@supabase/ssr": "^0.7.0",

--- a/src/components/sequence/storyboard-frame-with-script.tsx
+++ b/src/components/sequence/storyboard-frame-with-script.tsx
@@ -1,10 +1,11 @@
-import { Play, Video } from 'lucide-react';
+import { Copy, Play, Video } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import type * as React from 'react';
 import { useCallback, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Select } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { MOTION_ACCESS_DENIED_MESSAGE } from '@/constants';
 import { useAuthNavigation } from '@/hooks/use-auth-navigation';
 import { useEstimateImageCostByFal } from '@/hooks/use-fal-models';
@@ -48,6 +49,38 @@ export const StoryboardFrameWithScript: React.FC<
   const metadata = frame.metadata as Record<string, unknown> | null;
   const scriptChunk = metadata?.scriptChunk as string | undefined;
   const displayScript = scriptChunk || frame.description;
+
+  // Extract prompts from metadata
+  const scene = metadata as {
+    originalScript?: { extract?: string };
+    prompts?: {
+      visual?: { fullPrompt?: string };
+      motion?: { fullPrompt?: string };
+    };
+  } | null;
+  const scriptText = scene?.originalScript?.extract || displayScript;
+  const imagePrompt = scene?.prompts?.visual?.fullPrompt;
+  const motionPrompt = scene?.prompts?.motion?.fullPrompt;
+
+  // Copy state management
+  const [copiedTab, setCopiedTab] = useState<string | null>(null);
+
+  // Handle copy to clipboard
+  const handleCopy = useCallback(
+    async (text: string | undefined | null, tabName: string) => {
+      if (!text) return;
+
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopiedTab(tabName);
+        setTimeout(() => setCopiedTab(null), 2000);
+      } catch (error) {
+        console.error('Failed to copy to clipboard:', error);
+      }
+    },
+    []
+  );
+
   // Auth navigation for redirect preservation
   const { loginUrl } = useAuthNavigation();
 
@@ -262,23 +295,97 @@ export const StoryboardFrameWithScript: React.FC<
         {frame.orderIndex + 1}
       </div>
 
-      {/* Script section - Left side */}
+      {/* Script section with tabs - Left side */}
       <div className="flex-1 space-y-3">
-        <div className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-          Script Section
-        </div>
-        <div className="prose prose-sm max-w-none">
-          <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-            {displayScript}
-          </p>
-        </div>
-        {frame.durationMs !== undefined &&
-          frame.durationMs !== null &&
-          frame.durationMs > 0 && (
-            <div className="text-xs text-muted-foreground">
-              Duration: {(frame.durationMs / 1000).toFixed(1)}s
+        <Tabs defaultValue="script" className="w-full">
+          <TabsList>
+            <TabsTrigger value="script">Script</TabsTrigger>
+            <TabsTrigger value="image-prompt">Image Prompt</TabsTrigger>
+            <TabsTrigger value="motion-prompt">Motion Prompt</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="script" className="space-y-3">
+            <div className="relative">
+              <div className="absolute right-0 top-0">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleCopy(scriptText, 'script')}
+                  disabled={!scriptText}
+                  className="h-8 w-8 p-0"
+                >
+                  {copiedTab === 'script' ? (
+                    <span className="text-xs">✓</span>
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+              <div className="prose prose-sm max-w-none pr-10">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                  {scriptText || 'No script available'}
+                </p>
+              </div>
             </div>
-          )}
+            {frame.durationMs !== undefined &&
+              frame.durationMs !== null &&
+              frame.durationMs > 0 && (
+                <div className="text-xs text-muted-foreground">
+                  Duration: {(frame.durationMs / 1000).toFixed(1)}s
+                </div>
+              )}
+          </TabsContent>
+
+          <TabsContent value="image-prompt" className="space-y-3">
+            <div className="relative">
+              <div className="absolute right-0 top-0">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleCopy(imagePrompt, 'image-prompt')}
+                  disabled={!imagePrompt}
+                  className="h-8 w-8 p-0"
+                >
+                  {copiedTab === 'image-prompt' ? (
+                    <span className="text-xs">✓</span>
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+              <div className="prose prose-sm max-w-none pr-10">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                  {imagePrompt || 'No image prompt available'}
+                </p>
+              </div>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="motion-prompt" className="space-y-3">
+            <div className="relative">
+              <div className="absolute right-0 top-0">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleCopy(motionPrompt, 'motion-prompt')}
+                  disabled={!motionPrompt}
+                  className="h-8 w-8 p-0"
+                >
+                  {copiedTab === 'motion-prompt' ? (
+                    <span className="text-xs">✓</span>
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+              <div className="prose prose-sm max-w-none pr-10">
+                <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+                  {motionPrompt || 'No motion prompt available'}
+                </p>
+              </div>
+            </div>
+          </TabsContent>
+        </Tabs>
       </div>
 
       {/* Divider */}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/utils';
+
+function Tabs({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn('flex flex-col gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };


### PR DESCRIPTION
## Summary
- Added shadcn tabs component to UI library
- Modified StoryboardFrameWithScript to use tabbed interface for viewing script, image prompt, and motion prompt
- Added copy-to-clipboard functionality with visual feedback

## Changes
- **New Component**: Added `src/components/ui/tabs.tsx` (shadcn tabs component)
- **Modified Component**: Updated `src/components/sequence/storyboard-frame-with-script.tsx` to use tabs
- **Dependencies**: Added `@radix-ui/react-tabs` to package.json

## Features
- Three tabs: Script, Image Prompt, and Motion Prompt
- Copy button with icon in each tab for easy clipboard access
- Visual feedback (checkmark) after successful copy
- Extracts prompts from `frame.metadata.prompts` (visual/motion)
- Fallback messages when prompts are not available
- Maintains existing functionality and styling

## Test Plan
- [x] TypeScript compilation passes
- [x] Linting passes (no new errors)
- [x] Code formatted with Prettier
- [ ] Manual testing: Navigate to storyboard page
- [ ] Manual testing: Verify tabs switch correctly
- [ ] Manual testing: Test copy functionality works
- [ ] Manual testing: Verify prompts display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)