### PR TITLE
feat: encourage social interaction via X follow rewards

### DIFF
--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -189,22 +189,20 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
         </DialogHeader>
 
         <div className="flex flex-col gap-2 pt-1">
-          {context === 'onboarding' && (
-            <OptionCard
-              href="https://twitter.com/openstory"
-              icon={<XIcon className="size-4" />}
-              title="Follow us on X"
-              description="Follow @openstory and we'll DM you a $10 gift code"
-              variant="primary"
-              badge={
-                <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                  <Sparkles className="size-2.5" />
-                  Free credits
-                </span>
-              }
-              onClick={() => {}}
-            />
-          )}
+          <OptionCard
+            href="https://x.com/openstory_so"
+            icon={<XIcon className="size-4" />}
+            title="Follow us on X"
+            description="Follow @openstory_so and we'll DM you a $10 gift code"
+            variant="primary"
+            badge={
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                <Sparkles className="size-2.5" />
+                Free credits
+              </span>
+            }
+            onClick={() => {}}
+          />
 
           {stripeEnabled && (
             <OptionCard
@@ -212,15 +210,7 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
               icon={<CreditCard className="size-4" />}
               title="Add Credits"
               description="Pay as you go. Auto top-up keeps you generating."
-              variant={context === 'onboarding' ? 'warm' : 'primary'}
-              badge={
-                context !== 'onboarding' ? (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                    <Sparkles className="size-2.5" />
-                    Recommended
-                  </span>
-                ) : undefined
-              }
+              variant="warm"
               onClick={handleNav}
             />
           )}

