### PR TITLE
feat: add JSON workflow system for user-created workflows

### DIFF
--- a/drizzle/migrations/20260513213136_good_guardian/migration.sql
+++ b/drizzle/migrations/20260513213136_good_guardian/migration.sql
@@ -1,0 +1,38 @@
+CREATE TABLE `workflow_definitions` (
+	`id` text PRIMARY KEY,
+	`team_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`definition` text NOT NULL,
+	`trigger_type` text NOT NULL,
+	`trigger_event` text,
+	`enabled` integer DEFAULT true NOT NULL,
+	`version` integer DEFAULT 1 NOT NULL,
+	`created_by` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT `fk_workflow_definitions_team_id_teams_id_fk` FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON DELETE CASCADE,
+	CONSTRAINT `fk_workflow_definitions_created_by_user_id_fk` FOREIGN KEY (`created_by`) REFERENCES `user`(`id`) ON DELETE SET NULL
+);
+--> statement-breakpoint
+CREATE TABLE `workflow_runs` (
+	`id` text PRIMARY KEY,
+	`workflow_definition_id` text NOT NULL,
+	`team_id` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`trigger_data` text,
+	`step_results` text,
+	`error` text,
+	`qstash_workflow_run_id` text,
+	`started_at` integer,
+	`completed_at` integer,
+	`created_at` integer NOT NULL,
+	CONSTRAINT `fk_workflow_runs_workflow_definition_id_workflow_definitions_id_fk` FOREIGN KEY (`workflow_definition_id`) REFERENCES `workflow_definitions`(`id`) ON DELETE CASCADE,
+	CONSTRAINT `fk_workflow_runs_team_id_teams_id_fk` FOREIGN KEY (`team_id`) REFERENCES `teams`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE INDEX `idx_wf_def_team_id` ON `workflow_definitions` (`team_id`);--> statement-breakpoint
+CREATE INDEX `idx_wf_def_trigger` ON `workflow_definitions` (`team_id`,`trigger_type`,`trigger_event`);--> statement-breakpoint
+CREATE INDEX `idx_wf_run_def_id` ON `workflow_runs` (`workflow_definition_id`);--> statement-breakpoint
+CREATE INDEX `idx_wf_run_team_id` ON `workflow_runs` (`team_id`);--> statement-breakpoint
+CREATE INDEX `idx_wf_run_status` ON `workflow_runs` (`status`);

--- a/drizzle/migrations/20260513213136_good_guardian/snapshot.json
+++ b/drizzle/migrations/20260513213136_good_guardian/snapshot.json
@@ -1,0 +1,7451 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "581cfb96-f27a-4f6f-a9a2-334c86d49b07",
+  "prevIds": ["51f9dd24-b5fc-472f-a3ea-fd509306cc43"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frames",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_video_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "name": "workflow_definitions",
+      "entityType": "tables"
+    },
+    {
+      "name": "workflow_runs",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_thumbnail_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "variant_image_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "thumbnail_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "merged_video_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "definition",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "trigger_type",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "trigger_event",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "workflow_definitions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_definition_id",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "trigger_data",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step_results",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "qstash_workflow_run_id",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completed_at",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "workflow_runs"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frame_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frame_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frames_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_video_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_video_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workflow_definitions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "workflow_definitions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_workflow_definitions_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "workflow_definitions"
+    },
+    {
+      "columns": ["workflow_definition_id"],
+      "tableTo": "workflow_definitions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workflow_runs_workflow_definition_id_workflow_definitions_id_fk",
+      "entityType": "fks",
+      "table": "workflow_runs"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_workflow_runs_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "workflow_runs"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_prompt_variants_pk",
+      "table": "frame_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_variants_pk",
+      "table": "frame_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frames_pk",
+      "table": "frames",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_variants_pk",
+      "table": "sequence_music_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_video_variants_pk",
+      "table": "sequence_video_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workflow_definitions_pk",
+      "table": "workflow_definitions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "workflow_runs_pk",
+      "table": "workflow_runs",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_prompt_variants_frame_type_created",
+      "entityType": "indexes",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_prompt_variants\".\"input_hash\" IS NOT NULL AND \"frame_prompt_variants\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_frame_prompt_variants_frame_type_hash_ai",
+      "entityType": "indexes",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_frame_type",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "frame_variants_primary_key",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "frame_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_order",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_sequence_id",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "frames_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_prompt_variants\".\"input_hash\" IS NOT NULL AND \"sequence_music_prompt_variants\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_sequence_music_prompt_variants_sequence_hash_ai",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_video_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_video_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "workflow",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_video_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_video_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_video_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "workflow",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_video_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_video_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_video_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_wf_def_team_id",
+      "entityType": "indexes",
+      "table": "workflow_definitions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "trigger_type",
+          "isExpression": false
+        },
+        {
+          "value": "trigger_event",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_wf_def_trigger",
+      "entityType": "indexes",
+      "table": "workflow_definitions"
+    },
+    {
+      "columns": [
+        {
+          "value": "workflow_definition_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_wf_run_def_id",
+      "entityType": "indexes",
+      "table": "workflow_runs"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_wf_run_team_id",
+      "entityType": "indexes",
+      "table": "workflow_runs"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_wf_run_status",
+      "entityType": "indexes",
+      "table": "workflow_runs"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": []
+}

--- a/src/functions/workflow-definitions.ts
+++ b/src/functions/workflow-definitions.ts
@@ -4,7 +4,7 @@
  * CRUD operations for user-created JSON workflow definitions.
  */
 
-import type { WorkflowDefinition, WorkflowRun } from '@/lib/db/schema';
+import type { WorkflowDefinition } from '@/lib/db/schema';
 import { workflowDefinitionSchema } from '@/lib/json-workflows/schema';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { triggerWorkflow } from '@/lib/workflow/client';
@@ -153,25 +153,15 @@ const listRunsSchema = z.object({
   limit: z.number().int().positive().max(100).optional(),
 });
 
-/**
- * Serialize a workflow run for TanStack Start transport.
- * JSON round-trip strips undefined values so the result satisfies
- * the stricter Record<string, {}> column types.
- */
-function serializeRun(run: WorkflowRun): WorkflowRun {
-  return JSON.parse(JSON.stringify(run));
-}
-
 export const listWorkflowRunsFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
   .inputValidator(zodValidator(listRunsSchema))
   .handler(async ({ data, context }) => {
-    const runs = await context.scopedDb.workflowRuns.list({
+    return context.scopedDb.workflowRuns.list({
       workflowDefinitionId: data.workflowDefinitionId,
       status: data.status,
       limit: data.limit ?? 50,
     });
-    return runs.map(serializeRun);
   });
 
 // ── Get Run ─────────────────────────────────────────────────────
@@ -182,5 +172,5 @@ export const getWorkflowRunFn = createServerFn({ method: 'POST' })
   .handler(async ({ data, context }) => {
     const run = await context.scopedDb.workflowRuns.getById(data.id);
     if (!run) throw new Error(`Workflow run ${data.id} not found`);
-    return serializeRun(run);
+    return run;
   });

--- a/src/functions/workflow-definitions.ts
+++ b/src/functions/workflow-definitions.ts
@@ -1,0 +1,186 @@
+/**
+ * Workflow Definition Server Functions
+ *
+ * CRUD operations for user-created JSON workflow definitions.
+ */
+
+import type { WorkflowDefinition, WorkflowRun } from '@/lib/db/schema';
+import { workflowDefinitionSchema } from '@/lib/json-workflows/schema';
+import { ulidSchema } from '@/lib/schemas/id.schemas';
+import { triggerWorkflow } from '@/lib/workflow/client';
+import { createServerFn } from '@tanstack/react-start';
+import { zodValidator } from '@tanstack/zod-adapter';
+import { z } from 'zod';
+import { authWithTeamMiddleware } from './middleware';
+
+// ── List ────────────────────────────────────────────────────────
+
+export const listWorkflowDefinitionsFn = createServerFn({ method: 'GET' })
+  .middleware([authWithTeamMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.workflowDefinitions.list();
+  });
+
+// ── Get by ID ───────────────────────────────────────────────────
+
+export const getWorkflowDefinitionFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(z.object({ id: ulidSchema })))
+  .handler(async ({ data, context }) => {
+    const def = await context.scopedDb.workflowDefinitions.getById(data.id);
+    if (!def) throw new Error(`Workflow definition ${data.id} not found`);
+    return def;
+  });
+
+// ── Create ──────────────────────────────────────────────────────
+
+const createSchema = z.object({
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  definition: workflowDefinitionSchema,
+});
+
+export const createWorkflowDefinitionFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(createSchema))
+  .handler(async ({ data, context }) => {
+    const trigger = data.definition.trigger;
+
+    return context.scopedDb.workflowDefinitions.create({
+      name: data.name,
+      description: data.description ?? null,
+      definition: data.definition,
+      triggerType: trigger.type,
+      triggerEvent: trigger.type === 'event' ? trigger.event : null,
+      enabled: true,
+      version: 1,
+    });
+  });
+
+// ── Update ──────────────────────────────────────────────────────
+
+const updateSchema = z.object({
+  id: ulidSchema,
+  name: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).optional(),
+  definition: workflowDefinitionSchema.optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const updateWorkflowDefinitionFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(updateSchema))
+  .handler(async ({ data, context }) => {
+    const { id, name, description, definition, enabled } = data;
+
+    const updateData: Partial<
+      Pick<
+        WorkflowDefinition,
+        | 'name'
+        | 'description'
+        | 'definition'
+        | 'triggerType'
+        | 'triggerEvent'
+        | 'enabled'
+      >
+    > = {};
+    if (name !== undefined) updateData.name = name;
+    if (description !== undefined) updateData.description = description;
+    if (enabled !== undefined) updateData.enabled = enabled;
+
+    if (definition) {
+      updateData.definition = definition;
+      updateData.triggerType = definition.trigger.type;
+      updateData.triggerEvent =
+        definition.trigger.type === 'event' ? definition.trigger.event : null;
+    }
+
+    const updated = await context.scopedDb.workflowDefinitions.update(
+      id,
+      updateData
+    );
+    if (!updated) throw new Error(`Workflow definition ${id} not found`);
+    return updated;
+  });
+
+// ── Delete ──────────────────────────────────────────────────────
+
+export const deleteWorkflowDefinitionFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(z.object({ id: ulidSchema })))
+  .handler(async ({ data, context }) => {
+    await context.scopedDb.workflowDefinitions.delete(data.id);
+    return { success: true };
+  });
+
+// ── Trigger (manual run) ────────────────────────────────────────
+
+const triggerSchema = z.object({
+  definitionId: ulidSchema,
+  sequenceId: z.string().optional(),
+  frameId: z.string().optional(),
+  inputs: z.record(z.string(), z.any()).optional(),
+});
+
+export const triggerWorkflowDefinitionFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(triggerSchema))
+  .handler(async ({ data, context }) => {
+    const def = await context.scopedDb.workflowDefinitions.getById(
+      data.definitionId
+    );
+    if (!def)
+      throw new Error(`Workflow definition ${data.definitionId} not found`);
+
+    const workflowRunId = await triggerWorkflow('/json-workflow', {
+      userId: context.user.id,
+      teamId: context.teamId,
+      definitionId: data.definitionId,
+      sequenceId: data.sequenceId,
+      frameId: data.frameId,
+      triggerData: data.inputs ?? {},
+      inputs: data.inputs ?? {},
+    });
+
+    return { workflowRunId };
+  });
+
+// ── List Runs ───────────────────────────────────────────────────
+
+const listRunsSchema = z.object({
+  workflowDefinitionId: ulidSchema.optional(),
+  status: z.enum(['pending', 'running', 'completed', 'failed']).optional(),
+  limit: z.number().int().positive().max(100).optional(),
+});
+
+/**
+ * Serialize a workflow run for TanStack Start transport.
+ * JSON round-trip strips undefined values so the result satisfies
+ * the stricter Record<string, {}> column types.
+ */
+function serializeRun(run: WorkflowRun): WorkflowRun {
+  return JSON.parse(JSON.stringify(run));
+}
+
+export const listWorkflowRunsFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(listRunsSchema))
+  .handler(async ({ data, context }) => {
+    const runs = await context.scopedDb.workflowRuns.list({
+      workflowDefinitionId: data.workflowDefinitionId,
+      status: data.status,
+      limit: data.limit ?? 50,
+    });
+    return runs.map(serializeRun);
+  });
+
+// ── Get Run ─────────────────────────────────────────────────────
+
+export const getWorkflowRunFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(z.object({ id: ulidSchema })))
+  .handler(async ({ data, context }) => {
+    const run = await context.scopedDb.workflowRuns.getById(data.id);
+    if (!run) throw new Error(`Workflow run ${data.id} not found`);
+    return serializeRun(run);
+  });

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -57,6 +57,10 @@ import { teamApiKeys } from './team-api-keys';
 
 import { giftTokenRedemptions, giftTokens } from './gift-tokens';
 
+import { workflowDefinitions } from './workflow-definitions';
+
+import { workflowRuns } from './workflow-runs';
+
 // Better Auth tables
 export { account, passkey, session, user, verification };
 
@@ -277,6 +281,21 @@ export type {
   NewGiftTokenRedemption,
 } from './gift-tokens';
 
+// Workflow Definitions & Runs
+export { workflowDefinitions, workflowRuns };
+
+export type {
+  NewWorkflowDefinition,
+  WorkflowDefinition,
+  WorkflowTriggerType,
+} from './workflow-definitions';
+
+export type {
+  NewWorkflowRun,
+  WorkflowRun,
+  WorkflowRunStatus,
+} from './workflow-runs';
+
 /**
  * Complete schema object for Drizzle client initialization (tables only).
  * Relations are defined separately in ./relations.ts using defineRelations().
@@ -343,4 +362,8 @@ export const schema = {
   // Gift Tokens
   giftTokens,
   giftTokenRedemptions,
+
+  // Workflow Definitions & Runs
+  workflowDefinitions,
+  workflowRuns,
 };

--- a/src/lib/db/schema/relations.ts
+++ b/src/lib/db/schema/relations.ts
@@ -267,4 +267,27 @@ export const relations = defineRelations(schema, (r) => ({
       alias: 'giftTokenRedemptions_user',
     }),
   },
+
+  // ---- Workflow Definitions & Runs ----
+  workflowDefinitions: {
+    team: r.one.teams({
+      from: r.workflowDefinitions.teamId,
+      to: r.teams.id,
+    }),
+    createdByUser: r.one.user({
+      from: r.workflowDefinitions.createdBy,
+      to: r.user.id,
+    }),
+    runs: r.many.workflowRuns(),
+  },
+  workflowRuns: {
+    definition: r.one.workflowDefinitions({
+      from: r.workflowRuns.workflowDefinitionId,
+      to: r.workflowDefinitions.id,
+    }),
+    team: r.one.teams({
+      from: r.workflowRuns.teamId,
+      to: r.teams.id,
+    }),
+  },
 }));

--- a/src/lib/db/schema/workflow-definitions.ts
+++ b/src/lib/db/schema/workflow-definitions.ts
@@ -1,0 +1,58 @@
+/**
+ * Workflow Definitions Schema
+ * Stores user-created JSON workflow definitions (team-scoped)
+ */
+
+import type { WorkflowDefinitionJson } from '@/lib/json-workflows/schema';
+import { type InferInsertModel, type InferSelectModel } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { generateId } from '../id';
+import { user } from './auth';
+import { teams } from './teams';
+
+const TRIGGER_TYPES = ['manual', 'event'] as const;
+export type WorkflowTriggerType = (typeof TRIGGER_TYPES)[number];
+
+export const workflowDefinitions = sqliteTable(
+  'workflow_definitions',
+  {
+    id: text()
+      .$defaultFn(() => generateId())
+      .primaryKey()
+      .notNull(),
+    teamId: text('team_id')
+      .notNull()
+      .references(() => teams.id, { onDelete: 'cascade' }),
+    name: text().notNull(),
+    description: text(),
+    definition: text({ mode: 'json' })
+      .$type<WorkflowDefinitionJson>()
+      .notNull(),
+    triggerType: text('trigger_type').$type<WorkflowTriggerType>().notNull(),
+    triggerEvent: text('trigger_event'),
+    enabled: integer({ mode: 'boolean' }).default(true).notNull(),
+    version: integer().default(1).notNull(),
+    createdBy: text('created_by').references(() => user.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: integer('updated_at', { mode: 'timestamp' })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('idx_wf_def_team_id').on(table.teamId),
+    index('idx_wf_def_trigger').on(
+      table.teamId,
+      table.triggerType,
+      table.triggerEvent
+    ),
+  ]
+);
+
+export type WorkflowDefinition = InferSelectModel<typeof workflowDefinitions>;
+export type NewWorkflowDefinition = InferInsertModel<
+  typeof workflowDefinitions
+>;

--- a/src/lib/db/schema/workflow-runs.ts
+++ b/src/lib/db/schema/workflow-runs.ts
@@ -1,0 +1,51 @@
+/**
+ * Workflow Runs Schema
+ * Tracks execution instances of JSON workflow definitions
+ */
+
+import { type InferInsertModel, type InferSelectModel } from 'drizzle-orm';
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { generateId } from '../id';
+import { teams } from './teams';
+import { workflowDefinitions } from './workflow-definitions';
+
+const RUN_STATUSES = ['pending', 'running', 'completed', 'failed'] as const;
+export type WorkflowRunStatus = (typeof RUN_STATUSES)[number];
+
+export const workflowRuns = sqliteTable(
+  'workflow_runs',
+  {
+    id: text()
+      .$defaultFn(() => generateId())
+      .primaryKey()
+      .notNull(),
+    workflowDefinitionId: text('workflow_definition_id')
+      .notNull()
+      .references(() => workflowDefinitions.id, { onDelete: 'cascade' }),
+    teamId: text('team_id')
+      .notNull()
+      .references(() => teams.id, { onDelete: 'cascade' }),
+    status: text().$type<WorkflowRunStatus>().default('pending').notNull(),
+    triggerData: text('trigger_data', { mode: 'json' }).$type<
+      Record<string, {}>
+    >(),
+    stepResults: text('step_results', { mode: 'json' }).$type<
+      Record<string, {}>
+    >(),
+    error: text(),
+    qstashWorkflowRunId: text('qstash_workflow_run_id'),
+    startedAt: integer('started_at', { mode: 'timestamp' }),
+    completedAt: integer('completed_at', { mode: 'timestamp' }),
+    createdAt: integer('created_at', { mode: 'timestamp' })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('idx_wf_run_def_id').on(table.workflowDefinitionId),
+    index('idx_wf_run_team_id').on(table.teamId),
+    index('idx_wf_run_status').on(table.status),
+  ]
+);
+
+export type WorkflowRun = InferSelectModel<typeof workflowRuns>;
+export type NewWorkflowRun = InferInsertModel<typeof workflowRuns>;

--- a/src/lib/db/schema/workflow-runs.ts
+++ b/src/lib/db/schema/workflow-runs.ts
@@ -12,6 +12,14 @@ import { workflowDefinitions } from './workflow-definitions';
 const RUN_STATUSES = ['pending', 'running', 'completed', 'failed'] as const;
 export type WorkflowRunStatus = (typeof RUN_STATUSES)[number];
 
+export type WorkflowJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | WorkflowJsonValue[]
+  | { [key: string]: WorkflowJsonValue };
+
 export const workflowRuns = sqliteTable(
   'workflow_runs',
   {
@@ -27,10 +35,10 @@ export const workflowRuns = sqliteTable(
       .references(() => teams.id, { onDelete: 'cascade' }),
     status: text().$type<WorkflowRunStatus>().default('pending').notNull(),
     triggerData: text('trigger_data', { mode: 'json' }).$type<
-      Record<string, {}>
+      Record<string, WorkflowJsonValue>
     >(),
     stepResults: text('step_results', { mode: 'json' }).$type<
-      Record<string, {}>
+      Record<string, WorkflowJsonValue>
     >(),
     error: text(),
     qstashWorkflowRunId: text('qstash_workflow_run_id'),

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -54,6 +54,11 @@ import {
   createTeamManagementMethods,
   createTeamManagementReadMethods,
 } from '@/lib/db/scoped/team-management';
+import {
+  createWorkflowDefinitionsMethods,
+  createWorkflowDefinitionsReadMethods,
+} from '@/lib/db/scoped/workflow-definitions';
+import { createWorkflowRunsMethods } from '@/lib/db/scoped/workflow-runs';
 import { and, eq, sql } from 'drizzle-orm';
 
 export type {
@@ -260,6 +265,9 @@ export function createScopedDb(teamId: string, userId: string) {
     billing: createBillingMethods(db, teamId, userId),
     apiKeys: createApiKeysMethods(db, teamId, userId),
     teamManagement: createTeamManagementMethods(db, teamId, userId),
+
+    workflowDefinitions: createWorkflowDefinitionsMethods(db, teamId, userId),
+    workflowRuns: createWorkflowRunsMethods(db, teamId),
   };
 }
 
@@ -300,6 +308,8 @@ export function createReadOnlyScopedDb(teamId: string) {
     billing: createBillingReadMethods(db, teamId),
     apiKeys: createApiKeysReadMethods(db, teamId),
     teamManagement: createTeamManagementReadMethods(db, teamId),
+
+    workflowDefinitions: createWorkflowDefinitionsReadMethods(db, teamId),
   };
 }
 

--- a/src/lib/db/scoped/workflow-definitions.ts
+++ b/src/lib/db/scoped/workflow-definitions.ts
@@ -1,0 +1,166 @@
+/**
+ * Scoped Workflow Definitions Sub-module
+ * CRUD operations for workflow definitions (team-scoped).
+ */
+
+import type { Database } from '@/lib/db/client';
+import {
+  workflowDefinitions,
+  type NewWorkflowDefinition,
+  type WorkflowDefinition,
+} from '@/lib/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+export function createWorkflowDefinitionsMethods(
+  db: Database,
+  teamId: string,
+  userId: string
+) {
+  return {
+    list: async (): Promise<WorkflowDefinition[]> => {
+      return db
+        .select()
+        .from(workflowDefinitions)
+        .where(eq(workflowDefinitions.teamId, teamId));
+    },
+
+    getById: async (id: string): Promise<WorkflowDefinition | null> => {
+      const result = await db
+        .select()
+        .from(workflowDefinitions)
+        .where(
+          and(
+            eq(workflowDefinitions.id, id),
+            eq(workflowDefinitions.teamId, teamId)
+          )
+        );
+      return result[0] ?? null;
+    },
+
+    getByTriggerEvent: async (event: string): Promise<WorkflowDefinition[]> => {
+      return db
+        .select()
+        .from(workflowDefinitions)
+        .where(
+          and(
+            eq(workflowDefinitions.teamId, teamId),
+            eq(workflowDefinitions.triggerType, 'event'),
+            eq(workflowDefinitions.triggerEvent, event),
+            eq(workflowDefinitions.enabled, true)
+          )
+        );
+    },
+
+    create: async (
+      data: Omit<
+        NewWorkflowDefinition,
+        'id' | 'teamId' | 'createdBy' | 'createdAt' | 'updatedAt'
+      >
+    ): Promise<WorkflowDefinition> => {
+      const [created] = await db
+        .insert(workflowDefinitions)
+        .values({
+          ...data,
+          teamId,
+          createdBy: userId,
+        })
+        .returning();
+      return created;
+    },
+
+    update: async (
+      id: string,
+      data: Partial<
+        Pick<
+          WorkflowDefinition,
+          | 'name'
+          | 'description'
+          | 'definition'
+          | 'triggerType'
+          | 'triggerEvent'
+          | 'enabled'
+        >
+      >
+    ): Promise<WorkflowDefinition | null> => {
+      const results = await db
+        .update(workflowDefinitions)
+        .set({
+          ...data,
+          updatedAt: new Date(),
+          version: data.definition
+            ? // Bump version when definition changes
+              (
+                await db
+                  .select({ version: workflowDefinitions.version })
+                  .from(workflowDefinitions)
+                  .where(eq(workflowDefinitions.id, id))
+              )[0].version + 1
+            : undefined,
+        })
+        .where(
+          and(
+            eq(workflowDefinitions.id, id),
+            eq(workflowDefinitions.teamId, teamId)
+          )
+        )
+        .returning();
+      return results[0] ?? null;
+    },
+
+    delete: async (id: string): Promise<void> => {
+      await db
+        .delete(workflowDefinitions)
+        .where(
+          and(
+            eq(workflowDefinitions.id, id),
+            eq(workflowDefinitions.teamId, teamId)
+          )
+        );
+    },
+  };
+}
+
+/**
+ * Read-only workflow definitions methods (no userId needed).
+ * Used by event trigger system and system operations.
+ */
+export function createWorkflowDefinitionsReadMethods(
+  db: Database,
+  teamId: string
+) {
+  return {
+    list: async (): Promise<WorkflowDefinition[]> => {
+      return db
+        .select()
+        .from(workflowDefinitions)
+        .where(eq(workflowDefinitions.teamId, teamId));
+    },
+
+    getById: async (id: string): Promise<WorkflowDefinition | null> => {
+      const result = await db
+        .select()
+        .from(workflowDefinitions)
+        .where(
+          and(
+            eq(workflowDefinitions.id, id),
+            eq(workflowDefinitions.teamId, teamId)
+          )
+        );
+      return result[0] ?? null;
+    },
+
+    getByTriggerEvent: async (event: string): Promise<WorkflowDefinition[]> => {
+      return db
+        .select()
+        .from(workflowDefinitions)
+        .where(
+          and(
+            eq(workflowDefinitions.teamId, teamId),
+            eq(workflowDefinitions.triggerType, 'event'),
+            eq(workflowDefinitions.triggerEvent, event),
+            eq(workflowDefinitions.enabled, true)
+          )
+        );
+    },
+  };
+}

--- a/src/lib/db/scoped/workflow-runs.ts
+++ b/src/lib/db/scoped/workflow-runs.ts
@@ -47,6 +47,21 @@ export function createWorkflowRunsMethods(db: Database, teamId: string) {
       return result[0] ?? null;
     },
 
+    getByQstashRunId: async (
+      qstashRunId: string
+    ): Promise<WorkflowRun | null> => {
+      const result = await db
+        .select()
+        .from(workflowRuns)
+        .where(
+          and(
+            eq(workflowRuns.qstashWorkflowRunId, qstashRunId),
+            eq(workflowRuns.teamId, teamId)
+          )
+        );
+      return result[0] ?? null;
+    },
+
     create: async (
       data: Omit<NewWorkflowRun, 'id' | 'teamId' | 'createdAt'>
     ): Promise<WorkflowRun> => {

--- a/src/lib/db/scoped/workflow-runs.ts
+++ b/src/lib/db/scoped/workflow-runs.ts
@@ -1,0 +1,77 @@
+/**
+ * Scoped Workflow Runs Sub-module
+ * CRUD operations for workflow run instances (team-scoped).
+ */
+
+import type { Database } from '@/lib/db/client';
+import {
+  workflowRuns,
+  type NewWorkflowRun,
+  type WorkflowRun,
+  type WorkflowRunStatus,
+} from '@/lib/db/schema';
+import { and, desc, eq } from 'drizzle-orm';
+
+export function createWorkflowRunsMethods(db: Database, teamId: string) {
+  return {
+    list: async (options?: {
+      workflowDefinitionId?: string;
+      status?: WorkflowRunStatus;
+      limit?: number;
+    }): Promise<WorkflowRun[]> => {
+      const conditions = [eq(workflowRuns.teamId, teamId)];
+
+      if (options?.workflowDefinitionId) {
+        conditions.push(
+          eq(workflowRuns.workflowDefinitionId, options.workflowDefinitionId)
+        );
+      }
+
+      if (options?.status) {
+        conditions.push(eq(workflowRuns.status, options.status));
+      }
+
+      return db
+        .select()
+        .from(workflowRuns)
+        .where(and(...conditions))
+        .orderBy(desc(workflowRuns.createdAt))
+        .limit(options?.limit ?? 100);
+    },
+
+    getById: async (id: string): Promise<WorkflowRun | null> => {
+      const result = await db
+        .select()
+        .from(workflowRuns)
+        .where(and(eq(workflowRuns.id, id), eq(workflowRuns.teamId, teamId)));
+      return result[0] ?? null;
+    },
+
+    create: async (
+      data: Omit<NewWorkflowRun, 'id' | 'teamId' | 'createdAt'>
+    ): Promise<WorkflowRun> => {
+      const [created] = await db
+        .insert(workflowRuns)
+        .values({
+          ...data,
+          teamId,
+        })
+        .returning();
+      return created;
+    },
+
+    update: async (
+      id: string,
+      data: Partial<
+        Pick<WorkflowRun, 'status' | 'stepResults' | 'error' | 'completedAt'>
+      >
+    ): Promise<WorkflowRun | null> => {
+      const results = await db
+        .update(workflowRuns)
+        .set(data)
+        .where(and(eq(workflowRuns.id, id), eq(workflowRuns.teamId, teamId)))
+        .returning();
+      return results[0] ?? null;
+    },
+  };
+}

--- a/src/lib/json-workflows/actions/data-actions.ts
+++ b/src/lib/json-workflows/actions/data-actions.ts
@@ -1,0 +1,243 @@
+/**
+ * Data Actions
+ *
+ * Read and write operations on sequences, frames, characters, and locations.
+ * These wrap the existing scoped DB methods.
+ */
+
+import { z } from 'zod';
+import type { ActionDefinition } from './types';
+
+// ── Shared schemas ──────────────────────────────────────────────
+
+const frameIdInput = z.object({ frameId: z.string() });
+const sequenceIdInput = z.object({ sequenceId: z.string() });
+
+// ── Read Actions ────────────────────────────────────────────────
+
+const getFrame: ActionDefinition = {
+  name: 'get-frame',
+  description: 'Fetch a single frame by ID',
+  inputSchema: frameIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { frameId } = frameIdInput.parse(input);
+    const frame = await ctx.scopedDb.frames.getById(frameId);
+    if (!frame) throw new Error(`Frame ${frameId} not found`);
+    return frame;
+  },
+};
+
+const getFrameWithSequence: ActionDefinition = {
+  name: 'get-frame-with-sequence',
+  description: 'Fetch a frame with its parent sequence context',
+  inputSchema: frameIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { frameId } = frameIdInput.parse(input);
+    const frame = await ctx.scopedDb.frames.getWithSequence(frameId);
+    if (!frame) throw new Error(`Frame ${frameId} not found`);
+    return frame;
+  },
+};
+
+const listFramesInputSchema = z.object({
+  sequenceId: z.string(),
+  filter: z
+    .object({
+      hasThumbnail: z.boolean().optional(),
+      hasVideo: z.boolean().optional(),
+      limit: z.number().optional(),
+    })
+    .optional(),
+});
+
+const listFrames: ActionDefinition = {
+  name: 'list-frames',
+  description: 'List all frames in a sequence',
+  inputSchema: listFramesInputSchema,
+  outputSchema: z.object({ frames: z.array(z.any()) }),
+  execute: async (input, ctx) => {
+    const { sequenceId, filter } = listFramesInputSchema.parse(input);
+    const frames = await ctx.scopedDb.frames.listBySequence(sequenceId, filter);
+    return { frames };
+  },
+};
+
+const getSequence: ActionDefinition = {
+  name: 'get-sequence',
+  description: 'Fetch a single sequence by ID',
+  inputSchema: sequenceIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId } = sequenceIdInput.parse(input);
+    const sequence = await ctx.scopedDb.sequences.getById(sequenceId);
+    if (!sequence) throw new Error(`Sequence ${sequenceId} not found`);
+    return sequence;
+  },
+};
+
+const getSequenceWithFrames: ActionDefinition = {
+  name: 'get-sequence-with-frames',
+  description: 'Fetch a sequence with all its frames and style',
+  inputSchema: sequenceIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId } = sequenceIdInput.parse(input);
+    return ctx.scopedDb.sequences.getWithFrames(sequenceId);
+  },
+};
+
+const getCharacters: ActionDefinition = {
+  name: 'get-characters',
+  description: 'List all characters in a sequence',
+  inputSchema: sequenceIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId } = sequenceIdInput.parse(input);
+    return ctx.scopedDb.characters.list(sequenceId);
+  },
+};
+
+const getLocations: ActionDefinition = {
+  name: 'get-locations',
+  description: 'List all locations in a sequence',
+  inputSchema: sequenceIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId } = sequenceIdInput.parse(input);
+    return ctx.scopedDb.sequenceLocations.list(sequenceId);
+  },
+};
+
+const styleIdInput = z.object({ styleId: z.string() });
+
+const getStyle: ActionDefinition = {
+  name: 'get-style',
+  description: 'Fetch a style config by ID',
+  inputSchema: styleIdInput,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { styleId } = styleIdInput.parse(input);
+    const style = await ctx.scopedDb.styles.getById(styleId);
+    if (!style) throw new Error(`Style ${styleId} not found`);
+    return style;
+  },
+};
+
+// ── Write Actions ───────────────────────────────────────────────
+
+const updateFrameInputSchema = z.object({
+  frameId: z.string(),
+  fields: z.record(z.string(), z.any()),
+});
+
+const updateFrame: ActionDefinition = {
+  name: 'update-frame',
+  description: 'Update frame fields (status, URLs, metadata, etc.)',
+  inputSchema: updateFrameInputSchema,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { frameId, fields } = updateFrameInputSchema.parse(input);
+    return ctx.scopedDb.frames.update(frameId, fields);
+  },
+};
+
+/**
+ * Zod schema for frame inserts. Validates required fields and passes through
+ * optional columns so the parsed result is compatible with NewFrame.
+ */
+const frameInsertSchema = z
+  .object({
+    sequenceId: z.string(),
+    orderIndex: z.number(),
+  })
+  .passthrough();
+
+const bulkUpsertInputSchema = z.object({
+  frames: z.array(frameInsertSchema),
+});
+
+const bulkUpsertFrames: ActionDefinition = {
+  name: 'bulk-upsert-frames',
+  description: 'Bulk upsert frames into a sequence (idempotent on orderIndex)',
+  inputSchema: bulkUpsertInputSchema,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { frames } = bulkUpsertInputSchema.parse(input);
+    // Each frame is validated to have required sequenceId + orderIndex;
+    // remaining optional columns pass through to the DB insert.
+    return ctx.scopedDb.frames.bulkUpsert(
+      frames.map((f) => ({
+        ...f,
+        sequenceId: f.sequenceId,
+        orderIndex: f.orderIndex,
+      }))
+    );
+  },
+};
+
+const reorderInputSchema = z.object({
+  sequenceId: z.string(),
+  frameOrders: z.array(z.object({ id: z.string(), order_index: z.number() })),
+});
+
+const reorderFrames: ActionDefinition = {
+  name: 'reorder-frames',
+  description: 'Reorder frames in a sequence',
+  inputSchema: reorderInputSchema,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId, frameOrders } = reorderInputSchema.parse(input);
+    return ctx.scopedDb.frames.reorder(sequenceId, frameOrders);
+  },
+};
+
+const updateSequenceInputSchema = z.object({
+  sequenceId: z.string(),
+  fields: z.record(z.string(), z.any()),
+});
+
+const updateSequence: ActionDefinition = {
+  name: 'update-sequence',
+  description: 'Update sequence fields',
+  inputSchema: updateSequenceInputSchema,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId, fields } = updateSequenceInputSchema.parse(input);
+    return ctx.scopedDb.sequences.update({ id: sequenceId, ...fields });
+  },
+};
+
+const updateStatusInputSchema = z.object({
+  sequenceId: z.string(),
+  status: z.enum(['draft', 'processing', 'completed', 'failed', 'archived']),
+  error: z.string().optional(),
+});
+
+const updateSequenceStatus: ActionDefinition = {
+  name: 'update-sequence-status',
+  description: 'Set sequence processing status',
+  inputSchema: updateStatusInputSchema,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { sequenceId, status, error } = updateStatusInputSchema.parse(input);
+    return ctx.scopedDb.sequence(sequenceId).updateStatus(status, error);
+  },
+};
+
+export const dataActions: ActionDefinition[] = [
+  getFrame,
+  getFrameWithSequence,
+  listFrames,
+  getSequence,
+  getSequenceWithFrames,
+  getCharacters,
+  getLocations,
+  getStyle,
+  updateFrame,
+  bulkUpsertFrames,
+  reorderFrames,
+  updateSequence,
+  updateSequenceStatus,
+];

--- a/src/lib/json-workflows/actions/generation-actions.ts
+++ b/src/lib/json-workflows/actions/generation-actions.ts
@@ -33,19 +33,24 @@ const generateImage: ActionDefinition = {
     const { generateImageWithProvider } =
       await import('@/lib/image/image-generation');
     const { uploadImageToStorage } = await import('@/lib/image/image-storage');
-    const { DEFAULT_IMAGE_MODEL, safeTextToImageModel } =
+    const { DEFAULT_IMAGE_MODEL, isValidTextToImageModel } =
       await import('@/lib/ai/models');
     const { DEFAULT_IMAGE_SIZE } =
       await import('@/lib/constants/aspect-ratios');
 
     const params = generateImageInputSchema.parse(input);
 
-    const model = safeTextToImageModel(params.model ?? DEFAULT_IMAGE_MODEL);
-    const imageSizeResult = z
-      .enum(['square_hd', 'portrait_16_9', 'landscape_16_9'])
-      .safeParse(params.imageSize);
-    const imageSize = imageSizeResult.success
-      ? imageSizeResult.data
+    const requestedModel = params.model ?? DEFAULT_IMAGE_MODEL;
+    if (!isValidTextToImageModel(requestedModel)) {
+      throw new Error(
+        `generate-image: unknown text-to-image model "${requestedModel}"`
+      );
+    }
+    const model = requestedModel;
+    const imageSize = params.imageSize
+      ? z
+          .enum(['square_hd', 'portrait_16_9', 'landscape_16_9'])
+          .parse(params.imageSize)
       : DEFAULT_IMAGE_SIZE;
     const imageResult = await generateImageWithProvider(
       {
@@ -76,20 +81,24 @@ const generateImage: ActionDefinition = {
         frameId: params.frameId,
       });
 
-      if (result.url) {
-        imageUrl = result.url;
-        imagePath = result.path;
-
-        await ctx.scopedDb.frames.update(params.frameId, {
-          thumbnailUrl: result.url,
-          thumbnailPath: result.path || null,
-          thumbnailStatus: 'completed',
-          thumbnailGeneratedAt: new Date(),
-          thumbnailError: null,
-          imageModel: model,
-          imagePrompt: params.prompt,
-        });
+      if (!result.url) {
+        throw new Error(
+          `generate-image: upload to storage failed for frame ${params.frameId}`
+        );
       }
+
+      imageUrl = result.url;
+      imagePath = result.path;
+
+      await ctx.scopedDb.frames.update(params.frameId, {
+        thumbnailUrl: result.url,
+        thumbnailPath: result.path || null,
+        thumbnailStatus: 'completed',
+        thumbnailGeneratedAt: new Date(),
+        thumbnailError: null,
+        imageModel: model,
+        imagePrompt: params.prompt,
+      });
     }
 
     return { imageUrl, imagePath };
@@ -108,9 +117,9 @@ const generateMotionInputSchema = z.object({
 const generateMotion: ActionDefinition = {
   name: 'generate-motion',
   description:
-    'Generate motion video from an image. Uses invoke-workflow internally.',
+    'Trigger motion video generation from an image. Async — returns a workflowRunId; the resulting videoUrl is written to the frame by the motion workflow.',
   inputSchema: generateMotionInputSchema,
-  outputSchema: z.object({ videoUrl: z.string() }),
+  outputSchema: z.object({ workflowRunId: z.string() }),
   execute: async (input, ctx) => {
     const { triggerWorkflow } = await import('@/lib/workflow/client');
     const params = generateMotionInputSchema.parse(input);
@@ -127,7 +136,7 @@ const generateMotion: ActionDefinition = {
       aspectRatio: params.aspectRatio,
     });
 
-    return { videoUrl: '', workflowRunId };
+    return { workflowRunId };
   },
 };
 

--- a/src/lib/json-workflows/actions/generation-actions.ts
+++ b/src/lib/json-workflows/actions/generation-actions.ts
@@ -1,0 +1,240 @@
+/**
+ * Generation Actions
+ *
+ * AI generation operations: image, motion, music, variant, merge.
+ * These wrap existing service functions.
+ */
+
+import { z } from 'zod';
+import type { ActionDefinition } from './types';
+
+const generateImageInputSchema = z.object({
+  prompt: z.string(),
+  model: z.string().optional(),
+  imageSize: z.string().optional(),
+  numImages: z.number().optional(),
+  seed: z.number().optional(),
+  frameId: z.string().optional(),
+  sequenceId: z.string().optional(),
+  referenceImages: z.array(z.any()).optional(),
+  skipStorage: z.boolean().optional(),
+});
+
+const generateImage: ActionDefinition = {
+  name: 'generate-image',
+  description:
+    'Generate an image using AI, optionally upload to R2 and update frame',
+  inputSchema: generateImageInputSchema,
+  outputSchema: z.object({
+    imageUrl: z.string(),
+    imagePath: z.string().optional(),
+  }),
+  execute: async (input, ctx) => {
+    const { generateImageWithProvider } =
+      await import('@/lib/image/image-generation');
+    const { uploadImageToStorage } = await import('@/lib/image/image-storage');
+    const { DEFAULT_IMAGE_MODEL, safeTextToImageModel } =
+      await import('@/lib/ai/models');
+    const { DEFAULT_IMAGE_SIZE } =
+      await import('@/lib/constants/aspect-ratios');
+
+    const params = generateImageInputSchema.parse(input);
+
+    const model = safeTextToImageModel(params.model ?? DEFAULT_IMAGE_MODEL);
+    const imageSizeResult = z
+      .enum(['square_hd', 'portrait_16_9', 'landscape_16_9'])
+      .safeParse(params.imageSize);
+    const imageSize = imageSizeResult.success
+      ? imageSizeResult.data
+      : DEFAULT_IMAGE_SIZE;
+    const imageResult = await generateImageWithProvider(
+      {
+        model,
+        prompt: params.prompt,
+        imageSize,
+        numImages: params.numImages ?? 1,
+        seed: params.seed,
+        traceName: 'json-workflow-image',
+      },
+      { scopedDb: ctx.scopedDb }
+    );
+
+    let imageUrl = imageResult.imageUrls[0];
+    let imagePath: string | undefined;
+
+    if (
+      imageUrl &&
+      params.frameId &&
+      params.sequenceId &&
+      ctx.scopedDb.teamId &&
+      !params.skipStorage
+    ) {
+      const result = await uploadImageToStorage({
+        imageUrl,
+        teamId: ctx.scopedDb.teamId,
+        sequenceId: params.sequenceId,
+        frameId: params.frameId,
+      });
+
+      if (result.url) {
+        imageUrl = result.url;
+        imagePath = result.path;
+
+        await ctx.scopedDb.frames.update(params.frameId, {
+          thumbnailUrl: result.url,
+          thumbnailPath: result.path || null,
+          thumbnailStatus: 'completed',
+          thumbnailGeneratedAt: new Date(),
+          thumbnailError: null,
+          imageModel: model,
+          imagePrompt: params.prompt,
+        });
+      }
+    }
+
+    return { imageUrl, imagePath };
+  },
+};
+
+const generateMotionInputSchema = z.object({
+  imageUrl: z.string(),
+  prompt: z.string(),
+  model: z.string().optional(),
+  frameId: z.string().optional(),
+  duration: z.number().optional(),
+  aspectRatio: z.string().optional(),
+});
+
+const generateMotion: ActionDefinition = {
+  name: 'generate-motion',
+  description:
+    'Generate motion video from an image. Uses invoke-workflow internally.',
+  inputSchema: generateMotionInputSchema,
+  outputSchema: z.object({ videoUrl: z.string() }),
+  execute: async (input, ctx) => {
+    const { triggerWorkflow } = await import('@/lib/workflow/client');
+    const params = generateMotionInputSchema.parse(input);
+
+    const workflowRunId = await triggerWorkflow('/motion', {
+      userId: ctx.scopedDb.userId,
+      teamId: ctx.scopedDb.teamId,
+      frameId: params.frameId,
+      sequenceId: ctx.sequenceId,
+      imageUrl: params.imageUrl,
+      prompt: params.prompt,
+      model: params.model,
+      duration: params.duration,
+      aspectRatio: params.aspectRatio,
+    });
+
+    return { videoUrl: '', workflowRunId };
+  },
+};
+
+const generateMusic: ActionDefinition = {
+  name: 'generate-music',
+  description: 'Generate music from a prompt and tags',
+  inputSchema: z.object({
+    prompt: z.string(),
+    tags: z.string(),
+    duration: z.number(),
+    model: z.string().optional(),
+    sequenceId: z.string().optional(),
+  }),
+  outputSchema: z.object({ audioUrl: z.string() }),
+  execute: async () => {
+    throw new Error(
+      'generate-music action not yet implemented. Use invoke-workflow with name "music" instead.'
+    );
+  },
+};
+
+const generateVariantImage: ActionDefinition = {
+  name: 'generate-variant-image',
+  description: 'Generate a variant grid image from an existing thumbnail',
+  inputSchema: z.object({
+    thumbnailUrl: z.string(),
+    frameId: z.string().optional(),
+    scenePrompt: z.string().optional(),
+    aspectRatio: z.string().optional(),
+    model: z.string().optional(),
+  }),
+  outputSchema: z.object({ variantImageUrl: z.string() }),
+  execute: async () => {
+    throw new Error(
+      'generate-variant-image action not yet implemented. Use invoke-workflow with name "variant-image" instead.'
+    );
+  },
+};
+
+const mergeVideos: ActionDefinition = {
+  name: 'merge-videos',
+  description: 'Stitch frame videos into a single merged video',
+  inputSchema: z.object({
+    videoUrls: z.array(z.string()),
+    sequenceId: z.string().optional(),
+  }),
+  outputSchema: z.object({
+    mergedVideoUrl: z.string(),
+    mergedVideoPath: z.string().nullable(),
+  }),
+  execute: async () => {
+    throw new Error(
+      'merge-videos action not yet implemented. Use invoke-workflow with name "merge-video" instead.'
+    );
+  },
+};
+
+const mergeAudioVideo: ActionDefinition = {
+  name: 'merge-audio-video',
+  description: 'Mux audio onto a merged video',
+  inputSchema: z.object({
+    mergedVideoUrl: z.string(),
+    musicUrl: z.string(),
+    sequenceId: z.string().optional(),
+  }),
+  outputSchema: z.object({
+    mergedVideoUrl: z.string(),
+  }),
+  execute: async () => {
+    throw new Error(
+      'merge-audio-video action not yet implemented. Use invoke-workflow with name "merge-audio-video" instead.'
+    );
+  },
+};
+
+const invokeWorkflowInputSchema = z.object({
+  name: z.string(),
+  body: z.record(z.string(), z.any()),
+});
+
+const invokeWorkflow: ActionDefinition = {
+  name: 'invoke-workflow',
+  description:
+    'Invoke an existing registered workflow by name (escape hatch to TS workflows)',
+  inputSchema: invokeWorkflowInputSchema,
+  outputSchema: z.any(),
+  execute: async (input, ctx) => {
+    const { triggerWorkflow } = await import('@/lib/workflow/client');
+
+    const params = invokeWorkflowInputSchema.parse(input);
+
+    const workflowRunId = await triggerWorkflow(`/${params.name}`, {
+      userId: ctx.scopedDb.userId,
+      teamId: ctx.scopedDb.teamId,
+      ...params.body,
+    });
+
+    return { workflowRunId };
+  },
+};
+
+export const generationActions: ActionDefinition[] = [
+  generateImage,
+  generateMotion,
+  generateMusic,
+  generateVariantImage,
+  mergeVideos,
+  mergeAudioVideo,
+  invokeWorkflow,
+];

--- a/src/lib/json-workflows/actions/registry.ts
+++ b/src/lib/json-workflows/actions/registry.ts
@@ -1,0 +1,33 @@
+/**
+ * Action Registry
+ *
+ * Central registry mapping action names to their definitions.
+ * Actions are looked up by name during workflow execution.
+ */
+
+import type { ActionDefinition } from './types';
+import { dataActions } from './data-actions';
+import { generationActions } from './generation-actions';
+import { utilityActions } from './utility-actions';
+
+const allActions: ActionDefinition[] = [
+  ...dataActions,
+  ...generationActions,
+  ...utilityActions,
+];
+
+const registry = new Map<string, ActionDefinition>(
+  allActions.map((action) => [action.name, action])
+);
+
+export function getAction(name: string): ActionDefinition | undefined {
+  return registry.get(name);
+}
+
+export function getActionNames(): string[] {
+  return Array.from(registry.keys());
+}
+
+export function getActionDefinitions(): ActionDefinition[] {
+  return Array.from(registry.values());
+}

--- a/src/lib/json-workflows/actions/types.ts
+++ b/src/lib/json-workflows/actions/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Action Definition Types
+ *
+ * Each action is a named operation with typed input/output schemas
+ * that can be composed in JSON workflow definitions.
+ */
+
+import type { ScopedDb } from '@/lib/db/scoped';
+import type { z } from 'zod';
+
+export type ActionContext = {
+  scopedDb: ScopedDb;
+  sequenceId?: string;
+  frameId?: string;
+};
+
+export type ActionDefinition<TInput = unknown, TOutput = unknown> = {
+  name: string;
+  description: string;
+  inputSchema: z.ZodType<TInput>;
+  outputSchema: z.ZodType<TOutput>;
+  execute: (input: TInput, ctx: ActionContext) => Promise<TOutput>;
+};

--- a/src/lib/json-workflows/actions/utility-actions.ts
+++ b/src/lib/json-workflows/actions/utility-actions.ts
@@ -1,0 +1,129 @@
+/**
+ * Utility Actions
+ *
+ * Emit realtime events, log messages, billing operations, storage uploads.
+ */
+
+import { z } from 'zod';
+import type { ActionDefinition } from './types';
+
+const emitEventInputSchema = z.object({
+  sequenceId: z.string(),
+  event: z.string(),
+  data: z.record(z.string(), z.any()),
+});
+
+const emitEvent: ActionDefinition = {
+  name: 'emit-event',
+  description: 'Emit a realtime event for UI progress updates',
+  inputSchema: emitEventInputSchema,
+  outputSchema: z.void(),
+  execute: async (input) => {
+    const { emitDynamicEvent } = await import('@/lib/realtime');
+    const params = emitEventInputSchema.parse(input);
+    await emitDynamicEvent(params.sequenceId, params.event, params.data);
+  },
+};
+
+const logInputSchema = z.object({
+  message: z.string(),
+  level: z.enum(['info', 'warn', 'error']).optional(),
+});
+
+const log: ActionDefinition = {
+  name: 'log',
+  description: 'Log a message for debugging',
+  inputSchema: logInputSchema,
+  outputSchema: z.void(),
+  execute: async (input) => {
+    const params = logInputSchema.parse(input);
+    const level = params.level ?? 'info';
+    const prefix = '[JsonWorkflow]';
+
+    switch (level) {
+      case 'warn':
+        console.warn(prefix, params.message);
+        break;
+      case 'error':
+        console.error(prefix, params.message);
+        break;
+      default:
+        console.log(prefix, params.message);
+    }
+  },
+};
+
+const deductCreditsInputSchema = z.object({
+  costMicros: z.number(),
+  description: z.string(),
+  metadata: z.record(z.string(), z.any()).optional(),
+});
+
+const deductCredits: ActionDefinition = {
+  name: 'deduct-credits',
+  description: 'Deduct credits for an AI operation',
+  inputSchema: deductCreditsInputSchema,
+  outputSchema: z.void(),
+  execute: async (input, ctx) => {
+    const { deductWorkflowCredits } =
+      await import('@/lib/billing/workflow-deduction');
+    const { micros } = await import('@/lib/billing/money');
+    const params = deductCreditsInputSchema.parse(input);
+    await deductWorkflowCredits({
+      scopedDb: ctx.scopedDb,
+      costMicros: micros(params.costMicros),
+      usedOwnKey: false,
+      description: params.description,
+      metadata: params.metadata,
+    });
+  },
+};
+
+const checkCreditsInputSchema = z.object({
+  costMicros: z.number(),
+});
+
+const checkCredits: ActionDefinition = {
+  name: 'check-credits',
+  description: 'Check if team has enough credits for an operation',
+  inputSchema: checkCreditsInputSchema,
+  outputSchema: z.object({ hasCredits: z.boolean() }),
+  execute: async (input, ctx) => {
+    const params = checkCreditsInputSchema.parse(input);
+    const { micros } = await import('@/lib/billing/money');
+    const hasCredits = await ctx.scopedDb.billing.hasEnoughCredits(
+      micros(params.costMicros)
+    );
+    return { hasCredits };
+  },
+};
+
+const uploadInputSchema = z.object({
+  imageUrl: z.string(),
+  teamId: z.string(),
+  sequenceId: z.string(),
+  frameId: z.string(),
+});
+
+const uploadToStorage: ActionDefinition = {
+  name: 'upload-to-storage',
+  description: 'Upload an image URL to R2 storage',
+  inputSchema: uploadInputSchema,
+  outputSchema: z.object({
+    url: z.string().nullable(),
+    path: z.string().nullable(),
+  }),
+  execute: async (input) => {
+    const { uploadImageToStorage } = await import('@/lib/image/image-storage');
+    const params = uploadInputSchema.parse(input);
+    return uploadImageToStorage(params);
+  },
+};
+
+export const utilityActions: ActionDefinition[] = [
+  emitEvent,
+  log,
+  deductCredits,
+  checkCredits,
+  uploadToStorage,
+];

--- a/src/lib/json-workflows/executor.ts
+++ b/src/lib/json-workflows/executor.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ScopedDb } from '@/lib/db/scoped';
+import type { WorkflowJsonValue } from '@/lib/db/schema/workflow-runs';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type { WorkflowContext } from '@upstash/workflow';
@@ -251,8 +252,10 @@ export const jsonWorkflowExecutor = createScopedWorkflow<JsonWorkflowInput>(
 
     // Step 5: Mark run as completed
     await context.run('mark-complete', async () => {
-      // Serialize steps to strip undefined values for Record<string, {}> DB type
-      const stepResults: Record<string, {}> = JSON.parse(
+      // Coerce step results through JSON to enforce serializability — actions
+      // may return Date / class instances; libSQL stores via JSON.stringify
+      // anyway, so we do it here to match the typed column contract.
+      const stepResults: Record<string, WorkflowJsonValue> = JSON.parse(
         JSON.stringify(state.expressionCtx.steps)
       );
       await scopedDb.workflowRuns.update(run.id, {
@@ -275,24 +278,26 @@ export const jsonWorkflowExecutor = createScopedWorkflow<JsonWorkflowInput>(
         `[JsonWorkflow] Failed for definition ${input.definitionId}: ${error}`
       );
 
-      // Try to update the run record
       try {
-        // Find the run by qstash workflow run ID
-        const runs = await scopedDb.workflowRuns.list({
-          limit: 1,
-        });
-        const run = runs.find(
-          (r) => r.qstashWorkflowRunId === context.workflowRunId
+        const run = await scopedDb.workflowRuns.getByQstashRunId(
+          context.workflowRunId
         );
-        if (run) {
+        if (!run) {
+          console.error(
+            `[JsonWorkflow] No run record found for qstashWorkflowRunId=${context.workflowRunId}`
+          );
+        } else {
           await scopedDb.workflowRuns.update(run.id, {
             status: 'failed',
             error,
             completedAt: new Date(),
           });
         }
-      } catch {
-        // Ignore errors in failure handler
+      } catch (cleanupError) {
+        console.error(
+          `[JsonWorkflow] Failed to mark run as failed for qstashWorkflowRunId=${context.workflowRunId}:`,
+          cleanupError
+        );
       }
 
       return `JSON workflow failed: ${error}`;

--- a/src/lib/json-workflows/executor.ts
+++ b/src/lib/json-workflows/executor.ts
@@ -1,0 +1,301 @@
+/**
+ * JSON Workflow Executor
+ *
+ * A QStash durable workflow that interprets JSON workflow definitions at runtime.
+ * Each step in the definition is executed via context.run() for durability.
+ *
+ * Registered as 'json-workflow' in serveMany.
+ */
+
+import type { ScopedDb } from '@/lib/db/scoped';
+import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
+import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
+import type { WorkflowContext } from '@upstash/workflow';
+import { getAction } from './actions/registry';
+import type { ActionContext } from './actions/types';
+import {
+  createExpressionContext,
+  evaluateCondition,
+  resolveObject,
+  type ExpressionContext,
+} from './expressions';
+import { executeLLMStep } from './llm-step';
+import type {
+  ActionStep,
+  ConditionalStep,
+  ForEachStep,
+  JsonWorkflowInput,
+  LLMStep,
+  ParallelStep,
+  WorkflowStep,
+} from './schema';
+
+type ExecutorState = {
+  expressionCtx: ExpressionContext;
+  scopedDb: ScopedDb;
+  workflowContext: WorkflowContext<JsonWorkflowInput>;
+  runId: string;
+};
+
+/**
+ * Execute a single workflow step, dispatching by type.
+ */
+async function executeStep(
+  step: WorkflowStep,
+  state: ExecutorState
+): Promise<void> {
+  switch (step.type) {
+    case 'action':
+      await executeActionStep(step, state);
+      break;
+    case 'llm':
+      await executeLLMStepWrapper(step, state);
+      break;
+    case 'conditional':
+      await executeConditionalStep(step, state);
+      break;
+    case 'for-each':
+      await executeForEachStep(step, state);
+      break;
+    case 'parallel':
+      await executeParallelStep(step, state);
+      break;
+  }
+}
+
+/**
+ * Execute an action step: resolve inputs, look up action, run it durably.
+ */
+async function executeActionStep(
+  step: ActionStep,
+  state: ExecutorState
+): Promise<void> {
+  const action = getAction(step.action);
+  if (!action) {
+    throw new Error(`Unknown action "${step.action}" in step "${step.id}"`);
+  }
+
+  const result = await state.workflowContext.run(
+    `action:${step.id}`,
+    async () => {
+      const resolvedInputs = step.inputs
+        ? resolveObject(
+            step.inputs as Record<string, unknown>,
+            state.expressionCtx
+          )
+        : {};
+
+      const actionCtx: ActionContext = {
+        scopedDb: state.scopedDb,
+        sequenceId: state.expressionCtx.context.sequenceId,
+        frameId: state.expressionCtx.context.frameId,
+      };
+
+      return action.execute(resolvedInputs, actionCtx);
+    }
+  );
+
+  // Store result for downstream steps
+  state.expressionCtx.steps[step.id] = result;
+}
+
+/**
+ * Execute an LLM step: resolve prompt + variables, call LLM, validate output.
+ */
+async function executeLLMStepWrapper(
+  step: LLMStep,
+  state: ExecutorState
+): Promise<void> {
+  const result = await state.workflowContext.run(`llm:${step.id}`, async () => {
+    return executeLLMStep(step, state.expressionCtx, {
+      scopedDb: state.scopedDb,
+      sequenceId: state.expressionCtx.context.sequenceId,
+    });
+  });
+
+  state.expressionCtx.steps[step.id] = result;
+}
+
+/**
+ * Execute a conditional step: evaluate condition, run then/else branch.
+ */
+async function executeConditionalStep(
+  step: ConditionalStep,
+  state: ExecutorState
+): Promise<void> {
+  const conditionResult = evaluateCondition(
+    step.condition,
+    state.expressionCtx
+  );
+
+  const branch = conditionResult ? step.then : (step.else ?? []);
+
+  for (const branchStep of branch) {
+    await executeStep(branchStep, state);
+  }
+}
+
+/**
+ * Execute a for-each step: iterate over collection, run nested steps per item.
+ */
+async function executeForEachStep(
+  step: ForEachStep,
+  state: ExecutorState
+): Promise<void> {
+  const { resolveValue } = await import('./expressions');
+  const collection = resolveValue(step.collection, state.expressionCtx);
+
+  if (!Array.isArray(collection)) {
+    throw new Error(
+      `for-each step "${step.id}": collection resolved to ${typeof collection}, expected array`
+    );
+  }
+
+  for (let i = 0; i < collection.length; i++) {
+    // Set the item variable in expression context
+    const prevItem = { ...state.expressionCtx.item };
+    state.expressionCtx.item[step.itemVariable] = collection[i];
+
+    for (const innerStep of step.steps) {
+      // Namespace inner step IDs to avoid collisions across iterations
+      const namespacedStep = {
+        ...innerStep,
+        id: `${innerStep.id}[${i}]`,
+      } as WorkflowStep;
+      await executeStep(namespacedStep, state);
+    }
+
+    // Restore previous item context
+    state.expressionCtx.item = prevItem;
+  }
+}
+
+/**
+ * Execute a parallel step: run all branches concurrently.
+ */
+async function executeParallelStep(
+  step: ParallelStep,
+  state: ExecutorState
+): Promise<void> {
+  await Promise.all(
+    step.branches.map(async (branch, branchIdx) => {
+      for (const branchStep of branch) {
+        const namespacedStep = {
+          ...branchStep,
+          id: `${branchStep.id}:b${branchIdx}`,
+        } as WorkflowStep;
+        await executeStep(namespacedStep, state);
+      }
+    })
+  );
+}
+
+/**
+ * Execute all steps in a workflow definition sequentially.
+ */
+async function executeSteps(
+  steps: WorkflowStep[],
+  state: ExecutorState
+): Promise<void> {
+  for (const step of steps) {
+    await executeStep(step, state);
+  }
+}
+
+// ── QStash Workflow ─────────────────────────────────────────────
+
+export const jsonWorkflowExecutor = createScopedWorkflow<JsonWorkflowInput>(
+  async (context, scopedDb) => {
+    const input = context.requestPayload;
+    const { definitionId, triggerData, inputs, sequenceId, frameId } = input;
+
+    // Step 1: Load workflow definition from DB
+    const definition = await context.run('load-definition', async () => {
+      const def = await scopedDb.workflowDefinitions.getById(definitionId);
+      if (!def) {
+        throw new Error(`Workflow definition ${definitionId} not found`);
+      }
+      return def;
+    });
+
+    // Step 2: Create a run record
+    const run = await context.run('create-run', async () => {
+      return scopedDb.workflowRuns.create({
+        workflowDefinitionId: definitionId,
+        status: 'running',
+        triggerData: triggerData ?? null,
+        qstashWorkflowRunId: context.workflowRunId,
+        startedAt: new Date(),
+      });
+    });
+
+    // Step 3: Build expression context
+    const expressionCtx = createExpressionContext({
+      userId: input.userId,
+      teamId: input.teamId,
+      sequenceId,
+      frameId,
+      triggerData,
+      inputs,
+    });
+
+    const state: ExecutorState = {
+      expressionCtx,
+      scopedDb,
+      workflowContext: context,
+      runId: run.id,
+    };
+
+    // Step 4: Execute all steps
+    await executeSteps(definition.definition.steps, state);
+
+    // Step 5: Mark run as completed
+    await context.run('mark-complete', async () => {
+      // Serialize steps to strip undefined values for Record<string, {}> DB type
+      const stepResults: Record<string, {}> = JSON.parse(
+        JSON.stringify(state.expressionCtx.steps)
+      );
+      await scopedDb.workflowRuns.update(run.id, {
+        status: 'completed',
+        stepResults,
+        completedAt: new Date(),
+      });
+    });
+
+    console.log(
+      `[JsonWorkflow] Completed run ${run.id} for definition "${definition.name}"`
+    );
+  },
+  {
+    failureFunction: async ({ context, scopedDb, failResponse }) => {
+      const input = context.requestPayload;
+      const error = sanitizeFailResponse(failResponse);
+
+      console.error(
+        `[JsonWorkflow] Failed for definition ${input.definitionId}: ${error}`
+      );
+
+      // Try to update the run record
+      try {
+        // Find the run by qstash workflow run ID
+        const runs = await scopedDb.workflowRuns.list({
+          limit: 1,
+        });
+        const run = runs.find(
+          (r) => r.qstashWorkflowRunId === context.workflowRunId
+        );
+        if (run) {
+          await scopedDb.workflowRuns.update(run.id, {
+            status: 'failed',
+            error,
+            completedAt: new Date(),
+          });
+        }
+      } catch {
+        // Ignore errors in failure handler
+      }
+
+      return `JSON workflow failed: ${error}`;
+    },
+  }
+);

--- a/src/lib/json-workflows/expressions.test.ts
+++ b/src/lib/json-workflows/expressions.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  createExpressionContext,
+  evaluateCondition,
+  resolveObject,
+  resolveValue,
+  type ExpressionContext,
+} from './expressions';
+
+function makeCtx(overrides?: Partial<ExpressionContext>): ExpressionContext {
+  return {
+    context: { userId: 'user-1', teamId: 'team-1', sequenceId: 'seq-1' },
+    trigger: {},
+    steps: {},
+    item: {},
+    inputs: {},
+    ...overrides,
+  };
+}
+
+describe('resolveValue', () => {
+  test('returns non-string values as-is', () => {
+    const ctx = makeCtx();
+    expect(resolveValue(42, ctx)).toBe(42);
+    expect(resolveValue(true, ctx)).toBe(true);
+    expect(resolveValue(null, ctx)).toBe(null);
+  });
+
+  test('resolves a single expression to its typed value', () => {
+    const ctx = makeCtx({
+      steps: { 'get-frame': { thumbnailUrl: 'https://example.com/img.png' } },
+    });
+    expect(resolveValue('{{steps.get-frame.thumbnailUrl}}', ctx)).toBe(
+      'https://example.com/img.png'
+    );
+  });
+
+  test('preserves object type for single expression', () => {
+    const frameData = { id: 'f1', metadata: { title: 'Scene 1' } };
+    const ctx = makeCtx({ steps: { 'get-frame': frameData } });
+    const result = resolveValue('{{steps.get-frame}}', ctx);
+    expect(result).toEqual(frameData);
+  });
+
+  test('preserves array type for single expression', () => {
+    const frames = [{ id: 'f1' }, { id: 'f2' }];
+    const ctx = makeCtx({ steps: { 'list-frames': { frames } } });
+    const result = resolveValue('{{steps.list-frames.frames}}', ctx);
+    expect(result).toEqual(frames);
+  });
+
+  test('resolves nested dot-path', () => {
+    const ctx = makeCtx({
+      steps: {
+        scene: {
+          metadata: { prompts: { visual: { fullPrompt: 'a sunset' } } },
+        },
+      },
+    });
+    expect(
+      resolveValue('{{steps.scene.metadata.prompts.visual.fullPrompt}}', ctx)
+    ).toBe('a sunset');
+  });
+
+  test('interpolates mixed template strings', () => {
+    const ctx = makeCtx({
+      context: { userId: 'u1', teamId: 't1', sequenceId: 'seq-1' },
+      trigger: { name: 'World' },
+    });
+    expect(resolveValue('Hello {{trigger.name}}!', ctx)).toBe('Hello World!');
+  });
+
+  test('returns empty string for missing values in mixed templates', () => {
+    const ctx = makeCtx();
+    expect(resolveValue('prefix-{{trigger.missing}}-suffix', ctx)).toBe(
+      'prefix--suffix'
+    );
+  });
+
+  test('returns undefined for missing single expression', () => {
+    const ctx = makeCtx();
+    expect(resolveValue('{{steps.nonexistent.value}}', ctx)).toBeUndefined();
+  });
+
+  test('resolves context namespace', () => {
+    const ctx = makeCtx();
+    expect(resolveValue('{{context.userId}}', ctx)).toBe('user-1');
+    expect(resolveValue('{{context.teamId}}', ctx)).toBe('team-1');
+    expect(resolveValue('{{context.sequenceId}}', ctx)).toBe('seq-1');
+  });
+
+  test('resolves item namespace for for-each loops', () => {
+    const ctx = makeCtx({
+      item: { frame: { id: 'f1', thumbnailStatus: 'pending' } },
+    });
+    expect(resolveValue('{{item.frame.id}}', ctx)).toBe('f1');
+    expect(resolveValue('{{item.frame.thumbnailStatus}}', ctx)).toBe('pending');
+  });
+
+  test('resolves inputs namespace', () => {
+    const ctx = makeCtx({ inputs: { model: 'flux_schnell' } });
+    expect(resolveValue('{{inputs.model}}', ctx)).toBe('flux_schnell');
+  });
+
+  test('recursively resolves arrays', () => {
+    const ctx = makeCtx({ trigger: { x: 'hello' } });
+    const result = resolveValue(['{{trigger.x}}', 42], ctx);
+    expect(result).toEqual(['hello', 42]);
+  });
+
+  test('recursively resolves objects', () => {
+    const ctx = makeCtx({ trigger: { val: 'resolved' } });
+    const result = resolveValue({ key: '{{trigger.val}}', num: 5 }, ctx);
+    expect(result).toEqual({ key: 'resolved', num: 5 });
+  });
+});
+
+describe('resolveObject', () => {
+  test('resolves all values in an object', () => {
+    const ctx = makeCtx({
+      steps: { 'get-frame': { id: 'f1', url: 'https://example.com' } },
+    });
+    const result = resolveObject(
+      {
+        frameId: '{{steps.get-frame.id}}',
+        imageUrl: '{{steps.get-frame.url}}',
+        staticValue: 'hello',
+      },
+      ctx
+    );
+    expect(result).toEqual({
+      frameId: 'f1',
+      imageUrl: 'https://example.com',
+      staticValue: 'hello',
+    });
+  });
+});
+
+describe('evaluateCondition', () => {
+  test('truthy check on resolved value', () => {
+    const ctx = makeCtx({
+      steps: { 'get-frame': { thumbnailUrl: 'https://img.png' } },
+    });
+    expect(evaluateCondition('{{steps.get-frame.thumbnailUrl}}', ctx)).toBe(
+      true
+    );
+  });
+
+  test('falsy check on null value', () => {
+    const ctx = makeCtx({ steps: { 'get-frame': { thumbnailUrl: null } } });
+    expect(evaluateCondition('{{steps.get-frame.thumbnailUrl}}', ctx)).toBe(
+      false
+    );
+  });
+
+  test('falsy check on undefined value', () => {
+    const ctx = makeCtx();
+    expect(evaluateCondition('{{steps.missing.value}}', ctx)).toBe(false);
+  });
+
+  test('equality comparison with null', () => {
+    const ctx = makeCtx({ steps: { x: { val: null } } });
+    expect(evaluateCondition('{{steps.x.val}} == null', ctx)).toBe(true);
+  });
+
+  test('equality comparison with string', () => {
+    const ctx = makeCtx({ steps: { x: { status: 'pending' } } });
+    expect(evaluateCondition('{{steps.x.status}} == pending', ctx)).toBe(true);
+    expect(evaluateCondition('{{steps.x.status}} == completed', ctx)).toBe(
+      false
+    );
+  });
+
+  test('equality comparison with boolean', () => {
+    const ctx = makeCtx({ trigger: { autoGenerate: true } });
+    expect(evaluateCondition('{{trigger.autoGenerate}} == true', ctx)).toBe(
+      true
+    );
+    expect(evaluateCondition('{{trigger.autoGenerate}} == false', ctx)).toBe(
+      false
+    );
+  });
+
+  test('inequality comparison', () => {
+    const ctx = makeCtx({ steps: { x: { status: 'pending' } } });
+    expect(evaluateCondition('{{steps.x.status}} != completed', ctx)).toBe(
+      true
+    );
+    expect(evaluateCondition('{{steps.x.status}} != pending', ctx)).toBe(false);
+  });
+
+  test('numeric comparison', () => {
+    const ctx = makeCtx({ steps: { x: { count: 5 } } });
+    expect(evaluateCondition('{{steps.x.count}} == 5', ctx)).toBe(true);
+    expect(evaluateCondition('{{steps.x.count}} == 3', ctx)).toBe(false);
+  });
+});
+
+describe('createExpressionContext', () => {
+  test('creates context with all namespaces', () => {
+    const ctx = createExpressionContext({
+      userId: 'u1',
+      teamId: 't1',
+      sequenceId: 's1',
+      frameId: 'f1',
+      triggerData: { event: 'test' },
+      inputs: { model: 'flux' },
+    });
+    expect(ctx.context.userId).toBe('u1');
+    expect(ctx.context.teamId).toBe('t1');
+    expect(ctx.context.sequenceId).toBe('s1');
+    expect(ctx.context.frameId).toBe('f1');
+    expect(ctx.trigger).toEqual({ event: 'test' });
+    expect(ctx.inputs).toEqual({ model: 'flux' });
+    expect(ctx.steps).toEqual({});
+    expect(ctx.item).toEqual({});
+  });
+
+  test('defaults optional fields', () => {
+    const ctx = createExpressionContext({
+      userId: 'u1',
+      teamId: 't1',
+    });
+    expect(ctx.trigger).toEqual({});
+    expect(ctx.inputs).toEqual({});
+  });
+});

--- a/src/lib/json-workflows/expressions.ts
+++ b/src/lib/json-workflows/expressions.ts
@@ -1,0 +1,168 @@
+/**
+ * Expression Resolver
+ *
+ * Resolves {{template}} expressions in workflow step inputs.
+ * Expressions reference values from the execution context using dot-path notation.
+ *
+ * Available namespaces:
+ *   context.userId, context.teamId, context.sequenceId
+ *   trigger.*        — event payload or manual trigger data
+ *   steps.<id>.*     — output from a previous step
+ *   item.<var>.*     — current item in a for-each loop
+ *   inputs.*         — workflow-level input parameters
+ */
+
+const EXPRESSION_PATTERN = /\{\{([^}]+)\}\}/g;
+
+export type ExpressionContext = {
+  context: {
+    userId: string;
+    teamId: string;
+    sequenceId?: string;
+    frameId?: string;
+  };
+  trigger: Record<string, unknown>;
+  steps: Record<string, unknown>;
+  item: Record<string, unknown>;
+  inputs: Record<string, unknown>;
+};
+
+/**
+ * Resolve a dot-path like "steps.get-frame.thumbnailUrl" against the context.
+ */
+function resolvePath(path: string, ctx: ExpressionContext): unknown {
+  const parts = path.trim().split('.');
+  let current: unknown = ctx;
+
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current !== 'object') return undefined;
+    // biome-ignore lint: safe property access on validated object
+    current = Object.getOwnPropertyDescriptor(current, part)?.value;
+  }
+
+  return current;
+}
+
+/**
+ * Resolve all {{expressions}} in a value.
+ *
+ * - If the entire value is a single expression (e.g., "{{steps.x.result}}"),
+ *   return the resolved value directly (preserving its type: object, array, number, etc.)
+ * - If the value contains expressions mixed with text (e.g., "Hello {{name}}"),
+ *   return a string with the expressions interpolated.
+ * - Non-string values are returned as-is (no expression resolution).
+ */
+export function resolveValue(value: unknown, ctx: ExpressionContext): unknown {
+  if (typeof value !== 'string') {
+    // Recursively resolve objects and arrays
+    if (Array.isArray(value)) {
+      return value.map((item) => resolveValue(item, ctx));
+    }
+    if (value !== null && typeof value === 'object') {
+      return resolveObject(Object.fromEntries(Object.entries(value)), ctx);
+    }
+    return value;
+  }
+
+  // Check if the entire string is a single expression
+  const trimmed = value.trim();
+  if (
+    trimmed.startsWith('{{') &&
+    trimmed.endsWith('}}') &&
+    trimmed.indexOf('{{', 2) === -1
+  ) {
+    const path = trimmed.slice(2, -2);
+    return resolvePath(path, ctx);
+  }
+
+  // Mixed template: interpolate expressions within string
+  return value.replace(EXPRESSION_PATTERN, (_match, path: string) => {
+    const resolved = resolvePath(path, ctx);
+    if (resolved === undefined || resolved === null) return '';
+    if (typeof resolved === 'object') return JSON.stringify(resolved);
+    return String(resolved);
+  });
+}
+
+/**
+ * Resolve all expressions in an object's values.
+ */
+export function resolveObject(
+  obj: Record<string, unknown>,
+  ctx: ExpressionContext
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = resolveValue(value, ctx);
+  }
+  return result;
+}
+
+/**
+ * Evaluate a simple condition expression for conditional steps.
+ *
+ * Supports:
+ *   "{{expr}} == value"
+ *   "{{expr}} != value"
+ *   "{{expr}} == null"
+ *   "{{expr}} == true"
+ *   "{{expr}} == false"
+ *   "{{expr}}"  (truthy check)
+ */
+export function evaluateCondition(
+  condition: string,
+  ctx: ExpressionContext
+): boolean {
+  const trimmed = condition.trim();
+
+  // Check for comparison operators
+  for (const op of ['!=', '=='] as const) {
+    const idx = trimmed.indexOf(op);
+    if (idx === -1) continue;
+
+    const left = resolveValue(trimmed.slice(0, idx).trim(), ctx);
+    const rightRaw = trimmed.slice(idx + op.length).trim();
+
+    let right: unknown;
+    if (rightRaw === 'null') right = null;
+    else if (rightRaw === 'undefined') right = undefined;
+    else if (rightRaw === 'true') right = true;
+    else if (rightRaw === 'false') right = false;
+    else if (/^-?\d+(\.\d+)?$/.test(rightRaw)) right = Number(rightRaw);
+    else if (rightRaw.startsWith('{{')) right = resolveValue(rightRaw, ctx);
+    else right = rightRaw.replace(/^["']|["']$/g, '');
+
+    if (op === '==') return left == right;
+    if (op === '!=') return left != right;
+  }
+
+  // No operator: truthy check
+  const resolved = resolveValue(trimmed, ctx);
+  return Boolean(resolved);
+}
+
+/**
+ * Create an empty expression context with auth info.
+ */
+export function createExpressionContext(params: {
+  userId: string;
+  teamId: string;
+  sequenceId?: string;
+  frameId?: string;
+  triggerData?: Record<string, unknown>;
+  inputs?: Record<string, unknown>;
+}): ExpressionContext {
+  return {
+    context: {
+      userId: params.userId,
+      teamId: params.teamId,
+      sequenceId: params.sequenceId,
+      frameId: params.frameId,
+    },
+    trigger: params.triggerData ?? {},
+    steps: {},
+    item: {},
+    inputs: params.inputs ?? {},
+  };
+}

--- a/src/lib/json-workflows/expressions.ts
+++ b/src/lib/json-workflows/expressions.ts
@@ -79,9 +79,21 @@ export function resolveValue(value: unknown, ctx: ExpressionContext): unknown {
   // Mixed template: interpolate expressions within string
   return value.replace(EXPRESSION_PATTERN, (_match, path: string) => {
     const resolved = resolvePath(path, ctx);
-    if (resolved === undefined || resolved === null) return '';
-    if (typeof resolved === 'object') return JSON.stringify(resolved);
-    return String(resolved);
+    if (resolved === undefined || resolved === null) {
+      console.warn(
+        `[json-workflow] Expression "{{${path.trim()}}}" resolved to ${resolved} in template "${value}" — interpolating empty string. Check for typos in the path.`
+      );
+      return '';
+    }
+    if (typeof resolved === 'string') return resolved;
+    if (
+      typeof resolved === 'number' ||
+      typeof resolved === 'boolean' ||
+      typeof resolved === 'bigint'
+    ) {
+      return String(resolved);
+    }
+    return JSON.stringify(resolved);
   });
 }
 

--- a/src/lib/json-workflows/llm-call-direct.ts
+++ b/src/lib/json-workflows/llm-call-direct.ts
@@ -41,7 +41,13 @@ export async function durableLLMCallDirect(
     params;
 
   const resolvedId = modelId ?? DEFAULT_ANALYSIS_MODEL;
-  const model = getAnalysisModelById(resolvedId)?.id ?? DEFAULT_ANALYSIS_MODEL;
+  const matchedModel = getAnalysisModelById(resolvedId);
+  if (!matchedModel) {
+    throw new Error(
+      `Unknown analysis model "${resolvedId}". Specify a registered model id or omit modelId to use "${DEFAULT_ANALYSIS_MODEL}".`
+    );
+  }
+  const model = matchedModel.id;
 
   // Resolve API key
   const openRouterApiKeyInfo = await scopedDb.apiKeys.resolveKey('openrouter');

--- a/src/lib/json-workflows/llm-call-direct.ts
+++ b/src/lib/json-workflows/llm-call-direct.ts
@@ -1,0 +1,107 @@
+/**
+ * Direct LLM Call
+ *
+ * Thin wrapper around the existing LLM infrastructure for use in JSON workflows.
+ * Unlike durableLLMCall (which needs a WorkflowContext), this executes directly
+ * since the JSON workflow executor handles durability at the step level.
+ */
+
+import { createAdapter } from '@/lib/ai/create-adapter';
+import {
+  DEFAULT_ANALYSIS_MODEL,
+  getAnalysisModelById,
+  getContextWindow,
+} from '@/lib/ai/models.config';
+import type { ScopedDb } from '@/lib/db/scoped';
+import { type ChatMessage, getChatPrompt } from '@/lib/prompts';
+import { chat } from '@tanstack/ai';
+import type { z } from 'zod';
+
+type DirectLLMCallParams = {
+  prompt: string;
+  variables: Record<string, string>;
+  modelId?: string;
+  responseSchema?: z.ZodType;
+  scopedDb: ScopedDb;
+  sequenceId?: string;
+};
+
+/**
+ * Check if prompt is a Langfuse key (contains "/" like "phase/scene-splitting-chat")
+ * or an inline prompt string.
+ */
+function isPromptKey(prompt: string): boolean {
+  return prompt.includes('/') && !prompt.includes(' ');
+}
+
+export async function durableLLMCallDirect(
+  params: DirectLLMCallParams
+): Promise<unknown> {
+  const { prompt, variables, modelId, responseSchema, scopedDb, sequenceId } =
+    params;
+
+  const resolvedId = modelId ?? DEFAULT_ANALYSIS_MODEL;
+  const model = getAnalysisModelById(resolvedId)?.id ?? DEFAULT_ANALYSIS_MODEL;
+
+  // Resolve API key
+  const openRouterApiKeyInfo = await scopedDb.apiKeys.resolveKey('openrouter');
+
+  let messages: ChatMessage[];
+
+  if (isPromptKey(prompt)) {
+    // Langfuse prompt key — fetch template and compile with variables
+    const result = await getChatPrompt(prompt, variables);
+    messages = result.messages;
+  } else {
+    // Inline prompt — use as user message with variables interpolated
+    let content = prompt;
+    for (const [key, value] of Object.entries(variables)) {
+      content = content.replaceAll(`{{${key}}}`, value);
+    }
+    messages = [{ role: 'user', content }];
+  }
+
+  const adapter = createAdapter(model, openRouterApiKeyInfo.key);
+
+  const systemPrompts: string[] = [];
+  const chatMessages: Array<{
+    role: 'user' | 'assistant';
+    content: string;
+  }> = [];
+
+  for (const msg of messages) {
+    if (typeof msg.content !== 'string') {
+      throw new Error(
+        `JSON workflow LLM steps require text-only prompts; got multimodal content for role "${msg.role}"`
+      );
+    }
+    if (msg.role === 'system') {
+      systemPrompts.push(msg.content);
+    } else {
+      chatMessages.push({ role: msg.role, content: msg.content });
+    }
+  }
+
+  const abortController = new AbortController();
+  const timeout = setTimeout(() => abortController.abort(), 300_000);
+
+  try {
+    const result = await chat({
+      adapter,
+      messages: chatMessages,
+      systemPrompts,
+      stream: false,
+      maxTokens: Math.floor(getContextWindow(model) * 0.5),
+      abortController,
+      metadata: {
+        observationName: 'json-workflow-llm',
+        sessionId: sequenceId,
+      },
+      ...(responseSchema ? { outputSchema: responseSchema } : {}),
+    });
+
+    return responseSchema ? responseSchema.parse(result) : result;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/lib/json-workflows/llm-step.ts
+++ b/src/lib/json-workflows/llm-step.ts
@@ -1,0 +1,69 @@
+/**
+ * LLM Step Executor
+ *
+ * Executes LLM steps from JSON workflow definitions.
+ * Supports two prompt modes:
+ *   - Langfuse key: "phase/scene-splitting-chat" → fetched from prompt management
+ *   - Inline prompt: literal text used as user message
+ *
+ * Wraps the existing durableLLMCall helper for durable execution.
+ */
+
+import type { ScopedDb } from '@/lib/db/scoped';
+import type { LLMStep } from './schema';
+import { getOutputSchema } from './schema-registry';
+import type { ExpressionContext } from './expressions';
+import { resolveValue } from './expressions';
+
+export type LLMStepContext = {
+  scopedDb: ScopedDb;
+  sequenceId?: string;
+};
+
+/**
+ * Execute an LLM step, resolving prompt + variables from the expression context.
+ * Returns the parsed and optionally schema-validated LLM response.
+ */
+export async function executeLLMStep(
+  step: LLMStep,
+  expressionCtx: ExpressionContext,
+  llmCtx: LLMStepContext
+): Promise<unknown> {
+  const { durableLLMCallDirect } = await import('./llm-call-direct');
+
+  // Resolve variables through expression engine
+  const resolvedVariables: Record<string, string> = {};
+  if (step.variables) {
+    for (const [key, value] of Object.entries(step.variables)) {
+      const resolved = resolveValue(value, expressionCtx);
+      resolvedVariables[key] =
+        typeof resolved === 'string' ? resolved : JSON.stringify(resolved);
+    }
+  }
+
+  // Resolve model (may be an expression like "{{trigger.analysisModelId}}")
+  const resolvedModel = step.model
+    ? resolveValue(step.model, expressionCtx)
+    : undefined;
+  const model = typeof resolvedModel === 'string' ? resolvedModel : undefined;
+
+  // Resolve output schema from registry
+  const outputSchema = step.outputSchema
+    ? getOutputSchema(step.outputSchema)
+    : undefined;
+
+  if (step.outputSchema && !outputSchema) {
+    throw new Error(
+      `Unknown output schema "${step.outputSchema}". Available: ${(await import('./schema-registry')).getSchemaNames().join(', ')}`
+    );
+  }
+
+  return durableLLMCallDirect({
+    prompt: step.prompt,
+    variables: resolvedVariables,
+    modelId: model,
+    responseSchema: outputSchema,
+    scopedDb: llmCtx.scopedDb,
+    sequenceId: llmCtx.sequenceId,
+  });
+}

--- a/src/lib/json-workflows/schema-registry.ts
+++ b/src/lib/json-workflows/schema-registry.ts
@@ -1,0 +1,38 @@
+/**
+ * Output Schema Registry
+ *
+ * Maps schema names (used in LLM step `outputSchema` field) to existing Zod schemas.
+ * This allows JSON workflow definitions to reference response schemas by name
+ * without embedding schema definitions in the JSON.
+ */
+
+import {
+  characterExtractionResultSchema,
+  locationExtractionResultSchema,
+  locationMatchResponseSchema,
+  motionPromptGenerationResultSchema,
+  musicDesignResultSchema,
+  sceneSplittingResultSchema,
+  talentMatchResponseSchema,
+  visualPromptGenerationResultSchema,
+} from '@/lib/ai/response-schemas';
+import type { z } from 'zod';
+
+const registry = new Map<string, z.ZodType>([
+  ['scene-splitting', sceneSplittingResultSchema],
+  ['character-extraction', characterExtractionResultSchema],
+  ['location-extraction', locationExtractionResultSchema],
+  ['talent-matching', talentMatchResponseSchema],
+  ['location-matching', locationMatchResponseSchema],
+  ['visual-prompt', visualPromptGenerationResultSchema],
+  ['motion-prompt', motionPromptGenerationResultSchema],
+  ['music-design', musicDesignResultSchema],
+]);
+
+export function getOutputSchema(name: string): z.ZodType | undefined {
+  return registry.get(name);
+}
+
+export function getSchemaNames(): string[] {
+  return Array.from(registry.keys());
+}

--- a/src/lib/json-workflows/schema.test.ts
+++ b/src/lib/json-workflows/schema.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, test } from 'bun:test';
+import { workflowDefinitionSchema } from './schema';
+
+describe('workflowDefinitionSchema', () => {
+  test('validates a minimal manual workflow', () => {
+    const def = {
+      version: 1,
+      name: 'Test Workflow',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [
+        {
+          id: 'step-1',
+          type: 'action',
+          action: 'get-sequence',
+          inputs: { sequenceId: '{{context.sequenceId}}' },
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates an event-triggered workflow', () => {
+    const def = {
+      version: 1,
+      name: 'Auto Motion',
+      trigger: {
+        type: 'event',
+        event: 'generation.image:completed',
+        filter: { status: 'completed' },
+      },
+      steps: [
+        {
+          id: 'get-frame',
+          type: 'action',
+          action: 'get-frame',
+          inputs: { frameId: '{{trigger.frameId}}' },
+        },
+        {
+          id: 'gen-motion',
+          type: 'action',
+          action: 'generate-motion',
+          inputs: {
+            imageUrl: '{{steps.get-frame.thumbnailUrl}}',
+            prompt: '{{steps.get-frame.metadata.prompts.motion.fullPrompt}}',
+          },
+          dependsOn: ['get-frame'],
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates LLM steps', () => {
+    const def = {
+      version: 1,
+      name: 'LLM Workflow',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [
+        {
+          id: 'analyze',
+          type: 'llm',
+          prompt: 'phase/scene-splitting-chat',
+          variables: { script: '{{trigger.script}}' },
+          model: 'anthropic/claude-haiku-4.5',
+          outputSchema: 'scene-splitting',
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates conditional steps', () => {
+    const def = {
+      version: 1,
+      name: 'Conditional Workflow',
+      trigger: { type: 'manual', scope: 'frame' },
+      steps: [
+        {
+          id: 'check',
+          type: 'conditional',
+          condition: '{{trigger.autoGenerate}} == true',
+          then: [
+            {
+              id: 'gen',
+              type: 'action',
+              action: 'generate-image',
+              inputs: { prompt: 'test' },
+            },
+          ],
+          else: [
+            {
+              id: 'log-skip',
+              type: 'action',
+              action: 'log',
+              inputs: { message: 'Skipped generation' },
+            },
+          ],
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates for-each steps', () => {
+    const def = {
+      version: 1,
+      name: 'Batch Workflow',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [
+        {
+          id: 'list',
+          type: 'action',
+          action: 'list-frames',
+          inputs: { sequenceId: '{{context.sequenceId}}' },
+        },
+        {
+          id: 'loop',
+          type: 'for-each',
+          collection: '{{steps.list.frames}}',
+          itemVariable: 'frame',
+          steps: [
+            {
+              id: 'gen',
+              type: 'action',
+              action: 'generate-image',
+              inputs: { frameId: '{{item.frame.id}}', prompt: 'test' },
+            },
+          ],
+          maxConcurrency: 3,
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates parallel steps', () => {
+    const def = {
+      version: 1,
+      name: 'Parallel Workflow',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [
+        {
+          id: 'parallel-gen',
+          type: 'parallel',
+          branches: [
+            [
+              {
+                id: 'a',
+                type: 'action',
+                action: 'log',
+                inputs: { message: 'branch A' },
+              },
+            ],
+            [
+              {
+                id: 'b',
+                type: 'action',
+                action: 'log',
+                inputs: { message: 'branch B' },
+              },
+            ],
+          ],
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('validates workflow with inputs', () => {
+    const def = {
+      version: 1,
+      name: 'With Inputs',
+      trigger: { type: 'manual', scope: 'sequence' },
+      inputs: {
+        model: {
+          type: 'string',
+          required: true,
+          description: 'AI model to use',
+        },
+        count: { type: 'number', default: 5 },
+      },
+      steps: [
+        {
+          id: 's1',
+          type: 'action',
+          action: 'log',
+          inputs: { message: '{{inputs.model}}' },
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects empty steps array', () => {
+    const def = {
+      version: 1,
+      name: 'Empty',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects wrong version', () => {
+    const def = {
+      version: 2,
+      name: 'Bad Version',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [{ id: 's', type: 'action', action: 'log', inputs: {} }],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects missing step id', () => {
+    const def = {
+      version: 1,
+      name: 'No ID',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [{ type: 'action', action: 'log', inputs: {} }],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects parallel with fewer than 2 branches', () => {
+    const def = {
+      version: 1,
+      name: 'Bad Parallel',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [
+        {
+          id: 'p',
+          type: 'parallel',
+          branches: [
+            [
+              {
+                id: 'a',
+                type: 'action',
+                action: 'log',
+                inputs: { message: 'only one' },
+              },
+            ],
+          ],
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(false);
+  });
+
+  test('validates deeply nested control flow', () => {
+    const def = {
+      version: 1,
+      name: 'Nested',
+      trigger: { type: 'manual', scope: 'sequence' },
+      steps: [
+        {
+          id: 'outer-loop',
+          type: 'for-each',
+          collection: '{{trigger.scenes}}',
+          itemVariable: 'scene',
+          steps: [
+            {
+              id: 'inner-cond',
+              type: 'conditional',
+              condition: '{{item.scene.hasThumbnail}} == false',
+              then: [
+                {
+                  id: 'inner-parallel',
+                  type: 'parallel',
+                  branches: [
+                    [
+                      {
+                        id: 'gen-img',
+                        type: 'action',
+                        action: 'generate-image',
+                        inputs: { prompt: 'test' },
+                      },
+                    ],
+                    [
+                      {
+                        id: 'gen-llm',
+                        type: 'llm',
+                        prompt: 'Describe this scene',
+                        variables: {},
+                      },
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = workflowDefinitionSchema.safeParse(def);
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/json-workflows/schema.ts
+++ b/src/lib/json-workflows/schema.ts
@@ -1,0 +1,157 @@
+/**
+ * JSON Workflow Definition Schema
+ *
+ * Zod schemas for validating user-created workflow definitions.
+ * Workflows are stored as JSON in the database and interpreted
+ * by the executor at runtime.
+ */
+
+import { z } from 'zod';
+
+// ── Expression strings ──────────────────────────────────────────
+// Expressions like "{{steps.get-frame.thumbnailUrl}}" are resolved at runtime.
+// At schema level we just validate they're present (z.any() for Zod v4 compat).
+const expressionOrValue = z.any();
+
+// ── Trigger types ───────────────────────────────────────────────
+
+export const manualTriggerSchema = z.object({
+  type: z.literal('manual'),
+  scope: z.enum(['sequence', 'frame']),
+});
+
+export const eventTriggerSchema = z.object({
+  type: z.literal('event'),
+  event: z.string().min(1),
+  filter: z.record(z.string(), z.any()).optional(),
+});
+
+export const triggerSchema = z.discriminatedUnion('type', [
+  manualTriggerSchema,
+  eventTriggerSchema,
+]);
+
+// ── Input parameter definitions ─────────────────────────────────
+
+export const inputParameterSchema = z.object({
+  type: z.enum(['string', 'number', 'boolean', 'object', 'array']),
+  required: z.boolean().optional(),
+  default: z.any().optional(),
+  description: z.string().optional(),
+});
+
+// ── Step types ──────────────────────────────────────────────────
+
+// Forward-declare for recursive step types (manual type to avoid circular reference)
+export type WorkflowStep =
+  | z.infer<typeof actionStepSchema>
+  | z.infer<typeof llmStepSchema>
+  | {
+      id: string;
+      type: 'conditional';
+      condition: string;
+      then: WorkflowStep[];
+      else?: WorkflowStep[];
+    }
+  | {
+      id: string;
+      type: 'for-each';
+      collection: string;
+      itemVariable: string;
+      steps: WorkflowStep[];
+      maxConcurrency?: number;
+    }
+  | { id: string; type: 'parallel'; branches: WorkflowStep[][] };
+
+export const actionStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('action'),
+  action: z.string().min(1),
+  inputs: z.record(z.string(), expressionOrValue).optional(),
+  dependsOn: z.array(z.string()).optional(),
+  continueOnError: z.boolean().optional(),
+});
+
+export const llmStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('llm'),
+  prompt: z.string().min(1), // Langfuse key or inline prompt text
+  variables: z.record(z.string(), expressionOrValue).optional(),
+  model: z.string().optional(), // defaults to sequence's analysisModel
+  outputSchema: z.string().optional(), // registered schema name
+});
+
+// Lazy schemas for recursive step types
+const lazyStepsArray: z.ZodType<WorkflowStep[]> = z.lazy(() =>
+  z.array(workflowStepSchema)
+);
+
+export const conditionalStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('conditional'),
+  condition: z.string().min(1), // expression that evaluates to truthy/falsy
+  then: lazyStepsArray,
+  else: lazyStepsArray.optional(),
+});
+
+export const forEachStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('for-each'),
+  collection: z.string().min(1), // expression resolving to array
+  itemVariable: z.string().min(1),
+  steps: lazyStepsArray,
+  maxConcurrency: z.number().int().positive().optional(),
+});
+
+export const parallelStepSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal('parallel'),
+  branches: z.array(lazyStepsArray).min(2),
+});
+
+export const workflowStepSchema: z.ZodType<WorkflowStep> = z.discriminatedUnion(
+  'type',
+  [
+    actionStepSchema,
+    llmStepSchema,
+    conditionalStepSchema,
+    forEachStepSchema,
+    parallelStepSchema,
+  ]
+);
+
+// ── Workflow definition ─────────────────────────────────────────
+
+export const workflowDefinitionSchema = z.object({
+  version: z.literal(1),
+  name: z.string().min(1).max(200),
+  description: z.string().max(2000).optional(),
+  trigger: triggerSchema,
+  inputs: z.record(z.string(), inputParameterSchema).optional(),
+  steps: z.array(workflowStepSchema).min(1),
+});
+
+export type WorkflowDefinitionJson = z.infer<typeof workflowDefinitionSchema>;
+export type ManualTrigger = z.infer<typeof manualTriggerSchema>;
+export type EventTrigger = z.infer<typeof eventTriggerSchema>;
+export type Trigger = z.infer<typeof triggerSchema>;
+export type InputParameter = z.infer<typeof inputParameterSchema>;
+export type ActionStep = z.infer<typeof actionStepSchema>;
+export type LLMStep = z.infer<typeof llmStepSchema>;
+export type ConditionalStep = z.infer<typeof conditionalStepSchema>;
+export type ForEachStep = z.infer<typeof forEachStepSchema>;
+export type ParallelStep = z.infer<typeof parallelStepSchema>;
+
+// ── Executor input (what QStash receives) ───────────────────────
+
+export const jsonWorkflowInputSchema = z.object({
+  userId: z.string().min(1),
+  teamId: z.string().min(1),
+  definitionId: z.string().min(1),
+  sequenceId: z.string().optional(),
+  frameId: z.string().optional(),
+  triggerData: z.record(z.string(), z.any()).optional(),
+  inputs: z.record(z.string(), z.any()).optional(),
+});
+
+export type JsonWorkflowInput = z.infer<typeof jsonWorkflowInputSchema>;

--- a/src/lib/json-workflows/triggers.ts
+++ b/src/lib/json-workflows/triggers.ts
@@ -1,0 +1,83 @@
+/**
+ * Event Trigger System
+ *
+ * Checks for workflow definitions that match a given event and fires them.
+ * Called after realtime events are emitted in existing workflows.
+ */
+
+import { createReadOnlyScopedDb } from '@/lib/db/scoped';
+import { triggerWorkflow } from '@/lib/workflow/client';
+
+/**
+ * Check if event data matches a trigger's optional filter criteria.
+ * Each filter key must match the corresponding value in the event data.
+ */
+function matchesFilter(
+  filter: Record<string, unknown> | undefined,
+  data: Record<string, unknown>
+): boolean {
+  if (!filter) return true;
+
+  for (const [key, expectedValue] of Object.entries(filter)) {
+    if (data[key] !== expectedValue) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check for workflow definitions triggered by a given event and fire them.
+ *
+ * This is fire-and-forget — errors are logged but don't propagate.
+ * Call this after emitting realtime events in existing workflows.
+ *
+ * @param teamId - The team that owns the workflows
+ * @param event - The event name (e.g., "generation.image:completed")
+ * @param data - The event payload
+ * @param userId - The user who triggered the event (for auth context)
+ */
+export async function checkWorkflowTriggers(
+  teamId: string,
+  event: string,
+  data: Record<string, unknown>,
+  userId?: string
+): Promise<void> {
+  try {
+    const scopedDb = createReadOnlyScopedDb(teamId);
+    const matchingWorkflows =
+      await scopedDb.workflowDefinitions.getByTriggerEvent(event);
+
+    if (matchingWorkflows.length === 0) return;
+
+    for (const workflow of matchingWorkflows) {
+      const trigger = workflow.definition.trigger;
+      const filter = 'filter' in trigger ? trigger.filter : undefined;
+
+      if (!matchesFilter(filter, data)) continue;
+
+      console.log(
+        `[WorkflowTrigger] Firing workflow "${workflow.name}" (${workflow.id}) for event "${event}"`
+      );
+
+      const sequenceId =
+        typeof data.sequenceId === 'string' ? data.sequenceId : undefined;
+      const frameId =
+        typeof data.frameId === 'string' ? data.frameId : undefined;
+
+      await triggerWorkflow('/json-workflow', {
+        userId: userId ?? 'system',
+        teamId,
+        definitionId: workflow.id,
+        sequenceId,
+        frameId,
+        triggerData: data,
+      });
+    }
+  } catch (error) {
+    // Fire-and-forget: log but don't propagate
+    console.error(
+      `[WorkflowTrigger] Error checking triggers for event "${event}":`,
+      error
+    );
+  }
+}

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -358,3 +358,22 @@ export function getLocationChannel(locationId?: string) {
     ? getRealtime().channel(`location:${locationId}`)
     : noopChannel('location');
 }
+
+/**
+ * Emit a dynamic event on a generation channel without strict type checking.
+ * Used by JSON workflow actions where event names are determined at runtime.
+ *
+ * The channel.emit() is strictly typed to only accept known event paths from
+ * the realtime schema. For JSON workflows, event names are user-defined strings
+ * resolved at runtime, so we use Reflect.apply to bypass the type constraint.
+ */
+export async function emitDynamicEvent(
+  sequenceId: string,
+  event: string,
+  data: unknown
+): Promise<void> {
+  const channel = getGenerationChannel(sequenceId);
+  // Use Function.prototype.call to bypass strict event type checking
+  // since JSON workflow event names are user-defined strings
+  await Function.prototype.apply.call(channel.emit, channel, [event, data]);
+}

--- a/src/routes/api/workflows/$.ts
+++ b/src/routes/api/workflows/$.ts
@@ -41,6 +41,7 @@ import { upscaleShotVariantWorkflow } from '@/lib/workflows/upscale-shot-variant
 import { generateShotVariantWorkflow } from '@/lib/workflows/shot-variant-workflow';
 import { visualPromptSceneWorkflow } from '@/lib/workflows/visual-prompt-scene-workflow';
 import { visualPromptWorkflow } from '@/lib/workflows/visual-prompt-workflow';
+import { jsonWorkflowExecutor } from '@/lib/json-workflows/executor';
 import { createFileRoute } from '@tanstack/react-router';
 import { serveMany } from '@upstash/workflow/tanstack';
 
@@ -82,6 +83,7 @@ function getHandler() {
         'variant-image': generateShotVariantWorkflow,
         'visual-prompt-scene': visualPromptSceneWorkflow,
         'visual-prompts': visualPromptWorkflow,
+        'json-workflow': jsonWorkflowExecutor,
       },
       {
         qstashClient: getQStashClient(),


### PR DESCRIPTION
## Summary

- Adds a JSON-based workflow definition system that lets users compose custom workflows from AI generation, data mutation, and control flow primitives
- Workflows are stored in the DB (team-scoped), interpreted at runtime by a QStash durable executor, and can be triggered manually or by realtime events
- LLM is a first-class step type with `prompt` / `variables` / `outputSchema` abstraction
- Designed to eventually replace existing TS workflows as the canonical format

Closes #536

## What's new

**20 new files** across these layers:

| Layer | Key Files | Purpose |
|-------|-----------|---------|
| Schema | `json-workflows/schema.ts` | Zod schemas for 5 step types: action, llm, conditional, for-each, parallel |
| Expressions | `json-workflows/expressions.ts` | `{{template}}` resolver for step inputs |
| Actions | `json-workflows/actions/*.ts` | 18 actions: data CRUD, AI generation, utilities |
| LLM Step | `json-workflows/llm-step.ts`, `schema-registry.ts` | First-class LLM step mapping to 8 existing Zod response schemas |
| Executor | `json-workflows/executor.ts` | QStash durable workflow registered as `json-workflow` in serveMany |
| Triggers | `json-workflows/triggers.ts` | Event-based auto-firing via `checkWorkflowTriggers()` |
| DB | `db/schema/workflow-{definitions,runs}.ts` | Team-scoped tables with indexed trigger lookup |
| API | `functions/workflow-definitions.ts` | Server functions for CRUD + manual trigger + run listing |

## Test plan

- [x] 36 unit tests passing for expression resolver and schema validation
- [x] All pre-commit hooks pass (format, lint, typecheck)
- [ ] Manual test: Create a workflow definition via server function, trigger it, verify run record
- [ ] Event trigger test: Create event-triggered workflow, generate an image, verify auto-fire

https://claude.ai/code/session_016jW5GKeiTv5h78vwAi2Dum
