### PR TITLE
Add Kling O1 (Omni) video model

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -276,6 +276,53 @@ export const IMAGE_TO_VIDEO_MODELS = {
       quality: 'best',
     },
   },
+
+  kling_o1: {
+    id: 'fal-ai/kling-video/o1/image-to-video',
+    name: 'Kling O1 (Omni)',
+    provider: 'kling',
+    capabilities: {
+      supportsPrompt: true,
+      supportsAudio: false,
+      maxDuration: 10,
+      defaultDuration: 5,
+      fpsRange: { min: 24, max: 30, default: 30 }, // Standard for Kling models
+      supportedDurations: [5, 10], // API only accepts "5" or "10" as string enum
+      requiresStringDuration: true, // API expects string, not number
+    },
+    pricing: {
+      estimatedCost: 0.35, // Similar to kling_v2_5_turbo_pro
+      unit: 'video',
+    },
+    performance: {
+      estimatedGenerationTime: 15,
+      quality: 'best',
+    },
+  },
+
+  runway_gen3_turbo: {
+    id: 'fal-ai/runway-gen3/turbo/image-to-video',
+    name: 'Runway Gen-3 Turbo',
+    provider: 'runway',
+    capabilities: {
+      supportsPrompt: true,
+      supportsAudio: false,
+      maxDuration: 10,
+      defaultDuration: 5,
+      fpsRange: { min: 24, max: 30, default: 24 }, // Standard cinematic
+      supportedDurations: [5, 10],
+      requiresStringDuration: true, // API expects string duration
+      supportedAspectRatios: ['16:9', '9:16'],
+    },
+    pricing: {
+      estimatedCost: 0.5, // Premium tier
+      unit: 'video',
+    },
+    performance: {
+      estimatedGenerationTime: 10, // Fast turbo model
+      quality: 'best',
+    },
+  },
 } as const;
 
 /**
@@ -296,6 +343,8 @@ export const VIDEO_MODELS = {
   kling_v2_5_turbo_pro: IMAGE_TO_VIDEO_MODELS.kling_v2_5_turbo_pro.id,
   wan_2_5: IMAGE_TO_VIDEO_MODELS.wan_2_5.id,
   sora_2: IMAGE_TO_VIDEO_MODELS.sora_2.id,
+  kling_o1: IMAGE_TO_VIDEO_MODELS.kling_o1.id,
+  runway_gen3_turbo: IMAGE_TO_VIDEO_MODELS.runway_gen3_turbo.id,
 } as const;
 
 /**

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -299,30 +299,6 @@ export const IMAGE_TO_VIDEO_MODELS = {
       quality: 'best',
     },
   },
-
-  runway_gen3_turbo: {
-    id: 'fal-ai/runway-gen3/turbo/image-to-video',
-    name: 'Runway Gen-3 Turbo',
-    provider: 'runway',
-    capabilities: {
-      supportsPrompt: true,
-      supportsAudio: false,
-      maxDuration: 10,
-      defaultDuration: 5,
-      fpsRange: { min: 24, max: 30, default: 24 }, // Standard cinematic
-      supportedDurations: [5, 10],
-      requiresStringDuration: true, // API expects string duration
-      supportedAspectRatios: ['16:9', '9:16'],
-    },
-    pricing: {
-      estimatedCost: 0.5, // Premium tier
-      unit: 'video',
-    },
-    performance: {
-      estimatedGenerationTime: 10, // Fast turbo model
-      quality: 'best',
-    },
-  },
 } as const;
 
 /**
@@ -344,7 +320,6 @@ export const VIDEO_MODELS = {
   wan_2_5: IMAGE_TO_VIDEO_MODELS.wan_2_5.id,
   sora_2: IMAGE_TO_VIDEO_MODELS.sora_2.id,
   kling_o1: IMAGE_TO_VIDEO_MODELS.kling_o1.id,
-  runway_gen3_turbo: IMAGE_TO_VIDEO_MODELS.runway_gen3_turbo.id,
 } as const;
 
 /**

--- a/src/lib/services/motion.service.test.ts
+++ b/src/lib/services/motion.service.test.ts
@@ -167,6 +167,91 @@ describe('Motion Service', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('No video URL returned');
     });
+
+    it('should generate motion with Kling O1 model', async () => {
+      const mockVideoUrl = 'https://example.com/kling-o1-video.mp4';
+
+      mockSubscribe.mockResolvedValue({
+        data: {
+          video: {
+            url: mockVideoUrl,
+          },
+        },
+        requestId: 'test-kling-o1-request-id',
+      });
+
+      const result = await generateMotionForFrame({
+        imageUrl: 'https://example.com/image.jpg',
+        prompt: 'Smooth camera movement',
+        model: 'kling_o1',
+        duration: 10,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.videoUrl).toBe(mockVideoUrl);
+      expect(result.metadata?.model).toBe(
+        'fal-ai/kling-video/o1/image-to-video'
+      );
+      expect(result.metadata?.provider).toBe('kling');
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'fal-ai/kling-video/o1/image-to-video',
+        expect.objectContaining({
+          input: expect.objectContaining({
+            prompt: 'Smooth camera movement',
+            image_url: 'https://example.com/image.jpg',
+            duration: '10', // Should be string
+            cfg_scale: 0.5,
+            negative_prompt: 'blur, distort, and low quality',
+          }),
+          logs: true,
+          pollInterval: 5000,
+        })
+      );
+    });
+
+    it('should generate motion with Runway Gen-3 Turbo model', async () => {
+      const mockVideoUrl = 'https://example.com/runway-gen3-video.mp4';
+
+      mockSubscribe.mockResolvedValue({
+        data: {
+          video: {
+            url: mockVideoUrl,
+          },
+        },
+        requestId: 'test-runway-request-id',
+      });
+
+      const result = await generateMotionForFrame({
+        imageUrl: 'https://example.com/image.jpg',
+        prompt: 'Cinematic zoom out',
+        model: 'runway_gen3_turbo',
+        duration: 5,
+        aspectRatio: '9:16',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.videoUrl).toBe(mockVideoUrl);
+      expect(result.metadata?.model).toBe(
+        'fal-ai/runway-gen3/turbo/image-to-video'
+      );
+      expect(result.metadata?.provider).toBe('runway');
+
+      expect(mockSubscribe).toHaveBeenCalledWith(
+        'fal-ai/runway-gen3/turbo/image-to-video',
+        expect.objectContaining({
+          input: expect.objectContaining({
+            prompt_text: 'Cinematic zoom out',
+            prompt_image: 'https://example.com/image.jpg',
+            duration: '5', // Should be string
+            ratio: '9:16',
+            seed: expect.any(Number),
+          }),
+          logs: true,
+          pollInterval: 5000,
+        })
+      );
+    });
   });
 
   describe('Model configurations', () => {
@@ -219,6 +304,47 @@ describe('Motion Service', () => {
           estimatedCost: 0.5,
         },
         performance: {
+          quality: 'best',
+        },
+      });
+
+      expect(IMAGE_TO_VIDEO_MODELS.kling_o1).toMatchObject({
+        id: 'fal-ai/kling-video/o1/image-to-video',
+        name: 'Kling O1 (Omni)',
+        provider: 'kling',
+        capabilities: {
+          supportsPrompt: true,
+          supportsAudio: false,
+          maxDuration: 10,
+          defaultDuration: 5,
+          requiresStringDuration: true,
+        },
+        pricing: {
+          estimatedCost: 0.35,
+          unit: 'video',
+        },
+        performance: {
+          quality: 'best',
+        },
+      });
+
+      expect(IMAGE_TO_VIDEO_MODELS.runway_gen3_turbo).toMatchObject({
+        id: 'fal-ai/runway-gen3/turbo/image-to-video',
+        name: 'Runway Gen-3 Turbo',
+        provider: 'runway',
+        capabilities: {
+          supportsPrompt: true,
+          supportsAudio: false,
+          maxDuration: 10,
+          defaultDuration: 5,
+          requiresStringDuration: true,
+        },
+        pricing: {
+          estimatedCost: 0.5,
+          unit: 'video',
+        },
+        performance: {
+          estimatedGenerationTime: 10,
           quality: 'best',
         },
       });

--- a/src/lib/services/motion.service.test.ts
+++ b/src/lib/services/motion.service.test.ts
@@ -209,49 +209,6 @@ describe('Motion Service', () => {
         })
       );
     });
-
-    it('should generate motion with Runway Gen-3 Turbo model', async () => {
-      const mockVideoUrl = 'https://example.com/runway-gen3-video.mp4';
-
-      mockSubscribe.mockResolvedValue({
-        data: {
-          video: {
-            url: mockVideoUrl,
-          },
-        },
-        requestId: 'test-runway-request-id',
-      });
-
-      const result = await generateMotionForFrame({
-        imageUrl: 'https://example.com/image.jpg',
-        prompt: 'Cinematic zoom out',
-        model: 'runway_gen3_turbo',
-        duration: 5,
-        aspectRatio: '9:16',
-      });
-
-      expect(result.success).toBe(true);
-      expect(result.videoUrl).toBe(mockVideoUrl);
-      expect(result.metadata?.model).toBe(
-        'fal-ai/runway-gen3/turbo/image-to-video'
-      );
-      expect(result.metadata?.provider).toBe('runway');
-
-      expect(mockSubscribe).toHaveBeenCalledWith(
-        'fal-ai/runway-gen3/turbo/image-to-video',
-        expect.objectContaining({
-          input: expect.objectContaining({
-            prompt_text: 'Cinematic zoom out',
-            prompt_image: 'https://example.com/image.jpg',
-            duration: '5', // Should be string
-            ratio: '9:16',
-            seed: expect.any(Number),
-          }),
-          logs: true,
-          pollInterval: 5000,
-        })
-      );
-    });
   });
 
   describe('Model configurations', () => {
@@ -324,27 +281,6 @@ describe('Motion Service', () => {
           unit: 'video',
         },
         performance: {
-          quality: 'best',
-        },
-      });
-
-      expect(IMAGE_TO_VIDEO_MODELS.runway_gen3_turbo).toMatchObject({
-        id: 'fal-ai/runway-gen3/turbo/image-to-video',
-        name: 'Runway Gen-3 Turbo',
-        provider: 'runway',
-        capabilities: {
-          supportsPrompt: true,
-          supportsAudio: false,
-          maxDuration: 10,
-          defaultDuration: 5,
-          requiresStringDuration: true,
-        },
-        pricing: {
-          estimatedCost: 0.5,
-          unit: 'video',
-        },
-        performance: {
-          estimatedGenerationTime: 10,
           quality: 'best',
         },
       });

--- a/src/lib/services/motion.service.ts
+++ b/src/lib/services/motion.service.ts
@@ -219,6 +219,23 @@ const PROVIDER_INPUT_BUILDERS: Record<string, ProviderInputBuilder> = {
       seed: Math.floor(Math.random() * 1000000),
     };
   },
+
+  runway: (options, modelConfig) => {
+    const validatedDuration = options.duration
+      ? Math.min(options.duration, modelConfig.capabilities.maxDuration)
+      : modelConfig.capabilities.defaultDuration;
+
+    // Runway requires string duration: "5" or "10"
+    const runwayDuration = validatedDuration <= 7 ? '5' : '10';
+
+    return {
+      prompt_text: options.prompt,
+      prompt_image: options.imageUrl,
+      duration: runwayDuration,
+      ratio: options.aspectRatio || '16:9',
+      seed: Math.floor(Math.random() * 1000000),
+    };
+  },
 };
 
 /**

--- a/src/lib/services/motion.service.ts
+++ b/src/lib/services/motion.service.ts
@@ -219,23 +219,6 @@ const PROVIDER_INPUT_BUILDERS: Record<string, ProviderInputBuilder> = {
       seed: Math.floor(Math.random() * 1000000),
     };
   },
-
-  runway: (options, modelConfig) => {
-    const validatedDuration = options.duration
-      ? Math.min(options.duration, modelConfig.capabilities.maxDuration)
-      : modelConfig.capabilities.defaultDuration;
-
-    // Runway requires string duration: "5" or "10"
-    const runwayDuration = validatedDuration <= 7 ? '5' : '10';
-
-    return {
-      prompt_text: options.prompt,
-      prompt_image: options.imageUrl,
-      duration: runwayDuration,
-      ratio: options.aspectRatio || '16:9',
-      seed: Math.floor(Math.random() * 1000000),
-    };
-  },
 };
 
 /**


### PR DESCRIPTION
## Summary

Added **Kling O1 (Omni)** image-to-video model - a high-quality video generation model with 5s/10s duration support.

## Implementation

Model auto-integrates with existing motion workflows, UI selector, and API endpoints. Reuses the existing Kling provider infrastructure with full type safety and test coverage.

## Test Results

✅ All 7 motion service tests pass
✅ TypeScript types verified  
✅ Linter passes with no new warnings

## Note

Runway Gen-4.5 was requested but is not yet available via fal.ai API. Can be added in a future PR when API access becomes available.

🤖 Generated with Claude Code