### PR TITLE
feat: nest eval under admin with tabs and CSV export #597

### DIFF
--- a/src/components/eval/eval-view.tsx
+++ b/src/components/eval/eval-view.tsx
@@ -62,13 +62,22 @@ const defaultFilters: FilterState = {
   workflow: null,
 };
 
-export const EvalView: React.FC = () => {
+type EvalViewProps = {
+  initialUserFilter?: string;
+};
+
+export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
   const [viewMode, setViewMode] = useState<ViewMode>('prompts');
-  const [filters, setFilters] = useState<FilterState>(defaultFilters);
+  const [filters, setFilters] = useState<FilterState>(() =>
+    initialUserFilter
+      ? { ...defaultFilters, search: initialUserFilter }
+      : defaultFilters
+  );
   const [sortCriteria, setSortCriteria] = useState<SortCriteria[]>([
     { field: 'createdAt', direction: 'desc' },
   ]);
-  const [supportMode, setSupportMode] = useState(false);
+  const [supportMode, setSupportMode] = useState(Boolean(initialUserFilter));
+  const [hideInternal, setHideInternal] = useState(false);
 
   const { data: adminStatus } = useQuery({
     queryKey: ['system-admin-status'],
@@ -77,6 +86,10 @@ export const EvalView: React.FC = () => {
   });
 
   const isAdmin = adminStatus?.isAdmin ?? false;
+  const internalDomains = useMemo(
+    () => adminStatus?.internalDomains ?? [],
+    [adminStatus?.internalDomains]
+  );
 
   const ownData = useSequencesWithFrames();
   const adminData = useAdminAllSequencesWithFrames(supportMode);
@@ -87,10 +100,20 @@ export const EvalView: React.FC = () => {
   const isLoading = supportMode ? adminData.isLoading : ownData.isLoading;
   const error = supportMode ? adminData.error : ownData.error;
 
+  // Deep link wins: when a specific user is requested, never hide them.
+  const effectiveHideInternal =
+    hideInternal && !initialUserFilter && internalDomains.length > 0;
+
   // Client-side filtering for both modes
   const filteredAndSorted = useMemo(
-    () => applyFiltersAndSort(sequences || [], filters, sortCriteria),
-    [sequences, filters, sortCriteria]
+    () =>
+      applyFiltersAndSort(
+        sequences || [],
+        filters,
+        sortCriteria,
+        effectiveHideInternal ? internalDomains : []
+      ),
+    [sequences, filters, sortCriteria, effectiveHideInternal, internalDomains]
   );
 
   const handleLoadMore = supportMode
@@ -103,16 +126,31 @@ export const EvalView: React.FC = () => {
 
   const supportModeToggle = isAdmin ? (
     <Card className="p-3">
-      <div className="flex items-center gap-2">
-        <ShieldCheck className="h-4 w-4 text-muted-foreground" />
-        <Label htmlFor="support-mode" className="text-sm font-medium">
-          Support Mode
-        </Label>
-        <Switch
-          id="support-mode"
-          checked={supportMode}
-          onCheckedChange={setSupportMode}
-        />
+      <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-4 w-4 text-muted-foreground" />
+          <Label htmlFor="support-mode" className="text-sm font-medium">
+            Support Mode
+          </Label>
+          <Switch
+            id="support-mode"
+            checked={supportMode}
+            onCheckedChange={setSupportMode}
+          />
+        </div>
+        {supportMode && internalDomains.length > 0 && (
+          <div className="flex items-center gap-2">
+            <Label htmlFor="hide-internal" className="text-sm font-medium">
+              Hide internal
+            </Label>
+            <Switch
+              id="hide-internal"
+              checked={hideInternal}
+              onCheckedChange={setHideInternal}
+              disabled={Boolean(initialUserFilter)}
+            />
+          </div>
+        )}
       </div>
     </Card>
   ) : null;
@@ -208,9 +246,21 @@ export const EvalView: React.FC = () => {
 function applyFiltersAndSort(
   sequences: SequenceWithFrames[],
   filters: FilterState,
-  sortCriteria: SortCriteria[]
+  sortCriteria: SortCriteria[],
+  hideDomains: string[]
 ): SequenceWithFrames[] {
   let result = [...sequences];
+
+  if (hideDomains.length > 0) {
+    const suffixes = hideDomains.map((d) => `@${d.toLowerCase()}`);
+    result = result.filter((s) => {
+      if (!('creatorEmail' in s) || typeof s.creatorEmail !== 'string') {
+        return true;
+      }
+      const email = s.creatorEmail.toLowerCase();
+      return !suffixes.some((suffix) => email.endsWith(suffix));
+    });
+  }
 
   // Apply filters
   if (filters.search) {
@@ -221,6 +271,12 @@ function applyFiltersAndSort(
         'creatorName' in s &&
         typeof s.creatorName === 'string' &&
         s.creatorName.toLowerCase().includes(searchLower)
+      )
+        return true;
+      if (
+        'creatorEmail' in s &&
+        typeof s.creatorEmail === 'string' &&
+        s.creatorEmail.toLowerCase().includes(searchLower)
       )
         return true;
       return false;

--- a/src/functions/gift-tokens.ts
+++ b/src/functions/gift-tokens.ts
@@ -1,4 +1,4 @@
-import { isSystemAdmin } from '@/lib/auth/system-admin';
+import { getInternalDomains, isSystemAdmin } from '@/lib/auth/system-admin';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -89,5 +89,9 @@ export const listGiftTokensFn = createServerFn({ method: 'GET' })
 export const isSystemAdminFn = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
   .handler(async ({ context }) => {
-    return { isAdmin: isSystemAdmin(context.user.email) };
+    const isAdmin = isSystemAdmin(context.user.email);
+    return {
+      isAdmin,
+      internalDomains: isAdmin ? getInternalDomains() : [],
+    };
   });

--- a/src/hooks/use-admin-support.ts
+++ b/src/hooks/use-admin-support.ts
@@ -18,6 +18,7 @@ export const adminSupportKeys = {
 
 export type AdminSequenceWithFrames = SequenceWithFrames & {
   creatorName: string | null;
+  creatorEmail: string | null;
 };
 
 export function useAdminAllSequencesWithFrames(enabled: boolean) {
@@ -63,7 +64,13 @@ export function useAdminAllSequencesWithFrames(enabled: boolean) {
   const data = useMemo<AdminSequenceWithFrames[]>(() => {
     if (allSequences.length === 0) return [];
     return allSequences.map(
-      (seq: Sequence & { creatorName: string | null }, i: number) => ({
+      (
+        seq: Sequence & {
+          creatorName: string | null;
+          creatorEmail: string | null;
+        },
+        i: number
+      ) => ({
         ...seq,
         frames: framesQueries[i]?.data ?? [],
       })

--- a/src/lib/auth/system-admin.ts
+++ b/src/lib/auth/system-admin.ts
@@ -14,6 +14,17 @@ export function isSystemAdmin(email: string): boolean {
   return parseAdminEmails().includes(email.toLowerCase());
 }
 
+export function getInternalDomains(): string[] {
+  const domains = new Set<string>();
+  for (const email of parseAdminEmails()) {
+    const at = email.lastIndexOf('@');
+    if (at > 0 && at < email.length - 1) {
+      domains.add(email.slice(at + 1));
+    }
+  }
+  return [...domains];
+}
+
 export function requireSystemAdmin(email: string): void {
   if (!isSystemAdmin(email)) {
     throw new AuthenticationError('System admin access required');

--- a/src/lib/db/scoped/admin.ts
+++ b/src/lib/db/scoped/admin.ts
@@ -131,7 +131,10 @@ export function createAdminMethods(db: Database) {
 
   // ---- Support: cross-team sequence/frame access ----
 
-  type SequenceWithCreator = Sequence & { creatorName: string | null };
+  type SequenceWithCreator = Sequence & {
+    creatorName: string | null;
+    creatorEmail: string | null;
+  };
 
   async function getAllSequences(opts?: {
     limit?: number;
@@ -143,6 +146,7 @@ export function createAdminMethods(db: Database) {
       .select({
         sequence: sequences,
         creatorName: user.name,
+        creatorEmail: user.email,
       })
       .from(sequences)
       .leftJoin(user, eq(sequences.createdBy, user.id))
@@ -151,9 +155,10 @@ export function createAdminMethods(db: Database) {
       .limit(limit)
       .offset(offset);
 
-    return rows.map(({ sequence, creatorName }) => ({
+    return rows.map(({ sequence, creatorName, creatorEmail }) => ({
       ...sequence,
       creatorName,
+      creatorEmail,
     }));
   }
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -21,7 +21,6 @@ import { Route as MetaOgGithubRouteImport } from './routes/meta/og-github'
 import { Route as MetaOgRouteImport } from './routes/meta/og'
 import { Route as GiftCodeRouteImport } from './routes/gift/$code'
 import { Route as ApiRealtimeRouteImport } from './routes/api/realtime'
-import { Route as ProtectedEvalRouteImport } from './routes/_protected/eval'
 import { Route as ProtectedCreditsRouteImport } from './routes/_protected/credits'
 import { Route as MarketingTermsRouteImport } from './routes/_marketing/terms'
 import { Route as MarketingPrivacyRouteImport } from './routes/_marketing/privacy'
@@ -46,6 +45,7 @@ import { Route as ProtectedSettingsApiKeysRouteImport } from './routes/_protecte
 import { Route as ProtectedSequencesNewRouteImport } from './routes/_protected/sequences/new'
 import { Route as ProtectedLocationsLocationIdRouteImport } from './routes/_protected/locations/$locationId'
 import { Route as ProtectedAdminUsageRouteImport } from './routes/_protected/admin/usage'
+import { Route as ProtectedAdminEvalRouteImport } from './routes/_protected/admin/eval'
 import { Route as ProtectedSequencesIdRouteRouteImport } from './routes/_protected/sequences/$id/route'
 import { Route as ProtectedSequencesIdTheatreRouteImport } from './routes/_protected/sequences/$id/theatre'
 import { Route as ProtectedSequencesIdScriptRouteImport } from './routes/_protected/sequences/$id/script'
@@ -113,11 +113,6 @@ const ApiRealtimeRoute = ApiRealtimeRouteImport.update({
   id: '/api/realtime',
   path: '/api/realtime',
   getParentRoute: () => rootRouteImport,
-} as any)
-const ProtectedEvalRoute = ProtectedEvalRouteImport.update({
-  id: '/eval',
-  path: '/eval',
-  getParentRoute: () => ProtectedRouteRoute,
 } as any)
 const ProtectedCreditsRoute = ProtectedCreditsRouteImport.update({
   id: '/credits',
@@ -242,6 +237,11 @@ const ProtectedAdminUsageRoute = ProtectedAdminUsageRouteImport.update({
   path: '/usage',
   getParentRoute: () => ProtectedAdminRouteRoute,
 } as any)
+const ProtectedAdminEvalRoute = ProtectedAdminEvalRouteImport.update({
+  id: '/eval',
+  path: '/eval',
+  getParentRoute: () => ProtectedAdminRouteRoute,
+} as any)
 const ProtectedSequencesIdRouteRoute =
   ProtectedSequencesIdRouteRouteImport.update({
     id: '/sequences/$id',
@@ -315,13 +315,13 @@ export interface FileRoutesByFullPath {
   '/privacy': typeof MarketingPrivacyRoute
   '/terms': typeof MarketingTermsRoute
   '/credits': typeof ProtectedCreditsRoute
-  '/eval': typeof ProtectedEvalRoute
   '/api/realtime': typeof ApiRealtimeRoute
   '/gift/$code': typeof GiftCodeRoute
   '/meta/og': typeof MetaOgRoute
   '/meta/og-github': typeof MetaOgGithubRoute
   '/meta/og-linkedin': typeof MetaOgLinkedinRoute
   '/sequences/$id': typeof ProtectedSequencesIdRouteRouteWithChildren
+  '/admin/eval': typeof ProtectedAdminEvalRoute
   '/admin/usage': typeof ProtectedAdminUsageRoute
   '/locations/$locationId': typeof ProtectedLocationsLocationIdRoute
   '/sequences/new': typeof ProtectedSequencesNewRoute
@@ -360,13 +360,13 @@ export interface FileRoutesByTo {
   '/privacy': typeof MarketingPrivacyRoute
   '/terms': typeof MarketingTermsRoute
   '/credits': typeof ProtectedCreditsRoute
-  '/eval': typeof ProtectedEvalRoute
   '/api/realtime': typeof ApiRealtimeRoute
   '/gift/$code': typeof GiftCodeRoute
   '/meta/og': typeof MetaOgRoute
   '/meta/og-github': typeof MetaOgGithubRoute
   '/meta/og-linkedin': typeof MetaOgLinkedinRoute
   '/sequences/$id': typeof ProtectedSequencesIdRouteRouteWithChildren
+  '/admin/eval': typeof ProtectedAdminEvalRoute
   '/admin/usage': typeof ProtectedAdminUsageRoute
   '/locations/$locationId': typeof ProtectedLocationsLocationIdRoute
   '/sequences/new': typeof ProtectedSequencesNewRoute
@@ -409,7 +409,6 @@ export interface FileRoutesById {
   '/_marketing/privacy': typeof MarketingPrivacyRoute
   '/_marketing/terms': typeof MarketingTermsRoute
   '/_protected/credits': typeof ProtectedCreditsRoute
-  '/_protected/eval': typeof ProtectedEvalRoute
   '/api/realtime': typeof ApiRealtimeRoute
   '/gift/$code': typeof GiftCodeRoute
   '/meta/og': typeof MetaOgRoute
@@ -417,6 +416,7 @@ export interface FileRoutesById {
   '/meta/og-linkedin': typeof MetaOgLinkedinRoute
   '/_marketing/': typeof MarketingIndexRoute
   '/_protected/sequences/$id': typeof ProtectedSequencesIdRouteRouteWithChildren
+  '/_protected/admin/eval': typeof ProtectedAdminEvalRoute
   '/_protected/admin/usage': typeof ProtectedAdminUsageRoute
   '/_protected/locations/$locationId': typeof ProtectedLocationsLocationIdRoute
   '/_protected/sequences/new': typeof ProtectedSequencesNewRoute
@@ -458,13 +458,13 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/terms'
     | '/credits'
-    | '/eval'
     | '/api/realtime'
     | '/gift/$code'
     | '/meta/og'
     | '/meta/og-github'
     | '/meta/og-linkedin'
     | '/sequences/$id'
+    | '/admin/eval'
     | '/admin/usage'
     | '/locations/$locationId'
     | '/sequences/new'
@@ -503,13 +503,13 @@ export interface FileRouteTypes {
     | '/privacy'
     | '/terms'
     | '/credits'
-    | '/eval'
     | '/api/realtime'
     | '/gift/$code'
     | '/meta/og'
     | '/meta/og-github'
     | '/meta/og-linkedin'
     | '/sequences/$id'
+    | '/admin/eval'
     | '/admin/usage'
     | '/locations/$locationId'
     | '/sequences/new'
@@ -551,7 +551,6 @@ export interface FileRouteTypes {
     | '/_marketing/privacy'
     | '/_marketing/terms'
     | '/_protected/credits'
-    | '/_protected/eval'
     | '/api/realtime'
     | '/gift/$code'
     | '/meta/og'
@@ -559,6 +558,7 @@ export interface FileRouteTypes {
     | '/meta/og-linkedin'
     | '/_marketing/'
     | '/_protected/sequences/$id'
+    | '/_protected/admin/eval'
     | '/_protected/admin/usage'
     | '/_protected/locations/$locationId'
     | '/_protected/sequences/new'
@@ -693,13 +693,6 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/realtime'
       preLoaderRoute: typeof ApiRealtimeRouteImport
       parentRoute: typeof rootRouteImport
-    }
-    '/_protected/eval': {
-      id: '/_protected/eval'
-      path: '/eval'
-      fullPath: '/eval'
-      preLoaderRoute: typeof ProtectedEvalRouteImport
-      parentRoute: typeof ProtectedRouteRoute
     }
     '/_protected/credits': {
       id: '/_protected/credits'
@@ -869,6 +862,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ProtectedAdminUsageRouteImport
       parentRoute: typeof ProtectedAdminRouteRoute
     }
+    '/_protected/admin/eval': {
+      id: '/_protected/admin/eval'
+      path: '/eval'
+      fullPath: '/admin/eval'
+      preLoaderRoute: typeof ProtectedAdminEvalRouteImport
+      parentRoute: typeof ProtectedAdminRouteRoute
+    }
     '/_protected/sequences/$id': {
       id: '/_protected/sequences/$id'
       path: '/sequences/$id'
@@ -957,10 +957,12 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 )
 
 interface ProtectedAdminRouteRouteChildren {
+  ProtectedAdminEvalRoute: typeof ProtectedAdminEvalRoute
   ProtectedAdminUsageRoute: typeof ProtectedAdminUsageRoute
 }
 
 const ProtectedAdminRouteRouteChildren: ProtectedAdminRouteRouteChildren = {
+  ProtectedAdminEvalRoute: ProtectedAdminEvalRoute,
   ProtectedAdminUsageRoute: ProtectedAdminUsageRoute,
 }
 
@@ -1022,7 +1024,6 @@ interface ProtectedRouteRouteChildren {
   ProtectedAdminRouteRoute: typeof ProtectedAdminRouteRouteWithChildren
   ProtectedSettingsRouteRoute: typeof ProtectedSettingsRouteRouteWithChildren
   ProtectedCreditsRoute: typeof ProtectedCreditsRoute
-  ProtectedEvalRoute: typeof ProtectedEvalRoute
   ProtectedSequencesIdRouteRoute: typeof ProtectedSequencesIdRouteRouteWithChildren
   ProtectedLocationsLocationIdRoute: typeof ProtectedLocationsLocationIdRoute
   ProtectedSequencesNewRoute: typeof ProtectedSequencesNewRoute
@@ -1036,7 +1037,6 @@ const ProtectedRouteRouteChildren: ProtectedRouteRouteChildren = {
   ProtectedAdminRouteRoute: ProtectedAdminRouteRouteWithChildren,
   ProtectedSettingsRouteRoute: ProtectedSettingsRouteRouteWithChildren,
   ProtectedCreditsRoute: ProtectedCreditsRoute,
-  ProtectedEvalRoute: ProtectedEvalRoute,
   ProtectedSequencesIdRouteRoute: ProtectedSequencesIdRouteRouteWithChildren,
   ProtectedLocationsLocationIdRoute: ProtectedLocationsLocationIdRoute,
   ProtectedSequencesNewRoute: ProtectedSequencesNewRoute,

--- a/src/routes/_protected/admin/eval.tsx
+++ b/src/routes/_protected/admin/eval.tsx
@@ -1,19 +1,26 @@
 import { EvalView } from '@/components/eval/eval-view';
 import { PageContainer } from '@/components/layout/page-container';
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
 
-export const Route = createFileRoute('/_protected/eval')({
+const searchSchema = z.object({
+  user: z.string().email().optional(),
+});
+
+export const Route = createFileRoute('/_protected/admin/eval')({
+  validateSearch: searchSchema,
   component: EvalPage,
 });
 
 function EvalPage() {
+  const { user } = Route.useSearch();
   return (
     <div className="h-full overflow-hidden flex flex-col">
       <PageContainer
         maxWidth="full"
         className="flex-1 flex flex-col overflow-hidden"
       >
-        <EvalView />
+        <EvalView initialUserFilter={user} />
       </PageContainer>
     </div>
   );

--- a/src/routes/_protected/admin/route.tsx
+++ b/src/routes/_protected/admin/route.tsx
@@ -25,7 +25,7 @@ export const Route = createFileRoute('/_protected/admin')({
 
 const NAV_LINKS = [
   { to: '/admin/usage' as const, label: 'Usage', icon: BarChart3 },
-  { to: '/eval' as const, label: 'Eval', icon: FlaskConical },
+  { to: '/admin/eval' as const, label: 'Eval', icon: FlaskConical },
 ];
 
 function AdminNav() {
@@ -57,9 +57,11 @@ function AdminNav() {
 
 function AdminLayout() {
   return (
-    <div className="mx-auto w-full max-w-6xl p-6">
+    <div className="flex h-full flex-col p-6">
       <AdminNav />
-      <Outlet />
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <Outlet />
+      </div>
     </div>
   );
 }

--- a/src/routes/_protected/admin/usage.tsx
+++ b/src/routes/_protected/admin/usage.tsx
@@ -1,13 +1,21 @@
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { listUserActivityFn } from '@/functions/admin';
 import type { UserActivityRow } from '@/lib/db/scoped';
-import { micros, microsToDisplayUsd } from '@/lib/billing/money';
+import { micros, microsToDisplayUsd, microsToUsd } from '@/lib/billing/money';
 import { useQuery } from '@tanstack/react-query';
-import { createFileRoute } from '@tanstack/react-router';
-import { ArrowDown, ArrowUp, ArrowUpDown, Users } from 'lucide-react';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  Download,
+  LifeBuoy,
+  Users,
+} from 'lucide-react';
 import { Suspense, useMemo, useState } from 'react';
 
 export const Route = createFileRoute('/_protected/admin/usage')({
@@ -151,6 +159,15 @@ function UsageContent() {
         <span className="text-sm text-muted-foreground">
           {sorted.length} of {rows.length} users
         </span>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => downloadUsersCsv(sorted)}
+          disabled={sorted.length === 0}
+        >
+          <Download className="h-4 w-4 mr-1" />
+          Export CSV
+        </Button>
       </div>
 
       <div className="overflow-x-auto rounded-lg border">
@@ -233,13 +250,16 @@ function UsageContent() {
                 onSort={toggleSort}
                 align="right"
               />
+              <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                Support
+              </th>
             </tr>
           </thead>
           <tbody>
             {sorted.length === 0 ? (
               <tr>
                 <td
-                  colSpan={11}
+                  colSpan={12}
                   className="px-4 py-8 text-center text-muted-foreground"
                 >
                   {search ? 'No users match your search.' : 'No users found.'}
@@ -361,9 +381,91 @@ const UserRow: React.FC<{ row: UserActivityRow }> = ({ row }) => {
       <td className="px-4 py-3 text-right tabular-nums">
         {microsToDisplayUsd(micros(row.currentBalanceMicros))}
       </td>
+      <td className="px-4 py-3">
+        <Link
+          to="/admin/eval"
+          search={{ user: row.email }}
+          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+          aria-label={`Open eval support view for ${row.email}`}
+        >
+          <LifeBuoy className="h-4 w-4" />
+          Support
+        </Link>
+      </td>
     </tr>
   );
 };
+
+const CSV_COLUMNS = [
+  'userId',
+  'name',
+  'email',
+  'createdAt',
+  'status',
+  'teamId',
+  'teamName',
+  'sequenceCount',
+  'failedCount',
+  'avgAnalysisDurationSec',
+  'creditsSpentUsd',
+  'creditsPurchasedUsd',
+  'creditsGiftedUsd',
+  'currentBalanceUsd',
+  'supportUrl',
+] as const;
+
+function csvEscape(value: string | number | null): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function toCsv(rows: UserActivityRow[], origin: string): string {
+  const header = CSV_COLUMNS.join(',');
+  const lines = rows.map((row) => {
+    const avgSec =
+      row.avgAnalysisDurationMs === null
+        ? null
+        : Math.round(row.avgAnalysisDurationMs / 1000);
+    const supportUrl = `${origin}/admin/eval?user=${encodeURIComponent(row.email)}`;
+    const values: Array<string | number | null> = [
+      row.userId,
+      row.name,
+      row.email,
+      new Date(row.createdAt).toISOString(),
+      row.status,
+      row.teamId,
+      row.teamName,
+      row.sequenceCount,
+      row.failedCount,
+      avgSec,
+      microsToUsd(micros(row.creditsSpentMicros)).toFixed(2),
+      microsToUsd(micros(row.creditsPurchasedMicros)).toFixed(2),
+      microsToUsd(micros(row.creditsGiftedMicros)).toFixed(2),
+      microsToUsd(micros(row.currentBalanceMicros)).toFixed(2),
+      supportUrl,
+    ];
+    return values.map(csvEscape).join(',');
+  });
+  return [header, ...lines].join('\n');
+}
+
+function downloadUsersCsv(rows: UserActivityRow[]): void {
+  const csv = toCsv(rows, window.location.origin);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const filename = `openstory-users-${new Date().toISOString().slice(0, 10)}.csv`;
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
 
 function PageSkeleton() {
   return (


### PR DESCRIPTION
## Summary
- Nest `/eval` under `/admin/eval` so eval and usage share the admin nav tabs under a single layout
- Add CSV export and per-user Support deep links on the admin usage page
- Add a "Hide internal" toggle and email-based search in eval support mode, backed by `getInternalDomains()` derived from admin emails

## Test plan
- [ ] Visit `/admin/usage` as an admin → Usage and Eval tabs both render with correct active state
- [ ] Click Support on a user row → lands on `/admin/eval?user=<email>` with support mode on and that user pre-filtered
- [ ] Export CSV → downloaded file includes a `supportUrl` column pointing at `/admin/eval?user=…`
- [ ] Toggle "Hide internal" in eval support mode → sequences from internal domains are filtered out, toggle disabled when deep-linked to a specific user
- [ ] Non-admin users redirected away from `/admin/*` routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)