### PR TITLE
feat: apply sequence style to character sheet generation

### DIFF
--- a/src/functions/sequence-characters.ts
+++ b/src/functions/sequence-characters.ts
@@ -7,6 +7,7 @@ import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 
+import { StyleConfigSchema } from '@/lib/db/schema';
 import { buildCastingAttributes } from '@/lib/prompts/character-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
@@ -50,6 +51,17 @@ export const recastCharacterFn = createServerFn({ method: 'POST' })
     if (!character) {
       throw new Error('Character not found');
     }
+
+    // Fetch the sequence's style for character sheet generation
+    const sequence = await context.scopedDb.sequences.getForUser({
+      sequenceId: character.sequenceId,
+    });
+    const style = sequence.styleId
+      ? await context.scopedDb.styles.getById(sequence.styleId)
+      : null;
+    const styleConfig = style
+      ? StyleConfigSchema.parse(style.config)
+      : undefined;
 
     const talentWithSheets = await context.scopedDb.talent.getWithRelations(
       data.talentId
@@ -134,6 +146,7 @@ export const recastCharacterFn = createServerFn({ method: 'POST' })
       talentDescription:
         `This character must look exactly like ${talentWithSheets.name}. ${talentWithSheets.description ?? ''}`.trim(),
       affectedFrameIds,
+      styleConfig,
     };
 
     const workflowRunId = await triggerWorkflow(

--- a/src/functions/sequence-locations.ts
+++ b/src/functions/sequence-locations.ts
@@ -1,4 +1,4 @@
-import type { SequenceLocation } from '@/lib/db/schema';
+import { type SequenceLocation, StyleConfigSchema } from '@/lib/db/schema';
 import { getGenerationChannel } from '@/lib/realtime';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
@@ -94,6 +94,17 @@ export const recastLocationFn = createServerFn({ method: 'POST' })
       throw new Error('Location not found');
     }
 
+    // Fetch the sequence's style for location sheet generation
+    const sequence = await context.scopedDb.sequences.getForUser({
+      sequenceId: location.sequenceId,
+    });
+    const style = sequence.styleId
+      ? await context.scopedDb.styles.getById(sequence.styleId)
+      : null;
+    const styleConfig = style
+      ? StyleConfigSchema.parse(style.config)
+      : undefined;
+
     await context.scopedDb.sequenceLocations.updateReferenceStatus(
       data.locationId,
       'generating'
@@ -122,6 +133,7 @@ export const recastLocationFn = createServerFn({ method: 'POST' })
         referenceImageUrl: data.referenceImageUrl,
         libraryLocationDescription: data.description,
         affectedFrameIds,
+        styleConfig,
       } satisfies RecastLocationWorkflowInput,
       { label: buildWorkflowLabel(location.sequenceId) }
     );

