### PR TITLE
fix: prioritize generation banner over motion banner during analysis #584

### DIFF
--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -25,6 +25,8 @@ type MobileSceneDrawerProps = {
   regeneratingMotion: Set<string>;
   onBatchGenerateMotion?: (includeMusic: boolean) => Promise<void>;
   musicPromptsReady: boolean;
+  /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
+  hideBatchButton?: boolean;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -42,10 +44,13 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   regeneratingMotion,
   onBatchGenerateMotion,
   musicPromptsReady,
+  hideBatchButton = false,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(false);
+
+  const totalFrames = frames?.length ?? 0;
 
   // Get the currently selected frame
   const selectedFrame = useMemo(
@@ -99,7 +104,8 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
   const hasEligibleFrames = eligibleFrames.length > 0;
   const isMotionInProgress = regeneratingMotion.size > 0;
-  const showFooter = hasEligibleFrames || isMotionInProgress;
+  const showFooter =
+    !hideBatchButton && (hasEligibleFrames || isMotionInProgress);
   const isButtonDisabled =
     isGenerating ||
     isMotionInProgress ||
@@ -199,8 +205,8 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
                 ) : (
                   <>
                     <Video className="mr-2 h-4 w-4" />
-                    Generate Motion ({eligibleFrames.length}{' '}
-                    {eligibleFrames.length === 1 ? 'frame' : 'frames'})
+                    Generate {eligibleFrames.length} / {totalFrames}{' '}
+                    {totalFrames === 1 ? 'frame' : 'frames'}
                   </>
                 )}
               </Button>

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -16,6 +16,8 @@ type SceneListProps = {
   regeneratingMotion: Set<string>;
   onBatchGenerateMotion?: (includeMusic: boolean) => Promise<void>;
   musicPromptsReady: boolean;
+  /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
+  hideBatchButton?: boolean;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -33,9 +35,12 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   regeneratingMotion,
   onBatchGenerateMotion,
   musicPromptsReady,
+  hideBatchButton = false,
 }) => {
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
+
+  const totalFrames = frames?.length ?? 0;
 
   // Frames that need to be kicked off (not already generating)
   const notStartedFrames = useMemo(() => {
@@ -74,7 +79,8 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   };
 
   const isMotionInProgress = regeneratingMotion.size > 0 || hasGeneratingFrames;
-  const showButton = notStartedFrames.length > 0 || isMotionInProgress;
+  const showButton =
+    !hideBatchButton && (notStartedFrames.length > 0 || isMotionInProgress);
   const isButtonDisabled =
     isGenerating ||
     notStartedFrames.length === 0 ||
@@ -151,8 +157,8 @@ const SceneListComponent: React.FC<SceneListProps> = ({
             ) : (
               <>
                 <Video className="mr-2 h-4 w-4" />
-                Generate Motion ({notStartedFrames.length}{' '}
-                {notStartedFrames.length === 1 ? 'frame' : 'frames'})
+                Generate {notStartedFrames.length} / {totalFrames}{' '}
+                {totalFrames === 1 ? 'frame' : 'frames'}
               </>
             )}
           </Button>

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -427,33 +427,39 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
 
   const musicPromptsReady = !!(sequence?.musicPrompt && sequence.musicTags);
 
+  // Script-analysis workflow owns the UI (phases 1–5, including auto-motion)
+  // whenever it is running; standalone motion gen only wins after analysis.
+  const isGenerationActive = isProcessing || generationState.currentPhase > 0;
+
   return (
     <div className="flex h-full flex-col">
       {/* Generation progress banner */}
-      {(isProcessing || generationState.currentPhase > 0) &&
-        motionBannerState === null && (
-          <div className="pl-4 pr-4 pt-4 md:pr-8">
-            <GenerationProgressBanner
-              generationState={generationState}
-              isProcessing={isProcessing}
-              startedAt={sequence?.updatedAt}
-              script={sequence?.script ?? undefined}
-            />
-          </div>
-        )}
-
-      {/* Motion generation progress banner */}
-      {motionBannerState !== null && sequence && frames && (
+      {isGenerationActive && (
         <div className="pl-4 pr-4 pt-4 md:pr-8">
-          <MotionProgressBanner
-            frames={frames}
-            sequence={sequence}
-            includeMusic={motionBannerState.includeMusic}
-            startedAt={motionBannerState.startedAt}
-            onComplete={resetGenerationStream}
+          <GenerationProgressBanner
+            generationState={generationState}
+            isProcessing={isProcessing}
+            startedAt={sequence?.updatedAt}
+            script={sequence?.script ?? undefined}
           />
         </div>
       )}
+
+      {/* Motion generation progress banner */}
+      {!isGenerationActive &&
+        motionBannerState !== null &&
+        sequence &&
+        frames && (
+          <div className="pl-4 pr-4 pt-4 md:pr-8">
+            <MotionProgressBanner
+              frames={frames}
+              sequence={sequence}
+              includeMusic={motionBannerState.includeMusic}
+              startedAt={motionBannerState.startedAt}
+              onComplete={resetGenerationStream}
+            />
+          </div>
+        )}
 
       {/* Failure summary with smart retry */}
       {failureSummary?.hasFailed && (
@@ -477,6 +483,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             regeneratingMotion={regeneratingMotion}
             onBatchGenerateMotion={handleBatchMotionGeneration}
             musicPromptsReady={musicPromptsReady}
+            hideBatchButton={
+              phaseConfig.autoGenerateMotion && isGenerationActive
+            }
           />
         </div>
 
@@ -491,6 +500,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             regeneratingMotion={regeneratingMotion}
             onBatchGenerateMotion={handleBatchMotionGeneration}
             musicPromptsReady={musicPromptsReady}
+            hideBatchButton={
+              phaseConfig.autoGenerateMotion && isGenerationActive
+            }
           />
         </div>
 

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -134,7 +134,6 @@ export type SceneSplitWorkflowInput = SequenceWorkflowContext & {
   styleConfig: StyleConfig;
   aspectRatio: AspectRatio;
   script: string;
-  autoGenerateMotion?: boolean;
 };
 
 export type SceneSplitWorkflowResult = {

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -85,7 +85,6 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
         script: sanitizeScriptContent(script),
         styleConfig,
         modelId: analysisModelId,
-        autoGenerateMotion,
       },
     });
 

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -41,13 +41,7 @@ export const sceneSplitWorkflow = createScopedWorkflow<
 >(
   async (context, scopedDb) => {
     const input = context.requestPayload;
-    const {
-      sequenceId,
-      modelId,
-      styleConfig,
-      aspectRatio,
-      autoGenerateMotion = false,
-    } = input;
+    const { sequenceId, modelId, styleConfig, aspectRatio } = input;
 
     const phase = { number: 1, name: 'Analyzing script\u2026' };
     const name = 'scene-splitting';
@@ -156,7 +150,7 @@ export const sceneSplitWorkflow = createScopedWorkflow<
                     (event.scene.metadata?.durationSeconds || 3) * 1000
                   ),
                   thumbnailStatus: 'generating',
-                  videoStatus: autoGenerateMotion ? 'generating' : 'pending',
+                  videoStatus: 'pending',
                 } satisfies NewFrame);
               }
 
@@ -207,7 +201,7 @@ export const sceneSplitWorkflow = createScopedWorkflow<
                     (event.scene.metadata?.durationSeconds || 3) * 1000
                   ),
                   thumbnailStatus: 'generating',
-                  videoStatus: autoGenerateMotion ? 'generating' : 'pending',
+                  videoStatus: 'pending',
                 } satisfies NewFrame);
 
                 console.log(
@@ -346,7 +340,7 @@ export const sceneSplitWorkflow = createScopedWorkflow<
                 (scene.metadata?.durationSeconds || 3) * 1000
               ),
               thumbnailStatus: 'generating',
-              videoStatus: autoGenerateMotion ? 'generating' : 'pending',
+              videoStatus: 'pending',
             }) satisfies NewFrame
         );
 


### PR DESCRIPTION
## Summary
- While the script-analysis workflow is running, the generation progress banner now owns the UI across all phases (including auto-motion) instead of being overridden by the motion-only banner
- Hides the batch "Generate Motion" button in scene lists while auto-motion is in flight via a new `hideBatchButton` prop, and updates the button label to show `Generate X / Y frames`
- Removes the unused `autoGenerateMotion` flag from `scene-split-workflow`; frames now start with `videoStatus: 'pending'` and are transitioned by the workflow's own motion step

## Test plan
- [ ] Start a generation with auto-motion enabled → verify the single generation banner is shown through all phases (no flicker to motion banner, no duplicate batch button)
- [ ] Generate motion manually after analysis completes → verify the motion banner appears and the batch button is hidden while in progress
- [ ] Scene list / mobile drawer show `Generate N / Total frames` label correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)