### PR TITLE
fix: lowercase resolution for Grok Imagine API

### DIFF
--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -285,7 +285,7 @@ function buildFalModelOptions(
         aspect_ratio: imageSizeToAspectRatio(
           params.imageSize ?? DEFAULT_IMAGE_SIZE
         ),
-        resolution: params.resolution ?? '2K',
+        resolution: (params.resolution ?? '2K').toLowerCase(),
         ...(params.numImages !== undefined && { num_images: params.numImages }),
         ...(params.outputFormat && { output_format: params.outputFormat }),
         ...(params.referenceImageUrls?.length && {


### PR DESCRIPTION
## Summary
- Lowercase the resolution value sent to the Grok Imagine API (`'2K'` → `'2k'`), fixing validation errors
- The API expects `'1k'` or `'2k'` but we were sending uppercase values

Closes #541

## Test plan
- [x] `bun typecheck` passes
- [x] `bun test` — all 362 tests pass
- [ ] Trigger a Grok Imagine generation and confirm no resolution error

🤖 Generated with [Claude Code](https://claude.com/claude-code)