--- a/src/lib/prompts/character-prompt.test.ts
+++ b/src/lib/prompts/character-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { CharacterBibleEntry } from '@/lib/ai/scene-analysis.schema';
+import type { StyleConfig } from '@/lib/db/schema';
 import {
   buildCastingAttributes,
   buildCharacterSheetPrompt,
@@ -119,6 +120,85 @@ describe('buildCastingAttributes', () => {
     expect(result.gender).toBe('Female'); // falls back to script
     expect(result.ethnicity).toBe('Caucasian'); // falls back to script
     expect(result.physicalDescription).toBe('Muscular build');
+  });
+});
+
+const neoNoirStyle: StyleConfig = {
+  mood: 'Dark, brooding, and atmospheric',
+  artStyle:
+    'Neo-noir cinematic style with deep shadows and high contrast. Gritty urban realism with expressionist framing.',
+  lighting:
+    'Low-key chiaroscuro lighting with single hard sources. Venetian blind shadows, neon reflections, harsh rim lighting.',
+  colorPalette: ['#0A0A0A', '#1A1A2E', '#E94560', '#16213E', '#533483'],
+  cameraWork:
+    'Dutch angles, low-angle power shots, tight close-ups. Slow deliberate movements with dramatic reveals.',
+  referenceFilms: ['Blade Runner', 'Sin City', 'Drive'],
+  colorGrading:
+    'Desaturated with selective color pops. Teal and orange split toning with crushed blacks.',
+};
+
+describe('buildCharacterSheetPrompt with styleConfig', () => {
+  test('without styleConfig produces default studio prompt', () => {
+    const { prompt } = buildCharacterSheetPrompt(scriptEntry);
+
+    expect(prompt).toContain('cyclorama');
+    expect(prompt).toContain('5500K daylight');
+    expect(prompt).toContain('Commercial reference photography');
+  });
+
+  test('with styleConfig replaces environment, lighting, and optical sections', () => {
+    const { prompt } = buildCharacterSheetPrompt(
+      scriptEntry,
+      undefined,
+      neoNoirStyle
+    );
+
+    // Should NOT contain studio defaults
+    expect(prompt).not.toContain('cyclorama');
+    expect(prompt).not.toContain('5500K daylight');
+    expect(prompt).not.toContain('Commercial reference photography');
+
+    // Should contain style-derived content
+    expect(prompt).toContain('Neo-noir cinematic style');
+    expect(prompt).toContain('chiaroscuro');
+    expect(prompt).toContain('Dark, brooding');
+    expect(prompt).toContain('Blade Runner');
+  });
+
+  test('with styleConfig preserves layout and materiality sections', () => {
+    const { prompt } = buildCharacterSheetPrompt(
+      scriptEntry,
+      undefined,
+      neoNoirStyle
+    );
+
+    expect(prompt).toContain('[LAYOUT]');
+    expect(prompt).toContain('four distinct, technical views');
+    expect(prompt).toContain('[MATERIALITY]');
+    expect(prompt).toContain('Hyper-accurate rendering');
+  });
+
+  test('with styleConfig and talentOverrides composes correctly', () => {
+    const { prompt, referenceUrls } = buildCharacterSheetPrompt(
+      scriptEntry,
+      {
+        sheetMetadata: talentMetadata,
+        sheetImageUrl: 'https://example.com/sheet.png',
+      },
+      neoNoirStyle
+    );
+
+    // Style is applied
+    expect(prompt).toContain('Neo-noir cinematic style');
+    expect(prompt).not.toContain('cyclorama');
+
+    // Talent reference is preserved
+    expect(prompt).toContain('IMAGE takes priority');
+    expect(referenceUrls).toContain('https://example.com/sheet.png');
+
+    // Talent appearance is used
+    expect(prompt).toContain('Male');
+    expect(prompt).toContain('Dark hair, sideburns');
   });
 });
 

--- a/src/lib/prompts/character-prompt.ts
+++ b/src/lib/prompts/character-prompt.ts
@@ -9,7 +9,7 @@
 
 import type { CharacterBibleEntry } from '@/lib/ai/scene-analysis.schema';
 
