### PR TITLE
Simplify GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,61 +1,13 @@
 name: Bug Report
 description: Report a bug or unexpected behavior with OpenStory
-title: '[Bug] '
-labels: ['bug', 'triage']
+type: Bug
 
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to report a bug! Please fill out the information below to help us understand and reproduce the issue.
-
   - type: textarea
     id: description
     attributes:
-      label: Bug Description
-      description: A clear and concise description of what the bug is
-      placeholder: Describe what happened...
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected Behavior
-      description: What you expected to happen
-      placeholder: Describe the expected behavior...
-    validations:
-      required: true
-
-  - type: textarea
-    id: reproduction
-    attributes:
-      label: Steps to Reproduce
-      description: Step-by-step instructions to reproduce the bug
-      placeholder: |
-        1. Run `openstory ...`
-        2. Navigate to ...
-        3. Execute ...
-        4. See error
-    validations:
-      required: true
-
-  - type: textarea
-    id: logs
-    attributes:
-      label: Error Logs or Output
-      description: Any relevant error messages, logs, or command output
-      render: shell
-      placeholder: Paste any error messages or relevant output here...
-    validations:
-      required: false
-
-  - type: textarea
-    id: environment
-    attributes:
-      label: Environment Information
-      description: Please provide details about your environment
-      placeholder: |
-        - OS: (e.g., macOS 14.5, Ubuntu 22.04, Windows 11)
+      label: Description
+      description: Describe the bug, what you expected to happen, and how to reproduce it
+      placeholder: Describe what happened…
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,34 +1,13 @@
 name: Feature Request
 description: Suggest a new feature or enhancement for OpenStory
-title: '[Feature] '
-labels: ['enhancement', 'triage']
+type: Feature
 
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting a new feature! Please provide as much detail as possible to help us understand your request.
-
   - type: textarea
-    id: problem
+    id: description
     attributes:
-      label: Problem or Use Case
-      description: What problem does this feature solve? What use case does it address?
-      placeholder: |
-        I'm frustrated when...
-        It would be helpful if...
-        Currently, there's no way to...
-    validations:
-      required: true
-
-  - type: textarea
-    id: solution
-    attributes:
-      label: Proposed Solution
-      description: Describe the solution you'd like to see
-      placeholder: |
-        I would like OpenStory to...
-        This could work by...
-        The interface might look like...
+      label: Description
+      description: Describe the feature you'd like and the problem it solves
+      placeholder: I would like OpenStory to…
     validations:
       required: true


### PR DESCRIPTION
## Summary
- Simplified bug report and feature request templates to a single description field each
- Removed title prefixes (`[Bug]`, `[Feature]`) and auto-labels
- Uses GitHub's built-in issue `type` field (`Bug` / `Feature`) for categorization

Closes #475

## Test plan
- [ ] Verify templates render correctly on the new issue page
- [ ] Confirm issue type is automatically set when filing bugs and features

🤖 Generated with [Claude Code](https://claude.com/claude-code)