### PR TITLE
Add gift token voucher system #368

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,5 +78,8 @@ QSTASH_NEXT_SIGNING_KEY=sig_5ZB6DVzB1wjE8S6rZ7eenA8Pdnhs
 # LANGFUSE_SECRET_KEY=
 # LANGFUSE_BASE_URL=https://cloud.langfuse.com
 
+# System admin emails (comma-separated, for gift code management)
+# ADMIN_EMAILS=admin@example.com
+
 # AI generation concurrency
 # FAL_CONCURRENCY_LIMIT=10

--- a/drizzle/migrations/0004_graceful_hitman.sql
+++ b/drizzle/migrations/0004_graceful_hitman.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `gift_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`code` text NOT NULL,
+	`amount_usd` real NOT NULL,
+	`created_by_user_id` text NOT NULL,
+	`redeemed_by_team_id` text,
+	`redeemed_by_user_id` text,
+	`redeemed_at` integer,
+	`expires_at` integer,
+	`note` text,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`redeemed_by_team_id`) REFERENCES `teams`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`redeemed_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `gift_tokens_code_unique` ON `gift_tokens` (`code`);--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_gift_tokens_code` ON `gift_tokens` (`code`);--> statement-breakpoint
+CREATE INDEX `idx_gift_tokens_created_by` ON `gift_tokens` (`created_by_user_id`);

--- a/drizzle/migrations/meta/0004_snapshot.json
+++ b/drizzle/migrations/meta/0004_snapshot.json
@@ -1,0 +1,3367 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8d4e7901-888b-4f97-876b-b18c29f82301",
+  "prevId": "525a5e0e-0088-4fd7-ab48-14e71d868939",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audio": {
+      "name": "audio",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_audio_name": {
+          "name": "idx_audio_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_audio_team_id": {
+          "name": "idx_audio_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audio_team_id_teams_id_fk": {
+          "name": "audio_team_id_teams_id_fk",
+          "tableFrom": "audio",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audio_created_by_user_id_fk": {
+          "name": "audio_created_by_user_id_fk",
+          "tableFrom": "audio",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "character_sheets": {
+      "name": "character_sheets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_character_sheets_character_id": {
+          "name": "idx_character_sheets_character_id",
+          "columns": ["character_id"],
+          "isUnique": false
+        },
+        "idx_character_sheets_is_default": {
+          "name": "idx_character_sheets_is_default",
+          "columns": ["is_default"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "character_sheets_character_id_characters_id_fk": {
+          "name": "character_sheets_character_id_characters_id_fk",
+          "tableFrom": "character_sheets",
+          "tableTo": "characters",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "characters": {
+      "name": "characters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "talent_id": {
+          "name": "talent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "age": {
+          "name": "age",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ethnicity": {
+          "name": "ethnicity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "physical_description": {
+          "name": "physical_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "standard_clothing": {
+          "name": "standard_clothing",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distinguishing_features": {
+          "name": "distinguishing_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consistency_tag": {
+          "name": "consistency_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mention_scene_id": {
+          "name": "first_mention_scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mention_text": {
+          "name": "first_mention_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mention_line": {
+          "name": "first_mention_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sheet_image_url": {
+          "name": "sheet_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sheet_image_path": {
+          "name": "sheet_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sheet_status": {
+          "name": "sheet_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sheet_generated_at": {
+          "name": "sheet_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sheet_error": {
+          "name": "sheet_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_characters_sequence_id": {
+          "name": "idx_characters_sequence_id",
+          "columns": ["sequence_id"],
+          "isUnique": false
+        },
+        "idx_characters_talent_id": {
+          "name": "idx_characters_talent_id",
+          "columns": ["talent_id"],
+          "isUnique": false
+        },
+        "characters_sequence_character_key": {
+          "name": "characters_sequence_character_key",
+          "columns": ["sequence_id", "character_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "characters_sequence_id_sequences_id_fk": {
+          "name": "characters_sequence_id_sequences_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "sequences",
+          "columnsFrom": ["sequence_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_talent_id_talent_id_fk": {
+          "name": "characters_talent_id_talent_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "talent",
+          "columnsFrom": ["talent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "credits": {
+      "name": "credits",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance": {
+          "name": "balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credits_team_id_teams_id_fk": {
+          "name": "credits_team_id_teams_id_fk",
+          "tableFrom": "credits",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "positive_balance": {
+          "name": "positive_balance",
+          "value": "\"credits\".\"balance\" >= 0"
+        }
+      }
+    },
+    "frame_characters": {
+      "name": "frame_characters",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "character_sheet_id": {
+          "name": "character_sheet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_frame_characters_frame_id": {
+          "name": "idx_frame_characters_frame_id",
+          "columns": ["frame_id"],
+          "isUnique": false
+        },
+        "idx_frame_characters_character_id": {
+          "name": "idx_frame_characters_character_id",
+          "columns": ["character_id"],
+          "isUnique": false
+        },
+        "frame_characters_frame_character_key": {
+          "name": "frame_characters_frame_character_key",
+          "columns": ["frame_id", "character_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "frame_characters_frame_id_frames_id_fk": {
+          "name": "frame_characters_frame_id_frames_id_fk",
+          "tableFrom": "frame_characters",
+          "tableTo": "frames",
+          "columnsFrom": ["frame_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_characters_character_id_characters_id_fk": {
+          "name": "frame_characters_character_id_characters_id_fk",
+          "tableFrom": "frame_characters",
+          "tableTo": "characters",
+          "columnsFrom": ["character_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_characters_character_sheet_id_character_sheets_id_fk": {
+          "name": "frame_characters_character_sheet_id_character_sheets_id_fk",
+          "tableFrom": "frame_characters",
+          "tableTo": "character_sheets",
+          "columnsFrom": ["character_sheet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "frame_locations": {
+      "name": "frame_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "frame_id": {
+          "name": "frame_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_sheet_id": {
+          "name": "location_sheet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_frame_locations_frame_id": {
+          "name": "idx_frame_locations_frame_id",
+          "columns": ["frame_id"],
+          "isUnique": false
+        },
+        "idx_frame_locations_location_id": {
+          "name": "idx_frame_locations_location_id",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "frame_locations_frame_location_key": {
+          "name": "frame_locations_frame_location_key",
+          "columns": ["frame_id", "location_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "frame_locations_frame_id_frames_id_fk": {
+          "name": "frame_locations_frame_id_frames_id_fk",
+          "tableFrom": "frame_locations",
+          "tableTo": "frames",
+          "columnsFrom": ["frame_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_locations_location_id_sequence_locations_id_fk": {
+          "name": "frame_locations_location_id_sequence_locations_id_fk",
+          "tableFrom": "frame_locations",
+          "tableTo": "sequence_locations",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "frame_locations_location_sheet_id_location_sheets_id_fk": {
+          "name": "frame_locations_location_sheet_id_location_sheets_id_fk",
+          "tableFrom": "frame_locations",
+          "tableTo": "location_sheets",
+          "columnsFrom": ["location_sheet_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "frames": {
+      "name": "frames",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order_index": {
+          "name": "order_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 3000
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_path": {
+          "name": "thumbnail_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variant_image_url": {
+          "name": "variant_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variant_image_status": {
+          "name": "variant_image_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "variant_workflow_run_id": {
+          "name": "variant_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_status": {
+          "name": "thumbnail_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "thumbnail_workflow_run_id": {
+          "name": "thumbnail_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_generated_at": {
+          "name": "thumbnail_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail_error": {
+          "name": "thumbnail_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_model": {
+          "name": "image_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nano_banana_2'"
+        },
+        "image_prompt": {
+          "name": "image_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_status": {
+          "name": "video_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "video_workflow_run_id": {
+          "name": "video_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_generated_at": {
+          "name": "video_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_error": {
+          "name": "video_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motion_prompt": {
+          "name": "motion_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motion_model": {
+          "name": "motion_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_url": {
+          "name": "audio_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_path": {
+          "name": "audio_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_status": {
+          "name": "audio_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "audio_workflow_run_id": {
+          "name": "audio_workflow_run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_generated_at": {
+          "name": "audio_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_error": {
+          "name": "audio_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "audio_model": {
+          "name": "audio_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_frames_order": {
+          "name": "idx_frames_order",
+          "columns": ["sequence_id", "order_index"],
+          "isUnique": false
+        },
+        "idx_frames_sequence_id": {
+          "name": "idx_frames_sequence_id",
+          "columns": ["sequence_id"],
+          "isUnique": false
+        },
+        "frames_sequence_id_order_index_key": {
+          "name": "frames_sequence_id_order_index_key",
+          "columns": ["sequence_id", "order_index"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "frames_sequence_id_sequences_id_fk": {
+          "name": "frames_sequence_id_sequences_id_fk",
+          "tableFrom": "frames",
+          "tableTo": "sequences",
+          "columnsFrom": ["sequence_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gift_tokens": {
+      "name": "gift_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_usd": {
+          "name": "amount_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redeemed_by_team_id": {
+          "name": "redeemed_by_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "gift_tokens_code_unique": {
+          "name": "gift_tokens_code_unique",
+          "columns": ["code"],
+          "isUnique": true
+        },
+        "idx_gift_tokens_code": {
+          "name": "idx_gift_tokens_code",
+          "columns": ["code"],
+          "isUnique": true
+        },
+        "idx_gift_tokens_created_by": {
+          "name": "idx_gift_tokens_created_by",
+          "columns": ["created_by_user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "gift_tokens_created_by_user_id_user_id_fk": {
+          "name": "gift_tokens_created_by_user_id_user_id_fk",
+          "tableFrom": "gift_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["created_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "gift_tokens_redeemed_by_team_id_teams_id_fk": {
+          "name": "gift_tokens_redeemed_by_team_id_teams_id_fk",
+          "tableFrom": "gift_tokens",
+          "tableTo": "teams",
+          "columnsFrom": ["redeemed_by_team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "gift_tokens_redeemed_by_user_id_user_id_fk": {
+          "name": "gift_tokens_redeemed_by_user_id_user_id_fk",
+          "tableFrom": "gift_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["redeemed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "location_library": {
+      "name": "location_library",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_image_url": {
+          "name": "reference_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_image_path": {
+          "name": "reference_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_location_library_team_id": {
+          "name": "idx_location_library_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "idx_location_library_name": {
+          "name": "idx_location_library_name",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "location_library_team_id_teams_id_fk": {
+          "name": "location_library_team_id_teams_id_fk",
+          "tableFrom": "location_library",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "location_library_created_by_user_id_fk": {
+          "name": "location_library_created_by_user_id_fk",
+          "tableFrom": "location_library",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "location_sheets": {
+      "name": "location_sheets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_location_sheets_location_id": {
+          "name": "idx_location_sheets_location_id",
+          "columns": ["location_id"],
+          "isUnique": false
+        },
+        "idx_location_sheets_is_default": {
+          "name": "idx_location_sheets_is_default",
+          "columns": ["is_default"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "location_sheets_location_id_location_library_id_fk": {
+          "name": "location_sheets_location_id_location_library_id_fk",
+          "tableFrom": "location_sheets",
+          "tableTo": "location_library",
+          "columnsFrom": ["location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": ["credential_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequence_locations": {
+      "name": "sequence_locations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sequence_id": {
+          "name": "sequence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "library_location_id": {
+          "name": "library_location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "architectural_style": {
+          "name": "architectural_style",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key_features": {
+          "name": "key_features",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "color_palette": {
+          "name": "color_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lighting_setup": {
+          "name": "lighting_setup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ambiance": {
+          "name": "ambiance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consistency_tag": {
+          "name": "consistency_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mention_scene_id": {
+          "name": "first_mention_scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mention_text": {
+          "name": "first_mention_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_mention_line": {
+          "name": "first_mention_line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_image_url": {
+          "name": "reference_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_image_path": {
+          "name": "reference_image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_status": {
+          "name": "reference_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "reference_generated_at": {
+          "name": "reference_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reference_error": {
+          "name": "reference_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sequence_locations_sequence_id": {
+          "name": "idx_sequence_locations_sequence_id",
+          "columns": ["sequence_id"],
+          "isUnique": false
+        },
+        "idx_sequence_locations_library_location_id": {
+          "name": "idx_sequence_locations_library_location_id",
+          "columns": ["library_location_id"],
+          "isUnique": false
+        },
+        "sequence_locations_sequence_location_key": {
+          "name": "sequence_locations_sequence_location_key",
+          "columns": ["sequence_id", "location_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sequence_locations_sequence_id_sequences_id_fk": {
+          "name": "sequence_locations_sequence_id_sequences_id_fk",
+          "tableFrom": "sequence_locations",
+          "tableTo": "sequences",
+          "columnsFrom": ["sequence_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sequence_locations_library_location_id_location_library_id_fk": {
+          "name": "sequence_locations_library_location_id_location_library_id_fk",
+          "tableFrom": "sequence_locations",
+          "tableTo": "location_library",
+          "columnsFrom": ["library_location_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sequences": {
+      "name": "sequences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "script": {
+          "name": "script",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "style_id": {
+          "name": "style_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aspect_ratio": {
+          "name": "aspect_ratio",
+          "type": "text(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'16:9'"
+        },
+        "analysis_model": {
+          "name": "analysis_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'anthropic/claude-haiku-4.5'"
+        },
+        "analysis_duration_ms": {
+          "name": "analysis_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "image_model": {
+          "name": "image_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'nano_banana_2'"
+        },
+        "video_model": {
+          "name": "video_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'kling_v3_pro'"
+        },
+        "workflow": {
+          "name": "workflow",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merged_video_url": {
+          "name": "merged_video_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merged_video_path": {
+          "name": "merged_video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merged_video_status": {
+          "name": "merged_video_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "merged_video_generated_at": {
+          "name": "merged_video_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merged_video_error": {
+          "name": "merged_video_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_url": {
+          "name": "music_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_path": {
+          "name": "music_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_status": {
+          "name": "music_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "music_generated_at": {
+          "name": "music_generated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_error": {
+          "name": "music_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_model": {
+          "name": "music_model",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_prompt": {
+          "name": "music_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "music_tags": {
+          "name": "music_tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sequences_created_at": {
+          "name": "idx_sequences_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_sequences_status": {
+          "name": "idx_sequences_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_sequences_style_id": {
+          "name": "idx_sequences_style_id",
+          "columns": ["style_id"],
+          "isUnique": false
+        },
+        "idx_sequences_team_id": {
+          "name": "idx_sequences_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sequences_team_id_teams_id_fk": {
+          "name": "sequences_team_id_teams_id_fk",
+          "tableFrom": "sequences",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "sequences_created_by_user_id_fk": {
+          "name": "sequences_created_by_user_id_fk",
+          "tableFrom": "sequences",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sequences_updated_by_user_id_fk": {
+          "name": "sequences_updated_by_user_id_fk",
+          "tableFrom": "sequences",
+          "tableTo": "user",
+          "columnsFrom": ["updated_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "sequences_style_id_styles_id_fk": {
+          "name": "sequences_style_id_styles_id_fk",
+          "tableFrom": "sequences",
+          "tableTo": "styles",
+          "columnsFrom": ["style_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "styles": {
+      "name": "styles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_template": {
+          "name": "is_template",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 100
+        },
+        "usage_count": {
+          "name": "usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_styles_team_id": {
+          "name": "idx_styles_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "styles_team_id_teams_id_fk": {
+          "name": "styles_team_id_teams_id_fk",
+          "tableFrom": "styles",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "styles_created_by_user_id_fk": {
+          "name": "styles_created_by_user_id_fk",
+          "tableFrom": "styles",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talent": {
+      "name": "talent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_human": {
+          "name": "is_human",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_in_team_library": {
+          "name": "is_in_team_library",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_talent_team_id": {
+          "name": "idx_talent_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "idx_talent_name": {
+          "name": "idx_talent_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_talent_is_favorite": {
+          "name": "idx_talent_is_favorite",
+          "columns": ["is_favorite"],
+          "isUnique": false
+        },
+        "idx_talent_is_in_team_library": {
+          "name": "idx_talent_is_in_team_library",
+          "columns": ["is_in_team_library"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talent_team_id_teams_id_fk": {
+          "name": "talent_team_id_teams_id_fk",
+          "tableFrom": "talent",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "talent_created_by_user_id_fk": {
+          "name": "talent_created_by_user_id_fk",
+          "tableFrom": "talent",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talent_media": {
+      "name": "talent_media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "talent_id": {
+          "name": "talent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_talent_media_talent_id": {
+          "name": "idx_talent_media_talent_id",
+          "columns": ["talent_id"],
+          "isUnique": false
+        },
+        "idx_talent_media_type": {
+          "name": "idx_talent_media_type",
+          "columns": ["type"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talent_media_talent_id_talent_id_fk": {
+          "name": "talent_media_talent_id_talent_id_fk",
+          "tableFrom": "talent_media",
+          "tableTo": "talent",
+          "columnsFrom": ["talent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talent_sheets": {
+      "name": "talent_sheets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "talent_id": {
+          "name": "talent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_path": {
+          "name": "image_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual_upload'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_talent_sheets_talent_id": {
+          "name": "idx_talent_sheets_talent_id",
+          "columns": ["talent_id"],
+          "isUnique": false
+        },
+        "idx_talent_sheets_is_default": {
+          "name": "idx_talent_sheets_is_default",
+          "columns": ["is_default"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talent_sheets_talent_id_talent_id_fk": {
+          "name": "talent_sheets_talent_id_talent_id_fk",
+          "tableFrom": "talent_sheets",
+          "tableTo": "talent",
+          "columnsFrom": ["talent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_api_keys": {
+      "name": "team_api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_iv": {
+          "name": "key_iv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_tag": {
+          "name": "key_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hint": {
+          "name": "key_hint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_team_api_keys_team_provider": {
+          "name": "idx_team_api_keys_team_provider",
+          "columns": ["team_id", "provider"],
+          "isUnique": true
+        },
+        "idx_team_api_keys_team_id": {
+          "name": "idx_team_api_keys_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_api_keys_team_id_teams_id_fk": {
+          "name": "team_api_keys_team_id_teams_id_fk",
+          "tableFrom": "team_api_keys",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_api_keys_added_by_user_id_fk": {
+          "name": "team_api_keys_added_by_user_id_fk",
+          "tableFrom": "team_api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["added_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_billing_settings": {
+      "name": "team_billing_settings",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "auto_top_up_threshold_usd": {
+          "name": "auto_top_up_threshold_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 5
+        },
+        "auto_top_up_amount_usd": {
+          "name": "auto_top_up_amount_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 25
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_billing_settings_team_id_teams_id_fk": {
+          "name": "team_billing_settings_team_id_teams_id_fk",
+          "tableFrom": "team_billing_settings",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_invitations": {
+      "name": "team_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "token": {
+          "name": "token",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "declined_at": {
+          "name": "declined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_team_invitations_email": {
+          "name": "idx_team_invitations_email",
+          "columns": ["email"],
+          "isUnique": false
+        },
+        "idx_team_invitations_expires_at": {
+          "name": "idx_team_invitations_expires_at",
+          "columns": ["expires_at"],
+          "isUnique": false
+        },
+        "idx_team_invitations_status": {
+          "name": "idx_team_invitations_status",
+          "columns": ["status"],
+          "isUnique": false
+        },
+        "idx_team_invitations_team_id": {
+          "name": "idx_team_invitations_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "idx_team_invitations_token": {
+          "name": "idx_team_invitations_token",
+          "columns": ["token"],
+          "isUnique": true
+        },
+        "idx_team_invitations_unique_pending": {
+          "name": "idx_team_invitations_unique_pending",
+          "columns": ["team_id", "email"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_id_fk": {
+          "name": "team_invitations_team_id_teams_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_user_id_fk": {
+          "name": "team_invitations_invited_by_user_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_team_members_team_id": {
+          "name": "idx_team_members_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "idx_team_members_user_id": {
+          "name": "idx_team_members_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_user_id_fk": {
+          "name": "team_members_user_id_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_user_id_pk": {
+          "columns": ["team_id", "user_id"],
+          "name": "team_members_team_id_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_teams_slug": {
+          "name": "idx_teams_slug",
+          "columns": ["slug"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transactions": {
+      "name": "transactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_session_id": {
+          "name": "stripe_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_transactions_created_at": {
+          "name": "idx_transactions_created_at",
+          "columns": ["created_at"],
+          "isUnique": false
+        },
+        "idx_transactions_type": {
+          "name": "idx_transactions_type",
+          "columns": ["type"],
+          "isUnique": false
+        },
+        "idx_transactions_team_id": {
+          "name": "idx_transactions_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        },
+        "idx_transactions_user_id": {
+          "name": "idx_transactions_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_transactions_stripe_session_id": {
+          "name": "idx_transactions_stripe_session_id",
+          "columns": ["stripe_session_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "transactions_team_id_teams_id_fk": {
+          "name": "transactions_team_id_teams_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "transactions_user_id_user_id_fk": {
+          "name": "transactions_user_id_user_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "access_code": {
+          "name": "access_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'pending'"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": ["identifier"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vfx": {
+      "name": "vfx",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "preset_config": {
+          "name": "preset_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "preview_url": {
+          "name": "preview_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_vfx_name": {
+          "name": "idx_vfx_name",
+          "columns": ["name"],
+          "isUnique": false
+        },
+        "idx_vfx_team_id": {
+          "name": "idx_vfx_team_id",
+          "columns": ["team_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vfx_team_id_teams_id_fk": {
+          "name": "vfx_team_id_teams_id_fk",
+          "tableFrom": "vfx",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vfx_created_by_user_id_fk": {
+          "name": "vfx_created_by_user_id_fk",
+          "tableFrom": "vfx",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772957027134,
       "tag": "0003_minor_vertigo",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1773035326198,
+      "tag": "0004_graceful_hitman",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Link } from '@tanstack/react-router';
-import { ChevronRight, CreditCard, KeyRound } from 'lucide-react';
+import { ChevronRight, CreditCard, Gift, KeyRound } from 'lucide-react';
 
 const RETURN_KEY = 'openstory:billing-return';
 
@@ -77,6 +77,29 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
                   <CardDescription>
                     Pay as you go. Auto top-up keeps you generating without
                     interruption.
+                  </CardDescription>
+                </div>
+                <ChevronRight className="size-5 shrink-0 text-muted-foreground" />
+              </CardHeader>
+            </Card>
+          </Link>
+
+          <Link
+            to="/settings/gift-codes"
+            onClick={() => {
+              setReturnPath(returnTo);
+              onOpenChange(false);
+            }}
+          >
+            <Card className="cursor-pointer transition-colors hover:bg-accent">
+              <CardHeader className="flex-row items-center gap-4 space-y-0">
+                <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                  <Gift className="size-5 text-primary" />
+                </div>
+                <div className="flex-1 space-y-1">
+                  <CardTitle className="text-base">Redeem Gift Code</CardTitle>
+                  <CardDescription>
+                    Have a gift code? Redeem it to add credits instantly.
                   </CardDescription>
                 </div>
                 <ChevronRight className="size-5 shrink-0 text-muted-foreground" />

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -1,0 +1,396 @@
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Skeleton } from '@/components/ui/skeleton';
+import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
+import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
+import {
+  createGiftTokenFn,
+  isSystemAdminFn,
+  listGiftTokensFn,
+  redeemGiftTokenFn,
+} from '@/functions/gift-tokens';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from '@tanstack/react-router';
+import { Check, Copy, Gift, ShieldCheck } from 'lucide-react';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+const RETURN_KEY = 'openstory:billing-return';
+
+export function GiftCodeSettings() {
+  const { data: adminStatus, isLoading: adminLoading } = useQuery({
+    queryKey: ['system-admin-status'],
+    queryFn: () => isSystemAdminFn(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  function renderAdminSection() {
+    if (adminLoading) return <Skeleton className="h-48 w-full" />;
+    if (adminStatus?.isAdmin) return <AdminSection />;
+    return null;
+  }
+
+  return (
+    <div className="space-y-6">
+      <RedeemSection />
+      {renderAdminSection()}
+    </div>
+  );
+}
+
+function RedeemSection() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [code, setCode] = useState('');
+
+  const redeemMutation = useMutation({
+    mutationFn: (input: { code: string }) => redeemGiftTokenFn({ data: input }),
+    onSuccess: (result) => {
+      setCode('');
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_BALANCE_KEY],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_GATE_KEY],
+      });
+
+      const returnTo = localStorage.getItem(RETURN_KEY);
+      if (returnTo) {
+        localStorage.removeItem(RETURN_KEY);
+        toast.success(`$${result.amountUsd.toFixed(2)} added to your balance`, {
+          description: `New balance: $${result.newBalance.toFixed(2)}`,
+          action: {
+            label: 'Continue creating',
+            onClick: () => void navigate({ to: returnTo }),
+          },
+          duration: 15_000,
+        });
+      } else {
+        toast.success(`$${result.amountUsd.toFixed(2)} added to your balance`, {
+          description: `New balance: $${result.newBalance.toFixed(2)}`,
+        });
+      }
+    },
+    onError: (err) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to redeem code');
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = code.trim();
+    if (!trimmed) return;
+    redeemMutation.mutate({ code: trimmed });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <Gift className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle>Redeem Gift Code</CardTitle>
+            <CardDescription>
+              Enter a gift code to add credits to your team
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="flex gap-3">
+          <Input
+            name="code"
+            placeholder="Enter code…"
+            value={code}
+            onChange={(e) => setCode(e.target.value.toUpperCase())}
+            className="font-mono uppercase tracking-wider"
+            maxLength={6}
+            autoComplete="off"
+            spellCheck={false}
+            required
+          />
+          <Button
+            type="submit"
+            disabled={!code.trim() || redeemMutation.isPending}
+          >
+            {redeemMutation.isPending ? 'Redeeming…' : 'Redeem'}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AdminSection() {
+  return (
+    <>
+      <CreateGiftCodeCard />
+      <GiftCodeListCard />
+    </>
+  );
+}
+
+function CreateGiftCodeCard() {
+  const queryClient = useQueryClient();
+  const [amount, setAmount] = useState('');
+  const [note, setNote] = useState('');
+  const [expiresInDays, setExpiresInDays] = useState('');
+  const [createdCode, setCreatedCode] = useState<string | null>(null);
+
+  const createMutation = useMutation({
+    mutationFn: (input: {
+      amountUsd: number;
+      note?: string;
+      expiresInDays?: number;
+    }) => createGiftTokenFn({ data: input }),
+    onSuccess: (token) => {
+      setCreatedCode(token.code);
+      setAmount('');
+      setNote('');
+      setExpiresInDays('');
+      void queryClient.invalidateQueries({ queryKey: ['gift-tokens'] });
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to create gift code'
+      );
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const amountUsd = parseFloat(amount);
+    if (isNaN(amountUsd) || amountUsd <= 0) return;
+
+    const parsedDays = parseInt(expiresInDays, 10);
+    createMutation.mutate({
+      amountUsd,
+      note: note || undefined,
+      expiresInDays: parsedDays > 0 ? parsedDays : undefined,
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle>Create Gift Code</CardTitle>
+            <CardDescription>
+              Generate a new single-use gift code (admin only)
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="gift-amount">Amount (USD)</Label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                  $
+                </span>
+                <Input
+                  id="gift-amount"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  placeholder="10.00"
+                  value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  className="pl-7 tabular-nums"
+                  autoComplete="off"
+                  required
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="gift-expires">Expires in (days)</Label>
+              <Input
+                id="gift-expires"
+                type="number"
+                min="1"
+                step="1"
+                placeholder="No expiry"
+                value={expiresInDays}
+                onChange={(e) => setExpiresInDays(e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="gift-note">Note (optional)</Label>
+            <Input
+              id="gift-note"
+              placeholder="e.g. Beta tester reward…"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+          <Button type="submit" disabled={!amount || createMutation.isPending}>
+            {createMutation.isPending ? 'Creating…' : 'Create Gift Code'}
+          </Button>
+        </form>
+
+        {createdCode && (
+          <Alert>
+            <AlertDescription className="flex items-center justify-between">
+              <span>
+                Gift code created:{' '}
+                <span className="font-mono font-bold tracking-wider">
+                  {createdCode}
+                </span>
+              </span>
+              <CopyButton text={createdCode} />
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function GiftCodeListCard() {
+  const { data: tokens, isLoading } = useQuery({
+    queryKey: ['gift-tokens'],
+    queryFn: () => listGiftTokensFn(),
+    staleTime: 30_000,
+  });
+
+  function renderTokenList() {
+    if (isLoading) {
+      return (
+        <div className="space-y-3">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+        </div>
+      );
+    }
+
+    if (!tokens?.length) {
+      return (
+        <p className="text-center text-muted-foreground py-4">
+          No gift codes yet
+        </p>
+      );
+    }
+
+    return (
+      <div className="space-y-2">
+        {tokens.map((token) => (
+          <GiftTokenRow key={token.id} token={token} />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Gift Codes</CardTitle>
+        <CardDescription>All gift codes created by admins</CardDescription>
+      </CardHeader>
+      <CardContent>{renderTokenList()}</CardContent>
+    </Card>
+  );
+}
+
+type GiftTokenRowProps = {
+  token: {
+    id: string;
+    code: string;
+    status: string;
+    note: string | null;
+    createdAt: Date | string;
+    expiresAt: Date | string | null;
+    amountUsd: number;
+  };
+};
+
+function GiftTokenRow({ token }: GiftTokenRowProps) {
+  return (
+    <div className="flex items-center justify-between rounded-lg border p-3">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-mono font-semibold tracking-wider">
+            {token.code}
+          </span>
+          <StatusBadge status={token.status} />
+        </div>
+        <p className="text-xs text-muted-foreground truncate">
+          {token.note ? `${token.note} · ` : ''}
+          {new Date(token.createdAt).toLocaleDateString()}
+          {token.expiresAt &&
+            ` · Expires ${new Date(token.expiresAt).toLocaleDateString()}`}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 ml-4">
+        <span className="text-sm font-semibold tabular-nums">
+          ${token.amountUsd.toFixed(2)}
+        </span>
+        {token.status === 'available' && <CopyButton text={token.code} />}
+      </div>
+    </div>
+  );
+}
+
+function getStatusVariant(
+  status: string
+): 'default' | 'secondary' | 'destructive' {
+  switch (status) {
+    case 'available':
+      return 'default';
+    case 'redeemed':
+      return 'secondary';
+    default:
+      return 'destructive';
+  }
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return <Badge variant={getStatusVariant(status)}>{status}</Badge>;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-8 w-8"
+      onClick={handleCopy}
+      aria-label="Copy code"
+    >
+      {copied ? (
+        <Check className="h-4 w-4 text-green-600" />
+      ) : (
+        <Copy className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/src/functions/gift-tokens.ts
+++ b/src/functions/gift-tokens.ts
@@ -1,0 +1,63 @@
+import { createServerFn } from '@tanstack/react-start';
+import { zodValidator } from '@tanstack/zod-adapter';
+import { z } from 'zod';
+import {
+  authMiddleware,
+  authWithTeamMiddleware,
+  systemAdminMiddleware,
+} from './middleware';
+import { isSystemAdmin } from '@/lib/auth/system-admin';
+import {
+  createGiftToken,
+  redeemGiftToken,
+  listGiftTokens,
+} from '@/lib/billing/gift-token.service';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export const createGiftTokenFn = createServerFn({ method: 'POST' })
+  .middleware([systemAdminMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        amountUsd: z.number().positive(),
+        note: z.string().optional(),
+        expiresInDays: z.number().positive().optional(),
+      })
+    )
+  )
+  .handler(async ({ context, data }) => {
+    const expiresAt = data.expiresInDays
+      ? new Date(Date.now() + data.expiresInDays * MS_PER_DAY)
+      : undefined;
+
+    return createGiftToken({
+      createdByUserId: context.user.id,
+      amountUsd: data.amountUsd,
+      note: data.note,
+      expiresAt,
+    });
+  });
+
+export const redeemGiftTokenFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(z.object({ code: z.string().min(1) })))
+  .handler(async ({ context, data }) => {
+    return redeemGiftToken({
+      code: data.code,
+      teamId: context.teamId,
+      userId: context.user.id,
+    });
+  });
+
+export const listGiftTokensFn = createServerFn({ method: 'GET' })
+  .middleware([systemAdminMiddleware])
+  .handler(async () => {
+    return listGiftTokens();
+  });
+
+export const isSystemAdminFn = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    return { isAdmin: isSystemAdmin(context.user.email) };
+  });

--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -17,6 +17,7 @@ import {
   requireTeamAdminAccess,
   requireTeamOwnerAccess,
 } from '@/lib/auth/action-utils';
+import { requireSystemAdmin } from '@/lib/auth/system-admin';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import type { Sequence, Frame } from '@/types/database';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
@@ -33,6 +34,8 @@ export type AuthContext = {
 export type TeamContext = AuthContext & {
   teamId: string;
 };
+
+export type SystemAdminContext = TeamContext;
 
 export type SequenceContext = TeamContext & {
   sequence: Sequence;
@@ -130,6 +133,21 @@ export const authWithTeamMiddleware = createMiddleware({ type: 'function' })
         teamId: team.teamId,
       },
     });
+  });
+
+// ============================================================================
+// System Admin Middleware
+// ============================================================================
+
+/**
+ * System admin middleware - requires ADMIN_EMAILS env var match
+ * Extends authWithTeamMiddleware so context includes teamId
+ */
+export const systemAdminMiddleware = createMiddleware({ type: 'function' })
+  .middleware([authWithTeamMiddleware])
+  .server(async ({ next, context }) => {
+    requireSystemAdmin(context.user.email);
+    return next();
   });
 
 // ============================================================================

--- a/src/lib/auth/system-admin.ts
+++ b/src/lib/auth/system-admin.ts
@@ -1,0 +1,21 @@
+import { getEnv } from '#env';
+import { AuthenticationError } from '@/lib/errors';
+
+function parseAdminEmails(): string[] {
+  const raw = getEnv().ADMIN_EMAILS;
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isSystemAdmin(email: string): boolean {
+  return parseAdminEmails().includes(email.toLowerCase());
+}
+
+export function requireSystemAdmin(email: string): void {
+  if (!isSystemAdmin(email)) {
+    throw new AuthenticationError('System admin access required');
+  }
+}

--- a/src/lib/billing/credit-service.ts
+++ b/src/lib/billing/credit-service.ts
@@ -53,6 +53,7 @@ export async function addCredits(
   amountUsd: number,
   opts: {
     userId?: string | null;
+    type?: TransactionType;
     description?: string;
     metadata?: Record<string, unknown>;
     stripeSessionId?: string;
@@ -83,7 +84,7 @@ export async function addCredits(
     .values({
       teamId,
       userId: opts.userId ?? null,
-      type: 'credit_purchase' as TransactionType,
+      type: opts.type ?? ('credit_purchase' as TransactionType),
       amount: amountUsd,
       balanceAfter: updated.balance,
       description: opts.description ?? `Added $${amountUsd.toFixed(2)} credits`,

--- a/src/lib/billing/gift-token.service.test.ts
+++ b/src/lib/billing/gift-token.service.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+
+// --- Mocks ---
+
+let mockGiftTokenRows: Record<string, unknown>[] = [];
+let mockInsertedValues: Record<string, unknown>[] = [];
+let mockUpdatedValues: Record<string, unknown>[] = [];
+let mockAddCreditsResult = { newBalance: 50, transactionId: 'tx-1' };
+
+function createSelectChain() {
+  const chain: Record<string, unknown> = {};
+  chain.select = mock(() => chain);
+  chain.from = mock(() => chain);
+  chain.where = mock(() => chain);
+  chain.limit = mock(() => [...mockGiftTokenRows]);
+  chain.orderBy = mock(() => [...mockGiftTokenRows]);
+  return chain;
+}
+
+function createInsertChain() {
+  const chain: Record<string, unknown> = {};
+  chain.insert = mock(() => chain);
+  chain.values = mock((vals: Record<string, unknown>) => {
+    mockInsertedValues.push(vals);
+    return chain;
+  });
+  chain.returning = mock(() => [{ ...vals(), id: 'gt-1', code: 'HK7NWE' }]);
+  return chain;
+}
+
+function createUpdateChain() {
+  const chain: Record<string, unknown> = {};
+  chain.update = mock(() => chain);
+  chain.set = mock((vals: Record<string, unknown>) => {
+    mockUpdatedValues.push(vals);
+    return chain;
+  });
+  chain.where = mock(() => chain);
+  chain.returning = mock(() => []);
+  return chain;
+}
+
+function vals() {
+  return mockInsertedValues[mockInsertedValues.length - 1] ?? {};
+}
+
+// Build a mock db that returns the right chain based on method
+let selectChain = createSelectChain();
+let insertChain = createInsertChain();
+let updateChain = createUpdateChain();
+
+type MockFn = (...args: unknown[]) => unknown;
+
+const mockDb = {
+  select: (...args: unknown[]) => (selectChain.select as MockFn)(...args),
+  insert: (...args: unknown[]) => (insertChain.insert as MockFn)(...args),
+  update: (...args: unknown[]) => (updateChain.update as MockFn)(...args),
+};
+
+mock.module('#db-client', () => ({
+  getDb: () => mockDb,
+}));
+
+mock.module('./credit-service', () => ({
+  addCredits: mock(async () => mockAddCreditsResult),
+}));
+
+const { generateGiftCode, redeemGiftToken, getGiftTokenStatus } =
+  await import('./gift-token.service');
+
+// --- Tests ---
+
+describe('generateGiftCode', () => {
+  it('returns a 6-character string from the valid alphabet', () => {
+    const code = generateGiftCode();
+    expect(code).toHaveLength(6);
+    expect(code).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/);
+  });
+
+  it('generates unique codes', () => {
+    const codes = new Set(
+      Array.from({ length: 100 }, () => generateGiftCode())
+    );
+    expect(codes.size).toBeGreaterThan(95);
+  });
+});
+
+describe('getGiftTokenStatus', () => {
+  function tokenWith(
+    overrides: Partial<{ redeemedAt: Date | null; expiresAt: Date | null }>
+  ) {
+    return {
+      id: 'gt-test',
+      code: 'TEST01',
+      amountUsd: 10,
+      createdByUserId: 'user-1',
+      redeemedByTeamId: null,
+      redeemedByUserId: null,
+      redeemedAt: null,
+      expiresAt: null,
+      note: null,
+      createdAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  it('returns available for unredeemed, unexpired token', () => {
+    expect(getGiftTokenStatus(tokenWith({}))).toBe('available');
+  });
+
+  it('returns redeemed when redeemedAt is set', () => {
+    expect(getGiftTokenStatus(tokenWith({ redeemedAt: new Date() }))).toBe(
+      'redeemed'
+    );
+  });
+
+  it('returns expired when expiresAt is in the past', () => {
+    expect(
+      getGiftTokenStatus(tokenWith({ expiresAt: new Date(Date.now() - 1000) }))
+    ).toBe('expired');
+  });
+});
+
+describe('redeemGiftToken', () => {
+  beforeEach(() => {
+    mockGiftTokenRows = [];
+    mockInsertedValues = [];
+    mockUpdatedValues = [];
+    selectChain = createSelectChain();
+    insertChain = createInsertChain();
+    updateChain = createUpdateChain();
+
+    // Re-wire the mockDb
+    mockDb.select = (...args: unknown[]) =>
+      (selectChain.select as MockFn)(...args);
+    mockDb.insert = (...args: unknown[]) =>
+      (insertChain.insert as MockFn)(...args);
+    mockDb.update = (...args: unknown[]) =>
+      (updateChain.update as MockFn)(...args);
+  });
+
+  it('throws on invalid code', async () => {
+    mockGiftTokenRows = [];
+    try {
+      await redeemGiftToken({
+        code: 'BADCODE',
+        teamId: 'team-1',
+        userId: 'user-1',
+      });
+      throw new Error('Expected error');
+    } catch (err) {
+      expect((err as Error).message).toBe('Invalid gift code');
+    }
+  });
+
+  it('throws on already redeemed code', async () => {
+    mockGiftTokenRows = [
+      {
+        id: 'gt-1',
+        code: 'HK7NWE',
+        amountUsd: 10,
+        redeemedAt: new Date(),
+        expiresAt: null,
+      },
+    ];
+    try {
+      await redeemGiftToken({
+        code: 'HK7NWE',
+        teamId: 'team-1',
+        userId: 'user-1',
+      });
+      throw new Error('Expected error');
+    } catch (err) {
+      expect((err as Error).message).toBe(
+        'This gift code has already been redeemed'
+      );
+    }
+  });
+
+  it('throws on expired code', async () => {
+    mockGiftTokenRows = [
+      {
+        id: 'gt-1',
+        code: 'HK7NWE',
+        amountUsd: 10,
+        redeemedAt: null,
+        expiresAt: new Date(Date.now() - 1000),
+      },
+    ];
+    try {
+      await redeemGiftToken({
+        code: 'HK7NWE',
+        teamId: 'team-1',
+        userId: 'user-1',
+      });
+      throw new Error('Expected error');
+    } catch (err) {
+      expect((err as Error).message).toBe('This gift code has expired');
+    }
+  });
+});

--- a/src/lib/billing/gift-token.service.ts
+++ b/src/lib/billing/gift-token.service.ts
@@ -1,0 +1,119 @@
+import { getDb } from '#db-client';
+import { giftTokens } from '@/lib/db/schema/gift-tokens';
+import type { GiftToken } from '@/lib/db/schema/gift-tokens';
+import { generateId } from '@/lib/db/id';
+import { addCredits } from './credit-service';
+import { ValidationError } from '@/lib/errors';
+import { eq, desc } from 'drizzle-orm';
+
+// Ambiguity-free alphabet (no 0/O/1/I) — 32 chars → 32^6 ≈ 1B combinations
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+const CODE_LENGTH = 6;
+
+export function generateGiftCode(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(CODE_LENGTH));
+  return Array.from(bytes)
+    .map((b) => CODE_ALPHABET[b % CODE_ALPHABET.length])
+    .join('');
+}
+
+export type GiftTokenStatus = 'available' | 'redeemed' | 'expired';
+
+export function getGiftTokenStatus(token: GiftToken): GiftTokenStatus {
+  if (token.redeemedAt) return 'redeemed';
+  if (token.expiresAt && token.expiresAt < new Date()) return 'expired';
+  return 'available';
+}
+
+export async function createGiftToken(opts: {
+  createdByUserId: string;
+  amountUsd: number;
+  note?: string;
+  expiresAt?: Date;
+}): Promise<GiftToken> {
+  if (opts.amountUsd <= 0) {
+    throw new ValidationError('Gift token amount must be positive');
+  }
+
+  const db = getDb();
+  const code = generateGiftCode();
+
+  const [token] = await db
+    .insert(giftTokens)
+    .values({
+      id: generateId(),
+      code,
+      amountUsd: opts.amountUsd,
+      createdByUserId: opts.createdByUserId,
+      note: opts.note ?? null,
+      expiresAt: opts.expiresAt ?? null,
+    })
+    .returning();
+
+  return token;
+}
+
+export async function redeemGiftToken(opts: {
+  code: string;
+  teamId: string;
+  userId: string;
+}): Promise<{ newBalance: number; amountUsd: number }> {
+  const db = getDb();
+  const normalizedCode = opts.code.trim().toUpperCase();
+
+  const [token] = await db
+    .select()
+    .from(giftTokens)
+    .where(eq(giftTokens.code, normalizedCode))
+    .limit(1);
+
+  if (!token) {
+    throw new ValidationError('Invalid gift code');
+  }
+
+  if (token.redeemedAt) {
+    throw new ValidationError('This gift code has already been redeemed');
+  }
+
+  if (token.expiresAt && token.expiresAt < new Date()) {
+    throw new ValidationError('This gift code has expired');
+  }
+
+  // Mark as redeemed
+  await db
+    .update(giftTokens)
+    .set({
+      redeemedByTeamId: opts.teamId,
+      redeemedByUserId: opts.userId,
+      redeemedAt: new Date(),
+    })
+    .where(eq(giftTokens.id, token.id));
+
+  // Add credits to team
+  const result = await addCredits(opts.teamId, token.amountUsd, {
+    userId: opts.userId,
+    type: 'credit_adjustment',
+    description: `Gift code redeemed: ${normalizedCode} ($${token.amountUsd.toFixed(2)})`,
+    metadata: { giftTokenId: token.id, giftCode: normalizedCode },
+  });
+
+  return {
+    newBalance: result?.newBalance ?? 0,
+    amountUsd: token.amountUsd,
+  };
+}
+
+export type GiftTokenWithStatus = GiftToken & { status: GiftTokenStatus };
+
+export async function listGiftTokens(): Promise<GiftTokenWithStatus[]> {
+  const db = getDb();
+  const tokens = await db
+    .select()
+    .from(giftTokens)
+    .orderBy(desc(giftTokens.createdAt));
+
+  return tokens.map((token) => ({
+    ...token,
+    status: getGiftTokenStatus(token),
+  }));
+}

--- a/src/lib/db/schema/gift-tokens.ts
+++ b/src/lib/db/schema/gift-tokens.ts
@@ -1,0 +1,67 @@
+import {
+  type InferInsertModel,
+  type InferSelectModel,
+  relations,
+} from 'drizzle-orm';
+import {
+  integer,
+  sqliteTable,
+  text,
+  real,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
+import { generateId } from '../id';
+import { user } from './auth';
+import { teams } from './teams';
+
+export const giftTokens = sqliteTable(
+  'gift_tokens',
+  {
+    id: text()
+      .$defaultFn(() => generateId())
+      .primaryKey()
+      .notNull(),
+    code: text().unique().notNull(),
+    amountUsd: real('amount_usd').notNull(),
+    createdByUserId: text('created_by_user_id')
+      .notNull()
+      .references(() => user.id, { onDelete: 'cascade' }),
+    redeemedByTeamId: text('redeemed_by_team_id').references(() => teams.id, {
+      onDelete: 'set null',
+    }),
+    redeemedByUserId: text('redeemed_by_user_id').references(() => user.id, {
+      onDelete: 'set null',
+    }),
+    redeemedAt: integer('redeemed_at', { mode: 'timestamp' }),
+    expiresAt: integer('expires_at', { mode: 'timestamp' }),
+    note: text(),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex('idx_gift_tokens_code').on(table.code),
+    index('idx_gift_tokens_created_by').on(table.createdByUserId),
+  ]
+);
+
+export const giftTokensRelations = relations(giftTokens, ({ one }) => ({
+  createdBy: one(user, {
+    fields: [giftTokens.createdByUserId],
+    references: [user.id],
+    relationName: 'giftTokens_createdBy',
+  }),
+  redeemedByTeam: one(teams, {
+    fields: [giftTokens.redeemedByTeamId],
+    references: [teams.id],
+  }),
+  redeemedByUser: one(user, {
+    fields: [giftTokens.redeemedByUserId],
+    references: [user.id],
+    relationName: 'giftTokens_redeemedBy',
+  }),
+}));
+
+export type GiftToken = InferSelectModel<typeof giftTokens>;
+export type NewGiftToken = InferInsertModel<typeof giftTokens>;

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -89,6 +89,8 @@ import { scriptAnalysisAudit } from './audit';
 
 import { teamApiKeys, teamApiKeysRelations } from './team-api-keys';
 
+import { giftTokens, giftTokensRelations } from './gift-tokens';
+
 // ============================================================================
 // Relations defined here to avoid circular dependencies
 // ============================================================================
@@ -281,6 +283,11 @@ export type {
   TeamApiKey,
 } from './team-api-keys';
 
+// Gift Tokens
+export { giftTokens };
+
+export type { GiftToken, NewGiftToken } from './gift-tokens';
+
 /**
  * Complete schema object for Drizzle client initialization
  * Import this when creating your Drizzle instance
@@ -374,4 +381,8 @@ export const schema = {
   // Team API Keys
   teamApiKeys,
   teamApiKeysRelations,
+
+  // Gift Tokens
+  giftTokens,
+  giftTokensRelations,
 };

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as ApiBillingAutoTopupRouteImport } from './routes/api/billing/au
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 import { Route as ProtectedTalentIdRouteImport } from './routes/_protected/talent/$id'
 import { Route as ProtectedSettingsPasskeysRouteImport } from './routes/_protected/settings/passkeys'
+import { Route as ProtectedSettingsGiftCodesRouteImport } from './routes/_protected/settings/gift-codes'
 import { Route as ProtectedSettingsBillingRouteImport } from './routes/_protected/settings/billing'
 import { Route as ProtectedSettingsApiKeysRouteImport } from './routes/_protected/settings/api-keys'
 import { Route as ProtectedSequencesNewRouteImport } from './routes/_protected/sequences/new'
@@ -162,6 +163,12 @@ const ProtectedSettingsPasskeysRoute =
     path: '/passkeys',
     getParentRoute: () => ProtectedSettingsRouteRoute,
   } as any)
+const ProtectedSettingsGiftCodesRoute =
+  ProtectedSettingsGiftCodesRouteImport.update({
+    id: '/gift-codes',
+    path: '/gift-codes',
+    getParentRoute: () => ProtectedSettingsRouteRoute,
+  } as any)
 const ProtectedSettingsBillingRoute =
   ProtectedSettingsBillingRouteImport.update({
     id: '/billing',
@@ -265,6 +272,7 @@ export interface FileRoutesByFullPath {
   '/sequences/new': typeof ProtectedSequencesNewRoute
   '/settings/api-keys': typeof ProtectedSettingsApiKeysRoute
   '/settings/billing': typeof ProtectedSettingsBillingRoute
+  '/settings/gift-codes': typeof ProtectedSettingsGiftCodesRoute
   '/settings/passkeys': typeof ProtectedSettingsPasskeysRoute
   '/talent/$id': typeof ProtectedTalentIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -302,6 +310,7 @@ export interface FileRoutesByTo {
   '/sequences/new': typeof ProtectedSequencesNewRoute
   '/settings/api-keys': typeof ProtectedSettingsApiKeysRoute
   '/settings/billing': typeof ProtectedSettingsBillingRoute
+  '/settings/gift-codes': typeof ProtectedSettingsGiftCodesRoute
   '/settings/passkeys': typeof ProtectedSettingsPasskeysRoute
   '/talent/$id': typeof ProtectedTalentIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -343,6 +352,7 @@ export interface FileRoutesById {
   '/_protected/sequences/new': typeof ProtectedSequencesNewRoute
   '/_protected/settings/api-keys': typeof ProtectedSettingsApiKeysRoute
   '/_protected/settings/billing': typeof ProtectedSettingsBillingRoute
+  '/_protected/settings/gift-codes': typeof ProtectedSettingsGiftCodesRoute
   '/_protected/settings/passkeys': typeof ProtectedSettingsPasskeysRoute
   '/_protected/talent/$id': typeof ProtectedTalentIdRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -383,6 +393,7 @@ export interface FileRouteTypes {
     | '/sequences/new'
     | '/settings/api-keys'
     | '/settings/billing'
+    | '/settings/gift-codes'
     | '/settings/passkeys'
     | '/talent/$id'
     | '/api/auth/$'
@@ -420,6 +431,7 @@ export interface FileRouteTypes {
     | '/sequences/new'
     | '/settings/api-keys'
     | '/settings/billing'
+    | '/settings/gift-codes'
     | '/settings/passkeys'
     | '/talent/$id'
     | '/api/auth/$'
@@ -460,6 +472,7 @@ export interface FileRouteTypes {
     | '/_protected/sequences/new'
     | '/_protected/settings/api-keys'
     | '/_protected/settings/billing'
+    | '/_protected/settings/gift-codes'
     | '/_protected/settings/passkeys'
     | '/_protected/talent/$id'
     | '/api/auth/$'
@@ -667,6 +680,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedSettingsPasskeysRouteImport
       parentRoute: typeof ProtectedSettingsRouteRoute
     }
+    '/_protected/settings/gift-codes': {
+      id: '/_protected/settings/gift-codes'
+      path: '/gift-codes'
+      fullPath: '/settings/gift-codes'
+      preLoaderRoute: typeof ProtectedSettingsGiftCodesRouteImport
+      parentRoute: typeof ProtectedSettingsRouteRoute
+    }
     '/_protected/settings/billing': {
       id: '/_protected/settings/billing'
       path: '/billing'
@@ -792,6 +812,7 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 interface ProtectedSettingsRouteRouteChildren {
   ProtectedSettingsApiKeysRoute: typeof ProtectedSettingsApiKeysRoute
   ProtectedSettingsBillingRoute: typeof ProtectedSettingsBillingRoute
+  ProtectedSettingsGiftCodesRoute: typeof ProtectedSettingsGiftCodesRoute
   ProtectedSettingsPasskeysRoute: typeof ProtectedSettingsPasskeysRoute
   ProtectedSettingsIndexRoute: typeof ProtectedSettingsIndexRoute
 }
@@ -800,6 +821,7 @@ const ProtectedSettingsRouteRouteChildren: ProtectedSettingsRouteRouteChildren =
   {
     ProtectedSettingsApiKeysRoute: ProtectedSettingsApiKeysRoute,
     ProtectedSettingsBillingRoute: ProtectedSettingsBillingRoute,
+    ProtectedSettingsGiftCodesRoute: ProtectedSettingsGiftCodesRoute,
     ProtectedSettingsPasskeysRoute: ProtectedSettingsPasskeysRoute,
     ProtectedSettingsIndexRoute: ProtectedSettingsIndexRoute,
   }

--- a/src/routes/_protected/settings/gift-codes.tsx
+++ b/src/routes/_protected/settings/gift-codes.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { GiftCodeSettings } from '@/components/settings/gift-code-settings';
+
+export const Route = createFileRoute('/_protected/settings/gift-codes')({
+  component: GiftCodesPage,
+});
+
+function GiftCodesPage() {
+  return <GiftCodeSettings />;
+}

--- a/src/routes/_protected/settings/route.tsx
+++ b/src/routes/_protected/settings/route.tsx
@@ -10,7 +10,7 @@ import {
   Outlet,
   useLocation,
 } from '@tanstack/react-router';
-import { CreditCard, Fingerprint, Key } from 'lucide-react';
+import { CreditCard, Fingerprint, Gift, Key } from 'lucide-react';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export const Route = createFileRoute('/_protected/settings')({
@@ -38,6 +38,12 @@ const tabs = [
     label: 'Billing',
     href: '/settings/billing',
     icon: <CreditCard className="h-4 w-4" />,
+  },
+  {
+    value: 'gift-codes',
+    label: 'Gift Codes',
+    href: '/settings/gift-codes',
+    icon: <Gift className="h-4 w-4" />,
   },
 ];
 


### PR DESCRIPTION
Closes #368

## Summary
- Adds a gift token (voucher code) system for gifting credits to users via 6-character codes
- System admins (configured via `ADMIN_EMAILS` env var) can create single-use gift codes with optional expiry
- Any authenticated user can redeem codes to add credits to their team balance
- New "Gift Codes" tab in settings with redeem UI + admin create/list section
- Billing gate dialog now includes "Redeem Gift Code" as a third option alongside Add Credits and BYOK

## Test plan
- [x] `bun typecheck` — no type errors
- [x] `bun test src/lib/billing/gift-token.service.test.ts` — 8/8 tests pass (code generation, status logic, error cases)
- [x] `bun run build` — builds successfully
- [ ] Set `ADMIN_EMAILS` in `.env`, navigate to `/settings/gift-codes`
- [ ] Verify admin section shows only for admin emails
- [ ] Create a gift code, copy it, redeem it — balance increases
- [ ] Try redeeming same code again — error shown
- [ ] Trigger billing gate from a sequence — verify "Redeem Gift Code" option appears
- [ ] Redeem from billing gate flow — verify "Continue creating" toast navigates back

🤖 Generated with [Claude Code](https://claude.com/claude-code)