-import type { CharacterMinimal } from '@/lib/db/schema';
+import type { CharacterMinimal, StyleConfig } from '@/lib/db/schema';
 import {
   type PromptWithReferenceImages,
   type ReferenceImageDescription,
@@ -90,24 +90,60 @@ export const buildPromptWithCharacterReferences = (
 };
 
 /**
+ * Derive environment, optical, and lighting prompt sections from a sequence style.
+ * When provided, these replace the hardcoded studio defaults in character sheets
+ * so that character references match the sequence's visual direction.
+ */
+const formatStyleForSheet = (
+  styleConfig: StyleConfig
+): { environment: string; opticalSpecs: string; lighting: string } => {
+  const colorPaletteStr = styleConfig.colorPalette.join(', ');
+  const referencesStr =
+    styleConfig.referenceFilms.length > 0
+      ? ` Reference look: ${styleConfig.referenceFilms.join(', ')}.`
+      : '';
+
+  return {
+    environment: `Environment matching the visual style: ${styleConfig.artStyle}. Mood: ${styleConfig.mood}. Color palette: ${colorPaletteStr}. Color grading: ${styleConfig.colorGrading}.${referencesStr} The environment should reinforce the character's visual identity within this style direction.`,
+    opticalSpecs: `${styleConfig.artStyle} style rendering. Camera approach: ${styleConfig.cameraWork}. Maintain sharp focus and consistent character detail across all panels.`,
+    lighting: `${styleConfig.lighting}. The lighting should be consistent across all four panels and match the overall ${styleConfig.mood} mood.`,
+  };
+};
+
+/**
  * Build the base 4-panel reference sheet prompt structure
  *
  * Creates a consistent prompt with:
  * - 4-panel horizontal layout (frontal, portrait, side, rear)
- * - Studio environment (white cyclorama)
- * - Commercial photography specs
- * - High-key lighting
+ * - Style-derived or default studio environment, lighting, and optical specs
  * - Hyper-accurate materiality
  *
  * @param identitySection - The identity section of the prompt
  * @param additionalInstructions - Optional additional instructions (e.g., reference image handling)
+ * @param styleConfig - Optional sequence style to apply instead of default studio look
  * @returns Complete prompt string
  */
 export const buildBaseSheetPrompt = (
   identitySection: string,
   /** Optional additional instructions (e.g., reference image handling) */
-  additionalInstructions: string = ''
+  additionalInstructions: string = '',
+  /** Optional sequence style config — replaces default studio look when provided */
+  styleConfig?: StyleConfig
 ): string => {
+  const styled = styleConfig ? formatStyleForSheet(styleConfig) : null;
+
+  const environmentSection = styled
+    ? styled.environment
+    : 'Seamless, minimalist commercial photo studio cyclorama with flat neutral white background. Clean, sterile, analytical atmosphere designed for clarity.';
+
+  const opticalSection = styled
+    ? styled.opticalSpecs
+    : 'Commercial reference photography style. High-resolution medium format digital, tack-sharp focus across all panels, deep depth of field. Flat perspective, no lens distortion.';
+
+  const lightingSection = styled
+    ? styled.lighting
+    : 'Neutral, even, high-key studio lighting. Diffused illumination from large softboxes to eliminate harsh shadows and highlight shape and form evenly. 5500K daylight balance.';
+
   return `A professional four-panel photographic character reference grid, maintaining absolute anatomical and stylistic consistency.
 
 [LAYOUT]:
@@ -122,13 +158,13 @@ All attire, accessories, hair, and features must be perfectly consistent across 
 ${identitySection}
 ${additionalInstructions}
 [ENVIRONMENT]:
-Seamless, minimalist commercial photo studio cyclorama with flat neutral white background. Clean, sterile, analytical atmosphere designed for clarity.
+${environmentSection}
 
 [OPTICAL & CAMERA SPECS]:
-Commercial reference photography style. High-resolution medium format digital, tack-sharp focus across all panels, deep depth of field. Flat perspective, no lens distortion.
+${opticalSection}
 
 [LIGHTING]:
-Neutral, even, high-key studio lighting. Diffused illumination from large softboxes to eliminate harsh shadows and highlight shape and form evenly. 5500K daylight balance.
+${lightingSection}
 
 [MATERIALITY]:
 Hyper-accurate rendering of all fabrics, skin textures, hardware, and micro-details. Consistent texture rendering across all four angles without beautification or alteration.`.trim();
@@ -240,11 +276,13 @@ type CharacterSheetPromptResult = {
  *
  * @param entry - The character bible entry from script analysis
  * @param talentOverrides - Optional talent data for casting
+ * @param styleConfig - Optional sequence style to apply instead of default studio look
  * @returns Prompt and reference URLs for image generation
  */
 export const buildCharacterSheetPrompt = (
   entry: CharacterBibleEntry,
-  talentOverrides?: TalentOverrides
+  talentOverrides?: TalentOverrides,
+  styleConfig?: StyleConfig
 ): CharacterSheetPromptResult => {
   const talentMeta = talentOverrides?.sheetMetadata;
   const hasTalent = !!(talentMeta || talentOverrides?.description);
@@ -317,7 +355,11 @@ ${standardClothing}
 
 ${makeupStylingSection}`.trim();
 
-  const prompt = buildBaseSheetPrompt(identitySection, referenceInstruction);
+  const prompt = buildBaseSheetPrompt(
+    identitySection,
+    referenceInstruction,
+    styleConfig
+  );
 
   return { prompt, referenceUrls };
 };

--- a/src/lib/prompts/location-prompt.test.ts
+++ b/src/lib/prompts/location-prompt.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, it } from 'bun:test';
 import type { LocationBibleEntry } from '@/lib/ai/scene-analysis.schema';
-import type { SequenceLocationMinimal } from '@/lib/db/schema';
+import type { SequenceLocationMinimal, StyleConfig } from '@/lib/db/schema';
 import {
   buildLocationDescription,
   buildLocationReferenceImages,
@@ -121,6 +121,68 @@ describe('location-prompt', () => {
 
       expect(result.prompt).toBe(basePrompt);
       expect(result.referenceUrls).toHaveLength(0);
+    });
+  });
+
+  describe('buildLocationSheetPrompt with styleConfig', () => {
+    const animatedStyle: StyleConfig = {
+      mood: 'Whimsical, playful, and colorful',
+      artStyle:
+        'Pixar-style 3D animation with exaggerated proportions and rich textures.',
+      lighting:
+        'Soft global illumination with warm key lights and cool fill. Bounced light creates depth.',
+      colorPalette: ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7'],
+      cameraWork:
+        'Smooth dollies and gentle crane movements. Wide establishing shots with shallow depth of field on details.',
+      referenceFilms: ['Up', 'Ratatouille', 'Coco'],
+      colorGrading:
+        'Saturated and warm with a slight bloom. Shadows are never pure black.',
+    };
+
+    it('without styleConfig produces no style direction section', () => {
+      const result = buildLocationSheetPrompt(mockLocationEntry);
+      expect(result.prompt).not.toContain('[STYLE DIRECTION]');
+    });
+
+    it('with styleConfig includes style direction section', () => {
+      const result = buildLocationSheetPrompt(
+        mockLocationEntry,
+        undefined,
+        animatedStyle
+      );
+
+      expect(result.prompt).toContain('[STYLE DIRECTION]');
+      expect(result.prompt).toContain('Pixar-style 3D animation');
+      expect(result.prompt).toContain('Whimsical, playful');
+      expect(result.prompt).toContain('Up');
+    });
+
+    it('with styleConfig preserves location-specific attributes', () => {
+      const result = buildLocationSheetPrompt(
+        mockLocationEntry,
+        undefined,
+        animatedStyle
+      );
+
+      expect(result.prompt).toContain('Contemporary minimalist');
+      expect(result.prompt).toContain('Floor-to-ceiling windows');
+      expect(result.prompt).toContain('[GRID LAYOUT');
+    });
+
+    it('with styleConfig and library overrides composes correctly', () => {
+      const result = buildLocationSheetPrompt(
+        mockLocationEntry,
+        {
+          description: 'A sleek tech startup',
+          referenceImageUrl: 'https://example.com/lib.png',
+        },
+        animatedStyle
+      );
+
+      expect(result.prompt).toContain('[STYLE DIRECTION]');
+      expect(result.prompt).toContain('Pixar-style 3D animation');
+      expect(result.prompt).toContain('A sleek tech startup');
+      expect(result.referenceUrls).toContain('https://example.com/lib.png');
     });
   });
 

--- a/src/lib/prompts/location-prompt.ts
+++ b/src/lib/prompts/location-prompt.ts
@@ -8,7 +8,7 @@
  */
 
 import type { LocationBibleEntry } from '@/lib/ai/scene-analysis.schema';
-import type { SequenceLocationMinimal } from '@/lib/db/schema';
+import type { SequenceLocationMinimal, StyleConfig } from '@/lib/db/schema';
 import {
   type PromptWithReferenceImages,
   type ReferenceImageDescription,
@@ -74,6 +74,29 @@ export const buildPromptWithLocationReferences = (
 };
 
 /**
+ * Format a style direction section for location reference sheets.
+ * Overlays the sequence's visual style on top of the location-specific attributes.
+ */
+const formatStyleDirectionForLocation = (styleConfig: StyleConfig): string => {
+  const colorPaletteStr = styleConfig.colorPalette.join(', ');
+  const referencesStr =
+    styleConfig.referenceFilms.length > 0
+      ? `\nReference look: ${styleConfig.referenceFilms.join(', ')}.`
+      : '';
+
+  return `
+[STYLE DIRECTION]:
+Render this location in the following visual style:
+Art style: ${styleConfig.artStyle}
+Mood: ${styleConfig.mood}
+Lighting direction: ${styleConfig.lighting}
+Color palette: ${colorPaletteStr}
+Color grading: ${styleConfig.colorGrading}
+Camera approach: ${styleConfig.cameraWork}${referencesStr}
+All 9 panels must consistently reflect this style direction.`;
+};
+
+/**
  * Build a location reference sheet prompt structure
  *
  * Creates a 3x3 grid of 16:9 images showing different angles and views:
@@ -83,6 +106,7 @@ export const buildPromptWithLocationReferences = (
  *
  * @param entry - The location bible entry from script analysis
  * @param libraryLocationOverrides - Optional library location data for overrides
+ * @param styleConfig - Optional sequence style to apply to the location sheet
  * @returns Complete prompt string and reference URLs
  */
 export const buildLocationSheetPrompt = (
@@ -90,7 +114,8 @@ export const buildLocationSheetPrompt = (
   libraryLocationOverrides?: {
     description?: string;
     referenceImageUrl?: string;
-  }
+  },
+  styleConfig?: StyleConfig
 ): { prompt: string; referenceUrls: string[] } => {
   const referenceUrls: string[] = [];
   if (libraryLocationOverrides?.referenceImageUrl) {
@@ -148,7 +173,7 @@ ${entry.lightingSetup || 'Match time of day and mood - consistent across all pan
 
 [ATMOSPHERE]:
 ${entry.ambiance || 'Derive from description and setting'}
-${referenceInstruction}
+${referenceInstruction}${styleConfig ? formatStyleDirectionForLocation(styleConfig) : ''}
 [GRID LAYOUT - 3 rows × 3 columns, each panel 16:9 aspect ratio]:
 
 Row 1 - ESTABLISHING SHOTS:

--- a/src/lib/prompts/variant-image.ts
+++ b/src/lib/prompts/variant-image.ts
@@ -55,6 +55,8 @@ export function getVariantImagePrompt(
 
 Visual Parameters:
 
+Character Consistency: Every panel must show the EXACT SAME character(s) as Image 1 — identical face, hair color, hair style, skin tone, body type, and clothing. If character reference sheets are provided, match their likeness precisely in every panel. Do NOT change, substitute, or alter any character's appearance between panels.
+
 Lighting: Match Image 1's lighting setup exactly.
 
 Texture: Match Image 1's texture and grain characteristics.
@@ -67,7 +69,7 @@ Aspect Ratio: ${aspectDescription}
 
 ${sceneContext}
 
-CRITICAL: All ${count} panels must depict variant shots of the SAME scene shown in Image 1. Any additional reference images (characters, locations) are provided solely for likeness and environment consistency — do NOT turn them into separate panels or subjects.
+CRITICAL: All ${count} panels must depict variant shots of the SAME scene shown in Image 1 with the SAME character(s). Any additional reference images (characters, locations) are provided solely for likeness and environment consistency — do NOT turn them into separate panels or subjects. The character's appearance must be identical across all ${count} panels.
 
 `;
 }

--- a/src/lib/prompts/variant-image.ts
+++ b/src/lib/prompts/variant-image.ts
@@ -6,33 +6,18 @@ type GridLayout = {
 };
 
 /**
- * Get the arrangement description for the opening sentence based on grid shape
+ * Get the grid layout description based on shape
  */
-function getArrangementDescription(grid: GridLayout, count: number): string {
-  if (grid.rows === 1) {
-    return `${grid.cols} side-by-side vertical portrait panels. Each panel should be a complete portrait-oriented composition showing a distinct variant shot`;
-  }
-  return `${grid.cols} panels across (horizontal) and ${grid.rows} panels down (vertical). It should be a sequence of ${count} distinct frames showing a progression of action, laid out in a ${grid.cols}-column by ${grid.rows}-row grid`;
-}
-
-/**
- * Get the aspect ratio instruction based on image size and grid shape
- */
-function getAspectRatioDescription(
+function getLayoutDescription(
   imageSize: ImageSize,
   grid: GridLayout,
   count: number
 ): string {
   if (grid.rows === 1) {
-    return `The final image is landscape orientation (16:9 aspect ratio, wider than tall). Arrange the ${count} panels as ${grid.cols} side-by-side vertical portrait columns of equal width, filling the entire image. Each column is a complete portrait-oriented (9:16) composition.`;
+    return `${count} side-by-side portrait panels in a 16:9 landscape image. Each column is a full 9:16 composition.`;
   }
-  switch (imageSize) {
-    case 'square_hd':
-      return `The final image is square (1:1 aspect ratio). Arrange the ${count} panels in a balanced ${grid.cols}x${grid.rows} grid.`;
-    case 'landscape_16_9':
-    default:
-      return `The final image is landscape orientation (16:9 aspect ratio, wider than tall). Arrange the ${count} panels in a ${grid.cols}-column by ${grid.rows}-row grid that fits naturally within a wide, horizontal frame.`;
-  }
+  const ratio = imageSize === 'square_hd' ? '1:1 square' : '16:9 landscape';
+  return `${grid.cols}x${grid.rows} grid (${count} panels) in a ${ratio} image.`;
 }
 
 /**
@@ -44,32 +29,16 @@ export function getVariantImagePrompt(
   grid: GridLayout = { cols: 3, rows: 3 }
 ): string {
   const count = grid.cols * grid.rows;
-  const arrangement = getArrangementDescription(grid, count);
-  const aspectDescription = getAspectRatioDescription(imageSize, grid, count);
+  const layout = getLayoutDescription(imageSize, grid, count);
 
-  const sceneContext = scenePrompt
-    ? `\nScene Description:\n${scenePrompt}\n`
-    : '';
+  const sceneContext = scenePrompt ? `\nScene: ${scenePrompt}\n` : '';
 
-  return `Create a ${count}-panel cinematic storyboard sheet arranged as exactly ${arrangement}. Derived from the style and subject of Image 1 (the primary source scene). Include 'Wide' (setting the scene), 'Medium' (action), and 'Tight' (emotion) shots. There should be no borders between images.
+  return `${count}-panel cinematic storyboard sheet derived from Image 1. Mix Wide, Medium, and Tight shots of the same scene. No borders between panels.
 
-Visual Parameters:
-
-Character Consistency: Every panel must show the EXACT SAME character(s) as Image 1 — identical face, hair color, hair style, skin tone, body type, and clothing. If character reference sheets are provided, match their likeness precisely in every panel. Do NOT change, substitute, or alter any character's appearance between panels.
-
-Lighting: Match Image 1's lighting setup exactly.
-
-Texture: Match Image 1's texture and grain characteristics.
-
-Color: Color grade must perfectly match Image 1's LUT.
-
-Strict Negative Constraint: No borders between images, Zero text. No dialogue bubbles, no scene numbers, no 'Lorem Ipsum', and no subtitles. The final image should look like a clean, text-free photography contact sheet.
-
-Aspect Ratio: ${aspectDescription}
-
+Layout: ${layout}
 ${sceneContext}
+Match Image 1 exactly: same character(s) (face, hair, skin, clothing), lighting, color grade, and texture. If character reference sheets are provided, use them for likeness — do not render them as separate panels.
 
-CRITICAL: All ${count} panels must depict variant shots of the SAME scene shown in Image 1 with the SAME character(s). Any additional reference images (characters, locations) are provided solely for likeness and environment consistency — do NOT turn them into separate panels or subjects. The character's appearance must be identical across all ${count} panels.
-
+No text, dialogue bubbles, scene numbers, or watermarks.
 `;
 }

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -422,6 +422,8 @@ export interface LocationSheetWorkflowInput extends SequenceWorkflowContext {
   referenceImageUrl?: string;
   /** Library location description for overrides */
   libraryLocationDescription?: string;
+  /** Sequence style config to apply to the location sheet */
+  styleConfig?: StyleConfig;
 }
 
 export interface LocationSheetWorkflowResult {
@@ -470,6 +472,8 @@ export interface LocationBibleWorkflowInput extends UserWorkflowContext {
   imageModel?: TextToImageModel;
   /** Library location matches for locations that should use library references */
   libraryLocationMatches?: LibraryLocationMatch[];
+  /** Sequence style config to apply to location sheets */
+  styleConfig?: StyleConfig;
 }
 
 /**
@@ -533,6 +537,8 @@ export interface RecastLocationWorkflowInput extends SequenceWorkflowContext {
   libraryLocationDescription?: string;
   /** Frame IDs to regenerate after sheet generation */
   affectedFrameIds: string[];
+  /** Sequence style config to apply to the location sheet */
+  styleConfig?: StyleConfig;
 }
 
 /**

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -171,6 +171,8 @@ export interface CharacterSheetWorkflowInput extends SequenceWorkflowContext {
   talentMetadata?: CharacterBibleEntry;
   /** Talent description to include in prompt */
   talentDescription?: string;
+  /** Sequence style config to apply to the character sheet */
+  styleConfig?: StyleConfig;
 }
 
 /**
@@ -207,6 +209,8 @@ export interface RecastCharacterWorkflowInput extends SequenceWorkflowContext {
   talentDescription?: string;
   /** Frame IDs to regenerate after sheet generation */
   affectedFrameIds: string[];
+  /** Sequence style config to apply to the character sheet */
+  styleConfig?: StyleConfig;
 }
 
 /**
@@ -263,6 +267,9 @@ export interface CharacterBibleWorkflowInput extends SequenceWorkflowContext {
 
   /** Matched talent data for characters that should use talent references */
   talentMatches?: TalentCharacterMatch[];
+
+  /** Sequence style config to apply to character sheets */
+  styleConfig?: StyleConfig;
 }
 
 export type FrameMapping = Array<{ sceneId: string; frameId: string }>;

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -171,6 +171,7 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
           teamId: input.teamId,
           locationBible,
           libraryLocationMatches,
