### PR TITLE
feat: enable Seedance 2 only for animation style

### DIFF
--- a/src/components/model/motion-model-selector.tsx
+++ b/src/components/model/motion-model-selector.tsx
@@ -15,6 +15,8 @@ type MotionModelSelectorProps = {
   onModelChange: (model: ImageToVideoModel) => void;
   disabled?: boolean;
   aspectRatio?: AspectRatio;
+  /** When set, models with a matching `requiredStyleCategory` are included */
+  styleCategory?: string;
 };
 
 export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
@@ -22,6 +24,7 @@ export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
   onModelChange,
   disabled = false,
   aspectRatio,
+  styleCategory,
 }) => {
   const models = useMemo(
     () =>
@@ -29,6 +32,11 @@ export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
         .filter(([key, m]) => {
           if (!isValidImageToVideoModel(key)) return false;
           if ('hidden' in m) return false;
+          if (
+            'requiredStyleCategory' in m &&
+            m.requiredStyleCategory !== styleCategory
+          )
+            return false;
           return aspectRatio
             ? isModelCompatibleWithAspectRatio(key, aspectRatio)
             : true;
@@ -40,7 +48,7 @@ export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
           group: 'all',
           badge: m.license,
         })),
-    [aspectRatio]
+    [aspectRatio, styleCategory]
   );
 
   return (

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -79,6 +79,8 @@ type SceneScriptPromptsProps = {
     type: 'image' | 'motion' | 'scene-variants'
   ) => void;
   aspectRatio?: AspectRatio;
+  /** Current style category, used to show/hide style-restricted motion models */
+  styleCategory?: string;
 };
 
 type PromptTabContentProps = {
@@ -151,6 +153,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   regeneratingSceneVariants,
   onRegenerateStart,
   aspectRatio,
+  styleCategory,
 }) => {
   const [copiedTab, setCopiedTab] = useState<string | null>(null);
   const [shortenStatus, setShortenStatus] = useState<{
@@ -486,7 +489,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     setEditedMotionPrompt(rawMotionPrompt);
   }
 
-  const motionModelKey = `${frame?.motionModel ?? ''}:${aspectRatio ?? ''}`;
+  const motionModelKey = `${frame?.motionModel ?? ''}:${aspectRatio ?? ''}:${styleCategory ?? ''}`;
   if (motionModelKey !== prevMotionModelKeyRef.current) {
     prevMotionModelKeyRef.current = motionModelKey;
     const currentModel = frame?.motionModel
@@ -495,7 +498,14 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     const compatibleModel = aspectRatio
       ? getCompatibleModel(currentModel, aspectRatio)
       : currentModel;
-    setSelectedMotionModel(compatibleModel);
+    // Fall back if the model requires a style category that doesn't match
+    const modelConfig = IMAGE_TO_VIDEO_MODELS[compatibleModel];
+    const finalModel =
+      'requiredStyleCategory' in modelConfig &&
+      modelConfig.requiredStyleCategory !== styleCategory
+        ? DEFAULT_VIDEO_MODEL
+        : compatibleModel;
+    setSelectedMotionModel(finalModel);
   }
 
   // Check if image is currently generating
@@ -712,6 +722,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               onModelChange={setSelectedMotionModel}
               disabled={isGenerating || isGeneratingMotion}
               aspectRatio={aspectRatio}
+              styleCategory={styleCategory}
             />
           </div>
 

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -15,6 +15,7 @@ import { useActiveImageModel } from '@/hooks/use-active-model';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { useFramesBySequence } from '@/hooks/use-frames';
 import { useSequence } from '@/hooks/use-sequences';
+import { useStyle } from '@/hooks/use-styles';
 import {
   DEFAULT_ASPECT_RATIO,
   type AspectRatio,
@@ -106,6 +107,8 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   });
   const aspectRatio = sequence?.aspectRatio || DEFAULT_ASPECT_RATIO;
   const isProcessing = sequence?.status === 'processing';
