### PR TITLE
fix: visual prompts should not include character appearance

### DIFF
--- a/src/lib/prompts/character-prompt.ts
+++ b/src/lib/prompts/character-prompt.ts
@@ -104,7 +104,7 @@ const formatStyleForSheet = (
       : '';
 
   return {
-    environment: `Environment matching the visual style: ${styleConfig.artStyle}. Mood: ${styleConfig.mood}. Color palette: ${colorPaletteStr}. Color grading: ${styleConfig.colorGrading}.${referencesStr} The environment should reinforce the character's visual identity within this style direction.`,
+    environment: `Render the character in ${styleConfig.artStyle} style. Background: clean, seamless studio backdrop with no environmental detail — simple flat or gradient tone using the style's color palette: ${colorPaletteStr}. Color grading: ${styleConfig.colorGrading}. Mood: ${styleConfig.mood}.${referencesStr} All visual interest comes from the character, not the environment.`,
     opticalSpecs: `${styleConfig.artStyle} style rendering. Camera approach: ${styleConfig.cameraWork}. Maintain sharp focus and consistent character detail across all panels.`,
     lighting: `${styleConfig.lighting}. The lighting should be consistent across all four panels and match the overall ${styleConfig.mood} mood.`,
   };

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -788,7 +788,7 @@ Respond with exactly {{numTalent}} matches.`,
 2. **NO FORMATTING**: Inside the prompt string, use natural language only. No headers (e.g., "Subject:"), no bullet points.
 
 ### VISUAL CONSTRUCTION STRATEGY
-1. **REFERENCE ALIGNMENT**: We are injecting a reference image for the character. Your text description of the character (from the <CHARACTER_BIBLE>) must MATCH the visual reference to prevent generation artifacts. Do not alter the costume defined in the Bible.
+1. **CHARACTER IDENTITY VIA REFERENCE IMAGE**: A reference image handles each character's physical appearance. Do NOT describe face, hair, skin, build, or body type in the prompt text. Instead, refer to each character by NAME IN CAPS (e.g., "SERENA"). From the <CHARACTER_BIBLE>, include ONLY their costume/wardrobe (standardClothing) and any costume-relevant distinguishingFeatures. Do not alter the costume defined in the Bible.
 2. **THE "STARTING FRAME"**: Describe the exact moment the scene begins. Focus on the *potential energy*—muscles tensed, mid-breath, looking off-camera. This is a still image that implies motion.
 3. **ENVIRONMENT & LIGHTING**: Since the character identity is handled by reference, spend 60% of your tokens on the atmosphere, lighting texture, depth of field, and background details.
 4. **DIRECTOR STYLE**: Apply the <DIRECTOR_STYLE> to the camera lens (e.g., "anamorphic flares"), film stock, and color palette.
@@ -797,10 +797,10 @@ Respond with exactly {{numTalent}} matches.`,
 1. **NO HOLOGRAPHIC SCREENS**: Do NOT describe floating interfaces, holograms, or HUDs. Technology must be physical (glass screens, tactile buttons, cables, metal) and grounded.
 2. **NO TEXT**: No subtitles, no signs, no dialogue.
 3. **ONE SHOT**: Describe a single coherent frame.
-4. **ZERO MEMORY**: Re-describe the setting and character fully. Do not refer to "the previous scene."
+4. **ZERO MEMORY**: Re-describe the setting fully and name each character present with their costume. Do not refer to "the previous scene." Do NOT re-describe character physical appearance — the reference image provides identity.
 
 ### PROMPT STRUCTURE (Flatten into one paragraph)
-[Medium/Style] + [Character Appearance & EXACT Costume] + [Specific Pose/Action] + [Detailed Environment] + [Lighting Conditions] + [Camera Angle/Lens]`,
+[Medium/Style] + [CHARACTER NAME IN CAPS & Costume/Wardrobe] + [Specific Pose/Action] + [Detailed Environment] + [Lighting Conditions] + [Camera Angle/Lens]`,
     },
     {
       role: 'user',
@@ -821,6 +821,7 @@ Respond with exactly {{numTalent}} matches.`,
 </SCENE_AFTER>
 
 <CHARACTER_BIBLE>
+(Use ONLY for character names and costume/wardrobe. Do NOT describe physical appearance — the reference image handles identity.)
 {{characterBible}}
 </CHARACTER_BIBLE>
 


### PR DESCRIPTION
## Summary
- Visual prompts now refer to characters by NAME IN CAPS with costume/wardrobe only — physical appearance descriptions (hair, skin, build) are no longer included, leaving identity to reference images
- Character sheet generation forces clear studio backgrounds regardless of art style (e.g., Animated, Horror) while preserving stylistic rendering on the character itself
- Adds annotation to CHARACTER_BIBLE context in visual prompt generation to reinforce costume-only usage

## Test plan
- [x] Existing `character-prompt.test.ts` tests pass (13/13)
- [x] Type checking passes
- [x] Build succeeds
- [ ] Manual: generate a storyboard with cast characters and verify visual prompts use NAME IN CAPS + costume without physical descriptions
- [ ] Manual: generate a character sheet with the Animated style and verify clear background

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)