### PR TITLE
Add auto-scroll during script enhancement

### DIFF
--- a/src/components/script/script-editor.tsx
+++ b/src/components/script/script-editor.tsx
@@ -3,9 +3,10 @@ import { cn } from '@/lib/utils';
 import type * as React from 'react';
 import { useCallback } from 'react';
 
-interface ScriptEditorProps {
+type ScriptEditorProps = {
   value: string;
   onValueChange: (value: string) => void;
+  ref?: React.Ref<HTMLTextAreaElement>;
   error?: string;
   maxLength?: number;
   placeholder?: string;
@@ -13,11 +14,12 @@ interface ScriptEditorProps {
   showCharacterCount?: boolean;
   loading?: boolean;
   autoFocus?: boolean;
-}
+};
 
 export const ScriptEditor: React.FC<ScriptEditorProps> = ({
   value,
   onValueChange,
+  ref,
   error,
   maxLength = 5000,
   placeholder = 'Enter your script here...',
@@ -58,6 +60,7 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({
     <>
       <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
         <Textarea
+          ref={ref}
           name="script"
           id="script"
           value={loading ? 'Loading...' : value}

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/card';
 import { Kbd, KbdGroup } from '@/components/ui/kbd';
 import { enhanceScriptStreamFn } from '@/functions/ai';
+import { useAutoScroll } from '@/hooks/use-auto-scroll';
 import { useBillingGate } from '@/hooks/use-billing-gate';
 import { useGenerationSettings } from '@/hooks/use-generation-settings';
 import { useSequenceDraft } from '@/hooks/use-sequence-draft';
@@ -395,6 +396,10 @@ export const ScriptView: FC<{
     !isFormValid || isSubmitting || isProcessing || isEnhancing;
 
   const scriptValue = script ?? sequence?.script ?? '';
+  const { ref: textareaRef } = useAutoScroll({
+    enabled: isEnhancing,
+    content: scriptValue,
+  });
 
   return (
     <Card
@@ -441,6 +446,7 @@ export const ScriptView: FC<{
         <CardContent className="min-h-0 @container flex flex-col gap-4 py-6 overflow-hidden">
           <div className="relative min-h-0 flex flex-col">
             <ScriptEditor
+              ref={textareaRef}
               value={scriptValue}
               onValueChange={(val) => {
                 setScript(val);
@@ -592,7 +598,16 @@ export const ScriptView: FC<{
         </AlertDialogContent>
       </AlertDialog>
       <AlertDialog open={showEnhanceNudge} onOpenChange={setShowEnhanceNudge}>
-        <AlertDialogContent>
+        <AlertDialogContent
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              e.stopPropagation();
+              setShowEnhanceNudge(false);
+              void handleEnhance();
+            }
+          }}
+        >
           <AlertDialogHeader>
             <AlertDialogTitle>
               Your script is just a starting point

--- a/src/hooks/use-auto-scroll.ts
+++ b/src/hooks/use-auto-scroll.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+type UseAutoScrollOptions = {
+  enabled: boolean;
+  content: string;
+};
+
+const BOTTOM_THRESHOLD = 20;
+
+export function useAutoScroll({ enabled, content }: UseAutoScrollOptions) {
+  const ref = useRef<HTMLTextAreaElement | null>(null);
+  const shouldAutoScrollRef = useRef(true);
+
+  // Effect 1: Attach scroll listener when enabled, track user scroll position
+  useEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el) return;
+
+    shouldAutoScrollRef.current = true;
+
+    const onScroll = () => {
+      const nearBottom =
+        el.scrollTop + el.clientHeight >= el.scrollHeight - BOTTOM_THRESHOLD;
+      shouldAutoScrollRef.current = nearBottom;
+    };
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [enabled]);
+
+  // Effect 2: Scroll to bottom when content changes during streaming
+  useEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el || !shouldAutoScrollRef.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [content, enabled]);
+
+  return { ref };
+}


### PR DESCRIPTION
## Summary
- Adds smart auto-scroll to the script textarea during enhancement streaming — follows new content at the bottom, pauses if the user scrolls up, resumes when they scroll back down
- Adds Enter key support on the enhance nudge dialog to trigger "Enhance Script" as the primary action
- New `useAutoScroll` hook encapsulates all scroll-tracking logic with a passive scroll listener and bottom-proximity threshold

Closes #449

## Test plan
- [ ] Navigate to a sequence's script page, enter a script, and click "Enhance Script" — verify textarea scrolls to bottom as streamed text arrives
- [ ] During streaming, scroll up — verify auto-scroll pauses and user can read earlier content
- [ ] Scroll back to bottom — verify auto-scroll resumes
- [ ] Click Stop or press Escape — verify scroll behavior stops cleanly
- [ ] Open the enhance nudge dialog and press Enter — verify it triggers "Enhance Script"
- [ ] Verify `bun typecheck` and `bun test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)