### PR TITLE
fix: settings layout shift and inconsistent width between tabs #321

### DIFF
--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -26,15 +26,8 @@ import {
   BILLING_BALANCE_KEY,
 } from '@/hooks/use-billing-balance';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
 import type { LucideIcon } from 'lucide-react';
-import {
-  ArrowLeft,
-  CreditCard,
-  DollarSign,
-  RefreshCw,
-  Wallet,
-} from 'lucide-react';
+import { CreditCard, DollarSign, RefreshCw, Wallet } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 type BillingSettingsProps = {
@@ -106,7 +99,6 @@ function getErrorMessage(
 }
 
 export function BillingSettings({ success, canceled }: BillingSettingsProps) {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
   const [customAmount, setCustomAmount] = useState('');
@@ -207,16 +199,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
   };
 
   return (
-    <div className="mx-auto max-w-2xl p-6">
-      <Button
-        variant="ghost"
-        className="mb-4"
-        onClick={() => void navigate({ to: '/sequences' })}
-      >
-        <ArrowLeft className="mr-2 h-4 w-4" />
-        Back to sequences
-      </Button>
-
+    <div className="space-y-6">
       {success && (
         <Alert className="mb-4">
           <AlertDescription>
@@ -242,7 +225,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
       )}
 
       {/* Balance Card */}
-      <Card className="mb-6">
+      <Card>
         <CardHeader>
           <SectionHeader
             icon={Wallet}
@@ -262,7 +245,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
       </Card>
 
       {/* Top Up Card */}
-      <Card className="mb-6">
+      <Card>
         <CardHeader>
           <SectionHeader
             icon={DollarSign}
@@ -317,7 +300,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
       </Card>
 
       {/* Auto Top-Up Card */}
-      <Card className="mb-6">
+      <Card>
         <CardHeader>
           <SectionHeader
             icon={RefreshCw}

--- a/src/components/settings/passkey-settings.tsx
+++ b/src/components/settings/passkey-settings.tsx
@@ -86,8 +86,8 @@ export function PasskeySettings({ isSetupFlow }: PasskeySettingsProps) {
     void navigate({ to: '/sequences' });
   };
 
-  return (
-    <div className={isSetupFlow ? 'mx-auto max-w-2xl p-6' : undefined}>
+  const content = (
+    <div className="space-y-6">
       <Card>
         <CardHeader>
           <div className="flex items-center gap-3">
@@ -183,4 +183,11 @@ export function PasskeySettings({ isSetupFlow }: PasskeySettingsProps) {
       </Card>
     </div>
   );
+
+  // Only wrap with container when in setup flow (standalone page)
+  if (isSetupFlow) {
+    return <div className="mx-auto max-w-2xl p-6">{content}</div>;
+  }
+
+  return content;
 }

--- a/src/routes/_protected/route.tsx
+++ b/src/routes/_protected/route.tsx
@@ -1,5 +1,5 @@
 import { AppLayout } from '@/components/layout/app-layout';
-import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router';
 import { redirect } from '@tanstack/react-router';
 import { getSessionFn } from '@/lib/auth/server';
 
@@ -25,8 +25,15 @@ export const Route = createFileRoute('/_protected')({
 });
 
 function ProtectedLayout() {
+  const location = useLocation();
+  const isSettingsPage = location.pathname.startsWith('/settings');
+
   return (
-    <AppLayout>
+    <AppLayout
+      className={
+        isSettingsPage ? 'overflow-y-auto [scrollbar-gutter:stable]' : undefined
+      }
+    >
       <Outlet />
     </AppLayout>
   );

--- a/src/routes/_protected/settings/route.tsx
+++ b/src/routes/_protected/settings/route.tsx
@@ -3,15 +3,14 @@
  * Provides tab navigation between settings sub-pages
  */
 
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
 import {
   createFileRoute,
   Link,
   Outlet,
-  useMatchRoute,
+  useLocation,
 } from '@tanstack/react-router';
-import { ArrowLeft, Fingerprint, Key } from 'lucide-react';
+import { CreditCard, Fingerprint, Key } from 'lucide-react';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export const Route = createFileRoute('/_protected/settings')({
   component: SettingsLayout,
@@ -19,50 +18,46 @@ export const Route = createFileRoute('/_protected/settings')({
 
 const tabs = [
   {
+    value: 'api-keys',
     label: 'API Keys',
     href: '/settings/api-keys',
     icon: <Key className="h-4 w-4" />,
   },
   {
+    value: 'passkeys',
     label: 'Passkeys',
     href: '/settings/passkeys',
     icon: <Fingerprint className="h-4 w-4" />,
   },
+  {
+    value: 'billing',
+    label: 'Billing',
+    href: '/settings/billing',
+    icon: <CreditCard className="h-4 w-4" />,
+  },
 ];
 
 function SettingsLayout() {
-  const matchRoute = useMatchRoute();
+  const location = useLocation();
+
+  // Determine active tab from current route
+  const activeTab =
+    tabs.find((tab) => location.pathname === tab.href)?.value || 'api-keys';
 
   return (
-    <div className="mx-auto max-w-2xl p-6">
-      <Button variant="ghost" className="mb-4" asChild>
-        <Link to="/sequences">
-          <ArrowLeft className="mr-2 h-4 w-4" />
-          Back to sequences
-        </Link>
-      </Button>
-
-      <nav className="mb-6 flex items-center gap-2">
-        {tabs.map((tab) => {
-          const isActive = matchRoute({ to: tab.href, fuzzy: false });
-
-          return (
-            <Link
-              key={tab.href}
-              to={tab.href}
-              className={cn(
-                'flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-colors',
-                isActive
-                  ? 'border-primary bg-primary/10 text-primary'
-                  : 'border-transparent text-muted-foreground hover:border-muted hover:text-foreground'
-              )}
-            >
-              {tab.icon}
-              {tab.label}
-            </Link>
-          );
-        })}
-      </nav>
+    <div className="mx-auto w-full max-w-2xl p-6">
+      <Tabs value={activeTab} className="mb-6">
+        <TabsList className="w-full justify-start">
+          {tabs.map((tab) => (
+            <TabsTrigger key={tab.value} value={tab.value} asChild>
+              <Link to={tab.href} className="flex items-center gap-2">
+                {tab.icon}
+                {tab.label}
+              </Link>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
 
       <Outlet />
     </div>


### PR DESCRIPTION

## Related Issue

Closes #321

## Summary of Changes

- Add `w-full` to settings container so `mx-auto` centers correctly
  inside flex column parent (root cause of width inconsistency)
- Enable page-level scrolling on settings with `overflow-y-auto` and
  `scrollbar-gutter: stable` to prevent scrollbar CLS
- Replace custom tab nav with shadcn Tabs components
- Add Billing tab to settings navigation
- Remove redundant "Back to sequences" button and wrapper from billing
- Standardize all settings components to use `space-y-6` wrapper
- Extract passkey setup-flow container so it doesn't affect settings

Co-authored-by: Cursor <cursoragent@cursor.com>

## Risk Assessment

<!-- Assess the risk level of this PR:
- Low: Minimal impact, straightforward changes.
- Medium: Potential for some edge cases or indirect effects.
- High: Could affect critical functionality or many users.
-->

- [ ] Low
- [ ] Medium
- [ ] High

## Additional Notes

<!-- Add any other context or comments about the PR here -->

## Screenshots (if applicable)

<!-- Attach any screenshots that help explain your changes -->