+          styleConfig,
         },
         flowControl: getFalFlowControl(),
       }),

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -158,6 +158,7 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
           characterBible,
           talentMatches: talentCharacterMatches,
           imageModel,
+          styleConfig,
         },
         flowControl: getFalFlowControl(),
       }),

--- a/src/lib/workflows/character-bible-workflow.ts
+++ b/src/lib/workflows/character-bible-workflow.ts
@@ -112,14 +112,22 @@ export const characterBibleWorkflow = createScopedWorkflow<
               })
             : null;
 
-          // Generate character sheet (with talent appearance as reference)
+          // Generate character sheet (with talent appearance as reference + sequence style)
           const { prompt, referenceUrls } = talentMatch
-            ? buildCharacterSheetPrompt(character, {
-                sheetMetadata: talentMatch.sheetMetadata,
-                description: `This character must look exactly like ${talentMatch.talentName}`,
-                sheetImageUrl: talentMatch.sheetImageUrl,
-              })
-            : buildCharacterSheetPrompt(character);
+            ? buildCharacterSheetPrompt(
+                character,
+                {
+                  sheetMetadata: talentMatch.sheetMetadata,
+                  description: `This character must look exactly like ${talentMatch.talentName}`,
+                  sheetImageUrl: talentMatch.sheetImageUrl,
+                },
+                input.styleConfig
+              )
+            : buildCharacterSheetPrompt(
+                character,
+                undefined,
+                input.styleConfig
+              );
 
           const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
 

