### PR TITLE
feat: add admin usage analytics page

### DIFF
--- a/src/components/layout/user-badge.tsx
+++ b/src/components/layout/user-badge.tsx
@@ -3,7 +3,7 @@
  * Displays user authentication state with login/logout actions
  */
 
-import { LogOut, Settings, User, Wallet } from 'lucide-react';
+import { BarChart3, LogOut, Settings, User, Wallet } from 'lucide-react';
 import { Route as sequencesRoute } from '@/routes/_protected/sequences/index';
 import { Link } from '@tanstack/react-router';
 import { useState } from 'react';
@@ -17,9 +17,10 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { isSystemAdminFn } from '@/functions/gift-tokens';
 import { useUser } from '@/hooks/use-user';
 import { authClient } from '@/lib/auth/client';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 
 export function UserBadge() {
@@ -96,6 +97,7 @@ export function UserBadge() {
             Credits
           </Link>
         </DropdownMenuItem>
+        <AdminMenuItem />
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onClick={() => void handleSignOut()}
@@ -106,6 +108,25 @@ export function UserBadge() {
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function AdminMenuItem() {
+  const { data: adminStatus } = useQuery({
+    queryKey: ['system-admin-status'],
+    queryFn: () => isSystemAdminFn(),
+    staleTime: 5 * 60 * 1000,
+  });
+
+  if (!adminStatus?.isAdmin) return null;
+
+  return (
+    <DropdownMenuItem asChild>
+      <Link to="/admin/usage">
+        <BarChart3 className="mr-2 h-4 w-4" />
+        Admin
+      </Link>
+    </DropdownMenuItem>
   );
 }
 

--- a/src/functions/admin.ts
+++ b/src/functions/admin.ts
@@ -1,0 +1,8 @@
+import { createServerFn } from '@tanstack/react-start';
+import { systemAdminMiddleware } from './middleware';
+
+export const listUserActivityFn = createServerFn({ method: 'GET' })
+  .middleware([systemAdminMiddleware])
+  .handler(async ({ context }) => {
+    return context.adminScopedDb.admin.listUserActivity();
+  });

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -51,6 +51,7 @@ import { and, eq, sql } from 'drizzle-orm';
 export type {
   GiftTokenStatus,
   GiftTokenWithStatus,
+  UserActivityRow,
 } from '@/lib/db/scoped/admin';
 
 export type {

--- a/src/lib/db/scoped/admin.ts
+++ b/src/lib/db/scoped/admin.ts
@@ -7,8 +7,12 @@
 import { micros, microsToUsd, usdToMicros } from '@/lib/billing/money';
 import type { Database } from '@/lib/db/client';
 import { generateId } from '@/lib/db/id';
+import { user } from '@/lib/db/schema/auth';
+import { credits, transactions } from '@/lib/db/schema/credits';
 import { giftTokenRedemptions, giftTokens } from '@/lib/db/schema/gift-tokens';
 import type { GiftToken } from '@/lib/db/schema/gift-tokens';
+import { sequences } from '@/lib/db/schema/sequences';
+import { teamMembers, teams } from '@/lib/db/schema/teams';
 import { ValidationError } from '@/lib/errors';
 import { count, desc, eq, sql } from 'drizzle-orm';
 
@@ -38,6 +42,20 @@ export type GiftTokenWithStatus = GiftToken & {
   status: GiftTokenStatus;
   amountUsd: number;
   redemptionCount: number;
+};
+
+export type UserActivityRow = {
+  userId: string;
+  name: string;
+  email: string;
+  createdAt: Date;
+  status: string | null;
+  teamId: string;
+  teamName: string;
+  sequenceCount: number;
+  creditsSpentMicros: number;
+  creditsToppedUpMicros: number;
+  currentBalanceMicros: number;
 };
 
 export function createAdminMethods(db: Database) {
@@ -106,8 +124,62 @@ export function createAdminMethods(db: Database) {
     }));
   }
 
+  async function listUserActivity(): Promise<UserActivityRow[]> {
+    // Subquery: sequence count per team
+    const seqCountSq = db
+      .select({
+        teamId: sequences.teamId,
+        count: count().as('seq_count'),
+      })
+      .from(sequences)
+      .groupBy(sequences.teamId)
+      .as('seq_counts');
+
+    // Subquery: credit spending and top-ups per team
+    const txSumsSq = db
+      .select({
+        teamId: transactions.teamId,
+        spent:
+          sql<number>`coalesce(sum(case when ${transactions.type} = 'credit_usage' then abs(${transactions.amount}) else 0 end), 0)`.as(
+            'spent'
+          ),
+        toppedUp:
+          sql<number>`coalesce(sum(case when ${transactions.type} in ('credit_purchase', 'credit_adjustment') then ${transactions.amount} else 0 end), 0)`.as(
+            'topped_up'
+          ),
+      })
+      .from(transactions)
+      .groupBy(transactions.teamId)
+      .as('tx_sums');
+
+    const rows = await db
+      .select({
+        userId: user.id,
+        name: user.name,
+        email: user.email,
+        createdAt: user.createdAt,
+        status: user.status,
+        teamId: teams.id,
+        teamName: teams.name,
+        sequenceCount: sql<number>`coalesce(${seqCountSq.count}, 0)`,
+        creditsSpentMicros: sql<number>`coalesce(${txSumsSq.spent}, 0)`,
+        creditsToppedUpMicros: sql<number>`coalesce(${txSumsSq.toppedUp}, 0)`,
+        currentBalanceMicros: sql<number>`coalesce(${credits.balance}, 0)`,
+      })
+      .from(user)
+      .innerJoin(teamMembers, eq(user.id, teamMembers.userId))
+      .innerJoin(teams, eq(teamMembers.teamId, teams.id))
+      .leftJoin(seqCountSq, eq(teams.id, seqCountSq.teamId))
+      .leftJoin(txSumsSq, eq(teams.id, txSumsSq.teamId))
+      .leftJoin(credits, eq(teams.id, credits.teamId))
+      .orderBy(desc(user.createdAt));
+
+    return rows;
+  }
+
   return {
     createGiftToken,
     listGiftTokens,
+    listUserActivity,
   };
 }

--- a/src/lib/db/scoped/admin.ts
+++ b/src/lib/db/scoped/admin.ts
@@ -53,8 +53,11 @@ export type UserActivityRow = {
   teamId: string;
   teamName: string;
   sequenceCount: number;
+  failedCount: number;
+  avgAnalysisDurationMs: number | null;
   creditsSpentMicros: number;
-  creditsToppedUpMicros: number;
+  creditsPurchasedMicros: number;
+  creditsGiftedMicros: number;
   currentBalanceMicros: number;
 };
 
@@ -125,17 +128,25 @@ export function createAdminMethods(db: Database) {
   }
 
   async function listUserActivity(): Promise<UserActivityRow[]> {
-    // Subquery: sequence count per team
-    const seqCountSq = db
+    // Subquery: sequence stats per team (count, failures, avg duration)
+    const seqStatsSq = db
       .select({
         teamId: sequences.teamId,
         count: count().as('seq_count'),
+        failedCount:
+          sql<number>`sum(case when ${sequences.status} = 'failed' then 1 else 0 end)`.as(
+            'failed_count'
+          ),
+        avgAnalysisDurationMs:
+          sql<number>`avg(case when ${sequences.analysisDurationMs} > 0 then ${sequences.analysisDurationMs} else null end)`.as(
+            'avg_analysis_duration_ms'
+          ),
       })
       .from(sequences)
       .groupBy(sequences.teamId)
-      .as('seq_counts');
+      .as('seq_stats');
 
-    // Subquery: credit spending and top-ups per team
+    // Subquery: credit spending, purchases, and gifts per team
     const txSumsSq = db
       .select({
         teamId: transactions.teamId,
@@ -143,9 +154,13 @@ export function createAdminMethods(db: Database) {
           sql<number>`coalesce(sum(case when ${transactions.type} = 'credit_usage' then abs(${transactions.amount}) else 0 end), 0)`.as(
             'spent'
           ),
-        toppedUp:
-          sql<number>`coalesce(sum(case when ${transactions.type} in ('credit_purchase', 'credit_adjustment') then ${transactions.amount} else 0 end), 0)`.as(
-            'topped_up'
+        purchased:
+          sql<number>`coalesce(sum(case when ${transactions.type} = 'credit_purchase' then ${transactions.amount} else 0 end), 0)`.as(
+            'purchased'
+          ),
+        gifted:
+          sql<number>`coalesce(sum(case when ${transactions.type} = 'credit_adjustment' then ${transactions.amount} else 0 end), 0)`.as(
+            'gifted'
           ),
       })
       .from(transactions)
@@ -161,15 +176,20 @@ export function createAdminMethods(db: Database) {
         status: user.status,
         teamId: teams.id,
         teamName: teams.name,
-        sequenceCount: sql<number>`coalesce(${seqCountSq.count}, 0)`,
+        sequenceCount: sql<number>`coalesce(${seqStatsSq.count}, 0)`,
+        failedCount: sql<number>`coalesce(${seqStatsSq.failedCount}, 0)`,
+        avgAnalysisDurationMs: sql<
+          number | null
+        >`${seqStatsSq.avgAnalysisDurationMs}`,
         creditsSpentMicros: sql<number>`coalesce(${txSumsSq.spent}, 0)`,
-        creditsToppedUpMicros: sql<number>`coalesce(${txSumsSq.toppedUp}, 0)`,
+        creditsPurchasedMicros: sql<number>`coalesce(${txSumsSq.purchased}, 0)`,
+        creditsGiftedMicros: sql<number>`coalesce(${txSumsSq.gifted}, 0)`,
         currentBalanceMicros: sql<number>`coalesce(${credits.balance}, 0)`,
       })
       .from(user)
       .innerJoin(teamMembers, eq(user.id, teamMembers.userId))
       .innerJoin(teams, eq(teamMembers.teamId, teams.id))
-      .leftJoin(seqCountSq, eq(teams.id, seqCountSq.teamId))
+      .leftJoin(seqStatsSq, eq(teams.id, seqStatsSq.teamId))
       .leftJoin(txSumsSq, eq(teams.id, txSumsSq.teamId))
       .leftJoin(credits, eq(teams.id, credits.teamId))
       .orderBy(desc(user.createdAt));

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as MarketingPrivacyRouteImport } from './routes/_marketing/privac
 import { Route as AuthVerifyRouteImport } from './routes/_auth/verify'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as ProtectedSettingsRouteRouteImport } from './routes/_protected/settings/route'
+import { Route as ProtectedAdminRouteRouteImport } from './routes/_protected/admin/route'
 import { Route as ProtectedTalentIndexRouteImport } from './routes/_protected/talent/index'
 import { Route as ProtectedSettingsIndexRouteImport } from './routes/_protected/settings/index'
 import { Route as ProtectedSequencesIndexRouteImport } from './routes/_protected/sequences/index'
@@ -43,6 +44,7 @@ import { Route as ProtectedSettingsPasskeysRouteImport } from './routes/_protect
 import { Route as ProtectedSettingsApiKeysRouteImport } from './routes/_protected/settings/api-keys'
 import { Route as ProtectedSequencesNewRouteImport } from './routes/_protected/sequences/new'
 import { Route as ProtectedLocationsLocationIdRouteImport } from './routes/_protected/locations/$locationId'
+import { Route as ProtectedAdminUsageRouteImport } from './routes/_protected/admin/usage'
 import { Route as ProtectedSequencesIdRouteRouteImport } from './routes/_protected/sequences/$id/route'
 import { Route as ProtectedSequencesIdTheatreRouteImport } from './routes/_protected/sequences/$id/theatre'
 import { Route as ProtectedSequencesIdScriptRouteImport } from './routes/_protected/sequences/$id/script'
@@ -140,6 +142,11 @@ const ProtectedSettingsRouteRoute = ProtectedSettingsRouteRouteImport.update({
   path: '/settings',
   getParentRoute: () => ProtectedRouteRoute,
 } as any)
+const ProtectedAdminRouteRoute = ProtectedAdminRouteRouteImport.update({
+  id: '/admin',
+  path: '/admin',
+  getParentRoute: () => ProtectedRouteRoute,
+} as any)
 const ProtectedTalentIndexRoute = ProtectedTalentIndexRouteImport.update({
   id: '/talent/',
   path: '/talent/',
@@ -223,6 +230,11 @@ const ProtectedLocationsLocationIdRoute =
     path: '/locations/$locationId',
     getParentRoute: () => ProtectedRouteRoute,
   } as any)
+const ProtectedAdminUsageRoute = ProtectedAdminUsageRouteImport.update({
+  id: '/usage',
+  path: '/usage',
+  getParentRoute: () => ProtectedAdminRouteRoute,
+} as any)
 const ProtectedSequencesIdRouteRoute =
   ProtectedSequencesIdRouteRouteImport.update({
     id: '/sequences/$id',
@@ -283,6 +295,7 @@ export interface FileRoutesByFullPath {
   '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/admin': typeof ProtectedAdminRouteRouteWithChildren
   '/settings': typeof ProtectedSettingsRouteRouteWithChildren
   '/login': typeof AuthLoginRoute
   '/verify': typeof AuthVerifyRoute
@@ -295,6 +308,7 @@ export interface FileRoutesByFullPath {
   '/meta/og': typeof MetaOgRoute
   '/meta/og-linkedin': typeof MetaOgLinkedinRoute
   '/sequences/$id': typeof ProtectedSequencesIdRouteRouteWithChildren
+  '/admin/usage': typeof ProtectedAdminUsageRoute
   '/locations/$locationId': typeof ProtectedLocationsLocationIdRoute
   '/sequences/new': typeof ProtectedSequencesNewRoute
   '/settings/api-keys': typeof ProtectedSettingsApiKeysRoute
@@ -325,6 +339,7 @@ export interface FileRoutesByTo {
   '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/admin': typeof ProtectedAdminRouteRouteWithChildren
   '/login': typeof AuthLoginRoute
   '/verify': typeof AuthVerifyRoute
   '/privacy': typeof MarketingPrivacyRoute
@@ -336,6 +351,7 @@ export interface FileRoutesByTo {
   '/meta/og': typeof MetaOgRoute
   '/meta/og-linkedin': typeof MetaOgLinkedinRoute
   '/sequences/$id': typeof ProtectedSequencesIdRouteRouteWithChildren
+  '/admin/usage': typeof ProtectedAdminUsageRoute
   '/locations/$locationId': typeof ProtectedLocationsLocationIdRoute
   '/sequences/new': typeof ProtectedSequencesNewRoute
   '/settings/api-keys': typeof ProtectedSettingsApiKeysRoute
@@ -369,6 +385,7 @@ export interface FileRoutesById {
   '/llms.txt': typeof LlmsDottxtRoute
   '/robots.txt': typeof RobotsDottxtRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/_protected/admin': typeof ProtectedAdminRouteRouteWithChildren
   '/_protected/settings': typeof ProtectedSettingsRouteRouteWithChildren
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/verify': typeof AuthVerifyRoute
@@ -382,6 +399,7 @@ export interface FileRoutesById {
   '/meta/og-linkedin': typeof MetaOgLinkedinRoute
   '/_marketing/': typeof MarketingIndexRoute
   '/_protected/sequences/$id': typeof ProtectedSequencesIdRouteRouteWithChildren
+  '/_protected/admin/usage': typeof ProtectedAdminUsageRoute
   '/_protected/locations/$locationId': typeof ProtectedLocationsLocationIdRoute
   '/_protected/sequences/new': typeof ProtectedSequencesNewRoute
   '/_protected/settings/api-keys': typeof ProtectedSettingsApiKeysRoute
@@ -414,6 +432,7 @@ export interface FileRouteTypes {
     | '/llms.txt'
     | '/robots.txt'
     | '/sitemap.xml'
+    | '/admin'
     | '/settings'
     | '/login'
     | '/verify'
@@ -426,6 +445,7 @@ export interface FileRouteTypes {
     | '/meta/og'
     | '/meta/og-linkedin'
     | '/sequences/$id'
+    | '/admin/usage'
     | '/locations/$locationId'
     | '/sequences/new'
     | '/settings/api-keys'
@@ -456,6 +476,7 @@ export interface FileRouteTypes {
     | '/llms.txt'
     | '/robots.txt'
     | '/sitemap.xml'
+    | '/admin'
     | '/login'
     | '/verify'
     | '/privacy'
@@ -467,6 +488,7 @@ export interface FileRouteTypes {
     | '/meta/og'
     | '/meta/og-linkedin'
     | '/sequences/$id'
+    | '/admin/usage'
     | '/locations/$locationId'
     | '/sequences/new'
     | '/settings/api-keys'
@@ -499,6 +521,7 @@ export interface FileRouteTypes {
     | '/llms.txt'
     | '/robots.txt'
     | '/sitemap.xml'
+    | '/_protected/admin'
     | '/_protected/settings'
     | '/_auth/login'
     | '/_auth/verify'
@@ -512,6 +535,7 @@ export interface FileRouteTypes {
     | '/meta/og-linkedin'
     | '/_marketing/'
     | '/_protected/sequences/$id'
+    | '/_protected/admin/usage'
     | '/_protected/locations/$locationId'
     | '/_protected/sequences/new'
     | '/_protected/settings/api-keys'
@@ -686,6 +710,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedSettingsRouteRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
+    '/_protected/admin': {
+      id: '/_protected/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof ProtectedAdminRouteRouteImport
+      parentRoute: typeof ProtectedRouteRoute
+    }
     '/_protected/talent/': {
       id: '/_protected/talent/'
       path: '/talent'
@@ -798,6 +829,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedLocationsLocationIdRouteImport
       parentRoute: typeof ProtectedRouteRoute
     }
+    '/_protected/admin/usage': {
+      id: '/_protected/admin/usage'
+      path: '/usage'
+      fullPath: '/admin/usage'
+      preLoaderRoute: typeof ProtectedAdminUsageRouteImport
+      parentRoute: typeof ProtectedAdminRouteRoute
+    }
     '/_protected/sequences/$id': {
       id: '/_protected/sequences/$id'
       path: '/sequences/$id'
@@ -878,6 +916,17 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
   AuthRouteRouteChildren,
 )
 
+interface ProtectedAdminRouteRouteChildren {
+  ProtectedAdminUsageRoute: typeof ProtectedAdminUsageRoute
+}
+
+const ProtectedAdminRouteRouteChildren: ProtectedAdminRouteRouteChildren = {
+  ProtectedAdminUsageRoute: ProtectedAdminUsageRoute,
+}
+
+const ProtectedAdminRouteRouteWithChildren =
+  ProtectedAdminRouteRoute._addFileChildren(ProtectedAdminRouteRouteChildren)
+
 interface ProtectedSettingsRouteRouteChildren {
   ProtectedSettingsApiKeysRoute: typeof ProtectedSettingsApiKeysRoute
   ProtectedSettingsPasskeysRoute: typeof ProtectedSettingsPasskeysRoute
@@ -928,6 +977,7 @@ const ProtectedSequencesIdRouteRouteWithChildren =
   )
 
 interface ProtectedRouteRouteChildren {
+  ProtectedAdminRouteRoute: typeof ProtectedAdminRouteRouteWithChildren
   ProtectedSettingsRouteRoute: typeof ProtectedSettingsRouteRouteWithChildren
   ProtectedCreditsRoute: typeof ProtectedCreditsRoute
   ProtectedEvalRoute: typeof ProtectedEvalRoute
@@ -941,6 +991,7 @@ interface ProtectedRouteRouteChildren {
 }
 
 const ProtectedRouteRouteChildren: ProtectedRouteRouteChildren = {
+  ProtectedAdminRouteRoute: ProtectedAdminRouteRouteWithChildren,
   ProtectedSettingsRouteRoute: ProtectedSettingsRouteRouteWithChildren,
   ProtectedCreditsRoute: ProtectedCreditsRoute,
   ProtectedEvalRoute: ProtectedEvalRoute,

--- a/src/routes/_protected/admin/route.tsx
+++ b/src/routes/_protected/admin/route.tsx
@@ -1,0 +1,24 @@
+import { RouteErrorFallback } from '@/components/error/route-error-fallback';
+import { isSystemAdminFn } from '@/functions/gift-tokens';
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_protected/admin')({
+  beforeLoad: async () => {
+    const { isAdmin } = await isSystemAdminFn();
+    if (!isAdmin) {
+      throw redirect({ to: '/sequences' });
+    }
+  },
+  component: AdminLayout,
+  errorComponent: (props) => (
+    <RouteErrorFallback {...props} heading="Admin error" />
+  ),
+});
+
+function AdminLayout() {
+  return (
+    <div className="mx-auto w-full max-w-6xl p-6">
+      <Outlet />
+    </div>
+  );
+}

--- a/src/routes/_protected/admin/usage.tsx
+++ b/src/routes/_protected/admin/usage.tsx
@@ -18,8 +18,11 @@ type SortField =
   | 'name'
   | 'createdAt'
   | 'sequenceCount'
+  | 'failedCount'
+  | 'avgAnalysisDurationMs'
   | 'creditsSpentMicros'
-  | 'creditsToppedUpMicros'
+  | 'creditsPurchasedMicros'
+  | 'creditsGiftedMicros'
   | 'currentBalanceMicros';
 
 type SortDirection = 'asc' | 'desc';
@@ -74,10 +77,19 @@ function UsageContent() {
           );
         case 'sequenceCount':
           return dir * (a.sequenceCount - b.sequenceCount);
+        case 'failedCount':
+          return dir * (a.failedCount - b.failedCount);
+        case 'avgAnalysisDurationMs':
+          return (
+            dir *
+            ((a.avgAnalysisDurationMs ?? 0) - (b.avgAnalysisDurationMs ?? 0))
+          );
         case 'creditsSpentMicros':
           return dir * (a.creditsSpentMicros - b.creditsSpentMicros);
-        case 'creditsToppedUpMicros':
-          return dir * (a.creditsToppedUpMicros - b.creditsToppedUpMicros);
+        case 'creditsPurchasedMicros':
+          return dir * (a.creditsPurchasedMicros - b.creditsPurchasedMicros);
+        case 'creditsGiftedMicros':
+          return dir * (a.creditsGiftedMicros - b.creditsGiftedMicros);
         case 'currentBalanceMicros':
           return dir * (a.currentBalanceMicros - b.currentBalanceMicros);
         default:
@@ -99,23 +111,30 @@ function UsageContent() {
     return {
       users: rows.length,
       sequences: rows.reduce((sum, r) => sum + r.sequenceCount, 0),
+      failed: rows.reduce((sum, r) => sum + r.failedCount, 0),
       spent: rows.reduce((sum, r) => sum + r.creditsSpentMicros, 0),
-      toppedUp: rows.reduce((sum, r) => sum + r.creditsToppedUpMicros, 0),
+      purchased: rows.reduce((sum, r) => sum + r.creditsPurchasedMicros, 0),
+      gifted: rows.reduce((sum, r) => sum + r.creditsGiftedMicros, 0),
     };
   }, [rows]);
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-6">
         <SummaryCard label="Total Users" value={String(totals.users)} />
         <SummaryCard label="Total Sequences" value={String(totals.sequences)} />
+        <SummaryCard label="Failed" value={String(totals.failed)} />
         <SummaryCard
           label="Total Spent"
           value={microsToDisplayUsd(micros(totals.spent))}
         />
         <SummaryCard
-          label="Total Added"
-          value={microsToDisplayUsd(micros(totals.toppedUp))}
+          label="Purchased"
+          value={microsToDisplayUsd(micros(totals.purchased))}
+        />
+        <SummaryCard
+          label="Gifted"
+          value={microsToDisplayUsd(micros(totals.gifted))}
         />
       </div>
 
@@ -167,6 +186,22 @@ function UsageContent() {
                 align="right"
               />
               <SortableHeader
+                label="Errors"
+                field="failedCount"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+              <SortableHeader
+                label="Avg Time"
+                field="avgAnalysisDurationMs"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+              <SortableHeader
                 label="Spent"
                 field="creditsSpentMicros"
                 current={sortField}
@@ -175,8 +210,16 @@ function UsageContent() {
                 align="right"
               />
               <SortableHeader
-                label="Added"
-                field="creditsToppedUpMicros"
+                label="Purchased"
+                field="creditsPurchasedMicros"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+              <SortableHeader
+                label="Gifted"
+                field="creditsGiftedMicros"
                 current={sortField}
                 direction={sortDir}
                 onSort={toggleSort}
@@ -196,7 +239,7 @@ function UsageContent() {
             {sorted.length === 0 ? (
               <tr>
                 <td
-                  colSpan={8}
+                  colSpan={11}
                   className="px-4 py-8 text-center text-muted-foreground"
                 >
                   {search ? 'No users match your search.' : 'No users found.'}
@@ -263,6 +306,15 @@ function formatDate(date: Date | string): string {
   return d.toISOString().slice(0, 10);
 }
 
+function formatDuration(ms: number | null): string {
+  if (ms === null || ms === 0) return '-';
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m${remaining > 0 ? ` ${remaining}s` : ''}`;
+}
+
 const UserRow: React.FC<{ row: UserActivityRow }> = ({ row }) => {
   const statusVariant =
     row.status === 'active'
@@ -288,10 +340,23 @@ const UserRow: React.FC<{ row: UserActivityRow }> = ({ row }) => {
       <td className="px-4 py-3 text-muted-foreground">{row.teamName}</td>
       <td className="px-4 py-3 text-right tabular-nums">{row.sequenceCount}</td>
       <td className="px-4 py-3 text-right tabular-nums">
+        {row.failedCount > 0 ? (
+          <span className="text-destructive">{row.failedCount}</span>
+        ) : (
+          0
+        )}
+      </td>
+      <td className="px-4 py-3 text-right tabular-nums">
+        {formatDuration(row.avgAnalysisDurationMs)}
+      </td>
+      <td className="px-4 py-3 text-right tabular-nums">
         {microsToDisplayUsd(micros(row.creditsSpentMicros))}
       </td>
       <td className="px-4 py-3 text-right tabular-nums">
-        {microsToDisplayUsd(micros(row.creditsToppedUpMicros))}
+        {microsToDisplayUsd(micros(row.creditsPurchasedMicros))}
+      </td>
+      <td className="px-4 py-3 text-right tabular-nums">
+        {microsToDisplayUsd(micros(row.creditsGiftedMicros))}
       </td>
       <td className="px-4 py-3 text-right tabular-nums">
         {microsToDisplayUsd(micros(row.currentBalanceMicros))}

--- a/src/routes/_protected/admin/usage.tsx
+++ b/src/routes/_protected/admin/usage.tsx
@@ -1,0 +1,315 @@
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { listUserActivityFn } from '@/functions/admin';
+import type { UserActivityRow } from '@/lib/db/scoped';
+import { micros, microsToDisplayUsd } from '@/lib/billing/money';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import { ArrowDown, ArrowUp, ArrowUpDown, Users } from 'lucide-react';
+import { Suspense, useMemo, useState } from 'react';
+
+export const Route = createFileRoute('/_protected/admin/usage')({
+  component: AdminUsagePage,
+});
+
+type SortField =
+  | 'name'
+  | 'createdAt'
+  | 'sequenceCount'
+  | 'creditsSpentMicros'
+  | 'creditsToppedUpMicros'
+  | 'currentBalanceMicros';
+
+type SortDirection = 'asc' | 'desc';
+
+function AdminUsagePage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-2xl font-bold">User Activity</h1>
+        <p className="text-muted-foreground">
+          Overview of all users, their sequences, and credit activity.
+        </p>
+      </div>
+      <Suspense fallback={<PageSkeleton />}>
+        <UsageContent />
+      </Suspense>
+    </div>
+  );
+}
+
+function UsageContent() {
+  const { data: rows = [] } = useQuery({
+    queryKey: ['admin-user-activity'],
+    queryFn: () => listUserActivityFn(),
+  });
+
+  const [search, setSearch] = useState('');
+  const [sortField, setSortField] = useState<SortField>('createdAt');
+  const [sortDir, setSortDir] = useState<SortDirection>('desc');
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return rows;
+    const q = search.toLowerCase();
+    return rows.filter(
+      (r) =>
+        r.name.toLowerCase().includes(q) ||
+        r.email.toLowerCase().includes(q) ||
+        r.teamName.toLowerCase().includes(q)
+    );
+  }, [rows, search]);
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      const dir = sortDir === 'asc' ? 1 : -1;
+      switch (sortField) {
+        case 'name':
+          return dir * a.name.localeCompare(b.name);
+        case 'createdAt':
+          return (
+            dir *
+            (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+          );
+        case 'sequenceCount':
+          return dir * (a.sequenceCount - b.sequenceCount);
+        case 'creditsSpentMicros':
+          return dir * (a.creditsSpentMicros - b.creditsSpentMicros);
+        case 'creditsToppedUpMicros':
+          return dir * (a.creditsToppedUpMicros - b.creditsToppedUpMicros);
+        case 'currentBalanceMicros':
+          return dir * (a.currentBalanceMicros - b.currentBalanceMicros);
+        default:
+          return 0;
+      }
+    });
+  }, [filtered, sortField, sortDir]);
+
+  const toggleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('desc');
+    }
+  };
+
+  const totals = useMemo(() => {
+    return {
+      users: rows.length,
+      sequences: rows.reduce((sum, r) => sum + r.sequenceCount, 0),
+      spent: rows.reduce((sum, r) => sum + r.creditsSpentMicros, 0),
+      toppedUp: rows.reduce((sum, r) => sum + r.creditsToppedUpMicros, 0),
+    };
+  }, [rows]);
+
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <SummaryCard label="Total Users" value={String(totals.users)} />
+        <SummaryCard label="Total Sequences" value={String(totals.sequences)} />
+        <SummaryCard
+          label="Total Spent"
+          value={microsToDisplayUsd(micros(totals.spent))}
+        />
+        <SummaryCard
+          label="Total Added"
+          value={microsToDisplayUsd(micros(totals.toppedUp))}
+        />
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div className="relative max-w-sm flex-1">
+          <Users className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search by name, email, or team..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <span className="text-sm text-muted-foreground">
+          {sorted.length} of {rows.length} users
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b bg-muted/50">
+              <SortableHeader
+                label="User"
+                field="name"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+              />
+              <SortableHeader
+                label="Joined"
+                field="createdAt"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+              />
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Status
+              </th>
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Team
+              </th>
+              <SortableHeader
+                label="Sequences"
+                field="sequenceCount"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+              <SortableHeader
+                label="Spent"
+                field="creditsSpentMicros"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+              <SortableHeader
+                label="Added"
+                field="creditsToppedUpMicros"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+              <SortableHeader
+                label="Balance"
+                field="currentBalanceMicros"
+                current={sortField}
+                direction={sortDir}
+                onSort={toggleSort}
+                align="right"
+              />
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={8}
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  {search ? 'No users match your search.' : 'No users found.'}
+                </td>
+              </tr>
+            ) : (
+              sorted.map((row) => (
+                <UserRow key={`${row.userId}-${row.teamId}`} row={row} />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}
+
+const SummaryCard: React.FC<{ label: string; value: string }> = ({
+  label,
+  value,
+}) => (
+  <Card>
+    <CardContent className="p-4">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold tabular-nums">{value}</p>
+    </CardContent>
+  </Card>
+);
+
+const SortableHeader: React.FC<{
+  label: string;
+  field: SortField;
+  current: SortField;
+  direction: SortDirection;
+  onSort: (field: SortField) => void;
+  align?: 'left' | 'right';
+}> = ({ label, field, current, direction, onSort, align = 'left' }) => {
+  const isActive = current === field;
+  return (
+    <th
+      className={`cursor-pointer select-none px-4 py-3 font-medium text-muted-foreground hover:text-foreground ${
+        align === 'right' ? 'text-right' : 'text-left'
+      }`}
+      onClick={() => onSort(field)}
+    >
+      <span className="inline-flex items-center gap-1">
+        {label}
+        {isActive ? (
+          direction === 'asc' ? (
+            <ArrowUp className="h-3 w-3" />
+          ) : (
+            <ArrowDown className="h-3 w-3" />
+          )
+        ) : (
+          <ArrowUpDown className="h-3 w-3 opacity-30" />
+        )}
+      </span>
+    </th>
+  );
+};
+
+function formatDate(date: Date | string): string {
+  const d = typeof date === 'string' ? new Date(date) : date;
+  return d.toISOString().slice(0, 10);
+}
+
+const UserRow: React.FC<{ row: UserActivityRow }> = ({ row }) => {
+  const statusVariant =
+    row.status === 'active'
+      ? 'default'
+      : row.status === 'suspended'
+        ? 'destructive'
+        : 'secondary';
+
+  return (
+    <tr className="border-b last:border-b-0 hover:bg-muted/30">
+      <td className="px-4 py-3">
+        <div className="flex flex-col">
+          <span className="font-medium">{row.name}</span>
+          <span className="text-xs text-muted-foreground">{row.email}</span>
+        </div>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {formatDate(row.createdAt)}
+      </td>
+      <td className="px-4 py-3">
+        <Badge variant={statusVariant}>{row.status ?? 'unknown'}</Badge>
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">{row.teamName}</td>
+      <td className="px-4 py-3 text-right tabular-nums">{row.sequenceCount}</td>
+      <td className="px-4 py-3 text-right tabular-nums">
+        {microsToDisplayUsd(micros(row.creditsSpentMicros))}
+      </td>
+      <td className="px-4 py-3 text-right tabular-nums">
+        {microsToDisplayUsd(micros(row.creditsToppedUpMicros))}
+      </td>
+      <td className="px-4 py-3 text-right tabular-nums">
+        {microsToDisplayUsd(micros(row.currentBalanceMicros))}
+      </td>
+    </tr>
+  );
+};
+
+function PageSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-20 w-full rounded-lg" />
+        ))}
+      </div>
+      <Skeleton className="h-10 max-w-sm" />
+      <Skeleton className="h-96 w-full rounded-lg" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/admin/usage` route behind system admin auth to view all users, their sequences, credit spending, top-ups, and balance
- Add `listUserActivity()` query to admin scoped DB joining users, teams, sequences, and transactions
- Add "Admin" link in user dropdown menu (visible only to system admins)

Closes #523

## Test plan
- [ ] Log in as system admin (email in `ADMIN_EMAILS` env var)
- [ ] Verify "Admin" link appears in user dropdown
- [ ] Navigate to `/admin/usage` and confirm table loads with correct data
- [ ] Test search filtering by name, email, and team
- [ ] Test column sorting (click headers)
- [ ] Verify summary cards show correct totals
- [ ] Log in as non-admin and verify redirect away from `/admin/usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)