### PR TITLE
Make updated balance more obvious

### DIFF
--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -1,31 +1,50 @@
 /**
  * Credit Balance Pill
- * Shows as an amber warning when balance is low and user has no safety net
- * (no auto top-up and no BYOK API keys configured)
+ * Shows the credit balance badge in the header. Visible when:
+ * 1. Low balance with no safety net (amber warning)
+ * 2. Balance topped up — stays until credits are drawn down (green)
+ * 3. User toggled "always show" in credits page (neutral)
  */
 
+import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
+import { useBalanceFlash } from '@/hooks/use-balance-flash';
 import { useBillingBalance } from '@/hooks/use-billing-balance';
 import { useBillingGateQuery } from '@/hooks/use-billing-gate';
+import { useShowBalance } from '@/hooks/use-show-balance';
 import { Link } from '@tanstack/react-router';
 
 export const CreditBalancePill: React.FC = () => {
   const { balance, isLowBalance } = useBillingBalance();
   const { data: gateStatus } = useBillingGateQuery();
+  const { showBalance } = useShowBalance();
+  const { isFlashing } = useBalanceFlash();
 
-  // Only show when low balance AND no safety net configured
   const hasSafetyNet =
     gateStatus?.hasAutoTopUp ||
     gateStatus?.hasFalKey ||
     gateStatus?.hasOpenRouterKey;
 
-  if (!isLowBalance || hasSafetyNet) return null;
+  const isLowBalanceVisible = isLowBalance && !hasSafetyNet;
+  const isVisible = isLowBalanceVisible || showBalance || isFlashing;
+
+  if (!isVisible) return null;
+
+  // Flash (green) takes priority, then low-balance (amber), then neutral
+  const colorClass = isFlashing
+    ? 'border-emerald-500 text-emerald-600 dark:text-emerald-400'
+    : isLowBalanceVisible
+      ? 'border-amber-500 text-amber-600 dark:text-amber-400'
+      : '';
 
   return (
     <Link to="/credits">
       <Badge
         variant="outline"
-        className="tabular-nums cursor-pointer border-amber-500 text-amber-600 dark:text-amber-400"
+        className={cn(
+          'tabular-nums cursor-pointer animate-[balance-flash-in_300ms_ease-out_both]',
+          colorClass
+        )}
       >
         ${balance?.toFixed(2) ?? '0.00'}
       </Badge>

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -24,7 +24,7 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
 import { Skeleton } from '@/components/ui/skeleton';
 import {
   PRESET_TOPUP_AMOUNTS_USD,
@@ -39,6 +39,11 @@ import {
   useBillingBalance,
   BILLING_BALANCE_KEY,
 } from '@/hooks/use-billing-balance';
+import {
+  clearBalanceFlash,
+  prepareBalanceFlash,
+} from '@/hooks/use-balance-flash';
+import { useShowBalance } from '@/hooks/use-show-balance';
 import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { LucideIcon } from 'lucide-react';
@@ -64,16 +69,22 @@ type SectionHeaderProps = {
   description: string;
 };
 
-function SectionHeader({ icon: Icon, title, description }: SectionHeaderProps) {
+function SectionHeader({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: SectionHeaderProps & { action?: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10">
         <Icon className="h-5 w-5 text-primary" />
       </div>
-      <div>
+      <div className="flex-1">
         <CardTitle>{title}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </div>
+      {action}
     </div>
   );
 }
@@ -96,6 +107,11 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
   const [selectedAmount, setSelectedAmount] = useState<number | null>(100);
   const [autoTopUpPrompt, setAutoTopUpPrompt] = useState<number | null>(null);
   const navigate = useNavigate();
+
+  // Clear pending flash marker if checkout was canceled
+  useEffect(() => {
+    if (canceled) clearBalanceFlash();
+  }, [canceled]);
 
   // Clear success/canceled from URL after showing
   useEffect(() => {
@@ -215,6 +231,8 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
       'openstory:last-topup-amount',
       String(effectiveAmount)
     );
+    // Set pending marker before Stripe redirect so the flash shows on return
+    prepareBalanceFlash();
     checkoutMutation.mutate(effectiveAmount);
   };
 
@@ -283,7 +301,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
             description="Credits are used for image and video generation"
           />
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
           {balanceLoading ? (
             <Skeleton className="h-12 w-32" />
           ) : (
@@ -291,6 +309,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
               ${balanceData?.balance.toFixed(2) ?? '0.00'}
             </p>
           )}
+          <ShowBalanceToggle />
         </CardContent>
       </Card>
 
@@ -343,8 +362,6 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
                 ))}
               </div>
 
-              <Separator />
-
               <div className="relative">
                 <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
                   $
@@ -389,37 +406,12 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
           </Card>
 
           {/* Auto Top-Up Card */}
-          <Card>
-            <CardHeader>
-              <SectionHeader
-                icon={RefreshCw}
-                title="Auto Top-Up"
-                description="Automatically add credits when your balance is low"
-              />
-            </CardHeader>
-            <CardContent>
-              {balanceLoading ? (
-                <div className="space-y-3">
-                  <Skeleton className="h-10 w-full" />
-                  <Skeleton className="h-10 w-full" />
-                </div>
-              ) : !balanceData?.hasPaymentMethod ? (
-                <p className="text-sm text-muted-foreground">
-                  Make your first top-up to save a payment method and enable
-                  auto top-up.
-                </p>
-              ) : (
-                <AutoTopUpForm
-                  key={`${balanceData.autoTopUp.enabled}-${balanceData.autoTopUp.amountUsd}`}
-                  enabled={balanceData.autoTopUp.enabled}
-                  thresholdUsd={balanceData.autoTopUp.thresholdUsd ?? 5}
-                  amountUsd={balanceData.autoTopUp.amountUsd ?? 100}
-                  isPending={autoTopUpMutation.isPending}
-                  onSave={(settings) => autoTopUpMutation.mutate(settings)}
-                />
-              )}
-            </CardContent>
-          </Card>
+          <AutoTopUpCard
+            balanceLoading={balanceLoading}
+            balanceData={balanceData}
+            isPending={autoTopUpMutation.isPending}
+            onSave={(settings) => autoTopUpMutation.mutate(settings)}
+          />
 
           {/* Invoices */}
           <Card>
@@ -494,10 +486,25 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
   );
 }
 