--- a/src/lib/workflows/character-sheet-workflow.ts
+++ b/src/lib/workflows/character-sheet-workflow.ts
@@ -70,10 +70,11 @@ export const characterSheetWorkflow = createScopedWorkflow<
             }
           : undefined;
 
-        // Build prompt with character identity + talent appearance
+        // Build prompt with character identity + talent appearance + sequence style
         const { prompt, referenceUrls } = buildCharacterSheetPrompt(
           input.characterMetadata,
-          talentOverrides
+          talentOverrides,
+          input.styleConfig
         );
         const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
 

--- a/src/lib/workflows/location-bible-workflow.ts
+++ b/src/lib/workflows/location-bible-workflow.ts
@@ -100,13 +100,17 @@ export const locationBibleWorkflow = createScopedWorkflow<
           // Check if location has a library match
           const libraryMatch = matchMap.get(location.locationId);
 
-          // Build location sheet prompt (with library overrides if matched)
+          // Build location sheet prompt (with library overrides if matched + sequence style)
           const { prompt, referenceUrls } = libraryMatch
-            ? buildLocationSheetPrompt(location, {
-                description: libraryMatch.description,
-                referenceImageUrl: libraryMatch.referenceImageUrl,
-              })
-            : buildLocationSheetPrompt(location);
+            ? buildLocationSheetPrompt(
+                location,
+                {
+                  description: libraryMatch.description,
+                  referenceImageUrl: libraryMatch.referenceImageUrl,
+                },
+                input.styleConfig
+              )
+            : buildLocationSheetPrompt(location, undefined, input.styleConfig);
 
           const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
 

