### PR TITLE
fix: let sequence loader errors reach errorComponent #576

### DIFF
--- a/src/routes/_protected/sequences/$id/route.tsx
+++ b/src/routes/_protected/sequences/$id/route.tsx
@@ -21,7 +21,6 @@ import { isValidId } from '@/lib/db/id';
 import { useQuery } from '@tanstack/react-query';
 import {
   createFileRoute,
-  isNotFound,
   notFound,
   Outlet,
   useRouterState,
@@ -34,17 +33,10 @@ export const Route = createFileRoute('/_protected/sequences/$id')({
       throw notFound();
     }
 
-    try {
-      const sequence = await queryClient.ensureQueryData({
-        queryKey: sequenceKeys.detail(params.id),
-        queryFn: () => getSequenceFn({ data: { sequenceId: params.id } }),
-      });
-      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
-      if (!sequence) throw notFound();
-    } catch (error) {
-      if (isNotFound(error)) throw error;
-      throw notFound();
-    }
+    await queryClient.ensureQueryData({
+      queryKey: sequenceKeys.detail(params.id),
+      queryFn: () => getSequenceFn({ data: { sequenceId: params.id } }),
+    });
   },
   errorComponent: (props) => (
     <RouteErrorFallback {...props} heading="Sequence error" />


### PR DESCRIPTION
## Summary

- Drop the blanket \`try/catch → throw notFound()\` in the \`/sequences/\$id\` route loader. Any error from \`getSequenceFn\` now propagates to \`errorComponent\` (\`RouteErrorFallback\`), which already renders the 404 page for NOT_FOUND-shaped errors and a useful error UI for everything else.
- Fixes the noisy \`ERR! GET /_serverFn/...NOT_FOUND: Sequence not found\` lines seen in CI (see #576) by no longer amplifying transient server errors into a page-wide 404.

## Test plan

- [x] \`bun typecheck\` passes
- [ ] Navigate to \`/sequences/{valid-id}/scenes\` — page renders normally
- [ ] Navigate to \`/sequences/{fabricated-but-valid-ulid}/scenes\` — error UI renders (via \`RouteErrorFallback\` → \`DefaultNotFound\`), not a blank 404
- [ ] Navigate to \`/sequences/not-a-ulid/scenes\` — still 404s via the ID-validation branch
- [ ] CI e2e output no longer spams \`NOT_FOUND: Sequence not found\` on newly-created sequences

Closes #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)