--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -26,8 +26,17 @@ function setReturnPath(returnTo?: string) {
   localStorage.setItem(RETURN_KEY, path);
 }
 
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
 type OptionCardProps = {
-  to: string;
+  to?: string;
+  href?: string;
   search?: Record<string, string>;
   icon: React.ReactNode;
   title: string;
@@ -38,8 +47,57 @@ type OptionCardProps = {
   children?: React.ReactNode;
 };
 
+const cardClassName = (variant: 'primary' | 'warm' | 'muted') =>
+  cn(
+    'group relative flex items-center gap-3.5 rounded-xl border p-3.5 transition-all duration-200',
+    variant === 'primary' &&
+      'border-primary/20 bg-primary/[0.03] hover:border-primary/40 hover:bg-primary/[0.06]',
+    variant === 'warm' &&
+      'border-amber-500/20 bg-amber-500/[0.03] hover:border-amber-500/40 hover:bg-amber-500/[0.06] dark:border-amber-400/15 dark:bg-amber-400/[0.03] dark:hover:border-amber-400/30 dark:hover:bg-amber-400/[0.05]',
+    variant === 'muted' &&
+      'border-border/60 bg-transparent hover:border-border hover:bg-accent/50'
+  );
+
+const OptionCardContent: React.FC<
+  Pick<
+    OptionCardProps,
+    'icon' | 'title' | 'description' | 'badge' | 'variant' | 'children'
+  >
+> = ({ icon, title, description, badge, variant = 'muted', children }) => (
+  <>
+    <div
+      className={cn(
+        'flex size-10 shrink-0 items-center justify-center rounded-lg transition-colors duration-200',
+        variant === 'primary' &&
+          'bg-primary/10 text-primary group-hover:bg-primary/15',
+        variant === 'warm' &&
+          'bg-amber-500/10 text-amber-600 group-hover:bg-amber-500/15 dark:text-amber-400',
+        variant === 'muted' &&
+          'bg-muted text-muted-foreground group-hover:bg-muted/80'
+      )}
+    >
+      {icon}
+    </div>
+    <div className="flex-1 space-y-0.5">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium">{title}</span>
+        {badge}
+      </div>
+      <p className="text-xs text-muted-foreground">{description}</p>
+      {children}
+    </div>
+    <ArrowRight
+      className={cn(
+        'size-3.5 shrink-0 -translate-x-1 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-60',
+        variant === 'muted' && 'text-muted-foreground'
+      )}
+    />
+  </>
+);
+
 const OptionCard: React.FC<OptionCardProps> = ({
   to,
+  href,
   search,
   icon,
   title,
@@ -48,49 +106,39 @@ const OptionCard: React.FC<OptionCardProps> = ({
   variant = 'muted',
   onClick,
   children,
-}) => (
-  <Link to={to} search={search} onClick={onClick}>
-    <div
-      className={cn(
-        'group relative flex items-center gap-3.5 rounded-xl border p-3.5 transition-all duration-200',
-        variant === 'primary' &&
-          'border-primary/20 bg-primary/[0.03] hover:border-primary/40 hover:bg-primary/[0.06]',
-        variant === 'warm' &&
-          'border-amber-500/20 bg-amber-500/[0.03] hover:border-amber-500/40 hover:bg-amber-500/[0.06] dark:border-amber-400/15 dark:bg-amber-400/[0.03] dark:hover:border-amber-400/30 dark:hover:bg-amber-400/[0.05]',
-        variant === 'muted' &&
-          'border-border/60 bg-transparent hover:border-border hover:bg-accent/50'
-      )}
+}) => {
+  const content = (
+    <OptionCardContent
+      icon={icon}
+      title={title}
+      description={description}
+      badge={badge}
+      variant={variant}
     >
-      <div
-        className={cn(
-          'flex size-10 shrink-0 items-center justify-center rounded-lg transition-colors duration-200',
-          variant === 'primary' &&
-            'bg-primary/10 text-primary group-hover:bg-primary/15',
-          variant === 'warm' &&
-            'bg-amber-500/10 text-amber-600 group-hover:bg-amber-500/15 dark:text-amber-400',
-          variant === 'muted' &&
-            'bg-muted text-muted-foreground group-hover:bg-muted/80'
-        )}
+      {children}
+    </OptionCardContent>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClick}
+        className={cardClassName(variant)}
       >
-        {icon}
-      </div>
-      <div className="flex-1 space-y-0.5">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{title}</span>
-          {badge}
-        </div>
-        <p className="text-xs text-muted-foreground">{description}</p>
-        {children}
-      </div>
-      <ArrowRight
-        className={cn(
-          'size-3.5 shrink-0 -translate-x-1 opacity-0 transition-all duration-200 group-hover:translate-x-0 group-hover:opacity-60',
-          variant === 'muted' && 'text-muted-foreground'
-        )}
-      />
-    </div>
-  </Link>
-);
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <Link to={to ?? '/'} search={search} onClick={onClick}>
+      <div className={cardClassName(variant)}>{content}</div>
+    </Link>
+  );
+};
 
 type BillingGateDialogProps = {
   open: boolean;
@@ -141,18 +189,37 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
         </DialogHeader>
 
         <div className="flex flex-col gap-2 pt-1">
+          {context === 'onboarding' && (
+            <OptionCard
+              href="https://twitter.com/openstory"
+              icon={<XIcon className="size-4" />}
+              title="Follow us on X"
+              description="Follow @openstory and we'll DM you a $10 gift code"
+              variant="primary"
+              badge={
+                <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                  <Sparkles className="size-2.5" />
+                  Free credits
+                </span>
+              }
+              onClick={() => {}}
+            />
+          )}
+
           {stripeEnabled && (
             <OptionCard
               to="/credits"
               icon={<CreditCard className="size-4" />}
               title="Add Credits"
               description="Pay as you go. Auto top-up keeps you generating."
-              variant="primary"
+              variant={context === 'onboarding' ? 'warm' : 'primary'}
               badge={
-                <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                  <Sparkles className="size-2.5" />
-                  Recommended
-                </span>
+                context !== 'onboarding' ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                    <Sparkles className="size-2.5" />
+                    Recommended
+                  </span>
+                ) : undefined
               }
               onClick={handleNav}
             />

--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -3,6 +3,7 @@
  * Prompts users to add credits or configure BYOK API keys
  */
 
+import { XIcon } from '@/components/icons/x-icon';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -26,14 +27,6 @@ function setReturnPath(returnTo?: string) {
   localStorage.setItem(RETURN_KEY, path);
 }
 
-function XIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
-      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-    </svg>
-  );
-}
-
 type OptionCardProps = {
   to?: string;
   href?: string;
@@ -43,7 +36,7 @@ type OptionCardProps = {
   description: string;
   badge?: React.ReactNode;
   variant?: 'primary' | 'warm' | 'muted';
-  onClick: () => void;
+  onClick?: () => void;
   children?: React.ReactNode;
 };
 
@@ -145,7 +138,6 @@ type BillingGateDialogProps = {
   onOpenChange: (open: boolean) => void;
   hasFalKey?: boolean;
   hasOpenRouterKey?: boolean;
-  hasCredits?: boolean;
   stripeEnabled?: boolean;
   returnTo?: string;
   context?: 'generation' | 'onboarding';
@@ -193,7 +185,7 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
             href="https://x.com/openstory_so"
             icon={<XIcon className="size-4" />}
             title="Follow us on X"
-            description="Follow @openstory_so and we'll DM you a $10 gift code"
+            description="Follow @openstory_so and DM us for a $10 gift code"
             variant="primary"
             badge={
               <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
@@ -201,7 +193,6 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
                 Free credits
               </span>
             }
-            onClick={() => {}}
           />
 
           {stripeEnabled && (

--- a/src/components/icons/x-icon.tsx
+++ b/src/components/icons/x-icon.tsx
@@ -1,0 +1,7 @@
+export function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}

--- a/src/components/marketing/site-footer.tsx
+++ b/src/components/marketing/site-footer.tsx
@@ -2,28 +2,13 @@ import { Link } from '@tanstack/react-router';
 import { Image } from '@unpic/react';
 import { Button } from '@/components/ui/button';
 import { OpenStoryLogo } from '@/components/icons/openstory-logo';
+import { XIcon } from '@/components/icons/x-icon';
 import { FILMSTRIP_IMAGES, SITE_CONFIG } from '@/lib/marketing/constants';
-
-function TwitterIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className="size-5">
-      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-    </svg>
-  );
-}
 
 function GitHubIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" className="size-5">
       <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0112 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
-    </svg>
-  );
-}
-
-function YouTubeIcon() {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className="size-5">
-      <path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
     </svg>
   );
 }
