### PR TITLE
Support app.velro.ai and disable Google OAuth on preview branches

### DIFF
--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -43,9 +43,9 @@ export const auth = betterAuth({
   baseURL: requiredEnvVars.BETTER_AUTH_URL,
 
   // Trusted origins for CSRF protection
-  // Uses project-specific wildcards to allow all Vercel deployments
-  // while blocking requests from other Vercel users' deployments
+  // Production uses custom domain, previews use Vercel URLs
   trustedOrigins: [
+    'https://app.velro.ai', // Production custom domain
     'https://velro-*.vercel.app', // Production deployments
     'https://velro-git-*.vercel.app', // Branch preview deployments
     ...(process.env.NODE_ENV === 'development'
@@ -94,13 +94,16 @@ export const auth = betterAuth({
   },
 
   // Social providers
+  // Google OAuth only enabled in production and local development
+  // Preview branches use email/password or anonymous mode
   socialProviders: {
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID || '',
       clientSecret: process.env.GOOGLE_CLIENT_SECRET || '',
-      enabled: !!(
-        process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET
-      ),
+      enabled:
+        !!(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) &&
+        (process.env.VERCEL_ENV === 'production' ||
+          process.env.NODE_ENV === 'development'),
     },
   },
 


### PR DESCRIPTION
## Summary
- Add app.velro.ai to trusted CORS origins for production domain
- Disable Google OAuth on Vercel preview branches (only enabled in production and local development)
- Preview deployments fall back to email/password and anonymous authentication

## Test Plan
- [ ] Google OAuth login works on production (app.velro.ai)
- [ ] Google OAuth button is hidden on preview branches
- [ ] Email/password login works on preview branches
- [ ] Anonymous mode still works on all deployments
- [ ] Local development OAuth works (if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)