### PR TITLE
Persist scene generation progress across navigation

### DIFF
--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -28,7 +28,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 type ScenesViewProps = {
-  sequenceId?: string;
+  sequenceId: string;
 };
 
 // Full class names required for Tailwind JIT to detect at build time
@@ -202,12 +202,10 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   );
 
   const handleFullRetry = useCallback(() => {
-    if (!sequenceId) return;
     void navigate({ to: '/sequences/$id/script', params: { id: sequenceId } });
   }, [sequenceId, navigate]);
 
   const handleSmartRetry = useCallback(async () => {
-    if (!sequenceId) return;
     setIsRetrying(true);
     try {
       const result = await smartRetryFn({ data: { sequenceId } });
@@ -243,8 +241,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   // Handler for batch motion generation (server determines eligible frames)
   const handleBatchMotionGeneration = useCallback(
     async (includeMusic: boolean) => {
-      if (!sequenceId) return;
-
       // Optimistic: compute eligible frames locally (same filter as backend)
       const eligibleFrameIds = (frames ?? [])
         .filter(
@@ -375,7 +371,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
           </div>
           <SceneScriptPrompts
             frame={selectedFrame}
-            sequenceId={sequenceId ?? ''}
+            sequenceId={sequenceId}
             selectedTab={selectedTab}
             onTabChange={setSelectedTab}
             regeneratingImages={regeneratingImages}

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -201,7 +201,11 @@ let realtimeInstance: ReturnType<typeof createRealtime> | null = null;
 
 function createRealtime() {
   const redis = getRedis();
-  return new Realtime({ schema: realtimeSchema, redis });
+  return new Realtime({
+    schema: realtimeSchema,
+    redis,
+    history: { maxLength: 200, expireAfterSecs: 3600 },
+  });
 }
 
 /**

--- a/src/lib/realtime/use-generation-stream.ts
+++ b/src/lib/realtime/use-generation-stream.ts
@@ -217,7 +217,7 @@ function mapEventToAction(
  * ```
  */
 export function useGenerationStream(
-  sequenceId?: string,
+  sequenceId: string,
   phaseConfig?: GenerationPhaseConfig
 ) {
   const queryClient = useQueryClient();
@@ -233,9 +233,7 @@ export function useGenerationStream(
       const { event: eventName, data } = event;
 
       // Update TanStack Query cache for data-related events
-      if (sequenceId) {
-        updateQueryCacheFromEvent(queryClient, sequenceId, eventName, data);
-      }
+      updateQueryCacheFromEvent(queryClient, sequenceId, eventName, data);
 
       // Map event to typed action and dispatch
       const action = mapEventToAction(eventName, data);
@@ -246,10 +244,11 @@ export function useGenerationStream(
     [queryClient, sequenceId]
   );
 
-  // Subscribe to realtime events
-  // Only include the channel if sequenceId is defined to avoid invalid subscriptions
+  // Subscribe to realtime events with history replay.
+  // History replays past events on mount so progress persists across navigation.
+  // https://upstash.com/docs/realtime/features/history#subscribe-with-history
   const { status } = useRealtime({
-    channels: sequenceId ? [sequenceId] : [],
+    channels: [sequenceId],
     events: [
       'generation.phase:start',
       'generation.phase:complete',
@@ -269,8 +268,10 @@ export function useGenerationStream(
       'generation.updated',
       'generation.error',
     ] as const,
+    // @ts-expect-error history supported at runtime, not yet in SDK types
+    history: true,
     onData: handleEvent,
-    enabled: !!sequenceId, // Only subscribe if sequenceId is defined
+    enabled: true,
   });
 
   const reset = useCallback(() => {


### PR DESCRIPTION
## Summary
- Enable Upstash Realtime history on the server (`maxLength: 200`, `expireAfterSecs: 3600`) so generation events are persisted in Redis Streams
- Subscribe with `history: true` in `useGenerationStream` so past events replay through the existing `onData` pipeline on mount, restoring the progress banner to its correct state
- Tighten `ScenesView.sequenceId` from optional to required (TanStack Router always provides it synchronously via `useParams`)

## Test plan
- [ ] Start a sequence generation
- [ ] While generating, navigate away (e.g., sequences list) then navigate back — progress banner should show correct phase
- [ ] Refresh the page during generation — progress banner should restore
- [ ] Verify frame thumbnails already generated display correctly after navigation
- [ ] Verify generation that completes while user is away does not show stale banner

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)