### PR TITLE
Fix newline in script editor prompt placeholder

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -453,7 +453,7 @@ export const ScriptView: FC<{
                 if (canUndoEnhance) setCanUndoEnhance(false);
               }}
               maxLength={50000}
-              placeholder="A one-liner or website URL is all you need — click Enhance Script to do the rest.\nOr paste a full screenplay and generate directly."
+              placeholder="A one-liner or website URL is all you need — click Enhance Script to do the rest. Or paste a full screenplay and generate directly."
               disabled={loading}
               autoFocus={autoFocus}
               showCharacterCount={false}


### PR DESCRIPTION
## Summary
- Removes `\n` from the script editor placeholder text so it displays as a single continuous line instead of breaking across two lines

Closes #469

## Test plan
- [ ] Verify the placeholder text in the script editor textarea renders as one line

🤖 Generated with [Claude Code](https://claude.com/claude-code)