### PR TITLE
Auto-redeem gift codes on /gift/:code page

### DIFF
--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -22,16 +22,12 @@ import {
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { Check, Copy, Gift, LinkIcon, ShieldCheck } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 const RETURN_KEY = 'openstory:billing-return';
 
-type GiftCodeSettingsProps = {
-  code?: string;
-};
-
-export function GiftCodeSettings({ code }: GiftCodeSettingsProps) {
+export function GiftCodeSettings() {
   const { data: adminStatus, isLoading: adminLoading } = useQuery({
     queryKey: ['system-admin-status'],
     queryFn: () => isSystemAdminFn(),
@@ -46,35 +42,16 @@ export function GiftCodeSettings({ code }: GiftCodeSettingsProps) {
 
   return (
     <div className="space-y-6">
-      <RedeemSection code={code} />
+      <RedeemSection />
       {renderAdminSection()}
     </div>
   );
 }
 
-const PENDING_GIFT_KEY = 'openstory:pending-gift-code';
-
-function RedeemSection({ code: codeProp }: { code?: string }) {
+function RedeemSection() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [code, setCode] = useState(codeProp?.toUpperCase() ?? '');
-
-  // Sync code when URL search param changes after mount
-  useEffect(() => {
-    if (codeProp) {
-      setCode(codeProp.toUpperCase());
-    }
-  }, [codeProp]);
-
-  // Read pending gift code from sessionStorage (set by /gift/:code page for login flow)
-  useEffect(() => {
-    if (codeProp) return;
-    const stored = sessionStorage.getItem(PENDING_GIFT_KEY);
-    if (stored) {
-      sessionStorage.removeItem(PENDING_GIFT_KEY);
-      setCode(stored.toUpperCase());
-    }
-  }, [codeProp]);
+  const [code, setCode] = useState('');
 
   const redeemMutation = useMutation({
     mutationFn: (input: { code: string }) => redeemGiftTokenFn({ data: input }),

--- a/src/routes/_protected/credits.tsx
+++ b/src/routes/_protected/credits.tsx
@@ -18,7 +18,6 @@ const searchSchema = z.object({
   tab: z.enum(tabValues).optional().default('balance'),
   success: z.boolean().optional(),
   canceled: z.boolean().optional(),
-  code: z.string().optional(),
 });
 
 export const Route = createFileRoute('/_protected/credits')({
@@ -48,7 +47,7 @@ const tabs = [
 ];
 
 function CreditsPage() {
-  const { tab, success, canceled, code } = Route.useSearch();
+  const { tab, success, canceled } = Route.useSearch();
   const navigate = useNavigate();
 
   return (
@@ -82,7 +81,7 @@ function CreditsPage() {
           <TransactionSettings />
         </TabsContent>
         <TabsContent value="gift-codes">
-          <GiftCodeSettings code={code} />
+          <GiftCodeSettings />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/routes/gift/$code.tsx
+++ b/src/routes/gift/$code.tsx
@@ -1,3 +1,4 @@
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -6,17 +7,23 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { redeemGiftTokenFn } from '@/functions/gift-tokens';
+import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
+import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
 import { sessionQueryOptions } from '@/lib/auth/session-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createFileRoute,
   Link,
   redirect,
-  useParams,
+  useNavigate,
 } from '@tanstack/react-router';
-import { Gift } from 'lucide-react';
-import { useEffect } from 'react';
+import { Gift, Loader2 } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { toast } from 'sonner';
 
 const STORAGE_KEY = 'openstory:pending-gift-code';
+const RETURN_KEY = 'openstory:billing-return';
 
 function normalizeCode(raw: string): string {
   return raw
@@ -31,54 +38,176 @@ export const Route = createFileRoute('/gift/$code')({
     if (code.length !== 6) {
       throw redirect({ to: '/' });
     }
-
-    const session = await queryClient.ensureQueryData(sessionQueryOptions);
-    if (session?.user) {
-      throw redirect({
-        to: '/credits',
-        search: { tab: 'gift-codes', code },
-      });
-    }
+    await queryClient.ensureQueryData(sessionQueryOptions);
   },
-  component: GiftLandingPage,
+  component: GiftCodePage,
 });
 
-function GiftLandingPage() {
-  const { code: rawCode } = useParams({ from: '/gift/$code' });
+function GiftCodePage() {
+  const { code: rawCode } = Route.useParams();
   const code = normalizeCode(rawCode);
+  const { data: session } = useQuery(sessionQueryOptions);
 
+  if (session?.user) {
+    return <AutoRedeemView code={code} />;
+  }
+
+  return <GiftLandingPage code={code} />;
+}
+
+// -- Shared layout components --
+
+const CenteredLayout: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <div className="flex min-h-screen items-center justify-center bg-background p-4">
+    <Card className="w-full max-w-sm text-center">{children}</Card>
+  </div>
+);
+
+const CodeDisplay: React.FC<{ code: string }> = ({ code }) => (
+  <div className="rounded-lg border bg-muted/50 px-4 py-3">
+    <p className="font-mono text-2xl font-bold tracking-widest">{code}</p>
+  </div>
+);
+
+type IconBadgeProps = {
+  variant: 'primary' | 'destructive';
+  children: React.ReactNode;
+};
+
+const variantClasses = {
+  primary: 'bg-primary/10',
+  destructive: 'bg-destructive/10',
+} as const;
+
+const IconBadge: React.FC<IconBadgeProps> = ({ variant, children }) => (
+  <div
+    className={`mx-auto flex h-14 w-14 items-center justify-center rounded-full ${variantClasses[variant]}`}
+  >
+    {children}
+  </div>
+);
+
+// -- Views --
+
+type GiftCodeViewProps = {
+  code: string;
+};
+
+function AutoRedeemView({ code }: GiftCodeViewProps) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const hasTriggered = useRef(false);
+
+  const { mutate, isError, isPending, error } = useMutation({
+    mutationFn: (input: { code: string }) => redeemGiftTokenFn({ data: input }),
+    onSuccess: (result) => {
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_BALANCE_KEY],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_GATE_KEY],
+      });
+
+      toast.success(`$${result.amountUsd.toFixed(2)} added to your balance`, {
+        description: `New balance: $${result.newBalance.toFixed(2)}`,
+      });
+
+      const returnTo = localStorage.getItem(RETURN_KEY);
+      if (returnTo) {
+        localStorage.removeItem(RETURN_KEY);
+        void navigate({ to: returnTo });
+      } else {
+        void navigate({ to: '/sequences' });
+      }
+    },
+  });
+
+  // Fire once on mount with StrictMode double-mount protection via useRef.
+  useEffect(() => {
+    if (hasTriggered.current) return;
+    hasTriggered.current = true;
+    mutate({ code });
+  }, [code, mutate]);
+
+  if (isError) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Failed to redeem code';
+
+    return (
+      <CenteredLayout>
+        <CardHeader>
+          <IconBadge variant="destructive">
+            <Gift className="h-7 w-7 text-destructive" />
+          </IconBadge>
+          <CardTitle className="text-2xl">Redemption failed</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <Alert variant="destructive">
+            <AlertDescription>{errorMessage}</AlertDescription>
+          </Alert>
+          <div className="flex flex-col gap-2">
+            <Button
+              onClick={() => {
+                hasTriggered.current = false;
+                mutate({ code });
+              }}
+              disabled={isPending}
+            >
+              Try again
+            </Button>
+            <Button variant="ghost" asChild>
+              <Link to="/credits" search={{ tab: 'gift-codes' }}>
+                Enter code manually
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </CenteredLayout>
+    );
+  }
+
+  return (
+    <CenteredLayout>
+      <CardHeader>
+        <IconBadge variant="primary">
+          <Loader2 className="h-7 w-7 animate-spin text-primary" />
+        </IconBadge>
+        <CardTitle className="text-2xl">Redeeming your gift…</CardTitle>
+        <CardDescription>Adding credits to your account</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <CodeDisplay code={code} />
+      </CardContent>
+    </CenteredLayout>
+  );
+}
+
+function GiftLandingPage({ code }: GiftCodeViewProps) {
   useEffect(() => {
     sessionStorage.setItem(STORAGE_KEY, code);
   }, [code]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-sm text-center">
-        <CardHeader>
-          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
-            <Gift className="h-7 w-7 text-primary" />
-          </div>
-          <CardTitle className="text-2xl">Credits incoming!</CardTitle>
-          <CardDescription>
-            Sign in to redeem your gift and start creating.
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-4">
-          <div className="rounded-lg border bg-muted/50 px-4 py-3">
-            <p className="font-mono text-2xl font-bold tracking-widest">
-              {code}
-            </p>
-          </div>
-          <Button asChild size="lg">
-            <Link
-              to="/login"
-              search={{ redirectTo: '/credits?tab=gift-codes' }}
-            >
-              Sign in to redeem
-            </Link>
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
+    <CenteredLayout>
+      <CardHeader>
+        <IconBadge variant="primary">
+          <Gift className="h-7 w-7 text-primary" />
+        </IconBadge>
+        <CardTitle className="text-2xl">Credits incoming!</CardTitle>
+        <CardDescription>
+          Sign in to redeem your gift and start creating.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <CodeDisplay code={code} />
+        <Button asChild size="lg">
+          <Link to="/login" search={{ redirectTo: `/gift/${code}` }}>
+            Sign in to redeem
+          </Link>
+        </Button>
+      </CardContent>
+    </CenteredLayout>
   );
 }


### PR DESCRIPTION
## Summary
- `/gift/CODE` now auto-redeems for logged-in users with loading spinner, success toast, and redirect to `/sequences` (or billing-return path)
- Logged-out users see the same landing page but login now redirects back to `/gift/CODE` for auto-redeem after auth
- Removed `code` prop plumbing from credits page and gift-code-settings component

## Test plan
- [ ] Visit `/gift/CODE` logged in → auto-redeems, toast shown, lands on `/sequences`
- [ ] Visit `/gift/CODE` logged out → sign in → returns to `/gift/CODE` → auto-redeems → toast → `/sequences`
- [ ] Visit `/gift/BADCODE` logged in → error shown with retry option
- [ ] Hit billing gate → receive gift link → redeem → returns to original page
- [ ] Visit `/credits?tab=gift-codes` → manual entry still works

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)