--- a/src/lib/workflows/location-sheet-workflow.ts
+++ b/src/lib/workflows/location-sheet-workflow.ts
@@ -71,10 +71,11 @@ export const locationSheetWorkflow = createScopedWorkflow<
             }
           : undefined;
 
-        // Build prompt with location identity + library reference
+        // Build prompt with location identity + library reference + sequence style
         const { prompt, referenceUrls } = buildLocationSheetPrompt(
           input.locationMetadata,
-          libraryOverrides
+          libraryOverrides,
+          input.styleConfig
         );
         const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
 

--- a/src/lib/workflows/recast-character-workflow.ts
+++ b/src/lib/workflows/recast-character-workflow.ts
@@ -42,6 +42,7 @@ export const recastCharacterWorkflow =
             referenceImageUrl: input.referenceImageUrl,
             talentMetadata: input.talentMetadata,
             talentDescription: input.talentDescription,
+            styleConfig: input.styleConfig,
           },
         }
       );

--- a/src/lib/workflows/recast-location-workflow.ts
+++ b/src/lib/workflows/recast-location-workflow.ts
@@ -41,6 +41,7 @@ export const recastLocationWorkflow =
             imageModel: input.imageModel,
             referenceImageUrl: input.referenceImageUrl,
             libraryLocationDescription: input.libraryLocationDescription,
+            styleConfig: input.styleConfig,
           },
         }
       );


### PR DESCRIPTION
## Summary

- Threads `StyleConfig` through both character sheet generation paths (initial storyboard + recast) so character references match the sequence's visual direction
- Replaces hardcoded studio photography defaults (`[ENVIRONMENT]`, `[LIGHTING]`, `[OPTICAL & CAMERA SPECS]`) with style-derived sections when a sequence style is present
- Backward compatible — character sheets without a style still use the default studio look

Closes #530

## Test plan

- [ ] `bun typecheck` passes
- [ ] `bun test src/lib/prompts/character-prompt.test.ts` — all 13 tests pass (4 new)
- [ ] `bun run build` succeeds
- [ ] Manual: Create a sequence with "Animated" style → generate storyboard → verify character sheets reflect animated style
- [ ] Manual: Recast a character in a "Neo-Noir" styled sequence → verify new character sheet has noir look

🤖 Generated with [Claude Code](https://claude.com/claude-code)