### PR TITLE
Fix billing deduction double-conversion

### DIFF
--- a/src/lib/audio/music-generation.ts
+++ b/src/lib/audio/music-generation.ts
@@ -1,4 +1,5 @@
 import { calculateAudioCost } from '@/lib/ai/fal-cost';
+import { type Microdollars, microsToUsd } from '@/lib/billing/money';
 import {
   AUDIO_MODEL_KEYS,
   AUDIO_MODELS,
@@ -46,7 +47,7 @@ export type MusicResult = {
     model: string;
     provider: string;
     duration: number;
-    cost: number;
+    cost: Microdollars;
     generatedAt: string;
     usedOwnKey: boolean;
   };
@@ -165,10 +166,9 @@ export async function generateMusicForScene(
     span
       .update({
         output: { audioUrl: result.audioUrl },
-        costDetails:
-          typeof result.metadata?.cost === 'number'
-            ? { total: result.metadata.cost }
-            : undefined,
+        costDetails: result.metadata?.cost
+          ? { total: microsToUsd(result.metadata.cost) }
+          : undefined,
       })
       .end();
 

--- a/src/lib/billing/workflow-deduction.ts
+++ b/src/lib/billing/workflow-deduction.ts
@@ -14,12 +14,7 @@ import {
   deductCredits,
   hasEnoughCredits,
 } from '@/lib/billing/credit-service';
-import {
-  type Microdollars,
-  microsToUsd,
-  usdToMicros,
-  ZERO_MICROS,
-} from './money';
+import { type Microdollars, microsToUsd, ZERO_MICROS } from './money';
 
 type WorkflowDeductionOpts = {
   /** Team to deduct from. Skips deduction if undefined (e.g., anonymous workflows). */
@@ -74,11 +69,11 @@ export async function deductWorkflowCredits(
 }
 
 /**
- * Extract the numeric cost from a fal.ai image generation result's metadata.
- * Converts USD cost to Microdollars. Returns ZERO_MICROS if missing.
+ * Extract the cost from a generation result's metadata.
+ * Values are already in Microdollars. Returns ZERO_MICROS if missing.
  */
-export function extractImageCost(metadata: { cost?: unknown }): Microdollars {
-  return typeof metadata.cost === 'number'
-    ? usdToMicros(metadata.cost)
-    : ZERO_MICROS;
+export function extractImageCost(metadata: {
+  cost?: Microdollars;
+}): Microdollars {
+  return metadata.cost ?? ZERO_MICROS;
 }

--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -1,4 +1,5 @@
 import { calculateImageCost } from '@/lib/ai/fal-cost';
+import { type Microdollars, microsToUsd } from '@/lib/billing/money';
 import {
   getEditEndpoint,
   getTextToImageModelId,
@@ -70,7 +71,7 @@ export type ImageGenerationResult = {
     file_sizes: number[];
     seed?: number;
     has_nsfw_concepts?: boolean[];
-    cost?: number;
+    cost?: Microdollars;
     requestId?: string;
     usedOwnKey: boolean;
   };
@@ -146,7 +147,7 @@ export async function generateImageWithProvider(
           ...(imageMedia && { generatedImage: imageMedia }),
         },
         costDetails: result.metadata.cost
-          ? { total: result.metadata.cost }
+          ? { total: microsToUsd(result.metadata.cost) }
           : undefined,
       })
       .end();

--- a/src/lib/motion/motion-generation.test.ts
+++ b/src/lib/motion/motion-generation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { IMAGE_TO_VIDEO_MODELS } from '../ai/models';
+import { micros } from '../billing/money';
 import { apiKeyService } from '../byok/api-key.service';
 import {
   mockGenerateVideo,
@@ -56,7 +57,7 @@ describe('Motion Service', () => {
       expect(result.metadata?.provider).toBe('kling');
       expect(result.metadata?.duration).toBe(5);
       expect(result.metadata?.fps).toBe(30);
-      expect(result.metadata?.cost).toBe(840_000); // 140_000 micros/s * 1.2 (audio) * 5s
+      expect(result.metadata?.cost).toBe(micros(840_000)); // 140_000 micros/s * 1.2 (audio) * 5s
 
       expect(mockGenerateVideo).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -1,4 +1,5 @@
 import { calculateVideoCost } from '@/lib/ai/fal-cost';
+import { type Microdollars, microsToUsd } from '@/lib/billing/money';
 import {
   DEFAULT_VIDEO_MODEL,
   IMAGE_TO_VIDEO_MODEL_KEYS,
@@ -58,7 +59,7 @@ export type MotionResult = {
     fps: number;
     motionBucket?: number;
     totalFrames: number;
-    cost: number;
+    cost: Microdollars;
     generatedAt: string;
     usedOwnKey: boolean;
   };
@@ -222,10 +223,9 @@ export async function generateMotionForFrame(
           videoUrl: result.videoUrl,
           ...(outputVideoMedia && { generatedVideo: outputVideoMedia }),
         },
-        costDetails:
-          typeof result.metadata?.cost === 'number'
-            ? { total: result.metadata.cost }
-            : undefined,
+        costDetails: result.metadata?.cost
+          ? { total: microsToUsd(result.metadata.cost) }
+          : undefined,
       })
       .end();
     return result;

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
 import { isBillingEnabled } from '@/lib/billing/constants';
 import { deductCredits, hasEnoughCredits } from '@/lib/billing/credit-service';
-import { usdToMicros, microsToUsd } from '@/lib/billing/money';
+import { ZERO_MICROS, microsToUsd } from '@/lib/billing/money';
 import { DEFAULT_IMAGE_SIZE } from '@/lib/constants/aspect-ratios';
 import { updateFrame } from '@/lib/db/helpers/frames';
 import {
@@ -105,8 +105,7 @@ export const generateImageWorkflow = createWorkflow(
       });
     });
 
-    const imageCostRaw = imageResult.metadata.cost ?? 0;
-    const imageCostMicros = usdToMicros(imageCostRaw);
+    const imageCostMicros = imageResult.metadata.cost ?? ZERO_MICROS;
     const { teamId, frameId, sequenceId } = input;
     if (
       isBillingEnabled() &&

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -6,7 +6,7 @@
 import { DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
 import { isBillingEnabled } from '@/lib/billing/constants';
 import { deductCredits, hasEnoughCredits } from '@/lib/billing/credit-service';
-import { usdToMicros, microsToUsd } from '@/lib/billing/money';
+import { ZERO_MICROS, microsToUsd } from '@/lib/billing/money';
 import {
   getFrameWithSequence,
   getSequenceFrames,
@@ -98,11 +98,7 @@ export const generateMotionWorkflow = createWorkflow(
         : (input.duration ?? 2);
 
     // Deduct credits (skip if team used own fal key)
-    const motionCostRaw =
-      typeof videoResult.metadata?.cost === 'number'
-        ? videoResult.metadata.cost
-        : 0;
-    const motionCostMicros = usdToMicros(motionCostRaw);
+    const motionCostMicros = videoResult.metadata?.cost ?? ZERO_MICROS;
     const { teamId } = input;
     if (
       isBillingEnabled() &&

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -4,7 +4,7 @@ import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
 import { uploadAudioToStorage } from '@/lib/audio/audio-storage';
 import { generateMusicForScene } from '@/lib/audio/music-generation';
 import { deductCredits, hasEnoughCredits } from '@/lib/billing/credit-service';
-import { usdToMicros, microsToUsd } from '@/lib/billing/money';
+import { ZERO_MICROS, microsToUsd } from '@/lib/billing/money';
 import { sequences } from '@/lib/db/schema';
 import { getGenerationChannel } from '@/lib/realtime';
 import { triggerWorkflow } from '@/lib/workflow/client';
@@ -107,11 +107,7 @@ export const generateMusicWorkflow = createWorkflow(
         : (input.duration ?? 60);
 
     // Deduct credits (skip if team used own fal key)
-    const musicCostRaw =
-      typeof audioResult.metadata?.cost === 'number'
-        ? audioResult.metadata.cost
-        : 0;
-    const musicCostMicros = usdToMicros(musicCostRaw);
+    const musicCostMicros = audioResult.metadata?.cost ?? ZERO_MICROS;
     if (musicCostMicros > 0 && !audioResult.metadata.usedOwnKey) {
       await context.run('deduct-credits', async () => {
         const canAfford = await hasEnoughCredits(teamId, musicCostMicros);

--- a/src/lib/workflows/upscale-variant-workflow.ts
+++ b/src/lib/workflows/upscale-variant-workflow.ts
@@ -1,4 +1,4 @@
-import { usdToMicros } from '@/lib/billing/money';
+import { ZERO_MICROS } from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import { updateFrame } from '@/lib/db/helpers/frames';
 import { generateImageWithProvider } from '@/lib/image/image-generation';
@@ -78,7 +78,7 @@ export const upscaleVariantWorkflow = createWorkflow(
       });
       return {
         imageUrl: result.imageUrls[0],
-        cost: result.metadata.cost ?? 0,
+        cost: result.metadata.cost ?? ZERO_MICROS,
         usedOwnKey: result.metadata.usedOwnKey,
       };
     });
@@ -90,7 +90,7 @@ export const upscaleVariantWorkflow = createWorkflow(
     await context.run('deduct-credits', async () => {
       await deductWorkflowCredits({
         teamId: input.teamId,
-        costMicros: usdToMicros(upscaleResult.cost),
+        costMicros: upscaleResult.cost,
         usedOwnKey: upscaleResult.usedOwnKey,
         userId: input.userId,
         description: 'Variant upscale (nano_banana_2)',


### PR DESCRIPTION
## Summary

- **Fix 1,000,000x cost overcharge**: Generation result types (`ImageGenerationResult`, `MotionResult`, `MusicResult`) stored `cost` as plain `number`, stripping the `Microdollars` brand. Workflows then called `usdToMicros()` on already-Microdollar values, multiplying costs by 1,000,000x.
- **Propagate `Microdollars` branded type** through all result types so the type system prevents double-conversion at compile time.
- **Fix Langfuse reporting**: Was receiving Microdollars where it expects USD — now uses `microsToUsd()`.
- **Fix `extractImageCost`**: Changed from `{ cost?: unknown }` to `{ cost?: Microdollars }`, removing the `unknown` type and redundant `usdToMicros()` call.

## Test plan

- [x] `bun typecheck` passes — type changes compile correctly
- [x] `bun test` — all 236 tests pass (0 failures)
- [x] `bun run build` — production build succeeds
- [ ] Verify billing deductions in staging are correct (no longer 1M× inflated)

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)