### PR TITLE
Duck music volume via loudnorm and fix merge-video audio mux chain #515

### DIFF
--- a/src/lib/audio/loudness-normalize.ts
+++ b/src/lib/audio/loudness-normalize.ts
@@ -1,0 +1,98 @@
+/**
+ * Loudness Normalization Service
+ * Normalizes an audio track to a target integrated loudness (LUFS) using
+ * fal.ai's EBU R128 loudnorm endpoint. Used to duck background music so it
+ * sits consistently below dialogue in the final video mix.
+ */
+
+import { createFalClient } from '@fal-ai/client';
+import { getEnv } from '#env';
+import type { ScopedDb } from '@/lib/db/scoped';
+
+const LOUDNORM_MODEL_ID = 'fal-ai/ffmpeg-api/loudnorm';
+
+/**
+ * Target integrated loudness for background music (LUFS).
+ * Generated music typically outputs at -14 to -18 LUFS; dialogue in video output
+ * lands in a similar range. Targeting -24 LUFS puts the music bed ~6-10 LU
+ * below voice — audible but comfortably underneath, the standard broadcast
+ * offset for music-under-dialogue.
+ */
+export const DEFAULT_MUSIC_LOUDNESS_LUFS = -24;
+
+export type LoudnessNormalizeResult = {
+  audioUrl: string;
+  requestId?: string;
+  usedOwnKey: boolean;
+};
+
+function hasKey<K extends string>(
+  obj: object,
+  key: K
+): obj is Record<K, unknown> {
+  return key in obj;
+}
+
+function extractAudioUrl(data: unknown): string | undefined {
+  if (typeof data !== 'object' || data === null) return undefined;
+  for (const key of ['audio', 'audio_file'] as const) {
+    if (!hasKey(data, key)) continue;
+    const field = data[key];
+    if (typeof field === 'string') return field;
+    if (typeof field === 'object' && field !== null && hasKey(field, 'url')) {
+      if (typeof field.url === 'string') return field.url;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Normalize an audio file to a target integrated loudness.
+ * Uses two-pass (dynamic) mode for better quality.
+ */
+export async function normalizeAudioLoudness({
+  audioUrl,
+  integratedLoudness = DEFAULT_MUSIC_LOUDNESS_LUFS,
+  scopedDb,
+}: {
+  audioUrl: string;
+  /** Target integrated loudness in LUFS. Defaults to -30 LUFS (quiet background). */
+  integratedLoudness?: number;
+  scopedDb?: ScopedDb;
+}): Promise<LoudnessNormalizeResult> {
+  console.log('[LoudnessNormalize] Normalizing audio', {
+    audioUrl: audioUrl.slice(0, 80),
+    integratedLoudness,
+  });
+
+  const falApiKeyInfo = scopedDb
+    ? await scopedDb.apiKeys.resolveKey('fal')
+    : { key: getEnv().FAL_KEY, source: 'platform' as const };
+  const fal = createFalClient({ credentials: falApiKeyInfo.key });
+
+  let requestId: string | undefined;
+
+  const result = await fal.subscribe(LOUDNORM_MODEL_ID, {
+    input: {
+      audio_url: audioUrl,
+      integrated_loudness: integratedLoudness,
+    },
+    logs: true,
+    pollInterval: 5000,
+    onEnqueue: (reqId: string) => {
+      requestId = reqId;
+      console.log(`[LoudnessNormalize] Request enqueued: ${reqId}`);
+    },
+  });
+
+  const outputUrl = extractAudioUrl(result.data);
+  if (!outputUrl) {
+    throw new Error('No audio URL returned from loudness normalization');
+  }
+
+  return {
+    audioUrl: outputUrl,
+    requestId: requestId ?? result.requestId,
+    usedOwnKey: falApiKeyInfo.source === 'team',
+  };
+}

--- a/src/lib/workflows/merge-audio-video-workflow.ts
+++ b/src/lib/workflows/merge-audio-video-workflow.ts
@@ -4,6 +4,7 @@
  */
 
 import { composeAudioVideo } from '@/lib/audio/compose-audio-video';
+import { normalizeAudioLoudness } from '@/lib/audio/loudness-normalize';
 import { getGenerationChannel } from '@/lib/realtime';
 import { usdToMicros } from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
@@ -58,10 +59,21 @@ export const mergeAudioVideoWorkflow = createScopedWorkflow<
       }
     );
 
+    const normalizedMusicUrl = await context.run(
+      'normalize-music-loudness',
+      async () => {
+        const result = await normalizeAudioLoudness({
+          audioUrl: musicUrl,
+          scopedDb,
+        });
+        return result.audioUrl;
+      }
+    );
+
     const muxResult = await context.run('compose-audio-video', async () => {
       return composeAudioVideo({
         videoUrl: mergedVideoUrl,
-        musicUrl: musicUrl,
+        musicUrl: normalizedMusicUrl,
         durationMs: videoDurationMs,
         scopedDb,
       });

--- a/src/lib/workflows/merge-video-workflow.ts
+++ b/src/lib/workflows/merge-video-workflow.ts
@@ -15,9 +15,51 @@ import {
   getMimeTypeFromExtension,
 } from '@/lib/utils/file';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
+import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
-import type { MergeVideoWorkflowInput } from '@/lib/workflow/types';
+import type { ScopedDb } from '@/lib/db/scoped';
+import type {
+  MergeAudioVideoWorkflowInput,
+  MergeVideoWorkflowInput,
+} from '@/lib/workflow/types';
+import type { WorkflowContext } from '@upstash/workflow';
+import { mergeAudioVideoWorkflow } from './merge-audio-video-workflow';
+
+/**
+ * Chain to merge-audio-video if the sequence has a ready music track.
+ * This keeps the UI "Merge with Video" CTA honest — it restitches frames
+ * and also muxes the existing music onto the fresh output.
+ */
+async function chainAudioMux(
+  context: WorkflowContext<MergeVideoWorkflowInput>,
+  scopedDb: ScopedDb,
+  input: MergeVideoWorkflowInput & { sequenceId: string },
+  mergedVideoUrl: string
+): Promise<void> {
+  const musicUrl = await context.run('fetch-music-for-mux', async () => {
+    const status = await scopedDb.sequence(input.sequenceId).getMusicStatus();
+    return status?.musicStatus === 'completed'
+      ? (status.musicUrl ?? null)
+      : null;
+  });
+
+  if (!musicUrl) {
+    return;
+  }
+
+  await context.invoke('merge-audio-video', {
+    workflow: mergeAudioVideoWorkflow,
+    label: buildWorkflowLabel(input.sequenceId),
+    body: {
+      userId: input.userId,
+      teamId: input.teamId,
+      sequenceId: input.sequenceId,
+      mergedVideoUrl,
+      musicUrl,
+    } satisfies MergeAudioVideoWorkflowInput,
+  });
+}
 
 export const mergeVideoWorkflow = createScopedWorkflow<MergeVideoWorkflowInput>(
   async (context, scopedDb) => {
@@ -31,6 +73,7 @@ export const mergeVideoWorkflow = createScopedWorkflow<MergeVideoWorkflowInput>(
       throw new WorkflowValidationError('At least one video URL is required');
     }
 
+    const narrowedInput = { ...input, sequenceId: input.sequenceId };
     const seq = scopedDb.sequence(input.sequenceId);
 
     console.log(
@@ -56,6 +99,7 @@ export const mergeVideoWorkflow = createScopedWorkflow<MergeVideoWorkflowInput>(
         );
       });
 
+      await chainAudioMux(context, scopedDb, narrowedInput, singleUrl);
       return { mergedVideoUrl: singleUrl, mergedVideoPath: null };
     }
 
@@ -136,6 +180,8 @@ export const mergeVideoWorkflow = createScopedWorkflow<MergeVideoWorkflowInput>(
     console.log(
       `[MergeVideoWorkflow] Completed merge for sequence ${input.sequenceId}`
     );
+
+    await chainAudioMux(context, scopedDb, narrowedInput, storageResult.url);
 
     return {
       mergedVideoUrl: storageResult.url,


### PR DESCRIPTION
## Summary

- Music was often too loud over voices. Normalize the music track to `-24 LUFS` via `fal-ai/ffmpeg-api/loudnorm` (EBU R128) before the final compose, so it sits ~6 LU below typical dialogue.
- Fix the "Merge with Video" CTA on the music tab: `merge-video-workflow` now chains to `merge-audio-video-workflow` when music is ready (previously it only re-stitched frames and silently dropped music from the final output, despite a stale comment claiming otherwise).

## Test plan

- [x] `bun typecheck` clean
- [x] Pre-commit hooks (format, lint, typecheck) pass
- [x] Generate a sequence with music, click "Merge with Video" on the music tab, confirm final video has music at a comfortable level under dialogue
- [ ] Verify the motion-batch end-to-end path (auto-generate flow) still produces correctly-ducked mixes

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)