### PR TITLE
fix: use stable userId for PostHog identification #549

### DIFF
--- a/src/components/auth/verify-form.tsx
+++ b/src/components/auth/verify-form.tsx
@@ -57,7 +57,6 @@ export function VerifyForm({
             return;
           }
 
-          posthog.identify(email, { email });
           posthog.capture('user_signed_in', { method: 'email_otp' });
 
           await navigate({ to: redirectTo });

--- a/src/components/observability/posthog-identify.tsx
+++ b/src/components/observability/posthog-identify.tsx
@@ -1,0 +1,30 @@
+import { useUser } from '@/hooks/use-user';
+import { usePostHog } from '@posthog/react';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Identifies the authenticated user in PostHog using their stable userId.
+ * Automatically resets on logout. Mount inside PostHogProvider.
+ */
+export const PostHogIdentify: React.FC = () => {
+  const posthog = usePostHog();
+  const { data: user } = useUser();
+  const identifiedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!posthog) return;
+
+    if (user && identifiedRef.current !== user.id) {
+      posthog.identify(user.id, {
+        email: user.email,
+        name: user.name,
+      });
+      identifiedRef.current = user.id;
+    } else if (!user && identifiedRef.current) {
+      posthog.reset();
+      identifiedRef.current = null;
+    }
+  }, [posthog, user]);
+
+  return null;
+};

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,3 +1,4 @@
+import { PostHogIdentify } from '@/components/observability/posthog-identify';
 import { Toaster } from '@/components/ui/sonner';
 import { PostHogProvider } from '@posthog/react';
 import type { QueryClient } from '@tanstack/react-query';
@@ -82,6 +83,7 @@ export function Providers({ children, queryClient }: ProvidersProps) {
   return (
     <ObservabilityProvider>
       <QueryClientProvider client={queryClient}>
+        <PostHogIdentify />
         <RealtimeProvider
           api={{ url: '/api/realtime' }}
           maxReconnectAttempts={10}


### PR DESCRIPTION
## Summary
- Created a `PostHogIdentify` component that uses `useUser()` to identify users by their stable ULID (`user.id`) instead of email
- Removed the email-based `posthog.identify(email)` call from `verify-form.tsx`
- Mounted `PostHogIdentify` in `providers.tsx` so identification happens automatically when user data is available

This ensures client-side and server-side PostHog events share the same `distinctId`, fixing the user identification mismatch described in #549.

Closes #549

## Test plan
- [ ] Sign in via email OTP → verify PostHog debug panel shows `identify` call with userId (ULID), not email
- [ ] Sign out → verify `posthog.reset()` is called
- [ ] Check PostHog dashboard shows user events attributed to userId

🤖 Generated with [Claude Code](https://claude.com/claude-code)