### PR TITLE
fix: increase eval row height so titles are visible

### DIFF
--- a/src/components/eval/eval-matrix.tsx
+++ b/src/components/eval/eval-matrix.tsx
@@ -6,7 +6,7 @@ import { EvalSequenceRow } from './eval-sequence-row';
 import type { SequenceWithFrames } from '@/hooks/use-sequences-with-frames';
 import type { ViewMode } from './eval-view';
 
-const ROW_HEIGHT = 160; // Cell height (128px) + padding (32px)
+const ROW_HEIGHT = 240;
 const METADATA_WIDTH = 280;
 const VIDEO_WIDTH = 200;
 const CELL_WIDTH = 200;

--- a/src/components/eval/eval-sequence-metadata.tsx
+++ b/src/components/eval/eval-sequence-metadata.tsx
@@ -33,7 +33,7 @@ export const EvalSequenceMetadata: React.FC<EvalSequenceMetadataProps> = ({
       <Link
         to={sequencesScenesRoute.fullPath}
         params={{ id: sequence.id }}
-        className="font-medium text-sm text-foreground line-clamp-2 hover:underline"
+        className="font-medium text-sm text-foreground line-clamp-2 hover:underline shrink-0"
         title={sequence.title || 'Untitled Sequence'}
       >
         {sequence.title || 'Untitled Sequence'}


### PR DESCRIPTION
## Summary
- Increase `ROW_HEIGHT` from 160 to 240 so all metadata (title, creator name, model, workflow, date, scene count, errors) fits without overflow
- Add `shrink-0` to the title `<Link>` — `line-clamp-2` applies `overflow: hidden` which let the flex algorithm collapse the title to `height: 0` when the row was too short

Follows up on PR #534 which added `text-foreground` and `overflow-y-auto` but didn't fix the root cause (insufficient row height causing flex shrink).

Closes #533

## Test plan
- [ ] Toggle Support Mode on in the eval page
- [ ] Confirm sequence titles are visible as clickable links
- [ ] Confirm all metadata fits within the row without overflow/overlap
- [ ] Verify non-support mode rows still look correct
- [ ] Verify scene cell images display correctly at the new row height

🤖 Generated with [Claude Code](https://claude.com/claude-code)