### PR TITLE
Increase realtime history maxLength from 200 to 1000

### DIFF
--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -204,7 +204,7 @@ function createRealtime() {
   return new Realtime({
     schema: realtimeSchema,
     redis,
-    history: { maxLength: 200, expireAfterSecs: 3600 },
+    history: { maxLength: 1000, expireAfterSecs: 3600 },
   });
 }
 


### PR DESCRIPTION
## Summary

- Increases Redis realtime stream `maxLength` from 200 to 1000 in `src/lib/realtime/index.ts`
- A typical 25-scene sequence generates 250+ events, exceeding the previous cap and evicting early phase/scene/frame progress events
- Clients replaying history after navigation now see complete generation progress (~1.2MB per stream, supports up to ~100 scenes)

## Test Plan

- [x] `bun typecheck` passes
- [x] `bun run build` passes
- [x] All 357 tests pass
- [ ] Trigger generation for a sequence with 20+ scenes
- [ ] Verify Redis stream length exceeds 200 during generation
- [ ] Navigate away from scenes view and back — confirm progress banner and scene list restore correctly from history replay

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)