@@ -99,22 +84,13 @@ export function SiteFooter() {
               Privacy
             </Link>
             <a
-              href="https://twitter.com/openstory"
+              href="https://x.com/openstory_so"
               target="_blank"
               rel="noopener noreferrer"
               className="text-background/40 transition-colors hover:text-background"
-              aria-label="Twitter"
+              aria-label="X"
             >
-              <TwitterIcon />
-            </a>
-            <a
-              href="https://youtube.com/@openstory"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-background/40 transition-colors hover:text-background"
-              aria-label="YouTube"
-            >
-              <YouTubeIcon />
+              <XIcon className="size-5" />
             </a>
             <a
               href={SITE_CONFIG.githubHref}

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -316,7 +316,6 @@ export const ScriptView: FC<{
     gateProps,
     hasFalKey,
     hasOpenRouterKey,
-    hasCredits,
     stripeEnabled,
   } = useBillingGate();
 
@@ -699,7 +698,6 @@ export const ScriptView: FC<{
         {...gateProps}
         hasFalKey={hasFalKey}
         hasOpenRouterKey={hasOpenRouterKey}
-        hasCredits={hasCredits}
         stripeEnabled={stripeEnabled}
       />
       <AlertDialog

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -23,7 +23,16 @@ import {
 } from '@/functions/gift-tokens';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Check, Copy, Gift, Layers, LinkIcon, ShieldCheck } from 'lucide-react';
+import { useBillingGateQuery } from '@/hooks/use-billing-gate';
+import {
+  Check,
+  Copy,
+  Gift,
+  Layers,
+  LinkIcon,
+  ShieldCheck,
+  Sparkles,
+} from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -35,9 +44,11 @@ export function GiftCodeSettings() {
     queryFn: () => isSystemAdminFn(),
     staleTime: 5 * 60 * 1000,
   });
