### PR TITLE
fix: add PostHog env vars to production CI build and setup scripts

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -66,6 +66,8 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VITE_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ vars.VITE_PUBLIC_POSTHOG_HOST }}
 
   # ── PR preview deploy ─────────────────────────────────────────────
   deploy-preview:

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -916,7 +916,7 @@ async function deploySetup(
       const shouldPushVars = checkCancel(
         await p.confirm({
           message:
-            'Push R2 domain variables to GitHub production environment? (needed for CI seed)',
+            'Push variables to GitHub production environment? (needed for CI build + seed)',
           initialValue: true,
         })
       );
@@ -1101,14 +1101,18 @@ async function deploySetup(
   // 5. Push CI secrets to GitHub production environment
   const ciSecrets =
     platform === 'cloudflare'
-      ? (['CLOUDFLARE_ACCOUNT_ID', 'CLOUDFLARE_API_TOKEN'] as const)
+      ? ([
+          'CLOUDFLARE_ACCOUNT_ID',
+          'CLOUDFLARE_API_TOKEN',
+          'VITE_PUBLIC_POSTHOG_PROJECT_TOKEN',
+        ] as const)
       : (['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'] as const);
   const ciSecretsToPush = ciSecrets.filter((k) => vars.get(k));
 
   if (ciSecretsToPush.length > 0) {
     const shouldPushCiSecrets = checkCancel(
       await p.confirm({
-        message: `Push CI secrets (${ciSecretsToPush.join(', ')}) to GitHub production environment?`,
+        message: `Push CI/build secrets (${ciSecretsToPush.join(', ')}) to GitHub production environment?`,
         initialValue: true,
       })
     );


### PR DESCRIPTION
## Summary

- Add `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN` and `VITE_PUBLIC_POSTHOG_HOST` env vars to the production deploy step in CI workflow
- Add `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN` to the setup script's CI secrets push for the production environment
- Update confirm prompts to reflect the broader scope of variables/secrets being pushed

## Manual step after merge

Set the production PostHog project token (different from staging):
```
gh secret set VITE_PUBLIC_POSTHOG_PROJECT_TOKEN --env production
```

## Test plan

- [ ] Run `bun typecheck` — passes clean
- [ ] Run `bun setup:prd` — confirm it prompts to push `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN` alongside Cloudflare credentials
- [ ] After deploy, check GitHub Actions production deploy logs to confirm `VITE_PUBLIC_POSTHOG_*` vars are present during build
- [ ] Visit production site, open browser network tab — confirm requests to the PostHog host

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)