-type AutoTopUpFormProps = {
-  enabled: boolean;
-  thresholdUsd: number;
-  amountUsd: number;
+function ShowBalanceToggle() {
+  const { showBalance, setShowBalance } = useShowBalance();
+
+  return (
+    <div className="flex items-center justify-between border-t pt-4">
+      <div>
+        <p className="text-sm font-medium">Show balance in header</p>
+        <p className="text-xs text-muted-foreground">
+          Always display your credit balance
+        </p>
+      </div>
+      <Switch checked={showBalance} onCheckedChange={setShowBalance} />
+    </div>
+  );
+}
+
+type AutoTopUpCardProps = {
+  balanceLoading: boolean;
+  balanceData: ReturnType<typeof useBillingBalance>['data'];
   isPending: boolean;
   onSave: (settings: {
     enabled: boolean;
@@ -506,16 +513,20 @@ type AutoTopUpFormProps = {
   }) => void;
 };
 
-function AutoTopUpForm({
-  enabled: initialEnabled,
-  thresholdUsd: initialThreshold,
-  amountUsd: initialAmount,
+function AutoTopUpCard({
+  balanceLoading,
+  balanceData,
   isPending,
   onSave,
-}: AutoTopUpFormProps) {
+}: AutoTopUpCardProps) {
+  const initialEnabled = balanceData?.autoTopUp.enabled ?? false;
   const [enabled, setEnabled] = useState(initialEnabled);
-  const [threshold, setThreshold] = useState(String(initialThreshold));
-  const [amount, setAmount] = useState(String(initialAmount));
+  const [threshold, setThreshold] = useState(
+    String(balanceData?.autoTopUp.thresholdUsd ?? 5)
+  );
+  const [amount, setAmount] = useState(
+    String(balanceData?.autoTopUp.amountUsd ?? 100)
+  );
 
   const save = (overrides?: { enabled?: boolean }) => {
     onSave({
@@ -530,74 +541,86 @@ function AutoTopUpForm({
     save({ enabled: value });
   };
 
-  return (
-    <div className="space-y-4">
-      <div className="flex items-center gap-3">
-        <Button
-          variant={enabled ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => handleToggle(true)}
-          disabled={isPending}
-        >
-          On
-        </Button>
-        <Button
-          variant={!enabled ? 'default' : 'outline'}
-          size="sm"
-          onClick={() => handleToggle(false)}
-          disabled={isPending}
-        >
-          Off
-        </Button>
-        {isPending && (
-          <span className="text-xs text-muted-foreground">Saving…</span>
-        )}
-      </div>
+  const hasPaymentMethod = balanceData?.hasPaymentMethod ?? false;
 
-      {enabled && (
-        <div className="grid grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="threshold">When balance drops below</Label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
-                $
-              </span>
-              <Input
-                id="threshold"
-                type="text"
-                inputMode="decimal"
-                value={threshold}
-                onChange={(e) =>
-                  setThreshold(e.target.value.replace(/[^0-9.]/g, ''))
-                }
-                onBlur={() => save()}
-                className="pl-7 tabular-nums"
-                autoComplete="off"
+  return (
+    <Card>
+      <CardHeader>
+        <SectionHeader
+          icon={RefreshCw}
+          title="Auto Top-Up"
+          description="Automatically add credits when your balance is low"
+          action={
+            hasPaymentMethod && !balanceLoading ? (
+              <Switch
+                checked={enabled}
+                onCheckedChange={handleToggle}
+                disabled={isPending}
               />
+            ) : undefined
+          }
+        />
+      </CardHeader>
+      {balanceLoading ? (
+        <CardContent>
+          <div className="space-y-3">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        </CardContent>
+      ) : !hasPaymentMethod ? (
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Make your first top-up to save a payment method and enable auto
+            top-up.
+          </p>
+        </CardContent>
+      ) : enabled ? (
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="threshold">When balance drops below</Label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                  $
+                </span>
+                <Input
+                  id="threshold"
+                  type="text"
+                  inputMode="decimal"
+                  value={threshold}
+                  onChange={(e) =>
+                    setThreshold(e.target.value.replace(/[^0-9.]/g, ''))
+                  }
+                  onBlur={() => save()}
+                  className="pl-7 tabular-nums"
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="recharge">Top up with</Label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                  $
+                </span>
+                <Input
+                  id="recharge"
+                  type="text"
+                  inputMode="decimal"
+                  value={amount}
+                  onChange={(e) =>
+                    setAmount(e.target.value.replace(/[^0-9.]/g, ''))
+                  }
+                  onBlur={() => save()}
+                  className="pl-7 tabular-nums"
+                  autoComplete="off"
+                />
+              </div>
             </div>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="recharge">Top up with</Label>
-            <div className="relative">
-              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
-                $
-              </span>
-              <Input
-                id="recharge"
-                type="text"
-                inputMode="decimal"
-                value={amount}
-                onChange={(e) =>
-                  setAmount(e.target.value.replace(/[^0-9.]/g, ''))
-                }
-                onBlur={() => save()}
-                className="pl-7 tabular-nums"
-                autoComplete="off"
-              />
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+        </CardContent>
+      ) : null}
+    </Card>
   );
 }

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -11,6 +11,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
+import { triggerBalanceFlash } from '@/hooks/use-balance-flash';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
 import {
@@ -57,6 +58,7 @@ function RedeemSection() {
     mutationFn: (input: { code: string }) => redeemGiftTokenFn({ data: input }),
     onSuccess: (result) => {
       setCode('');
+      triggerBalanceFlash();
       void queryClient.invalidateQueries({
         queryKey: [...BILLING_BALANCE_KEY],
       });

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Switch as SwitchPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Switch({
+  className,
+  size = 'default',
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        'peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80',
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground'
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/hooks/use-balance-flash.ts
+++ b/src/hooks/use-balance-flash.ts
@@ -1,0 +1,84 @@
+/**
+ * Balance Flash Hook
+ * Shows the balance badge for 5 seconds after credits are added.
+ *
+ * Two trigger mechanisms:
+ * - prepareBalanceFlash(): call before Stripe redirect. Sets a 'pending' marker
+ *   that converts to a live timer when the page loads back with ?success=true.
+ * - triggerBalanceFlash(): call for same-page events (gift code redemption).
+ *   Sets timestamp + dispatches event so the hook reacts immediately.
+ * - clearBalanceFlash(): call on canceled checkout to remove the pending marker.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const FLASH_KEY = 'openstory:balance-flash';
+const FLASH_EVENT = 'openstory:balance-flash';
+const FLASH_DURATION = 5000;
+
+/** Call before Stripe redirect — marker survives the round-trip. */
+export function prepareBalanceFlash() {
+  sessionStorage.setItem(FLASH_KEY, 'pending');
+}
+
+/** Call for same-page credit additions (gift codes). */
+export function triggerBalanceFlash() {
+  sessionStorage.setItem(FLASH_KEY, String(Date.now()));
+  window.dispatchEvent(new Event(FLASH_EVENT));
+}
+
+/** Call when checkout is canceled to clear the pending marker. */
+export function clearBalanceFlash() {
+  sessionStorage.removeItem(FLASH_KEY);
+}
+
+export function useBalanceFlash() {
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const startFlash = useCallback((durationMs: number) => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    setVisible(true);
+    timerRef.current = setTimeout(() => {
+      sessionStorage.removeItem(FLASH_KEY);
+      setVisible(false);
+    }, durationMs);
+  }, []);
+
+  // On mount: check sessionStorage for pending or active flash
+  useEffect(() => {
+    const stored = sessionStorage.getItem(FLASH_KEY);
+    if (stored === null) return;
+
+    if (stored === 'pending') {
+      // Returned from Stripe — start the 5s timer now
+      sessionStorage.setItem(FLASH_KEY, String(Date.now()));
+      startFlash(FLASH_DURATION);
+      return;
+    }
+
+    // Active timestamp — show for remaining time
+    const remaining = FLASH_DURATION - (Date.now() - parseInt(stored, 10));
+    if (remaining > 0) {
+      startFlash(remaining);
+    } else {
+      sessionStorage.removeItem(FLASH_KEY);
+    }
+  }, [startFlash]);
+
+  // Listen for same-page triggers (gift codes)
+  useEffect(() => {
+    const handler = () => startFlash(FLASH_DURATION);
+    window.addEventListener(FLASH_EVENT, handler);
+    return () => window.removeEventListener(FLASH_EVENT, handler);
+  }, [startFlash]);
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return { isFlashing: visible };
+}

--- a/src/hooks/use-show-balance.ts
+++ b/src/hooks/use-show-balance.ts
@@ -1,0 +1,24 @@
+/**
+ * Show Balance Preference Hook
+ * localStorage-backed toggle for always showing credit balance in the header
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+const STORAGE_KEY = 'openstory:show-balance';
+
+export function useShowBalance() {
+  const [show, setShow] = useState(false);
+
+  // Hydration-safe: load real value in useEffect
+  useEffect(() => {
+    setShow(localStorage.getItem(STORAGE_KEY) === 'true');
+  }, []);
+
+  const setShowBalance = useCallback((value: boolean) => {
+    setShow(value);
+    localStorage.setItem(STORAGE_KEY, String(value));
+  }, []);
+
+  return { showBalance: show, setShowBalance };
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -350,8 +350,28 @@ body {
   letter-spacing: 0.15em;
 }
 
+/* Balance flash: entrance for the credit badge after top-up */
+@keyframes balance-flash-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 /* Reduced motion: simple fade pulse */
 @media (prefers-reduced-motion: reduce) {
+  @keyframes balance-flash-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
   @keyframes blob-morph {
     0%,
     100% {


### PR DESCRIPTION
## Summary
- Show a green balance badge in the header for 5 seconds after credits are added (Stripe top-up or gift code redemption)
- Add "Show balance in header" toggle on the credits page (localStorage-backed) so users can always see their balance
- Replace On/Off button pairs with shadcn Switch for auto-topup and show-balance toggles
- Move auto-topup switch into card header row and remove unnecessary separator for cleaner layout

## Test plan
- [ ] Top up credits via Stripe → verify green badge flashes in header for ~5 seconds
- [ ] Redeem a gift code → verify green badge flashes in header for ~5 seconds
- [ ] Cancel Stripe checkout → verify no badge flash on return
- [ ] Toggle "Show balance in header" On in credits page → verify neutral badge appears in header
- [ ] Toggle Off → verify badge disappears (unless low balance)
- [ ] Verify low balance amber badge still works when no safety net configured
- [ ] Check `prefers-reduced-motion` → animation simplifies to opacity-only
- [ ] Verify mobile viewport → badge fits in header

Closes #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)