### PR TITLE
Fix migration 0006 timestamp to enable proper migration ordering #233

### DIFF
--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -47,7 +47,7 @@
     {
       "idx": 6,
       "version": "6",
-      "when": 1732500000000,
+      "when": 1764030114649,
       "tag": "0006_melted_ulik",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Fixed migration 0006_melted_ulik timestamp that was preventing the status column from being added to user table in Turso databases
- Migration had incorrect timestamp (2024-11-25) that was earlier than migrations 0004 and 0005 (2025-11-24/25)
- Updated timestamp from 1732500000000 to 1764030114649 to ensure proper chronological ordering

## Root Cause
Migration 0006 was created with a timestamp that was a full year earlier than the previous migrations:
- Migration 0004: 2025-11-24 23:35:06
- Migration 0005: 2025-11-25 00:21:54
- Migration 0006: **2024-11-25 02:00:00** ← Wrong year!

This caused Drizzle to skip the migration during `bun db:migrate` because it assumed an older migration was already applied.

## Changes
- Updated `drizzle/migrations/meta/_journal.json` timestamp for migration 0006 from 1732500000000 to 1764030114649

## Testing
- ✅ Verified migration applies successfully to velro-preview after timestamp fix
- ✅ Confirmed status column now exists in velro-preview user table
- ✅ Migration recorded in __drizzle_migrations table with correct hash (16ec90b)

## Test plan
- [ ] Verify CI/CD workflow applies migration to preview database
- [ ] After merge, verify migration applies to production database
- [ ] Confirm status column exists in velro-prod user table

🤖 Generated with [Claude Code](https://claude.com/claude-code)