### PR TITLE
fix: pass video duration through all motion generation paths

### DIFF
--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -66,7 +66,7 @@ export const generateFrameMotionFn = createServerFn({ method: 'POST' })
           imageUrl: frame.thumbnailUrl,
           prompt,
           model,
-          duration: data.duration,
+          duration,
           fps: data.fps,
           motionBucket: data.motionBucket,
           aspectRatio: sequence.aspectRatio,
@@ -170,7 +170,11 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
           prompt: resolveMotionPrompt(frame, frameModel),
           model: frameModel,
           duration:
-            data.duration || frame.metadata?.metadata?.durationSeconds || 3,
+            data.duration ??
+            (frame.durationMs
+              ? frame.durationMs / 1000
+              : frame.metadata?.metadata?.durationSeconds) ??
+            3,
           fps: data.fps,
           motionBucket: data.motionBucket,
           aspectRatio: sequence.aspectRatio,

--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -238,6 +238,7 @@ export const smartRetryFn = createServerFn({ method: 'POST' })
           prompt: resolveMotionPrompt(frame, videoModel),
           model: videoModel,
           aspectRatio: sequence.aspectRatio,
+          duration: frame.durationMs ? frame.durationMs / 1000 : undefined,
         };
 
         await triggerWorkflow('/motion', workflowInput, {


### PR DESCRIPTION
## Summary
- **Single-frame generation**: was passing `data.duration` (always `undefined` from UI) instead of the snapped `duration` variable — now uses the correctly computed value
- **Batch generation**: switched from `||` to `??` and prefers the authoritative `frame.durationMs` DB column over nested metadata for duration resolution
- **Smart retry**: was missing `duration` entirely in `MotionWorkflowInput` — now passes `frame.durationMs` converted to seconds

Closes #564

## Test plan
- [x] `bun tsgo --noEmit` passes
- [x] `bun test src/lib/motion/` — all 50 tests pass
- [ ] Trigger single-frame motion with LTX/Veo and verify `[Motion Service]` log includes `duration` in `modelOptions`
- [ ] Trigger batch motion generation and verify duration values match scene analysis
- [ ] Trigger smart retry on a failed motion frame and verify duration is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)