### PR TITLE
Fix talent matching schema for Anthropic structured output

### DIFF
--- a/src/lib/services/talent-matching.service.ts
+++ b/src/lib/services/talent-matching.service.ts
@@ -28,7 +28,7 @@ const talentMatchResponseSchema = z.object({
     z.object({
       characterId: z.string(),
       talentId: z.string(),
-      confidence: z.number().min(0).max(1),
+      confidence: z.number(), // 0-1 range enforced by prompt, not schema (Anthropic doesn't support min/max)
       reason: z.string(),
     })
   ),


### PR DESCRIPTION
## Summary
- Remove `.min(0).max(1)` constraint from `confidence` field in talent matching response schema
- Anthropic's structured output doesn't support `minimum`/`maximum` JSON Schema properties for number types

## Context
The talent matching service was failing with error:
```
output_format.schema: For 'number' type, properties maximum, minimum are not supported
```

Zod's `.min(0).max(1)` converts to JSON Schema with `minimum` and `maximum` properties, which Anthropic rejects. The AI will still return confidence values between 0-1 based on semantic understanding.

## Test plan
- [ ] Verify talent matching works without schema validation errors
- [ ] Confirm confidence values are still returned in expected range

🤖 Generated with [Claude Code](https://claude.com/claude-code)