### PR TITLE
Replace db.transaction() for D1 compatibility

### DIFF
--- a/.claude/hookify.block-db-transaction.local.md
+++ b/.claude/hookify.block-db-transaction.local.md
@@ -1,0 +1,23 @@
+---
+name: block-db-transaction
+enabled: true
+event: file
+action: block
+conditions:
+  - field: new_text
+    operator: regex_match
+    pattern: \.transaction\s*\(
+---
+
+**D1/Cloudflare does not support interactive transactions (BEGIN/COMMIT).**
+
+`db.transaction()` will fail at runtime with: `"Failed query: begin params:"`
+
+**Instead, use sequential queries:**
+
+1. Query data with `db.select()`
+2. Validate in application code
+3. Insert/update with `db.insert()` or `db.update()`
+4. Use unique indexes + `onConflictDoNothing()` to prevent race conditions
+
+See commit `f31442b` and issue #401 for the established pattern.

--- a/src/lib/billing/gift-token.service.test.ts
+++ b/src/lib/billing/gift-token.service.test.ts
@@ -3,19 +3,34 @@ import { describe, expect, it, mock, beforeEach } from 'bun:test';
 // --- Mocks ---
 
 let mockGiftTokenRows: Record<string, unknown>[] = [];
-let mockRedemptionRows: Record<string, unknown>[] = [];
 let mockRedemptionCountRows: { value: number }[] = [{ value: 0 }];
 let mockInsertedValues: Record<string, unknown>[] = [];
+let mockInsertReturning: Record<string, unknown>[] = [];
 let mockAddCreditsResult = { newBalance: 50, transactionId: 'tx-1' };
 
 type MockFn = (...args: unknown[]) => unknown;
 
+// Track select call order: 1 = token lookup, 2 = count redemptions
+let selectCallCount = 0;
+
 function createSelectChain() {
-  const chain: Record<string, unknown> = {};
-  chain.select = mock(() => chain);
+  const resolveData = () => {
+    if (selectCallCount === 1) return [...mockGiftTokenRows];
+    if (selectCallCount === 2) return [...mockRedemptionCountRows];
+    return [];
+  };
+
+  const chain: Record<string | symbol, unknown> = {};
+  chain.select = mock(() => {
+    selectCallCount++;
+    return chain;
+  });
   chain.from = mock(() => chain);
   chain.where = mock(() => chain);
-  chain.limit = mock(() => [...mockGiftTokenRows]);
+  chain.limit = mock(() => resolveData());
+  // Make chain awaitable for queries without .limit() (e.g. count query)
+  chain.then = (resolve: (v: unknown[]) => void) =>
+    Promise.resolve(resolveData()).then(resolve);
   chain.orderBy = mock(() => [...mockGiftTokenRows]);
   chain.leftJoin = mock(() => chain);
   chain.groupBy = mock(() => chain);
@@ -30,69 +45,17 @@ function createInsertChain() {
     mockInsertedValues.push(vals);
     return chain;
   });
-  chain.returning = mock(() => [{ ...vals(), id: 'gt-1', code: 'HK7NWE' }]);
+  chain.onConflictDoNothing = mock(() => chain);
+  chain.returning = mock(() => [...mockInsertReturning]);
   return chain;
-}
-
-function vals() {
-  return mockInsertedValues[mockInsertedValues.length - 1] ?? {};
 }
 
 let selectChain = createSelectChain();
 let insertChain = createInsertChain();
 