+  const { data: style } = useStyle(sequence?.styleId ?? '');
+  const styleCategory = style?.category ?? undefined;
 
   // Phase config from DB — set in stone when the workflow was triggered
   const phaseConfig = useMemo<GenerationPhaseConfig>(
@@ -437,6 +440,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             regeneratingSceneVariants={regeneratingSceneVariants}
             onRegenerateStart={handleRegenerateStart}
             aspectRatio={aspectRatio}
+            styleCategory={styleCategory}
           />
         </ScrollArea>
       </div>

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -39,6 +39,7 @@ import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
+  IMAGE_TO_VIDEO_MODELS,
   safeAudioModel,
   safeImageToVideoModel,
   safeTextToImageModel,
@@ -184,6 +185,14 @@ export const ScriptView: FC<{
     }
   }, [styles, isLoadingStyles, styleId, sequence?.styleId]);
 
+  // Derive style category for motion model filtering
+  const styleCategory = useMemo(
+    () =>
+      styles.find((s) => s.id === (styleId || sequence?.styleId))?.category ??
+      undefined,
+    [styles, styleId, sequence?.styleId]
+  );
+
   // Sync draft state when creating new sequences (not editing)
   const hasSyncedDraftRef = React.useRef(false);
   useEffect(() => {
@@ -266,6 +275,17 @@ export const ScriptView: FC<{
     selectedLocationIds,
     saveDraft,
   ]);
+
+  // Auto-fallback motion model when style changes away from a required category
+  useEffect(() => {
+    const model = IMAGE_TO_VIDEO_MODELS[motionModel];
+    if (
+      'requiredStyleCategory' in model &&
+      model.requiredStyleCategory !== styleCategory
+    ) {
+      updateGen('motionModel', DEFAULT_VIDEO_MODEL);
+    }
+  }, [styleCategory, motionModel]);
 
   const [targetDuration, setTargetDuration] = useState(30);
   const [enhancePopoverOpen, setEnhancePopoverOpen] = useState(false);
@@ -484,6 +504,7 @@ export const ScriptView: FC<{
             onMusicModelChange={(v) => updateGen('musicModel', v)}
             onAutoGenerateMusicChange={(v) => updateGen('autoGenerateMusic', v)}
             disabled={loading}
+            styleCategory={styleCategory}
           />
           <div className="flex items-center gap-2">
             {selectedTalentIds.length === 0 &&

--- a/src/components/settings/generation-settings.tsx
+++ b/src/components/settings/generation-settings.tsx
@@ -72,6 +72,8 @@ type GenerationSettingsProps = {
   singleSelectAnalysis?: boolean;
   /** Use single-select for image model (e.g. in regeneration context) */
   singleSelectImage?: boolean;
+  /** Current style category, used to show/hide style-restricted motion models */
+  styleCategory?: string;
 };
 
 export const GenerationSettings: FC<GenerationSettingsProps> = ({
@@ -92,6 +94,7 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
   disabled = false,
   singleSelectAnalysis = false,
   singleSelectImage = false,
+  styleCategory,
 }) => {
   const [open, setOpen] = useState(false);
 
@@ -175,6 +178,7 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
               onModelChange={onMotionModelChange}
               disabled={disabled || !autoGenerateMotion}
               aspectRatio={aspectRatio}
+              styleCategory={styleCategory}
             />
           </section>
 

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -91,7 +91,7 @@ export const IMAGE_TO_VIDEO_MODELS = {
     qualityRank: 2,
     maxPromptLength: 4096,
     performance: { estimatedGenerationTime: 20, quality: 'best' as const },
-    hidden: true,
+    requiredStyleCategory: 'animation',
   },
 } as const;
 


### PR DESCRIPTION
## Summary

- Replace `hidden: true` on `seedance_v2` video model with a declarative `requiredStyleCategory: 'animation'` field
- Thread `styleCategory` prop through `GenerationSettings` and `SceneScriptPrompts` to the `MotionModelSelector`
- Auto-fallback to default video model when style changes away from animation while Seedance 2 is selected

Closes #553

## Test plan

- [ ] Select animation style → verify Seedance 2 appears in motion model dropdown
- [ ] Select a non-animation style → verify Seedance 2 is hidden from dropdown
- [ ] Select Seedance 2 with animation style, then switch style → verify model resets to default
- [ ] In scenes view with an animation-style sequence → verify Seedance 2 appears in per-scene motion selector
- [ ] Verify `bun typecheck` passes
- [ ] Verify `bun test` passes (362 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)