### PR TITLE
Remove forced redirect from /sequences when no sequences exist

### DIFF
--- a/src/routes/_protected/sequences/index.tsx
+++ b/src/routes/_protected/sequences/index.tsx
@@ -12,7 +12,7 @@ import { useBillingGate } from '@/hooks/use-billing-gate';
 import { sequenceKeys, useSequences } from '@/hooks/use-sequences';
 import { getSequencesFn } from '@/functions/sequences';
 import { Route as sequencesNewRoute } from '@/routes/_protected/sequences/new';
-import { createFileRoute, Link, redirect } from '@tanstack/react-router';
+import { createFileRoute, Link } from '@tanstack/react-router';
 
 const BILLING_PROMPT_KEY = 'openstory:billing-prompt-dismissed';
 const BILLING_PROMPT_EXPIRY_DAYS = 1;
@@ -37,15 +37,11 @@ function dismissBillingPrompt() {
 export const Route = createFileRoute('/_protected/sequences/')({
   component: SequencesPage,
   beforeLoad: async ({ context: { queryClient } }) => {
-    const sequences = await queryClient.ensureQueryData({
+    await queryClient.ensureQueryData({
       queryKey: sequenceKeys.list(),
       queryFn: () => getSequencesFn(),
       staleTime: 5 * 60 * 1000,
     });
-
-    if (sequences.length === 0) {
-      throw redirect({ to: '/sequences/new' });
-    }
   },
 });
 


### PR DESCRIPTION
## Summary

- Removed the `beforeLoad` redirect in `/sequences` that forced users with zero sequences to `/sequences/new`
- The page already has a proper `EmptyState` component — it was just never reachable
- Users can now visit `/sequences` and see "No sequences yet" with a "Create Your First Sequence" button

Closes #479

## Test plan

- [ ] Log in as a user with no sequences → visit `/sequences` → see empty state with create button
- [ ] Log in as a user with sequences → visit `/sequences` → see sequences list as before
- [ ] `bun typecheck` passes
- [ ] `bun test` passes (357 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)