### PR TITLE
fix: refresh user email from Google on every sign-in #586

### DIFF
--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -73,6 +73,7 @@ function createAuth() {
         clientId: runtimeEnv.GOOGLE_CLIENT_ID,
         clientSecret: runtimeEnv.GOOGLE_CLIENT_SECRET,
         enabled: true,
+        overrideUserInfoOnSignIn: true,
       },
     },
 


### PR DESCRIPTION
## Summary
- Enables Better Auth's `overrideUserInfoOnSignIn` on the Google provider so `email`, `name`, `image`, and `emailVerified` on the `user` row are refreshed on every OAuth callback.
- Previously the email captured at first sign-up was retained even after the user changed their primary email at Google. Verified in `better-auth@1.5.6` (`oauth2/link-account.mjs`) that this option triggers `internalAdapter.updateUser(...)` after sign-in.

Closes #586

## Test plan
- [ ] Sign in with a Google account; confirm a `user` row is created with that email.
- [ ] Change the primary email on the Google account (or use a second Google identity that maps to a different email), then sign in again. Verify `user.email` is updated to the new value while `user.id` and `team_members` membership are unchanged.
- [ ] Pre-create another user with the email Google will return and sign in; confirm the OAuth callback fails cleanly (unique-email collision) rather than corrupting data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)