### PR TITLE
Add GPT Image 2 model support for image generation

### DIFF
--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -117,6 +117,15 @@ export const IMAGE_MODELS = {
     description: 'Enhanced realism and typography',
     maxPromptLength: 50000,
   },
+  gpt_image_2: {
+    id: 'openai/gpt-image-2' as const,
+    name: 'GPT Image 2',
+    provider: 'OpenAI',
+    license: 'proprietary' as const,
+    qualityRank: 2,
+    description: 'Near-perfect text rendering, UI fidelity, up to 4K',
+    maxPromptLength: 32000,
+  },
   grok_imagine_image: {
     id: 'xai/grok-imagine-image' as const,
     name: 'Grok Imagine Image',
@@ -578,6 +587,7 @@ export function safeAudioModel(
 export const EDIT_ENDPOINTS: Partial<Record<TextToImageModel, string>> = {
   nano_banana_2: 'fal-ai/nano-banana-2/edit',
   nano_banana_pro: 'fal-ai/nano-banana-pro/edit',
+  gpt_image_2: 'openai/gpt-image-2/edit',
   grok_imagine_image: 'xai/grok-imagine-image/edit',
   flux_2_max: 'fal-ai/flux-2-max/edit',
   phota: 'fal-ai/phota/edit',

--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -286,6 +286,18 @@ function buildFalModelOptions(
         sync_mode: false,
       };
 
+    case 'gpt_image_2':
+      return {
+        image_size: params.imageSize ?? DEFAULT_IMAGE_SIZE,
+        quality: 'high',
+        ...(params.numImages !== undefined && { num_images: params.numImages }),
+        ...(params.outputFormat && { output_format: params.outputFormat }),
+        ...(params.referenceImageUrls?.length && {
+          image_urls: params.referenceImageUrls,
+        }),
+        sync_mode: false,
+      };
+
     case 'grok_imagine_image':
       return {
         aspect_ratio: imageSizeToAspectRatio(


### PR DESCRIPTION
## Related Issue

Closes #<issue>

## Summary of Changes

Added support for the GPT Image 2 model (`gpt_image_2`) to the image generation system:

- **Model Registration**: Added `gpt_image_2` to the `IMAGE_MODELS` registry with metadata including OpenAI provider, quality rank 2, and description highlighting near-perfect text rendering and UI fidelity up to 4K
- **Model Options Builder**: Implemented `buildFalModelOptions` case for `gpt_image_2` to handle parameter mapping including image size, quality, number of images, output format, and reference image URLs
- **Edit Endpoint**: Added edit endpoint mapping for `gpt_image_2` to `openai/gpt-image-2/edit`

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes

This change follows the existing pattern used for other image generation models in the codebase. The implementation is straightforward and isolated to model configuration and parameter handling.

## Test Plan

N/A - Configuration and model registration changes. Existing tests should continue to pass.

https://claude.ai/code/session_01LHbgxAMw9f3NoVLw5gLSHi