### PR TITLE
Add rate limiting for Fal.ai API requests

### DIFF
--- a/src/app/api/workflows/[...any]/image-workflow.ts
+++ b/src/app/api/workflows/[...any]/image-workflow.ts
@@ -284,6 +284,12 @@ export const generateImageWorkflow = createWorkflow(
   {
     retries: 3,
     retryDelay: 'pow(2, retried) * 1000', // 1s, 2s, 4s, 8s
+    flowControl: {
+      key: 'fal-requests', // Shared key for both image & motion
+      parallelism: process.env.FAL_CONCURRENCY_LIMIT
+        ? parseInt(process.env.FAL_CONCURRENCY_LIMIT)
+        : 10,
+    },
     failureFunction: async ({ context, failResponse }) => {
       const input = context.requestPayload;
 

--- a/src/app/api/workflows/[...any]/motion-workflow.ts
+++ b/src/app/api/workflows/[...any]/motion-workflow.ts
@@ -15,8 +15,8 @@ import { createWorkflow } from '@upstash/workflow/nextjs';
 import { generateMotionForFrame } from '@/lib/services/motion.service';
 
 import { DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
-import { eq } from 'drizzle-orm';
 import { getImageUrlForApi } from '@/lib/utils/environment';
+import { eq } from 'drizzle-orm';
 
 /**
  * Motion generation workflow
@@ -202,6 +202,12 @@ export const generateMotionWorkflow = createWorkflow(
   {
     retries: 3,
     retryDelay: 'pow(2, retried) * 1000', // 1s, 2s, 4s, 8s
+    flowControl: {
+      key: 'fal-requests', // Shared key for both image & motion
+      parallelism: process.env.FAL_CONCURRENCY_LIMIT
+        ? parseInt(process.env.FAL_CONCURRENCY_LIMIT)
+        : 10,
+    },
     failureFunction: async ({ context, failResponse }) => {
       const input = context.requestPayload;
 


### PR DESCRIPTION
## Summary
- Implemented flow control for Fal.ai API requests to prevent rate limiting
- Added shared concurrency limit across image and motion workflows using QStash's flow control feature

## Changes
- **Image Workflow**: Added flow control configuration with shared key 'fal-requests' and configurable parallelism limit (default: 10)
- **Motion Workflow**: Added matching flow control configuration to coordinate with image workflow

## Configuration
- Uses `FAL_CONCURRENCY_LIMIT` environment variable to configure max parallel requests
- Defaults to 10 concurrent requests if not configured
- Shared key ensures both image and motion workflows respect the same limit

## Test plan
- ✅ Verify workflows respect concurrency limits
- ✅ Confirm rate limiting errors are prevented
- ✅ Test with high volume of requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)