+  const { data: gateStatus } = useBillingGateQuery();
 
   return (
     <div className="space-y-6">
+      {gateStatus && !gateStatus.hasRedeemedGift && <FollowOnXCard />}
       <RedeemSection />
       {adminLoading ? (
         <Skeleton className="h-48 w-full" />
@@ -45,6 +56,51 @@ export function GiftCodeSettings() {
         <AdminSection />
       ) : null}
     </div>
+  );
+}
+
+function XIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function FollowOnXCard() {
+  return (
+    <Card className="border-primary/20 bg-primary/[0.02]">
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <XIcon className="h-5 w-5 text-primary" />
+          </div>
+          <div className="flex-1">
+            <div className="flex items-center gap-2">
+              <CardTitle>Get $10 Free Credits</CardTitle>
+              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
+                <Sparkles className="size-2.5" />
+                Free
+              </span>
+            </div>
+            <CardDescription>
+              Follow @openstory on X and we'll DM you a gift code worth $10
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Button asChild>
+          <a
+            href="https://twitter.com/openstory"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Follow @openstory on X
+          </a>
+        </Button>
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -1,3 +1,4 @@
+import { XIcon } from '@/components/icons/x-icon';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -59,14 +60,6 @@ export function GiftCodeSettings() {
   );
 }
 
-function XIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className}>
-      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
-    </svg>
-  );
-}
-
 function FollowOnXCard() {
   return (
     <Card className="border-primary/20 bg-primary/[0.02]">
@@ -84,7 +77,7 @@ function FollowOnXCard() {
               </span>
             </div>
             <CardDescription>
-              Follow @openstory_so on X and we'll DM you a gift code worth $10
+              Follow @openstory_so on X and DM us to get a gift code worth $10
             </CardDescription>
           </div>
         </div>

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -84,7 +84,7 @@ function FollowOnXCard() {
               </span>
             </div>
             <CardDescription>
-              Follow @openstory on X and we'll DM you a gift code worth $10
+              Follow @openstory_so on X and we'll DM you a gift code worth $10
             </CardDescription>
           </div>
         </div>
@@ -92,11 +92,11 @@ function FollowOnXCard() {
       <CardContent>
         <Button asChild>
           <a
-            href="https://twitter.com/openstory"
+            href="https://x.com/openstory_so"
             target="_blank"
             rel="noopener noreferrer"
           >
-            Follow @openstory on X
+            Follow @openstory_so on X
           </a>
         </Button>
       </CardContent>

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -15,6 +15,7 @@ import { triggerBalanceFlash } from '@/hooks/use-balance-flash';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
 import {
+  batchCreateGiftTokensFn,
   createGiftTokenFn,
   isSystemAdminFn,
   listGiftTokensFn,
@@ -22,7 +23,7 @@ import {
 } from '@/functions/gift-tokens';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { Check, Copy, Gift, LinkIcon, ShieldCheck } from 'lucide-react';
+import { Check, Copy, Gift, Layers, LinkIcon, ShieldCheck } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -136,9 +137,191 @@ function RedeemSection() {
 function AdminSection() {
   return (
     <>
+      <BatchCreateCard />
       <CreateGiftCodeCard />
       <GiftCodeListCard />
     </>
+  );
+}
+
+const INITIAL_BATCH_FORM = {
+  count: '100',
+  amount: '10',
+  note: 'X follow reward',
+  expiresInDays: '',
+};
+
+function BatchCreateCard() {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState(INITIAL_BATCH_FORM);
+  const [createdCodes, setCreatedCodes] = useState<string[] | null>(null);
+  const [copied, setCopied] = useState(false);
+  const updateField = (field: keyof typeof form, value: string) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  const batchMutation = useMutation({
+    mutationFn: (input: {
+      count: number;
+      amountUsd: number;
+      note?: string;
+      expiresInDays?: number;
+    }) => batchCreateGiftTokensFn({ data: input }),
+    onSuccess: (result) => {
+      setCreatedCodes(result.codes);
+      setForm(INITIAL_BATCH_FORM);
+      void queryClient.invalidateQueries({ queryKey: ['gift-tokens'] });
+      toast.success(`${result.codes.length} gift codes created`);
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to create batch'
+      );
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const countNum = parseInt(form.count, 10);
+    const amountUsd = parseFloat(form.amount);
+    if (isNaN(countNum) || countNum < 1 || countNum > 500) return;
+    if (isNaN(amountUsd) || amountUsd <= 0) return;
+
+    const parsedDays = parseInt(form.expiresInDays, 10);
+    batchMutation.mutate({
+      count: countNum,
+      amountUsd,
+      note: form.note || undefined,
+      expiresInDays: parsedDays > 0 ? parsedDays : undefined,
+    });
+  };
+
+  const handleCopyAll = () => {
+    if (!createdCodes) return;
+    void navigator.clipboard.writeText(createdCodes.join('\n'));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+            <Layers className="h-5 w-5 text-primary" />
+          </div>
+          <div>
+            <CardTitle>Batch Create Gift Codes</CardTitle>
+            <CardDescription>
+              Generate multiple single-use codes for X follow rewards
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div className="space-y-2">
+              <Label htmlFor="batch-count">Count</Label>
+              <Input
+                id="batch-count"
+                type="number"
+                min="1"
+                max="500"
+                step="1"
+                placeholder="100"
+                value={form.count}
+                onChange={(e) => updateField('count', e.target.value)}
+                className="tabular-nums"
+                autoComplete="off"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="batch-amount">Amount (USD)</Label>
+              <div className="relative">
+                <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">
+                  $
+                </span>
+                <Input
+                  id="batch-amount"
+                  type="number"
+                  min="0.01"
+                  step="0.01"
+                  placeholder="10.00"
+                  value={form.amount}
+                  onChange={(e) => updateField('amount', e.target.value)}
+                  className="pl-7 tabular-nums"
+                  autoComplete="off"
+                  required
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="batch-expires">Expires in (days)</Label>
+              <Input
+                id="batch-expires"
+                type="number"
+                min="1"
+                step="1"
+                placeholder="No expiry"
+                value={form.expiresInDays}
+                onChange={(e) => updateField('expiresInDays', e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="batch-note">Note</Label>
+              <Input
+                id="batch-note"
+                placeholder="e.g. X follow reward…"
+                value={form.note}
+                onChange={(e) => updateField('note', e.target.value)}
+                autoComplete="off"
+              />
+            </div>
+          </div>
+          <Button
+            type="submit"
+            disabled={!form.count || !form.amount || batchMutation.isPending}
+          >
+            {batchMutation.isPending
+              ? `Creating ${form.count} codes…`
+              : `Create ${form.count} Codes`}
+          </Button>
+        </form>
+
+        {createdCodes && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>{createdCodes.length} codes generated</Label>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCopyAll}
+                className="gap-1.5"
+              >
+                {copied ? (
+                  <Check className="h-3.5 w-3.5 text-green-600" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+                {copied ? 'Copied' : 'Copy All'}
+              </Button>
+            </div>
+            <textarea
+              readOnly
+              value={createdCodes.join('\n')}
+              className="h-48 w-full resize-y rounded-md border bg-muted/50 p-3 font-mono text-sm tracking-wider"
+              onClick={(e) => {
+                if (e.target instanceof HTMLTextAreaElement) {
+                  e.target.select();
+                }
+              }}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/src/functions/billing-gate.ts
+++ b/src/functions/billing-gate.ts
@@ -17,13 +17,19 @@ export const getBillingGateStatusFn = createServerFn({ method: 'GET' })
   .handler(async ({ context }) => {
     const { scopedDb } = context;
 
-    const [balance, hasFalKey, hasOpenRouterKey, billingSettings] =
-      await Promise.all([
-        scopedDb.billing.getBalance(),
-        scopedDb.apiKeys.hasKey('fal'),
-        scopedDb.apiKeys.hasKey('openrouter'),
-        scopedDb.billing.getBillingSettings(),
-      ]);
+    const [
+      balance,
+      hasFalKey,
+      hasOpenRouterKey,
+      billingSettings,
+      hasRedeemedGift,
+    ] = await Promise.all([
+      scopedDb.billing.getBalance(),
+      scopedDb.apiKeys.hasKey('fal'),
+      scopedDb.apiKeys.hasKey('openrouter'),
+      scopedDb.billing.getBillingSettings(),
+      scopedDb.billing.hasRedeemedGiftCode(),
+    ]);
 
     return {
       hasCredits: balance > 0,
@@ -33,5 +39,6 @@ export const getBillingGateStatusFn = createServerFn({ method: 'GET' })
       hasAutoTopUp:
         billingSettings.autoTopUpEnabled && !!billingSettings.stripeCustomerId,
       stripeEnabled: isStripeEnabled(),
+      hasRedeemedGift,
     };
   });

--- a/src/functions/gift-tokens.ts
+++ b/src/functions/gift-tokens.ts
@@ -37,6 +37,37 @@ export const createGiftTokenFn = createServerFn({ method: 'POST' })
     });
   });
 
+export const batchCreateGiftTokensFn = createServerFn({ method: 'POST' })
+  .middleware([systemAdminMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        count: z.number().int().min(1).max(500),
+        amountUsd: z.number().positive(),
+        note: z.string().optional(),
+        expiresInDays: z.number().positive().optional(),
+      })
+    )
+  )
+  .handler(async ({ context, data }) => {
+    const expiresAt = data.expiresInDays
+      ? new Date(Date.now() + data.expiresInDays * MS_PER_DAY)
+      : undefined;
+
+    const codes: string[] = [];
+    for (let i = 0; i < data.count; i++) {
+      const token = await context.adminScopedDb.admin.createGiftToken({
+        createdByUserId: context.user.id,
+        amountUsd: data.amountUsd,
+        maxRedemptions: 1,
+        note: data.note,
+        expiresAt,
+      });
+      codes.push(token.code);
+    }
+    return { codes };
+  });
+
 export const redeemGiftTokenFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
   .inputValidator(zodValidator(z.object({ code: z.string().min(1) })))

--- a/src/hooks/use-billing-gate.ts
+++ b/src/hooks/use-billing-gate.ts
@@ -17,6 +17,7 @@ type BillingGateStatus = {
   balance: number;
   hasAutoTopUp: boolean;
   stripeEnabled: boolean;
+  hasRedeemedGift: boolean;
 };
 
 export function useBillingGateQuery() {
@@ -74,6 +75,7 @@ export function useBillingGate(mode: 'all' | 'fal' = 'all') {
     hasCredits: data?.hasCredits ?? true,
     hasAutoTopUp: data?.hasAutoTopUp ?? false,
     stripeEnabled: data?.stripeEnabled ?? true,
+    hasRedeemedGift: data?.hasRedeemedGift ?? false,
     showGate,
     gateProps: { open, onOpenChange: setOpen },
     isLoading: query.isLoading,

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -141,11 +141,22 @@ export function createBillingReadMethods(db: Database, teamId: string) {
     return row;
   }
 
+  async function hasRedeemedGiftCode(): Promise<boolean> {
+    const [row] = await db
+      .select({ value: count() })
+      .from(giftTokenRedemptions)
+      .where(eq(giftTokenRedemptions.teamId, teamId))
+      .limit(1);
+
+    return (row?.value ?? 0) > 0;
+  }
+
   return {
     getBalance,
     hasEnoughCredits,
     getTransactionHistory,
     getBillingSettings,
+    hasRedeemedGiftCode,
   };
 }
 

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -143,12 +143,12 @@ export function createBillingReadMethods(db: Database, teamId: string) {
 
   async function hasRedeemedGiftCode(): Promise<boolean> {
     const [row] = await db
-      .select({ value: count() })
+      .select({ id: giftTokenRedemptions.id })
       .from(giftTokenRedemptions)
       .where(eq(giftTokenRedemptions.teamId, teamId))
       .limit(1);
 
-    return (row?.value ?? 0) > 0;
+    return !!row;
   }
 
   return {

--- a/src/routes/_protected/sequences/index.tsx
+++ b/src/routes/_protected/sequences/index.tsx
@@ -1,6 +1,4 @@
-import { useEffect, useState } from 'react';
 import { VideoIcon } from '@/components/icons/video-icon';
-import { BillingGateDialog } from '@/components/billing/billing-gate-dialog';
 import { PageContainer } from '@/components/layout/page-container';
 import { PageDescription } from '@/components/typography/page-description';
 import { PageHeader } from '@/components/typography/page-header';
@@ -8,31 +6,10 @@ import { PageHeading } from '@/components/typography/page-heading';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { SequencesList } from '@/components/sequence/sequences-list';
-import { useBillingGate } from '@/hooks/use-billing-gate';
 import { sequenceKeys, useSequences } from '@/hooks/use-sequences';
 import { getSequencesFn } from '@/functions/sequences';
 import { Route as sequencesNewRoute } from '@/routes/_protected/sequences/new';
 import { createFileRoute, Link } from '@tanstack/react-router';
-
-const BILLING_PROMPT_KEY = 'openstory:billing-prompt-dismissed';
-const BILLING_PROMPT_EXPIRY_DAYS = 1;
-
-function wasBillingPromptDismissed(): boolean {
-  if (typeof window === 'undefined') return false;
-  const raw = localStorage.getItem(BILLING_PROMPT_KEY);
-  if (!raw) return false;
-  const expiry = Number(raw);
-  if (Date.now() > expiry) {
-    localStorage.removeItem(BILLING_PROMPT_KEY);
-    return false;
-  }
-  return true;
-}
-
-function dismissBillingPrompt() {
-  const expiry = Date.now() + BILLING_PROMPT_EXPIRY_DAYS * 24 * 60 * 60 * 1000;
-  localStorage.setItem(BILLING_PROMPT_KEY, String(expiry));
-}
 
 export const Route = createFileRoute('/_protected/sequences/')({
   component: SequencesPage,
@@ -47,29 +24,9 @@ export const Route = createFileRoute('/_protected/sequences/')({
 
 function SequencesPage() {
   const { data: sequences, isLoading } = useSequences();
-  const { needsBillingSetup, hasFalKey, hasOpenRouterKey, stripeEnabled } =
-    useBillingGate();
-  const [billingOpen, setBillingOpen] = useState(false);
-
-  useEffect(() => {
-    if (needsBillingSetup && !wasBillingPromptDismissed()) {
-      setBillingOpen(true);
-    }
-  }, [needsBillingSetup]);
 
   return (
     <div className="h-full overflow-auto">
-      <BillingGateDialog
-        open={billingOpen}
-        onOpenChange={(open) => {
-          setBillingOpen(open);
-          if (!open) dismissBillingPrompt();
-        }}
-        hasFalKey={hasFalKey}
-        hasOpenRouterKey={hasOpenRouterKey}
-        stripeEnabled={stripeEnabled}
-        context="onboarding"
-      />
       <PageContainer>
         <PageHeader
           actions={

--- a/src/routes/_protected/sequences/new.tsx
+++ b/src/routes/_protected/sequences/new.tsx
@@ -1,19 +1,51 @@
+import { BillingGateDialog } from '@/components/billing/billing-gate-dialog';
 import { PageContainer } from '@/components/layout/page-container';
 import { ScriptView } from '@/components/script/script-view';
+import { useBillingGate } from '@/hooks/use-billing-gate';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Route as ScenesRoute } from '@/routes/_protected/sequences/$id/scenes';
+
+const BILLING_PROMPT_KEY = 'openstory:billing-prompt-dismissed';
+const BILLING_PROMPT_EXPIRY_DAYS = 1;
+
+function wasBillingPromptDismissed(): boolean {
+  if (typeof window === 'undefined') return false;
+  const raw = localStorage.getItem(BILLING_PROMPT_KEY);
+  if (!raw) return false;
+  const expiry = Number(raw);
+  if (Date.now() > expiry) {
+    localStorage.removeItem(BILLING_PROMPT_KEY);
+    return false;
+  }
+  return true;
+}
+
+function dismissBillingPrompt() {
+  const expiry = Date.now() + BILLING_PROMPT_EXPIRY_DAYS * 24 * 60 * 60 * 1000;
+  localStorage.setItem(BILLING_PROMPT_KEY, String(expiry));
+}
+
 export const Route = createFileRoute('/_protected/sequences/new')({
   component: NewSequencePage,
 });
 
 function NewSequencePage() {
   const navigate = useNavigate();
+  const { needsBillingSetup, hasFalKey, hasOpenRouterKey, stripeEnabled } =
+    useBillingGate();
+  const [billingOpen, setBillingOpen] = useState(false);
 
   // Clear billing return flag when user is back on this page
   useEffect(() => {
     localStorage.removeItem('openstory:billing-return');
   }, []);
+
+  useEffect(() => {
+    if (needsBillingSetup && !wasBillingPromptDismissed()) {
+      setBillingOpen(true);
+    }
+  }, [needsBillingSetup]);
 
   const handleSuccess = useCallback(
     (sequenceIds: string[]) => {
@@ -30,6 +62,17 @@ function NewSequencePage() {
 
   return (
     <div className="h-full">
+      <BillingGateDialog
+        open={billingOpen}
+        onOpenChange={(open) => {
+          setBillingOpen(open);
+          if (!open) dismissBillingPrompt();
+        }}
+        hasFalKey={hasFalKey}
+        hasOpenRouterKey={hasOpenRouterKey}
+        stripeEnabled={stripeEnabled}
+        context="onboarding"
+      />
       <PageContainer maxWidth="narrow" fullHeight>
         <ScriptView loading={false} onSuccess={handleSuccess} />
       </PageContainer>


### PR DESCRIPTION
## Summary
- Added "Follow us on X" as the top option in the onboarding billing gate dialog, linking to the X profile where an external automation DMs new followers a $10 gift code
- Added batch gift code generation (up to 500 single-use codes) to the admin gift codes page, with copyable output for export to the X automation tool
- Refactored OptionCard to support external links via `href` prop

## Test plan
- [ ] Visit `/sequences` as a new user without credits — verify "Follow us on X" appears as the top option with "Free credits" badge
- [ ] Click the X follow card — verify it opens twitter.com/openstory in a new tab and the dialog stays open
- [ ] Trigger billing gate in generation context — verify the X follow card does NOT appear
- [ ] As admin, visit `/credits?tab=gift-codes` — verify the "Batch Create Gift Codes" card appears
- [ ] Generate 100 codes with $10 amount — verify codes appear in textarea and "Copy All" works
- [ ] Spot-check that a generated code is redeemable for $10

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)