### PR TITLE
Compress Kling start frame images exceeding 10MB

### DIFF
--- a/src/lib/image/image-compress.ts
+++ b/src/lib/image/image-compress.ts
@@ -1,0 +1,78 @@
+/**
+ * Image Compression Utility
+ * Uses @cf-wasm/photon (WASM-based) to compress images under a size limit.
+ * Compatible with Cloudflare Workers (Sharp's native binaries don't work in workerd).
+ */
+
+import { PhotonImage } from '@cf-wasm/photon';
+
+type CompressionResult = {
+  buffer: Buffer;
+  contentType: string;
+  originalSizeBytes: number;
+  compressedSizeBytes: number;
+};
+
+const JPEG_QUALITY = 85;
+
+/**
+ * Ensure an image is under the given byte limit by converting to JPEG.
+ * Returns null if the image is already under the limit.
+ */
+export async function ensureImageUnderLimit(
+  imageUrl: string,
+  maxBytes: number
+): Promise<CompressionResult | null> {
+  // Try HEAD first to check Content-Length without downloading
+  const headResponse = await fetch(imageUrl, { method: 'HEAD' });
+  const contentLength = headResponse.headers.get('content-length');
+
+  if (contentLength && Number(contentLength) <= maxBytes) {
+    return null;
+  }
+
+  // Download the image
+  const response = await fetch(imageUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch image for compression: ${response.status}`
+    );
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  const originalSizeBytes = arrayBuffer.byteLength;
+
+  if (originalSizeBytes <= maxBytes) {
+    return null;
+  }
+
+  console.log(
+    `[ImageCompress] Image is ${(originalSizeBytes / 1024 / 1024).toFixed(1)}MB, compressing under ${(maxBytes / 1024 / 1024).toFixed(1)}MB limit`
+  );
+
+  const inputBytes = new Uint8Array(arrayBuffer);
+  const inputImage = PhotonImage.new_from_byteslice(inputBytes);
+
+  try {
+    const outputBytes = inputImage.get_bytes_jpeg(JPEG_QUALITY);
+
+    if (outputBytes.byteLength > maxBytes) {
+      throw new Error(
+        `JPEG compression insufficient: ${(outputBytes.byteLength / 1024 / 1024).toFixed(1)}MB still exceeds ${(maxBytes / 1024 / 1024).toFixed(1)}MB limit (original: ${(originalSizeBytes / 1024 / 1024).toFixed(1)}MB)`
+      );
+    }
+
+    console.log(
+      `[ImageCompress] Compressed to ${(outputBytes.byteLength / 1024 / 1024).toFixed(1)}MB (JPEG quality=${JPEG_QUALITY})`
+    );
+
+    return {
+      buffer: Buffer.from(outputBytes),
+      contentType: 'image/jpeg',
+      originalSizeBytes,
+      compressedSizeBytes: outputBytes.byteLength,
+    };
+  } finally {
+    inputImage.free();
+  }
+}

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -7,7 +7,7 @@
  * This reduces QStash steps by ~10x vs one-step-per-poll.
  */
 
-import { DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
+import { DEFAULT_VIDEO_MODEL, IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
 import { deductCredits, hasEnoughCredits } from '@/lib/billing/credit-service';
 import { micros, microsToUsd } from '@/lib/billing/money';
 import {
@@ -15,6 +15,8 @@ import {
   getSequenceFrames,
   updateFrame,
 } from '@/lib/db/helpers/frames';
+import { ensureImageUnderLimit } from '@/lib/image/image-compress';
+import { uploadImageBufferToStorage } from '@/lib/image/image-storage';
 import {
   calculateMotionMetadata,
   pollMotionJob,
@@ -37,6 +39,8 @@ const POLL_BATCH_DURATION_MS = 30_000;
 const POLL_INTERVAL_MS = 3_000;
 /** 30 batches × 30s = 15 minutes total timeout */
 const MAX_BATCHES = 30;
+/** Kling rejects start frame images over 10MB — use 9.5MB safety margin */
+const KLING_MAX_IMAGE_BYTES = 9.5 * 1024 * 1024;
 
 export const generateMotionWorkflow = createWorkflow(
   async (context: WorkflowContext<MotionWorkflowInput>) => {
@@ -85,10 +89,47 @@ export const generateMotionWorkflow = createWorkflow(
       return { videoUrl: '', duration: 0 };
     }
 
-    // Step 2a: Submit the motion generation job
+    // Step 2: Prepare start image — compress if Kling model and image exceeds 10MB
+    const startImageUrl = await context.run('prepare-start-image', async () => {
+      const modelConfig = IMAGE_TO_VIDEO_MODELS[model];
+      if (modelConfig.provider !== 'kling') {
+        return input.imageUrl;
+      }
+
+      const compressed = await ensureImageUnderLimit(
+        input.imageUrl,
+        KLING_MAX_IMAGE_BYTES
+      );
+      if (!compressed) {
+        return input.imageUrl;
+      }
+
+      if (!input.teamId || !input.sequenceId || !input.frameId) {
+        console.warn(
+          '[MotionWorkflow] Missing storage context, using original image URL'
+        );
+        return input.imageUrl;
+      }
+
+      const result = await uploadImageBufferToStorage({
+        imageBuffer: compressed.buffer,
+        teamId: input.teamId,
+        sequenceId: input.sequenceId,
+        frameId: input.frameId,
+        contentType: compressed.contentType,
+      });
+
+      console.log(
+        `[MotionWorkflow] Compressed start image: ${(compressed.originalSizeBytes / 1024 / 1024).toFixed(1)}MB → ${(compressed.compressedSizeBytes / 1024 / 1024).toFixed(1)}MB`
+      );
+
+      return result.url;
+    });
+
+    // Step 3a: Submit the motion generation job
     const job = await context.run('submit-motion', async () => {
       return submitMotionJob({
-        imageUrl: input.imageUrl,
+        imageUrl: startImageUrl,
         prompt: input.prompt,
         model,
         duration: input.duration,
@@ -99,7 +140,7 @@ export const generateMotionWorkflow = createWorkflow(
       });
     });
 
-    // Step 2b: Batched polling — tight loop inside each context.run, checkpoint between batches
+    // Step 3b: Batched polling — tight loop inside each context.run, checkpoint between batches
     let videoUrl = '';
 
     for (let batch = 0; batch < MAX_BATCHES; batch++) {


### PR DESCRIPTION
## Summary
- Kling image-to-video models reject start frame images over 10MB. Large PNGs from text-to-image models can exceed this limit.
- Adds `ensureImageUnderLimit()` in `src/lib/image/image-compress.ts` — converts oversized images to JPEG (quality 85) using `@cf-wasm/photon` with proper WASM memory management.
- Inserts a `prepare-start-image` workflow step in the motion workflow that only activates for Kling models when the image exceeds 9.5MB (safety margin). Compressed images are uploaded to R2 with a ULID filename. Non-Kling models are completely unaffected.
- Original full-quality thumbnails are preserved — only the start frame sent to Kling is compressed.

Closes #412

## Test plan
- [x] `bun typecheck` — no type errors
- [x] `bun test` — all 260 tests pass
- [ ] Manual: trigger motion generation for a frame with a large PNG thumbnail using a Kling model, verify workflow log shows compression and video generates successfully
- [ ] Manual: trigger motion generation with a non-Kling model, verify no compression step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)