### PR TITLE
fix: make eval sequence title visible in support mode

### DIFF
--- a/src/components/eval/eval-sequence-metadata.tsx
+++ b/src/components/eval/eval-sequence-metadata.tsx
@@ -28,12 +28,12 @@ export const EvalSequenceMetadata: React.FC<EvalSequenceMetadataProps> = ({
   const imageModel = getImageModelById(sequence.imageModel);
 
   return (
-    <div className="h-full border-r border-b p-3 flex flex-col gap-2">
+    <div className="h-full border-r border-b p-3 flex flex-col gap-2 overflow-y-auto">
       {/* Title */}
       <Link
         to={sequencesScenesRoute.fullPath}
         params={{ id: sequence.id }}
-        className="font-medium text-sm line-clamp-2 hover:underline"
+        className="font-medium text-sm text-foreground line-clamp-2 hover:underline"
         title={sequence.title || 'Untitled Sequence'}
       >
         {sequence.title || 'Untitled Sequence'}


### PR DESCRIPTION
## Summary
- Add explicit `text-foreground` color to the sequence title `<Link>` so it isn't overridden by video.js anchor styles in dark mode
- Add `overflow-y-auto` to the metadata container to prevent error indicators from bleeding into adjacent rows

Closes #533

## Test plan
- [ ] Toggle Support Mode on in the eval page
- [ ] Confirm sequence titles are visible as clickable links in dark mode
- [ ] Confirm error indicators stay within the metadata cell boundary
- [ ] Verify non-support-mode rows still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)