### PR TITLE
Fix talent matching silently dropping matches without imageUrl

### DIFF
--- a/src/lib/workflows/talent-matching-workflow.ts
+++ b/src/lib/workflows/talent-matching-workflow.ts
@@ -94,7 +94,7 @@ export const talentMatchingWorkflow = createScopedWorkflow<
           if (usedCharacterIds.has(match.characterId)) continue;
 
           const talent = talentList.find((t) => t.id === match.talentId);
-          if (!talent?.imageUrl) continue;
+          if (!talent) continue;
 
           const character = characterBible.find(
             (c) => c.characterId === match.characterId


### PR DESCRIPTION
## Summary

- Remove unnecessary `imageUrl` guard in `build-matches` workflow step that silently dropped valid LLM matches when talent headshot hadn't been generated yet
- Only talent existence is needed — downstream code uses `talentName` and `sheetImageUrl` (which already defaults to `''`)

Closes #442

## Test plan

- [x] `bun typecheck` passes
- [x] `bun test` — all 286 tests pass
- [x] Verified no downstream workflow code depends on `talent.imageUrl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)