-// Track which table is being queried to return different results
-let selectCallCount = 0;
-
-function createTxSelectChain() {
-  const chain = Object.create(null) as Record<string | symbol, unknown>;
-  chain[Symbol.iterator] = function* () {
-    if (selectCallCount === 2) yield* mockRedemptionCountRows;
-    else if (selectCallCount === 3) yield* mockRedemptionRows;
-  };
-  chain.select = mock(() => {
-    selectCallCount++;
-    return chain;
-  });
-  chain.from = mock(() => chain);
-  chain.where = mock(() => chain);
-  chain.then = mock((resolve: (v: unknown[]) => void) => {
-    if (selectCallCount === 2) resolve([...mockRedemptionCountRows]);
-    else if (selectCallCount === 3) resolve([...mockRedemptionRows]);
-    else resolve([]);
-  });
-  chain.limit = mock(() => {
-    if (selectCallCount === 1) return [...mockGiftTokenRows];
-    if (selectCallCount === 3) return [...mockRedemptionRows];
-    return [...mockRedemptionCountRows];
-  });
-  return chain;
-}
-
-function createTxInsertChain() {
-  const chain: Record<string, unknown> = {};
-  chain.insert = mock(() => chain);
-  chain.values = mock((vals: Record<string, unknown>) => {
-    mockInsertedValues.push(vals);
-    return chain;
-  });
-  chain.returning = mock(() => []);
-  return chain;
-}
-
 const mockDb = {
   select: (...args: unknown[]) => (selectChain.select as MockFn)(...args),
   insert: (...args: unknown[]) => (insertChain.insert as MockFn)(...args),
-  transaction: mock(async (fn: (tx: Record<string, unknown>) => unknown) => {
-    const txSelect = createTxSelectChain();
-    const txInsert = createTxInsertChain();
-    selectCallCount = 0;
-    const tx = {
-      select: (...args: unknown[]) => (txSelect.select as MockFn)(...args),
-      insert: (...args: unknown[]) => (txInsert.insert as MockFn)(...args),
-    };
-    return fn(tx);
-  }),
 };
 
 mock.module('#db-client', () => ({
@@ -187,9 +150,10 @@ describe('getGiftTokenStatus', () => {
 describe('redeemGiftToken', () => {
   beforeEach(() => {
     mockGiftTokenRows = [];
-    mockRedemptionRows = [];
     mockRedemptionCountRows = [{ value: 0 }];
     mockInsertedValues = [];
+    mockInsertReturning = [{ id: 'r-new' }];
+    selectCallCount = 0;
     selectChain = createSelectChain();
     insertChain = createInsertChain();
 
@@ -249,7 +213,7 @@ describe('redeemGiftToken', () => {
       },
     ];
     mockRedemptionCountRows = [{ value: 2 }];
-    mockRedemptionRows = [{ id: 'r-1', giftTokenId: 'gt-1', teamId: 'team-1' }];
+    mockInsertReturning = []; // Conflict → insert is a no-op
     try {
       await redeemGiftToken({
         code: 'HK7NWE',

--- a/src/lib/billing/gift-token.service.ts
+++ b/src/lib/billing/gift-token.service.ts
@@ -3,7 +3,7 @@ import { generateId } from '@/lib/db/id';
 import { giftTokenRedemptions, giftTokens } from '@/lib/db/schema/gift-tokens';
 import type { GiftToken } from '@/lib/db/schema/gift-tokens';
 import { ValidationError } from '@/lib/errors';
-import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { count, desc, eq, sql } from 'drizzle-orm';
 import { addCredits } from './credit-service';
 import { micros, microsToDisplayUsd, microsToUsd, usdToMicros } from './money';
 
@@ -73,59 +73,46 @@ export async function redeemGiftToken(opts: {
   const db = getDb();
   const normalizedCode = opts.code.trim().toUpperCase();
 
-  const token = await db.transaction(async (tx) => {
-    const [found] = await tx
-      .select()
-      .from(giftTokens)
-      .where(eq(giftTokens.code, normalizedCode))
-      .limit(1);
+  // Find the token
+  const [token] = await db
+    .select()
+    .from(giftTokens)
+    .where(eq(giftTokens.code, normalizedCode))
+    .limit(1);
 
-    if (!found) {
-      throw new ValidationError('Invalid gift code');
-    }
+  if (!token) {
+    throw new ValidationError('Invalid gift code');
+  }
 
-    if (found.expiresAt && found.expiresAt < new Date()) {
-      throw new ValidationError('This gift code has expired');
-    }
+  if (token.expiresAt && token.expiresAt < new Date()) {
+    throw new ValidationError('This gift code has expired');
+  }
 
-    // Count existing redemptions
-    const [{ value: redemptionCount }] = await tx
-      .select({ value: count() })
-      .from(giftTokenRedemptions)
-      .where(eq(giftTokenRedemptions.giftTokenId, found.id));
+  // Count existing redemptions
+  const [{ value: redemptionCount }] = await db
+    .select({ value: count() })
+    .from(giftTokenRedemptions)
+    .where(eq(giftTokenRedemptions.giftTokenId, token.id));
 
-    if (redemptionCount >= found.maxRedemptions) {
-      throw new ValidationError('This gift code has been fully redeemed');
-    }
+  if (redemptionCount >= token.maxRedemptions) {
+    throw new ValidationError('This gift code has been fully redeemed');
+  }
 
-    // Check if this team already redeemed
-    const [existing] = await tx
-      .select()
-      .from(giftTokenRedemptions)
-      .where(
-        and(
-          eq(giftTokenRedemptions.giftTokenId, found.id),
-          eq(giftTokenRedemptions.teamId, opts.teamId)
-        )
-      )
-      .limit(1);
-
-    if (existing) {
-      throw new ValidationError(
-        'Your team has already redeemed this gift code'
-      );
-    }
-
-    // Record redemption
-    await tx.insert(giftTokenRedemptions).values({
+  // Record redemption — unique index on (giftTokenId, teamId) prevents duplicates
+  const [inserted] = await db
+    .insert(giftTokenRedemptions)
+    .values({
       id: generateId(),
-      giftTokenId: found.id,
+      giftTokenId: token.id,
       teamId: opts.teamId,
       userId: opts.userId,
-    });
+    })
+    .onConflictDoNothing()
+    .returning();
 
-    return found;
-  });
+  if (!inserted) {
+    throw new ValidationError('Your team has already redeemed this gift code');
+  }
 
   const amountMicros = micros(token.amountMicros);
 


### PR DESCRIPTION
## Summary
- Replace `db.transaction()` in `redeemGiftToken` with sequential queries — D1/Cloudflare doesn't support interactive transactions (`BEGIN`/`COMMIT`), causing `"Failed query: begin params:"` errors
- Use existing unique index on `(giftTokenId, teamId)` + `onConflictDoNothing()` for race condition safety instead of a separate duplicate check query
- Add hookify rule to block future `db.transaction()` usage

Closes #401

## Test plan
- [x] `bun typecheck` passes
- [x] `bun test` passes (236 pass, 0 fail)
- [x] `bun run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)