### PR TITLE
fix: scope GenerationProgressBanner to script-analysis only #610

### DIFF
--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -427,9 +427,13 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
 
   const musicPromptsReady = !!(sequence?.musicPrompt && sequence.musicTags);
 
-  // Script-analysis workflow owns the UI (phases 1–5, including auto-motion)
-  // whenever it is running; standalone motion gen only wins after analysis.
-  const isGenerationActive = isProcessing || generationState.currentPhase > 0;
+  // GenerationProgressBanner is owned by the script-analysis pipeline
+  // (sequence.status === 'processing'). Standalone motion gen runs when the
+  // sequence is already 'completed' / 'ready', so it must render via the
+  // dedicated MotionProgressBanner — never the 5-stage banner. Trusting
+  // generationState.currentPhase here would let leftover phase events from
+  // past runs hijack the UI back to the 5-stage banner.
+  const isGenerationActive = isProcessing;
 
   return (
     <div className="flex h-full flex-col">

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -374,6 +374,16 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
         };
       });
 
+      // Phase 5 START
+      await context.run('phase-5-start', async () => {
+        await getGenerationChannel(sequenceId).emit('generation.phase:start', {
+          phase: 5,
+          phaseName: shouldGenerateMusic
+            ? 'Generating motion & music\u2026'
+            : 'Generating motion\u2026',
+        });
+      });
+
       // Phase 5: single orchestrator for motion + optional music + merge
       await context.invoke('motion-batch', {
         workflow: motionBatchWorkflow,

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -385,7 +385,7 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
       });
 
       // Phase 5: single orchestrator for motion + optional music + merge
-      await context.invoke('motion-batch', {
+      const motionBatchResult = await context.invoke('motion-batch', {
         workflow: motionBatchWorkflow,
         label,
         body: {
@@ -404,6 +404,9 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
             : undefined,
         } satisfies BatchMotionMusicWorkflowInput,
       });
+
+      if (motionBatchResult.isFailed || motionBatchResult.isCanceled)
+        throw new Error('Motion/music batch failed');
     }
 
     if (sequenceId) {

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -4,7 +4,6 @@
  * then merges videos and optionally muxes audio onto the final output.
  */
 
-import { getGenerationChannel } from '@/lib/realtime';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
@@ -42,18 +41,7 @@ export const motionBatchWorkflow =
         );
       }
 
-      // Step 1: Emit phase start for UI progress
-      await context.run('phase-start', async () => {
-        const phaseName = includeMusic
-          ? 'Generating motion & music\u2026'
-          : 'Generating motion\u2026';
-        await getGenerationChannel(sequenceId).emit('generation.phase:start', {
-          phase: 5,
-          phaseName,
-        });
-      });
-
-      // Step 2: Invoke all motion workflows + optional music workflow in parallel
+      // Step 1: Invoke all motion workflows + optional music workflow in parallel
       const motionInvocations = input.frames.map((frame, index) =>
         context.invoke(`motion-${index}`, {
           workflow: generateMotionWorkflow,
@@ -102,7 +90,7 @@ export const motionBatchWorkflow =
         ...(musicInvocation ? [musicInvocation] : []),
       ]);
 
-      // Step 3: Collect video URLs from DB (authoritative order)
+      // Step 2: Collect video URLs from DB (authoritative order)
       const videoUrls = await context.run('collect-video-urls', async () => {
         const frames = await scopedDb.frames.listBySequence(sequenceId);
         return frames
@@ -117,7 +105,7 @@ export const motionBatchWorkflow =
         );
       }
 
-      // Step 4: Merge all frame videos into one
+      // Step 3: Merge all frame videos into one
       await context.invoke('merge-video', {
         workflow: mergeVideoWorkflow,
         label,
@@ -129,7 +117,7 @@ export const motionBatchWorkflow =
         } satisfies MergeVideoWorkflowInput,
       });
 
-      // Step 5: If music was generated, mux audio onto merged video
+      // Step 4: If music was generated, mux audio onto merged video
       if (includeMusic) {
         // Get URLs from DB (authoritative, set by child workflows)
         const mergeAndMusicUrls = await context.run(
@@ -178,17 +166,6 @@ export const motionBatchWorkflow =
       failureFunction: async ({ context, failResponse }) => {
         const input = context.requestPayload;
         const error = sanitizeFailResponse(failResponse);
-
-        if (input.sequenceId) {
-          try {
-            await getGenerationChannel(input.sequenceId).emit(
-              'generation.phase:start',
-              { phase: 5, phaseName: 'Generation failed' }
-            );
-          } catch {
-            // Ignore emit errors in failure handler
-          }
-        }
 
         console.error(
           `[MotionBatchWorkflow] Failed for sequence ${input.sequenceId}: ${error}`

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -4,6 +4,7 @@
  * then merges videos and optionally muxes audio onto the final output.
  */
 
+import { getGenerationChannel } from '@/lib/realtime';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
@@ -166,6 +167,20 @@ export const motionBatchWorkflow =
       failureFunction: async ({ context, failResponse }) => {
         const input = context.requestPayload;
         const error = sanitizeFailResponse(failResponse);
+
+        if (input.sequenceId) {
+          try {
+            await getGenerationChannel(input.sequenceId).emit(
+              'generation.failed',
+              { message: error }
+            );
+          } catch (emitError) {
+            console.error(
+              `[MotionBatchWorkflow] Failed to emit generation.failed for sequence ${input.sequenceId}:`,
+              emitError
+            );
+          }
+        }
 
         console.error(
           `[MotionBatchWorkflow] Failed for sequence ${input.sequenceId}: ${error}`


### PR DESCRIPTION
## Summary

- Standalone motion regen was emitting \`generation.phase:start phase=5\` from \`motion-batch-workflow\`, which flipped the focused \`MotionProgressBanner\` out for the 5-stage \`GenerationProgressBanner\` (phases 1–4 falsely "completed"). Sometimes leftover \`currentPhase\`/\`isComplete\` left **both** banners hidden — the bug in #610.
- The phase-5 emit now lives in \`analyze-script-workflow\` (right before invoking \`motion-batch\`), consistent with how phases 1, 3, 4 are emitted there. The auto-pipeline 5-stage banner is unchanged.
- \`scenes-view\` no longer trusts \`generationState.currentPhase\` for the banner switch — it gates purely on \`sequence.status === 'processing'\`, so stale phase events from prior runs can't hijack the UI.

Closes #610.

## Test plan

- [ ] Standalone motion gen on a ready sequence → \`MotionProgressBanner\` appears immediately and stays until completion; no flip to the 5-stage banner.
- [ ] Per-frame motion regen → same as above.
- [ ] Auto-pipeline (script analysis with auto-motion) → 5-stage \`GenerationProgressBanner\` walks Script → Casting → References → Images → motion & music as before.
- [ ] Motion failure path → \`FailureSummaryBanner\` shows; no flip to the 5-stage banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)