### PR TITLE
Fix passkey conditional UI cleanup for OTP login

### DIFF
--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -36,6 +36,8 @@ export function AuthForm({
 
   // Preload passkeys for conditional UI (browser autofill)
   useEffect(() => {
+    let cancelled = false;
+
     const preloadPasskeys = async () => {
       if (
         !window.PublicKeyCredential?.isConditionalMediationAvailable ||
@@ -43,16 +45,21 @@ export function AuthForm({
       ) {
         return;
       }
-      void authClient.signIn.passkey({
+      if (cancelled) return;
+
+      const result = await authClient.signIn.passkey({
         autoFill: true,
-        fetchOptions: {
-          onSuccess: () => {
-            void navigate({ to: redirectTo });
-          },
-        },
       });
+
+      if (!cancelled && result?.data) {
+        void navigate({ to: redirectTo });
+      }
     };
     void preloadPasskeys();
+
+    return () => {
+      cancelled = true;
+    };
   }, [navigate, redirectTo]);
 
   const handleSendOtp = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary
- Add `cancelled` flag and `useEffect` cleanup to passkey conditional UI in `auth-form.tsx`
- Await passkey result instead of fire-and-forget `fetchOptions.onSuccess` to prevent stale navigation after unmount
- Prevents race condition between passkey ceremony and OTP flow that caused 400 errors on `/api/auth/sign-in/email-otp`

Closes #372

## Test plan
- [ ] Go to `/login`, enter email, send OTP, verify on `/verify` — should succeed without 400
- [ ] Console should be clean of AbortError (except library-level `[Better Auth] Error verifying passkey` log which is hardcoded)
- [ ] Passkey autofill should still work if user has a registered passkey
- [ ] `bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)