### PR TITLE
feat: add overnight agent harness for dependent issue chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ scripts/schemas/
 # claude code local state
 .claude/*.lock
 
+# agent harness
+.claude-harness/
+
 # previews
 preview*/
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "setup:previews": "bun scripts/generate-style-previews.ts && bun scripts/upload-style-previews-to-r2.ts",
     "setup:system-previews": "bun scripts/generate-system-previews.ts && bun scripts/upload-system-previews-to-r2.ts",
     "upload:prompts": "bun --bun scripts/upload-all-prompts.ts",
+    "agent-harness": "bun --bun scripts/agent-harness/index.ts",
     "dev": "bun run --parallel dev:db stripe:dev qstash:dev",
     "dev:db": "bun --bun --sequential db:migrate:local db:seed:local dev:e2e",
     "dev:e2e": "bun --bun vite dev",

--- a/scripts/agent-harness/README.md
+++ b/scripts/agent-harness/README.md
@@ -1,0 +1,73 @@
+# Agent Harness
+
+Overnight runner for chains of dependent GitHub issues. Spawns Claude Code to implement each issue in order, opens a stacked PR, gates on CI, runs a `/review` reviewer pass, and loops review→fix until clean or `--max-rounds` is reached.
+
+## Usage
+
+```bash
+# Start a fresh run
+bun agent-harness --issues 504,505,506
+
+# Preview the chain plan without spawning Claude
+bun agent-harness --issues 504,505,506 --dry-run
+
+# Resume a crashed run
+bun agent-harness --resume
+
+# Tweak knobs
+bun agent-harness --issues 504,505 --max-rounds 2 --on-failure stop
+```
+
+## Pre-requisites
+
+- `claude` CLI installed and logged in (`claude --version` works).
+- `gh` CLI authenticated (`gh auth status` clean).
+- Working tree clean and on `main` (or pass `--base <ref>`).
+- `lefthook.yml` present at repo root.
+
+No `ANTHROPIC_API_KEY` needed — the CLI uses your existing OAuth session.
+
+## What it does, per issue
+
+1. **Implement** — creates `<issue>-<slug>` branch in a dedicated worktree off the previous PR's branch (or `main` for the first), spawns Claude with the implement prompt, verifies commits, pushes, opens a stacked PR.
+2. **CI gate** — polls `gh pr checks` until green/red. CI failures feed the fix loop.
+3. **Review** — spawns a second Claude in a clean read-only worktree at the PR head, runs the `/review` skill, parses a verdict JSON.
+4. **Fix** — if `needs_changes`, spawns Claude with review comments + CI failures, commits a `fix:` commit, pushes.
+5. **Loop** — repeats review→fix up to `--max-rounds` (default 3).
+6. **Done** — sets the next issue's `baseRef` to this PR's branch and continues.
+
+## State
+
+Everything lives under `.claude-harness/` (gitignored):
+
+- `state.json` — chain state, idempotent on `--resume`.
+- `runs/<runId>/events.jsonl` — structured event log.
+- `runs/<runId>/issue-<N>/transcripts/{implement,review-N,fix-N}.jsonl` — full Claude stream-JSON transcripts for debugging.
+- `runs/<runId>/worktrees/issue-<N>/` — git worktree dedicated to the issue.
+
+## Stacked PR mechanics
+
+- Each PR's base = previous PR's branch.
+- Squash-merging the first PR (with "delete branch on merge" enabled) auto-retargets the next PR's base to `main` — no manual rebase needed.
+- If you don't squash-merge, the chain may need rebases. Document this with your reviewers.
+
+## Failure modes
+
+- `--on-failure stop` (default) — chain halts on the first failed issue.
+- `--on-failure skip` — continue with the next issue (rarely useful for true dependency chains).
+- `--on-failure prompt` — same as `stop` for unattended runs (no TTY to prompt).
+
+Time budgets per phase (configurable in `lib/state.ts` `DEFAULT_BUDGETS`):
+
+- Implement: 45 min
+- CI poll: 15 min
+- Review: 15 min
+- Fix per round: 30 min
+- Issue hard cap: 3 hours
+
+## Risks worth knowing
+
+- **OAuth token expiry mid-run** — pre-flight check + transcript will surface auth errors; rerun with `--resume`.
+- **Concurrent commits to `main`** by other contributors break the stacked chain's mergeability — harness pins `baseRef` at branch creation only.
+- **Reviewer ↔ fixer ping-pong** is hard-capped by `--max-rounds`. If the reviewer fails to emit verdict JSON, the round is treated as `clean`.
+- **`@claude` workflow collision** — harness adds a `harness-active` label and the reviewer prompt forbids `@`-mentioning Claude; teammates should avoid driving the same PR overnight.

--- a/scripts/agent-harness/index.ts
+++ b/scripts/agent-harness/index.ts
@@ -1,0 +1,300 @@
+/**
+ * Agent harness — overnight runner for chains of dependent GitHub issues.
+ *
+ * Usage:
+ *   bun scripts/agent-harness --issues 504,505,506
+ *   bun scripts/agent-harness --issues 504,505,506 --max-rounds 3
+ *   bun scripts/agent-harness --resume
+ *   bun scripts/agent-harness --issues 504 --dry-run
+ *
+ * See scripts/agent-harness/README.md for design.
+ */
+
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { claudeAvailable } from './lib/claude';
+import {
+  detectRepo,
+  fetchAll,
+  ghAuthOk,
+  ghIssueView,
+  gitStatusClean,
+  type Repo,
+} from './lib/git';
+import { createLogger } from './lib/log';
+import { runChain } from './runner';
+import {
+  DEFAULT_BUDGETS,
+  loadState,
+  saveState,
+  type FailureMode,
+  type HarnessState,
+  type IssueState,
+} from './lib/state';
+
+type Args = {
+  issues: number[];
+  maxRounds: number;
+  onFailure: FailureMode;
+  dryRun: boolean;
+  resume: boolean;
+  baseRef: string;
+};
+
+const STATE_DIR = '.claude-harness';
+const STATE_FILE = join(STATE_DIR, 'state.json');
+
+function parseArgs(argv: string[]): Args {
+  const issues: number[] = [];
+  let maxRounds = 3;
+  let onFailure: FailureMode = 'stop';
+  let dryRun = false;
+  let resume = false;
+  let baseRef = process.env.CLAUDE_HARNESS_DEFAULT_BASE ?? 'main';
+
+  const requireValue = (flag: string, idx: number): string => {
+    if (idx >= argv.length) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return argv[idx];
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--issues') {
+      const list = requireValue('--issues', ++i);
+      for (const part of list.split(',')) {
+        const n = Number.parseInt(part.trim(), 10);
+        if (!Number.isFinite(n) || n <= 0) {
+          throw new Error(`Invalid issue number: ${part}`);
+        }
+        issues.push(n);
+      }
+    } else if (a === '--max-rounds') {
+      maxRounds = Number.parseInt(requireValue('--max-rounds', ++i), 10);
+    } else if (a === '--on-failure') {
+      const v = requireValue('--on-failure', ++i);
+      if (v !== 'stop' && v !== 'skip' && v !== 'prompt') {
+        throw new Error(`--on-failure must be stop|skip|prompt, got: ${v}`);
+      }
+      onFailure = v;
+    } else if (a === '--base') {
+      baseRef = requireValue('--base', ++i);
+    } else if (a === '--dry-run') {
+      dryRun = true;
+    } else if (a === '--resume') {
+      resume = true;
+    } else if (a === '--help' || a === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+
+  if (!resume && issues.length === 0) {
+    throw new Error('Provide --issues N,N,N or --resume');
+  }
+  return { issues, maxRounds, onFailure, dryRun, resume, baseRef };
+}
+
+function printHelp(): void {
+  console.log(`agent-harness — overnight chain runner for dependent issues
+
+Usage:
+  bun scripts/agent-harness --issues 504,505,506
+  bun scripts/agent-harness --resume
+  bun scripts/agent-harness --issues 504 --dry-run
+
+Options:
+  --issues 504,505,506   Ordered list of issue numbers (required unless --resume)
+  --resume               Resume the run recorded in .claude-harness/state.json
+  --max-rounds N         Max review/fix rounds per PR (default: 3)
+  --on-failure MODE      stop | skip | prompt (default: stop)
+  --base REF             Base ref for the first issue's branch (default: main)
+  --dry-run              Print the chain plan without spawning Claude
+  --help                 Show this message
+`);
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+function makeRunId(): string {
+  // Compact sortable id; ULID would be nicer but adds a dep.
+  const ts = Date.now().toString(36);
+  const rnd = Math.random().toString(36).slice(2, 8);
+  return `${ts}-${rnd}`;
+}
+
+async function buildChainState(args: {
+  issues: number[];
+  repo: Repo;
+  baseRef: string;
+  maxRounds: number;
+  onFailure: FailureMode;
+  runId: string;
+  runDir: string;
+  cwd: string;
+}): Promise<HarnessState> {
+  const chain: IssueState[] = [];
+  for (const [i, n] of args.issues.entries()) {
+    const meta = await ghIssueView(n, args.repo);
+    const slug = slugify(meta.title);
+    const branch = `${String(n)}-${slug}`;
+    const worktreePath = join(args.runDir, 'worktrees', `issue-${String(n)}`);
+    chain.push({
+      issue: n,
+      title: meta.title,
+      slug,
+      branch,
+      baseRef: i === 0 ? args.baseRef : '__placeholder__',
+      worktreePath,
+      phase: 'PENDING',
+      attempts: { implement: 0, fix: 0, review: 0 },
+      events: [],
+    });
+  }
+  // Wire up baseRefs in a second pass so each points at the prior branch.
+  for (let i = 1; i < chain.length; i++) {
+    chain[i].baseRef = chain[i - 1].branch;
+  }
+  return {
+    runId: args.runId,
+    startedAt: new Date().toISOString(),
+    config: {
+      maxRounds: args.maxRounds,
+      onFailure: args.onFailure,
+      budgets: { ...DEFAULT_BUDGETS },
+    },
+    chain,
+  };
+}
+
+async function preflight(repoRoot: string): Promise<void> {
+  if (!(await claudeAvailable())) {
+    throw new Error('`claude --version` failed. Install Claude Code CLI.');
+  }
+  if (!(await ghAuthOk())) {
+    throw new Error('`gh auth status` failed. Run `gh auth login`.');
+  }
+  if (!(await gitStatusClean(repoRoot))) {
+    throw new Error(
+      'Working tree has uncommitted changes. Commit or stash before running.'
+    );
+  }
+  // Probe lefthook config to fail fast if missing.
+  if (!existsSync(join(repoRoot, 'lefthook.yml'))) {
+    throw new Error('lefthook.yml not found at repo root.');
+  }
+}
+
+function summarizePlan(state: HarnessState): string {
+  const lines: string[] = [
+    `Run ID: ${state.runId}`,
+    `Issues: ${state.chain.length}`,
+    `Max rounds: ${state.config.maxRounds}`,
+    `On failure: ${state.config.onFailure}`,
+    '',
+    'Chain plan:',
+  ];
+  for (const [i, s] of state.chain.entries()) {
+    lines.push(`  ${String(i + 1)}. #${String(s.issue)} "${s.title}"`);
+    lines.push(`       branch: ${s.branch}`);
+    lines.push(`       base:   ${s.baseRef}`);
+    lines.push(`       wt:     ${s.worktreePath}`);
+  }
+  return lines.join('\n');
+}
+
+async function main(): Promise<void> {
+  const cwd = process.cwd();
+  const args = parseArgs(process.argv.slice(2));
+  const repoRoot = cwd;
+
+  await preflight(repoRoot);
+  const repo = await detectRepo(repoRoot);
+  await fetchAll(repoRoot);
+
+  const statePath = join(repoRoot, STATE_FILE);
+  let state: HarnessState | null = null;
+
+  if (args.resume) {
+    state = loadState(statePath);
+    if (!state) {
+      throw new Error(
+        `--resume specified but no state at ${statePath}. Run without --resume first.`
+      );
+    }
+    console.log(`Resuming run ${state.runId} (${state.chain.length} issues)`);
+  } else {
+    if (existsSync(statePath)) {
+      throw new Error(
+        `State already exists at ${statePath}. Pass --resume to continue, or remove it to start fresh.`
+      );
+    }
+    const runId = makeRunId();
+    const runDir = join(repoRoot, STATE_DIR, 'runs', runId);
+    mkdirSync(runDir, { recursive: true });
+    state = await buildChainState({
+      issues: args.issues,
+      repo,
+      baseRef: args.baseRef,
+      maxRounds: args.maxRounds,
+      onFailure: args.onFailure,
+      runId,
+      runDir,
+      cwd: repoRoot,
+    });
+    saveState(statePath, state);
+  }
+
+  console.log('\n' + summarizePlan(state) + '\n');
+
+  if (args.dryRun) {
+    console.log('Dry run — exiting without spawning Claude.');
+    return;
+  }
+
+  const runDir = join(repoRoot, STATE_DIR, 'runs', state.runId);
+  const log = createLogger(join(runDir, 'events.jsonl'), {
+    runId: state.runId,
+  });
+
+  log.info('chain.start', {
+    issues: state.chain.map((s) => s.issue),
+    repo: `${repo.owner}/${repo.name}`,
+  });
+
+  const final = await runChain({
+    state,
+    statePath,
+    repo,
+    repoRoot,
+    runDir,
+    log,
+  });
+
+  // Print final summary.
+  console.log('\n=== Final ===');
+  for (const s of final.chain) {
+    const pr = s.prNumber ? `PR #${s.prNumber}` : 'no PR';
+    console.log(`  #${s.issue} → ${s.phase} (${pr})`);
+    if (s.lastError) {
+      console.log(`     error: ${s.lastError.message}`);
+    }
+  }
+
+  const allDone = final.chain.every((s) => s.phase === 'DONE');
+  process.exit(allDone ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack : err);
+  process.exit(1);
+});

--- a/scripts/agent-harness/lib/claude.ts
+++ b/scripts/agent-harness/lib/claude.ts
@@ -1,0 +1,211 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import type { Logger } from './log';
+
+export type ClaudeRunOpts = {
+  prompt: string;
+  cwd: string;
+  transcriptPath: string;
+  allowedTools?: string[];
+  disallowedTools?: string[];
+  permissionMode?: 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions';
+  model?: string;
+  signal?: AbortSignal;
+  log: Logger;
+};
+
+export type ClaudeRunResult = {
+  exitCode: number;
+  durationMs: number;
+  lastAssistantText: string;
+  resultEvent: ClaudeStreamEvent | null;
+  toolUseCount: number;
+  abortedForTimeout: boolean;
+};
+
+type ClaudeStreamEvent =
+  | { type: 'system'; subtype?: string }
+  | {
+      type: 'assistant';
+      message: { content: Array<{ type: string; text?: string }> };
+    }
+  | { type: 'user'; message: { content: unknown } }
+  | { type: 'result'; subtype?: string; is_error?: boolean; result?: string };
+
+function isClaudeStreamEvent(value: unknown): value is ClaudeStreamEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const t = (value as { type?: unknown }).type;
+  return t === 'system' || t === 'assistant' || t === 'user' || t === 'result';
+}
+
+function lastTextFromAssistant(event: ClaudeStreamEvent): string | null {
+  if (event.type !== 'assistant') return null;
+  const parts = event.message.content;
+  const texts: string[] = [];
+  for (const p of parts) {
+    if (p.type === 'text' && typeof p.text === 'string') texts.push(p.text);
+  }
+  return texts.length > 0 ? texts.join('\n') : null;
+}
+
+export async function runClaude(opts: ClaudeRunOpts): Promise<ClaudeRunResult> {
+  mkdirSync(dirname(opts.transcriptPath), { recursive: true });
+
+  const args = [
+    'claude',
+    '-p',
+    opts.prompt,
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--permission-mode',
+    opts.permissionMode ?? 'acceptEdits',
+  ];
+  if (opts.allowedTools?.length) {
+    args.push('--allowedTools', opts.allowedTools.join(','));
+  }
+  if (opts.disallowedTools?.length) {
+    args.push('--disallowedTools', opts.disallowedTools.join(','));
+  }
+  if (opts.model) {
+    args.push('--model', opts.model);
+  }
+
+  opts.log.info('claude.spawn', {
+    cmd: args
+      .slice(0, 1)
+      .concat(args.slice(2).filter((a) => a !== opts.prompt)),
+    cwd: opts.cwd,
+  });
+
+  const startedAt = Date.now();
+  const proc = Bun.spawn(args, {
+    cwd: opts.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    signal: opts.signal,
+  });
+
+  let lastAssistantText = '';
+  let resultEvent: ClaudeStreamEvent | null = null;
+  let toolUseCount = 0;
+  let buf = '';
+
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+
+  try {
+    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- exits via break on stream done
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let nl = buf.indexOf('\n');
+      while (nl !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        if (line.trim().length > 0) {
+          appendFileSync(opts.transcriptPath, `${line}\n`);
+          try {
+            const raw: unknown = JSON.parse(line);
+            if (!isClaudeStreamEvent(raw)) continue;
+            const evt = raw;
+            if (evt.type === 'assistant') {
+              const text = lastTextFromAssistant(evt);
+              if (text) lastAssistantText = text;
+              for (const part of evt.message.content) {
+                if (part.type === 'tool_use') toolUseCount++;
+              }
+            } else if (evt.type === 'result') {
+              resultEvent = evt;
+            }
+          } catch {
+            // Non-JSON line; already persisted to transcript.
+          }
+        }
+        nl = buf.indexOf('\n');
+      }
+    }
+  } catch (err) {
+    opts.log.warn('claude.stream.error', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // Flush stderr to transcript for debugging.
+  const stderr = await new Response(proc.stderr).text();
+  if (stderr.trim().length > 0) {
+    appendFileSync(opts.transcriptPath, `--- stderr ---\n${stderr}\n`);
+  }
+
+  const exitCode = await proc.exited;
+  const durationMs = Date.now() - startedAt;
+  const abortedForTimeout = opts.signal?.aborted ?? false;
+
+  opts.log.info('claude.exit', {
+    exitCode,
+    durationMs,
+    toolUseCount,
+    abortedForTimeout,
+  });
+
+  return {
+    exitCode,
+    durationMs,
+    lastAssistantText,
+    resultEvent,
+    toolUseCount,
+    abortedForTimeout,
+  };
+}
+
+export function extractFencedJson<T>(
+  text: string,
+  validate: (value: unknown) => value is T
+): T | null {
+  // Match the LAST ```json ... ``` block in the text.
+  const re = /```json\s*([\s\S]*?)```/g;
+  let last: string | null = null;
+  for (const m of text.matchAll(re)) {
+    last = m[1];
+  }
+  if (last === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(last.trim());
+    return validate(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export type ImplementVerdict = {
+  status: 'done' | 'blocked';
+  reason?: string;
+  summary?: string;
+};
+
+export function isImplementVerdict(v: unknown): v is ImplementVerdict {
+  if (typeof v !== 'object' || v === null) return false;
+  const status = (v as { status?: unknown }).status;
+  return status === 'done' || status === 'blocked';
+}
+
+export type ReviewVerdictJson = {
+  verdict: 'clean' | 'needs_changes';
+  blockingCount?: number;
+  summary?: string;
+};
+
+export function isReviewVerdict(v: unknown): v is ReviewVerdictJson {
+  if (typeof v !== 'object' || v === null) return false;
+  const verdict = (v as { verdict?: unknown }).verdict;
+  return verdict === 'clean' || verdict === 'needs_changes';
+}
+
+export async function claudeAvailable(): Promise<boolean> {
+  const proc = Bun.spawn(['claude', '--version'], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  return (await proc.exited) === 0;
+}

--- a/scripts/agent-harness/lib/git.ts
+++ b/scripts/agent-harness/lib/git.ts
@@ -119,6 +119,31 @@ export async function pushBranch(branch: string, cwd: string): Promise<void> {
   await runOk(['git', 'push', '-u', 'origin', branch], { cwd });
 }
 
+export type RemoteSyncStatus = 'in-sync' | 'ahead' | 'behind' | 'diverged';
+
+export async function remoteSyncStatus(
+  branch: string,
+  cwd: string
+): Promise<RemoteSyncStatus> {
+  await runOk(['git', 'fetch', 'origin', branch], { cwd });
+  const local = await runOk(['git', 'rev-parse', 'HEAD'], { cwd });
+  const remote = await runOk(['git', 'rev-parse', `origin/${branch}`], { cwd });
+  if (local === remote) return 'in-sync';
+  const { stdout: ahead } = await run(
+    ['git', 'rev-list', '--count', `origin/${branch}..HEAD`],
+    { cwd }
+  );
+  const { stdout: behind } = await run(
+    ['git', 'rev-list', '--count', `HEAD..origin/${branch}`],
+    { cwd }
+  );
+  const a = Number.parseInt(ahead.trim(), 10) || 0;
+  const b = Number.parseInt(behind.trim(), 10) || 0;
+  if (a > 0 && b === 0) return 'ahead';
+  if (a === 0 && b > 0) return 'behind';
+  return 'diverged';
+}
+
 export async function runLefthookPreCommit(cwd: string): Promise<RunResult> {
   return run(['bun', 'lefthook', 'run', 'pre-commit'], { cwd });
 }

--- a/scripts/agent-harness/lib/git.ts
+++ b/scripts/agent-harness/lib/git.ts
@@ -1,0 +1,326 @@
+import { z } from 'zod';
+import type { Logger } from './log';
+
+type RunOpts = { cwd?: string; signal?: AbortSignal };
+type RunResult = { stdout: string; stderr: string; exitCode: number };
+
+export async function run(
+  cmd: string[],
+  opts: RunOpts = {}
+): Promise<RunResult> {
+  const proc = Bun.spawn(cmd, {
+    cwd: opts.cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    signal: opts.signal,
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+export async function runOk(
+  cmd: string[],
+  opts: RunOpts = {}
+): Promise<string> {
+  const { stdout, stderr, exitCode } = await run(cmd, opts);
+  if (exitCode !== 0) {
+    throw new Error(
+      `Command failed (exit ${exitCode}): ${cmd.join(' ')}\n${stderr || stdout}`
+    );
+  }
+  return stdout.trim();
+}
+
+export type Repo = { owner: string; name: string };
+
+export async function detectRepo(cwd: string): Promise<Repo> {
+  const url = await runOk(['git', 'remote', 'get-url', 'origin'], { cwd });
+  // Match git@github.com:owner/name.git or https://github.com/owner/name(.git)
+  const m = url.match(/github\.com[:/]([^/]+)\/([^/.]+?)(?:\.git)?$/);
+  const owner = m?.[1];
+  const name = m?.[2];
+  if (owner === undefined || name === undefined) {
+    throw new Error(`Cannot parse GitHub repo from origin: ${url}`);
+  }
+  return { owner, name };
+}
+
+export async function gitStatusClean(cwd: string): Promise<boolean> {
+  const out = await runOk(['git', 'status', '--porcelain'], { cwd });
+  return out.length === 0;
+}
+
+export async function fetchAll(cwd: string): Promise<void> {
+  await runOk(['git', 'fetch', '--all', '--prune'], { cwd });
+}
+
+export async function currentBranch(cwd: string): Promise<string> {
+  return runOk(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
+}
+
+export async function revParse(ref: string, cwd: string): Promise<string> {
+  return runOk(['git', 'rev-parse', ref], { cwd });
+}
+
+export async function branchExistsRemote(
+  branch: string,
+  cwd: string
+): Promise<boolean> {
+  const { exitCode } = await run(
+    ['git', 'show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`],
+    { cwd }
+  );
+  return exitCode === 0;
+}
+
+export async function addWorktree(
+  worktreePath: string,
+  branch: string,
+  baseRef: string,
+  cwd: string
+): Promise<void> {
+  // Create new branch from baseRef in a fresh worktree.
+  await runOk(['git', 'worktree', 'add', '-b', branch, worktreePath, baseRef], {
+    cwd,
+  });
+}
+
+export async function adoptWorktree(
+  worktreePath: string,
+  branch: string,
+  cwd: string
+): Promise<void> {
+  // Branch already exists; just attach a worktree.
+  await runOk(['git', 'worktree', 'add', worktreePath, branch], { cwd });
+}
+
+export async function removeWorktree(
+  worktreePath: string,
+  cwd: string
+): Promise<void> {
+  await run(['git', 'worktree', 'remove', '--force', worktreePath], { cwd });
+}
+
+export async function commitsSince(
+  baseRef: string,
+  cwd: string
+): Promise<number> {
+  const out = await runOk(['git', 'rev-list', '--count', `${baseRef}..HEAD`], {
+    cwd,
+  });
+  return Number.parseInt(out, 10);
+}
+
+export async function pushBranch(branch: string, cwd: string): Promise<void> {
+  await runOk(['git', 'push', '-u', 'origin', branch], { cwd });
+}
+
+export async function runLefthookPreCommit(cwd: string): Promise<RunResult> {
+  return run(['bun', 'lefthook', 'run', 'pre-commit'], { cwd });
+}
+
+export async function ghAuthOk(): Promise<boolean> {
+  const { exitCode } = await run(['gh', 'auth', 'status']);
+  return exitCode === 0;
+}
+
+const issueViewSchema = z.object({
+  title: z.string(),
+  body: z.string().nullish(),
+  state: z.string(),
+  labels: z.array(z.object({ name: z.string() })),
+});
+
+export async function ghIssueView(
+  issue: number,
+  repo: Repo
+): Promise<{ title: string; body: string; state: string; labels: string[] }> {
+  const json = await runOk([
+    'gh',
+    'issue',
+    'view',
+    String(issue),
+    '--repo',
+    `${repo.owner}/${repo.name}`,
+    '--json',
+    'title,body,state,labels',
+  ]);
+  const data = issueViewSchema.parse(JSON.parse(json));
+  return {
+    title: data.title,
+    body: data.body ?? '',
+    state: data.state,
+    labels: data.labels.map((l) => l.name),
+  };
+}
+
+export async function ghPrCreate(args: {
+  cwd: string;
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  draft?: boolean;
+}): Promise<number> {
+  const cmd = [
+    'gh',
+    'pr',
+    'create',
+    '--base',
+    args.base,
+    '--head',
+    args.head,
+    '--title',
+    args.title,
+    '--body',
+    args.body,
+  ];
+  if (args.draft) cmd.push('--draft');
+  const url = await runOk(cmd, { cwd: args.cwd });
+  const m = url.match(/\/pull\/(\d+)/);
+  const num = m?.[1];
+  if (num === undefined) {
+    throw new Error(`Could not parse PR number from: ${url}`);
+  }
+  return Number.parseInt(num, 10);
+}
+
+export async function ghPrFindForBranch(
+  branch: string,
+  repo: Repo
+): Promise<number | null> {
+  const json = await runOk([
+    'gh',
+    'pr',
+    'list',
+    '--repo',
+    `${repo.owner}/${repo.name}`,
+    '--head',
+    branch,
+    '--state',
+    'open',
+    '--json',
+    'number',
+  ]);
+  const arr = z.array(z.object({ number: z.number() })).parse(JSON.parse(json));
+  return arr[0]?.number ?? null;
+}
+
+export type CiCheck = {
+  name: string;
+  status: string; // queued | in_progress | completed
+  conclusion: string | null; // success | failure | cancelled | skipped | null
+};
+
+export async function ghPrChecks(pr: number, repo: Repo): Promise<CiCheck[]> {
+  const { stdout, exitCode } = await run([
+    'gh',
+    'pr',
+    'checks',
+    String(pr),
+    '--repo',
+    `${repo.owner}/${repo.name}`,
+    '--json',
+    'name,status,conclusion',
+  ]);
+  // gh exits 8 when checks are pending or have failed; output is still JSON.
+  if (exitCode !== 0 && exitCode !== 8) {
+    throw new Error(`gh pr checks failed (exit ${exitCode})`);
+  }
+  return ciCheckArraySchema.parse(JSON.parse(stdout || '[]'));
+}
+
+const ciCheckArraySchema = z.array(
+  z.object({
+    name: z.string(),
+    status: z.string(),
+    conclusion: z.string().nullable(),
+  })
+);
+
+export async function ghPrComments(
+  pr: number,
+  repo: Repo
+): Promise<{
+  reviews: Array<{
+    author: string;
+    state: string;
+    body: string;
+    submittedAt: string;
+  }>;
+  comments: Array<{ author: string; body: string; createdAt: string }>;
+}> {
+  const json = await runOk([
+    'gh',
+    'pr',
+    'view',
+    String(pr),
+    '--repo',
+    `${repo.owner}/${repo.name}`,
+    '--json',
+    'reviews,comments',
+  ]);
+  const data = prCommentsSchema.parse(JSON.parse(json));
+  return {
+    reviews: data.reviews.map((r) => ({
+      author: r.author.login,
+      state: r.state,
+      body: r.body,
+      submittedAt: r.submittedAt,
+    })),
+    comments: data.comments.map((c) => ({
+      author: c.author.login,
+      body: c.body,
+      createdAt: c.createdAt,
+    })),
+  };
+}
+
+const prCommentsSchema = z.object({
+  reviews: z.array(
+    z.object({
+      author: z.object({ login: z.string() }),
+      state: z.string(),
+      body: z.string(),
+      submittedAt: z.string(),
+    })
+  ),
+  comments: z.array(
+    z.object({
+      author: z.object({ login: z.string() }),
+      body: z.string(),
+      createdAt: z.string(),
+    })
+  ),
+});
+
+export async function ghPrAddLabel(
+  pr: number,
+  label: string,
+  repo: Repo
+): Promise<void> {
+  await run([
+    'gh',
+    'pr',
+    'edit',
+    String(pr),
+    '--repo',
+    `${repo.owner}/${repo.name}`,
+    '--add-label',
+    label,
+  ]);
+}
+
+export async function ensureSafeAbort(cwd: string, log: Logger): Promise<void> {
+  // Recovery: if a previous run died mid-commit, drop the partial state.
+  const status = await runOk(['git', 'status', '--porcelain'], { cwd });
+  if (status.length > 0) {
+    log.warn('Worktree dirty on resume; resetting hard', { cwd });
+    await runOk(['git', 'reset', '--hard', 'HEAD'], { cwd });
+    await runOk(['git', 'clean', '-fd'], { cwd });
+  }
+}

--- a/scripts/agent-harness/lib/log.ts
+++ b/scripts/agent-harness/lib/log.ts
@@ -1,0 +1,65 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+type LogLevel = 'info' | 'warn' | 'error' | 'debug';
+
+type LogContext = Record<string, unknown> & {
+  issue?: number;
+  phase?: string;
+  runId?: string;
+};
+
+export type Logger = {
+  info: (msg: string, data?: Record<string, unknown>) => void;
+  warn: (msg: string, data?: Record<string, unknown>) => void;
+  error: (msg: string, data?: Record<string, unknown>) => void;
+  debug: (msg: string, data?: Record<string, unknown>) => void;
+  child: (extra: LogContext) => Logger;
+};
+
+function format(prefix: string, msg: string): string {
+  const t = new Date().toISOString().slice(11, 19);
+  return `[${t}] ${prefix} ${msg}`;
+}
+
+export function createLogger(
+  jsonlPath: string,
+  context: LogContext = {}
+): Logger {
+  mkdirSync(dirname(jsonlPath), { recursive: true });
+
+  const write = (
+    level: LogLevel,
+    msg: string,
+    data?: Record<string, unknown>
+  ): void => {
+    const entry = {
+      at: new Date().toISOString(),
+      level,
+      msg,
+      ...context,
+      ...data,
+    };
+    appendFileSync(jsonlPath, `${JSON.stringify(entry)}\n`);
+
+    const issue =
+      typeof context.issue === 'number' ? `#${String(context.issue)}` : '';
+    const phase = typeof context.phase === 'string' ? `[${context.phase}]` : '';
+    const prefix = [phase, issue].filter(Boolean).join(' ');
+    const line = format(prefix, msg);
+
+    if (level === 'error') console.error(line);
+    else if (level === 'warn') console.warn(line);
+    else if (level === 'debug') {
+      if (process.env.HARNESS_DEBUG) console.log(line);
+    } else console.log(line);
+  };
+
+  return {
+    info: (msg, data) => write('info', msg, data),
+    warn: (msg, data) => write('warn', msg, data),
+    error: (msg, data) => write('error', msg, data),
+    debug: (msg, data) => write('debug', msg, data),
+    child: (extra) => createLogger(jsonlPath, { ...context, ...extra }),
+  };
+}

--- a/scripts/agent-harness/lib/prompt.ts
+++ b/scripts/agent-harness/lib/prompt.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TEMPLATE_DIR = join(import.meta.dir, '..', 'prompts');
+
+function load(name: string): string {
+  return readFileSync(join(TEMPLATE_DIR, name), 'utf-8');
+}
+
+function render(
+  template: string,
+  vars: Record<string, string | number>
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, key: string) => {
+    if (!(key in vars)) {
+      throw new Error(`Missing template variable: ${key}`);
+    }
+    return String(vars[key]);
+  });
+}
+
+export type ImplementVars = {
+  issue: number;
+  title: string;
+  body: string;
+  repo: string;
+  cwd: string;
+  branch: string;
+  baseRef: string;
+  prevPrSummary: string;
+  budgetMinutes: number;
+};
+
+export function buildImplementPrompt(vars: ImplementVars): string {
+  return render(load('implement.md'), vars);
+}
+
+export type ReviewVars = {
+  repo: string;
+  pr: number;
+  branch: string;
+  baseRef: string;
+  issue: number;
+  title: string;
+  cwd: string;
+  round: number;
+  maxRounds: number;
+};
+
+export function buildReviewPrompt(vars: ReviewVars): string {
+  return render(load('review.md'), vars);
+}
+
+export type FixVars = {
+  repo: string;
+  pr: number;
+  issue: number;
+  title: string;
+  branch: string;
+  cwd: string;
+  round: number;
+  maxRounds: number;
+  reviewBlock: string;
+  ciBlock: string;
+  ciLogPath: string;
+  budgetMinutes: number;
+};
+
+export function buildFixPrompt(vars: FixVars): string {
+  return render(load('fix.md'), vars);
+}

--- a/scripts/agent-harness/lib/state.ts
+++ b/scripts/agent-harness/lib/state.ts
@@ -1,0 +1,119 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+export type Phase =
+  | 'PENDING'
+  | 'PREPARING_BRANCH'
+  | 'IMPLEMENTING'
+  | 'IMPL_FAILED'
+  | 'PUSHED'
+  | 'PR_OPEN'
+  | 'CI_PENDING'
+  | 'CI_GREEN'
+  | 'CI_RED'
+  | 'FIXING_CI'
+  | 'REVIEWING'
+  | 'HAS_FEEDBACK'
+  | 'FIXING'
+  | 'CLEAN'
+  | 'REVIEW_FAILED'
+  | 'MAX_ROUNDS_EXCEEDED'
+  | 'DONE';
+
+export type FailureMode = 'stop' | 'skip' | 'prompt';
+
+export type IssueState = {
+  issue: number;
+  title: string;
+  slug: string;
+  branch: string;
+  baseRef: string;
+  prNumber?: number;
+  worktreePath: string;
+  phase: Phase;
+  attempts: { implement: number; fix: number; review: number };
+  lastError?: {
+    phase: Phase;
+    message: string;
+    transcriptPath?: string;
+    at: string;
+  };
+  events: Array<{ at: string; from: Phase; to: Phase; note?: string }>;
+};
+
+export type HarnessState = {
+  runId: string;
+  startedAt: string;
+  config: {
+    maxRounds: number;
+    onFailure: FailureMode;
+    budgets: {
+      implementMs: number;
+      ciMs: number;
+      reviewMs: number;
+      fixMs: number;
+      issueHardCapMs: number;
+    };
+  };
+  chain: IssueState[];
+};
+
+export const DEFAULT_BUDGETS = {
+  implementMs: 45 * 60 * 1000,
+  ciMs: 15 * 60 * 1000,
+  reviewMs: 15 * 60 * 1000,
+  fixMs: 30 * 60 * 1000,
+  issueHardCapMs: 3 * 60 * 60 * 1000,
+} as const;
+
+export function loadState(path: string): HarnessState | null {
+  if (!existsSync(path)) return null;
+  // Trusted file: it was written by saveState in a prior run of this same
+  // harness. We deliberately skip schema validation to keep the state file
+  // forward-compatible across small additions to IssueState.
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- harness-owned state file
+  return JSON.parse(readFileSync(path, 'utf-8')) as HarnessState;
+}
+
+export function saveState(path: string, state: HarnessState): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2));
+  renameSync(tmp, path);
+}
+
+export function transition(
+  issue: IssueState,
+  to: Phase,
+  note?: string
+): IssueState {
+  const from = issue.phase;
+  if (from === to) return issue;
+  return {
+    ...issue,
+    phase: to,
+    events: [...issue.events, { at: new Date().toISOString(), from, to, note }],
+  };
+}
+
+export function recordError(
+  issue: IssueState,
+  message: string,
+  transcriptPath?: string
+): IssueState {
+  return {
+    ...issue,
+    lastError: {
+      phase: issue.phase,
+      message,
+      transcriptPath,
+      at: new Date().toISOString(),
+    },
+  };
+}

--- a/scripts/agent-harness/phases/ci.ts
+++ b/scripts/agent-harness/phases/ci.ts
@@ -1,0 +1,80 @@
+import { ghPrChecks, type CiCheck, type Repo } from '../lib/git';
+import type { Logger } from '../lib/log';
+
+export type CiResult =
+  | { status: 'green'; checks: CiCheck[] }
+  | { status: 'red'; checks: CiCheck[]; failureSummary: string }
+  | { status: 'timeout'; checks: CiCheck[] };
+
+const POLL_INTERVAL_MS = 30_000;
+
+export async function pollCi(args: {
+  pr: number;
+  repo: Repo;
+  budgetMs: number;
+  log: Logger;
+  signal?: AbortSignal;
+}): Promise<CiResult> {
+  const { pr, repo, budgetMs, log } = args;
+  const phaseLog = log.child({ phase: 'ci' });
+  const deadline = Date.now() + budgetMs;
+  let lastSummary = '';
+
+  while (Date.now() < deadline) {
+    if (args.signal?.aborted) break;
+    const checks = await ghPrChecks(pr, repo);
+
+    if (checks.length === 0) {
+      // No checks yet — keep waiting.
+      phaseLog.debug('ci.empty');
+    } else {
+      const summary = summarize(checks);
+      if (summary !== lastSummary) {
+        phaseLog.info('ci.update', { summary });
+        lastSummary = summary;
+      }
+
+      const allDone = checks.every((c) => c.status === 'completed');
+      if (allDone) {
+        const failed = checks.filter((c) => c.conclusion === 'failure');
+        if (failed.length === 0) {
+          return { status: 'green', checks };
+        }
+        return {
+          status: 'red',
+          checks,
+          failureSummary: failed
+            .map((c) => `- ${c.name}: ${c.conclusion}`)
+            .join('\n'),
+        };
+      }
+    }
+
+    await sleep(POLL_INTERVAL_MS, args.signal);
+  }
+
+  return { status: 'timeout', checks: [] };
+}
+
+function summarize(checks: CiCheck[]): string {
+  const counts = new Map<string, number>();
+  for (const c of checks) {
+    const key =
+      c.status === 'completed' ? (c.conclusion ?? 'unknown') : c.status;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([k, v]) => `${k}=${v}`)
+    .sort()
+    .join(' ');
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}

--- a/scripts/agent-harness/phases/fix.ts
+++ b/scripts/agent-harness/phases/fix.ts
@@ -1,0 +1,170 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  extractFencedJson,
+  isImplementVerdict,
+  runClaude,
+} from '../lib/claude';
+import {
+  commitsSince,
+  ensureSafeAbort,
+  ghPrComments,
+  type CiCheck,
+  type Repo,
+} from '../lib/git';
+import type { Logger } from '../lib/log';
+import { buildFixPrompt } from '../lib/prompt';
+import type { IssueState } from '../lib/state';
+
+const ALLOWED_TOOLS = [
+  'Bash',
+  'Edit',
+  'Write',
+  'Read',
+  'Grep',
+  'Glob',
+  'TodoWrite',
+  'Task',
+];
+
+const DISALLOWED_TOOLS = [
+  'Bash(gh pr create:*)',
+  'Bash(gh pr merge:*)',
+  'Bash(gh pr close:*)',
+  'Bash(curl:*)',
+  'Bash(wget:*)',
+];
+
+export type FixResult = {
+  ok: boolean;
+  newCommits: number;
+  error?: string;
+  transcriptPath: string;
+};
+
+export async function runFixPhase(args: {
+  issue: IssueState;
+  repo: Repo;
+  runDir: string;
+  round: number;
+  maxRounds: number;
+  budgetMs: number;
+  ciFailures: CiCheck[] | null;
+  log: Logger;
+}): Promise<FixResult> {
+  const { issue, repo, runDir, round, maxRounds, budgetMs, ciFailures, log } =
+    args;
+  const phaseLog = log.child({ phase: 'fix', issue: issue.issue });
+
+  if (issue.prNumber === undefined) {
+    throw new Error(`Fix phase requires a PR number for issue #${issue.issue}`);
+  }
+
+  const issueDir = join(runDir, `issue-${issue.issue}`);
+  const transcriptPath = join(issueDir, 'transcripts', `fix-${round}.jsonl`);
+  mkdirSync(join(issueDir, 'transcripts'), { recursive: true });
+
+  await ensureSafeAbort(issue.worktreePath, phaseLog);
+
+  // Build the review feedback block.
+  const { reviews, comments } = await ghPrComments(issue.prNumber, repo);
+  const reviewLines = reviews
+    .filter((r) => r.body && r.body.trim().length > 0)
+    .map((r) => `### Review by @${r.author} (${r.state})\n${r.body}`);
+  const commentLines = comments
+    .filter((c) => c.body && c.body.trim().length > 0)
+    .map((c) => `### Comment by @${c.author}\n${c.body}`);
+  const reviewBlock =
+    [...reviewLines, ...commentLines].join('\n\n') || '_No review feedback._';
+
+  // CI failure block + log file the prompt can reference.
+  const ciLogPath = join(issueDir, `ci-failures-${round}.txt`);
+  let ciBlock = '_No CI failures._';
+  if (ciFailures && ciFailures.length > 0) {
+    const failed = ciFailures.filter((c) => c.conclusion === 'failure');
+    if (failed.length > 0) {
+      ciBlock = failed
+        .map((c) => `- **${c.name}**: ${c.conclusion}`)
+        .join('\n');
+      writeFileSync(
+        ciLogPath,
+        failed
+          .map(
+            (c) => `${c.name}\n  status=${c.status} conclusion=${c.conclusion}`
+          )
+          .join('\n\n')
+      );
+    }
+  }
+
+  const prompt = buildFixPrompt({
+    repo: `${repo.owner}/${repo.name}`,
+    pr: issue.prNumber,
+    issue: issue.issue,
+    title: issue.title,
+    branch: issue.branch,
+    cwd: issue.worktreePath,
+    round,
+    maxRounds,
+    reviewBlock,
+    ciBlock,
+    ciLogPath,
+    budgetMinutes: Math.round(budgetMs / 60000),
+  });
+
+  const startSha = await commitsSince(issue.baseRef, issue.worktreePath);
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), budgetMs);
+
+  let result;
+  try {
+    result = await runClaude({
+      prompt,
+      cwd: issue.worktreePath,
+      transcriptPath,
+      allowedTools: ALLOWED_TOOLS,
+      disallowedTools: DISALLOWED_TOOLS,
+      permissionMode: 'acceptEdits',
+      signal: ctrl.signal,
+      log: phaseLog,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (result.abortedForTimeout) {
+    return {
+      ok: false,
+      newCommits: 0,
+      error: `Fix phase timed out after ${budgetMs}ms`,
+      transcriptPath,
+    };
+  }
+  if (result.exitCode !== 0) {
+    return {
+      ok: false,
+      newCommits: 0,
+      error: `Claude exited with code ${result.exitCode}`,
+      transcriptPath,
+    };
+  }
+
+  const verdict = extractFencedJson(
+    result.lastAssistantText,
+    isImplementVerdict
+  );
+  if (verdict?.status === 'blocked') {
+    return {
+      ok: false,
+      newCommits: 0,
+      error: `Claude reported blocked: ${verdict.reason ?? ''}`,
+      transcriptPath,
+    };
+  }
+
+  const endSha = await commitsSince(issue.baseRef, issue.worktreePath);
+  const added = endSha - startSha;
+  phaseLog.info('fix.commits-added', { added });
+  // The fix prompt instructs Claude to push; we don't redundantly push here.
+  return { ok: true, newCommits: added, transcriptPath };
+}

--- a/scripts/agent-harness/phases/fix.ts
+++ b/scripts/agent-harness/phases/fix.ts
@@ -9,6 +9,9 @@ import {
   commitsSince,
   ensureSafeAbort,
   ghPrComments,
+  pushBranch,
+  remoteSyncStatus,
+  runLefthookPreCommit,
   type CiCheck,
   type Repo,
 } from '../lib/git';
@@ -165,6 +168,48 @@ export async function runFixPhase(args: {
   const endSha = await commitsSince(issue.baseRef, issue.worktreePath);
   const added = endSha - startSha;
   phaseLog.info('fix.commits-added', { added });
-  // The fix prompt instructs Claude to push; we don't redundantly push here.
+
+  if (added === 0) {
+    // No commits = nothing to push, but also nothing to verify against
+    // CI feedback. Treat as a no-op fix; the next review round will decide.
+    return { ok: true, newCommits: 0, transcriptPath };
+  }
+
+  // Lefthook self-check before push.
+  const lefthook = await runLefthookPreCommit(issue.worktreePath);
+  if (lefthook.exitCode !== 0) {
+    phaseLog.warn('lefthook.failed', {
+      exitCode: lefthook.exitCode,
+      stderr: lefthook.stderr.slice(0, 2000),
+    });
+    return {
+      ok: false,
+      newCommits: added,
+      error: `Pre-push lefthook failed (exit ${lefthook.exitCode}).`,
+      transcriptPath,
+    };
+  }
+
+  // Verify the push happened. Claude may have forgotten or been killed.
+  const sync = await remoteSyncStatus(issue.branch, issue.worktreePath);
+  if (sync === 'ahead') {
+    phaseLog.warn('fix.push-missed-by-claude; pushing now');
+    await pushBranch(issue.branch, issue.worktreePath);
+  } else if (sync === 'diverged') {
+    return {
+      ok: false,
+      newCommits: added,
+      error: `Local and remote diverged on ${issue.branch}; refusing to force-push.`,
+      transcriptPath,
+    };
+  } else if (sync === 'behind') {
+    return {
+      ok: false,
+      newCommits: added,
+      error: `Local is behind origin/${issue.branch}; another writer is on this branch.`,
+      transcriptPath,
+    };
+  }
+
   return { ok: true, newCommits: added, transcriptPath };
 }

--- a/scripts/agent-harness/phases/implement.ts
+++ b/scripts/agent-harness/phases/implement.ts
@@ -1,0 +1,239 @@
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  extractFencedJson,
+  isImplementVerdict,
+  runClaude,
+} from '../lib/claude';
+import {
+  addWorktree,
+  adoptWorktree,
+  commitsSince,
+  ensureSafeAbort,
+  ghIssueView,
+  ghPrAddLabel,
+  ghPrCreate,
+  ghPrFindForBranch,
+  pushBranch,
+  type Repo,
+} from '../lib/git';
+import type { Logger } from '../lib/log';
+import { buildImplementPrompt } from '../lib/prompt';
+import type { IssueState } from '../lib/state';
+
+const HARNESS_LABEL = 'harness-active';
+
+const ALLOWED_TOOLS = [
+  'Bash',
+  'Edit',
+  'Write',
+  'Read',
+  'Grep',
+  'Glob',
+  'TodoWrite',
+  'Task',
+];
+
+const DISALLOWED_TOOLS = [
+  'Bash(git push:*)',
+  'Bash(gh pr create:*)',
+  'Bash(gh pr merge:*)',
+  'Bash(curl:*)',
+  'Bash(wget:*)',
+];
+
+export type ImplementResult = {
+  ok: boolean;
+  prNumber?: number;
+  error?: string;
+  transcriptPath: string;
+};
+
+export async function runImplementPhase(args: {
+  issue: IssueState;
+  repo: Repo;
+  repoRoot: string;
+  runDir: string;
+  prevPrSummary: string;
+  budgetMs: number;
+  log: Logger;
+}): Promise<ImplementResult> {
+  const { issue, repo, repoRoot, runDir, prevPrSummary, budgetMs, log } = args;
+  const phaseLog = log.child({ phase: 'implement', issue: issue.issue });
+  const transcriptPath = join(
+    runDir,
+    `issue-${issue.issue}`,
+    'transcripts',
+    `implement-${issue.attempts.implement + 1}.jsonl`
+  );
+  mkdirSync(join(runDir, `issue-${issue.issue}`, 'transcripts'), {
+    recursive: true,
+  });
+
+  // 1. Set up the worktree (idempotent on resume).
+  if (!existsSync(issue.worktreePath)) {
+    phaseLog.info('worktree.create', {
+      path: issue.worktreePath,
+      base: issue.baseRef,
+      branch: issue.branch,
+    });
+    try {
+      await addWorktree(
+        issue.worktreePath,
+        issue.branch,
+        issue.baseRef,
+        repoRoot
+      );
+    } catch (err) {
+      // Branch may already exist (resume after partial run).
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('already exists')) {
+        phaseLog.info('worktree.adopt', {
+          path: issue.worktreePath,
+          branch: issue.branch,
+        });
+        await adoptWorktree(issue.worktreePath, issue.branch, repoRoot);
+      } else {
+        throw err;
+      }
+    }
+  } else {
+    phaseLog.info('worktree.exists', { path: issue.worktreePath });
+    await ensureSafeAbort(issue.worktreePath, phaseLog);
+  }
+
+  // 2. Fetch issue body (the spawned Claude could too, but we want it in context).
+  const meta = await ghIssueView(issue.issue, repo);
+
+  // 3. Build prompt and run Claude.
+  const prompt = buildImplementPrompt({
+    issue: issue.issue,
+    title: meta.title,
+    body: meta.body || '(no body)',
+    repo: `${repo.owner}/${repo.name}`,
+    cwd: issue.worktreePath,
+    branch: issue.branch,
+    baseRef: issue.baseRef,
+    prevPrSummary,
+    budgetMinutes: Math.round(budgetMs / 60000),
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), budgetMs);
+
+  let result;
+  try {
+    result = await runClaude({
+      prompt,
+      cwd: issue.worktreePath,
+      transcriptPath,
+      allowedTools: ALLOWED_TOOLS,
+      disallowedTools: DISALLOWED_TOOLS,
+      permissionMode: 'acceptEdits',
+      signal: ctrl.signal,
+      log: phaseLog,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (result.abortedForTimeout) {
+    return {
+      ok: false,
+      error: `Implement phase timed out after ${budgetMs}ms`,
+      transcriptPath,
+    };
+  }
+  if (result.exitCode !== 0) {
+    return {
+      ok: false,
+      error: `Claude exited with code ${result.exitCode}`,
+      transcriptPath,
+    };
+  }
+
+  const verdict = extractFencedJson(
+    result.lastAssistantText,
+    isImplementVerdict
+  );
+  if (verdict?.status === 'blocked') {
+    return {
+      ok: false,
+      error: `Claude reported blocked: ${verdict.reason ?? 'no reason given'}`,
+      transcriptPath,
+    };
+  }
+
+  // 4. Verify there are commits on the branch.
+  const newCommits = await commitsSince(issue.baseRef, issue.worktreePath);
+  if (newCommits === 0) {
+    return {
+      ok: false,
+      error: 'No commits on branch — Claude did not implement anything.',
+      transcriptPath,
+    };
+  }
+  phaseLog.info('commits.created', { count: newCommits });
+
+  // 5. Push.
+  await pushBranch(issue.branch, issue.worktreePath);
+  phaseLog.info('branch.pushed', { branch: issue.branch });
+
+  // 6. Open PR (or adopt existing one if a previous run got this far).
+  let prNumber = await ghPrFindForBranch(issue.branch, repo);
+  if (prNumber === null) {
+    const prTitle = formatPrTitle(meta.title, issue.issue);
+    const prBody = formatPrBody({
+      issue: issue.issue,
+      summary: result.lastAssistantText,
+      isStacked: issue.baseRef !== 'main',
+      baseRef: issue.baseRef,
+    });
+    prNumber = await ghPrCreate({
+      cwd: issue.worktreePath,
+      base: issue.baseRef,
+      head: issue.branch,
+      title: prTitle,
+      body: prBody,
+      draft: false,
+    });
+    phaseLog.info('pr.created', { pr: prNumber });
+  } else {
+    phaseLog.info('pr.adopted', { pr: prNumber });
+  }
+
+  // 7. Tag with harness label so collaborators know to leave it alone.
+  await ghPrAddLabel(prNumber, HARNESS_LABEL, repo);
+
+  return { ok: true, prNumber, transcriptPath };
+}
+
+function formatPrTitle(issueTitle: string, issue: number): string {
+  // Mirror the project's commit style: `<title> #<issue>`.
+  return `${issueTitle} #${issue}`;
+}
+
+function formatPrBody(args: {
+  issue: number;
+  summary: string;
+  isStacked: boolean;
+  baseRef: string;
+}): string {
+  const stacked = args.isStacked
+    ? `\n> Stacked on \`${args.baseRef}\`. Merge the parent PR first; GitHub will auto-retarget this one to \`main\`.\n`
+    : '';
+  return `## Related Issue
+Closes #${args.issue}
+${stacked}
+## Summary of Changes
+${args.summary.split('\n').slice(0, 20).join('\n')}
+
+## Risk Assessment
+- [x] Low
+- [ ] Medium
+- [ ] High
+
+## Additional Notes
+Opened by the agent-harness overnight runner. See the \`harness-active\` label.
+`;
+}

--- a/scripts/agent-harness/phases/implement.ts
+++ b/scripts/agent-harness/phases/implement.ts
@@ -15,6 +15,7 @@ import {
   ghPrCreate,
   ghPrFindForBranch,
   pushBranch,
+  runLefthookPreCommit,
   type Repo,
 } from '../lib/git';
 import type { Logger } from '../lib/log';
@@ -175,7 +176,21 @@ export async function runImplementPhase(args: {
   }
   phaseLog.info('commits.created', { count: newCommits });
 
-  // 5. Push.
+  // 5. Lefthook self-check pre-push. Catches cases where Claude forgot.
+  const lefthook = await runLefthookPreCommit(issue.worktreePath);
+  if (lefthook.exitCode !== 0) {
+    phaseLog.warn('lefthook.failed', {
+      exitCode: lefthook.exitCode,
+      stderr: lefthook.stderr.slice(0, 2000),
+    });
+    return {
+      ok: false,
+      error: `Pre-push lefthook failed (exit ${lefthook.exitCode}). Last commit may not pass CI.`,
+      transcriptPath,
+    };
+  }
+
+  // 6. Push.
   await pushBranch(issue.branch, issue.worktreePath);
   phaseLog.info('branch.pushed', { branch: issue.branch });
 

--- a/scripts/agent-harness/phases/review.ts
+++ b/scripts/agent-harness/phases/review.ts
@@ -1,0 +1,162 @@
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { extractFencedJson, isReviewVerdict, runClaude } from '../lib/claude';
+import {
+  addWorktree,
+  adoptWorktree,
+  removeWorktree,
+  type Repo,
+} from '../lib/git';
+import type { Logger } from '../lib/log';
+import { buildReviewPrompt } from '../lib/prompt';
+import type { IssueState } from '../lib/state';
+
+const ALLOWED_TOOLS = [
+  'Bash(gh:*)',
+  'Bash(git diff:*)',
+  'Bash(git log:*)',
+  'Bash(git show:*)',
+  'Read',
+  'Grep',
+  'Glob',
+  'TodoWrite',
+];
+
+const DISALLOWED_TOOLS = [
+  'Edit',
+  'Write',
+  'Bash(git push:*)',
+  'Bash(git commit:*)',
+  'Bash(git reset:*)',
+  'Bash(curl:*)',
+  'Bash(wget:*)',
+];
+
+export type ReviewVerdict = {
+  verdict: 'clean' | 'needs_changes';
+  blockingCount: number;
+  summary: string;
+  transcriptPath: string;
+};
+
+export async function runReviewPhase(args: {
+  issue: IssueState;
+  repo: Repo;
+  repoRoot: string;
+  runDir: string;
+  round: number;
+  maxRounds: number;
+  budgetMs: number;
+  log: Logger;
+}): Promise<ReviewVerdict> {
+  const { issue, repo, repoRoot, runDir, round, maxRounds, budgetMs, log } =
+    args;
+  const phaseLog = log.child({ phase: 'review', issue: issue.issue });
+  const transcriptPath = join(
+    runDir,
+    `issue-${issue.issue}`,
+    'transcripts',
+    `review-${round}.jsonl`
+  );
+  mkdirSync(join(runDir, `issue-${issue.issue}`, 'transcripts'), {
+    recursive: true,
+  });
+
+  // Reviewer runs in a separate read-only worktree at the PR head so it
+  // physically cannot modify the implementing worktree.
+  const reviewWorktree = join(
+    runDir,
+    `issue-${issue.issue}`,
+    `review-${round}-worktree`
+  );
+  if (existsSync(reviewWorktree)) {
+    rmSync(reviewWorktree, { recursive: true, force: true });
+  }
+
+  // Adopt the existing branch into a fresh worktree.
+  try {
+    await adoptWorktree(reviewWorktree, issue.branch, repoRoot);
+  } catch (err) {
+    // If something stale is checked out elsewhere, try a clean add.
+    const msg = err instanceof Error ? err.message : String(err);
+    phaseLog.warn('review.worktree.adopt-failed', { msg });
+    await addWorktree(
+      reviewWorktree,
+      `${issue.branch}-rev-${round}`,
+      issue.branch,
+      repoRoot
+    );
+  }
+
+  if (issue.prNumber === undefined) {
+    throw new Error(
+      `Review phase requires a PR number for issue #${issue.issue}`
+    );
+  }
+
+  const prompt = buildReviewPrompt({
+    repo: `${repo.owner}/${repo.name}`,
+    pr: issue.prNumber,
+    branch: issue.branch,
+    baseRef: issue.baseRef,
+    issue: issue.issue,
+    title: issue.title,
+    cwd: reviewWorktree,
+    round,
+    maxRounds,
+  });
+
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), budgetMs);
+
+  let result;
+  try {
+    result = await runClaude({
+      prompt,
+      cwd: reviewWorktree,
+      transcriptPath,
+      allowedTools: ALLOWED_TOOLS,
+      disallowedTools: DISALLOWED_TOOLS,
+      permissionMode: 'default',
+      signal: ctrl.signal,
+      log: phaseLog,
+    });
+  } finally {
+    clearTimeout(timer);
+    await removeWorktree(reviewWorktree, repoRoot);
+  }
+
+  if (result.abortedForTimeout || result.exitCode !== 0) {
+    phaseLog.warn('review.failed-or-timed-out', {
+      abortedForTimeout: result.abortedForTimeout,
+      exitCode: result.exitCode,
+    });
+    // Per prompt contract: treat unparseable failures as clean to avoid
+    // pinning the chain on reviewer flakes.
+    return {
+      verdict: 'clean',
+      blockingCount: 0,
+      summary: 'Reviewer phase failed; treated as clean.',
+      transcriptPath,
+    };
+  }
+
+  const parsed = extractFencedJson(result.lastAssistantText, isReviewVerdict);
+
+  if (!parsed) {
+    phaseLog.warn('review.no-verdict-json');
+    return {
+      verdict: 'clean',
+      blockingCount: 0,
+      summary: 'Reviewer did not emit verdict JSON; treated as clean.',
+      transcriptPath,
+    };
+  }
+
+  return {
+    verdict: parsed.verdict,
+    blockingCount: parsed.blockingCount ?? 0,
+    summary: parsed.summary ?? '',
+    transcriptPath,
+  };
+}

--- a/scripts/agent-harness/phases/review.ts
+++ b/scripts/agent-harness/phases/review.ts
@@ -11,8 +11,16 @@ import type { Logger } from '../lib/log';
 import { buildReviewPrompt } from '../lib/prompt';
 import type { IssueState } from '../lib/state';
 
+// Reviewer is read-only on the working tree and limited to gh subcommands
+// that fetch PR context or post comments — it cannot close, merge, edit
+// labels/title, or otherwise mutate the PR's metadata.
 const ALLOWED_TOOLS = [
-  'Bash(gh:*)',
+  'Bash(gh issue view:*)',
+  'Bash(gh pr view:*)',
+  'Bash(gh pr diff:*)',
+  'Bash(gh pr checks:*)',
+  'Bash(gh pr review:*)',
+  'Bash(gh pr comment:*)',
   'Bash(git diff:*)',
   'Bash(git log:*)',
   'Bash(git show:*)',
@@ -28,6 +36,11 @@ const DISALLOWED_TOOLS = [
   'Bash(git push:*)',
   'Bash(git commit:*)',
   'Bash(git reset:*)',
+  'Bash(gh pr close:*)',
+  'Bash(gh pr merge:*)',
+  'Bash(gh pr edit:*)',
+  'Bash(gh issue close:*)',
+  'Bash(gh issue edit:*)',
   'Bash(curl:*)',
   'Bash(wget:*)',
 ];

--- a/scripts/agent-harness/prompts/fix.md
+++ b/scripts/agent-harness/prompts/fix.md
@@ -1,0 +1,49 @@
+You are an autonomous engineer running inside an overnight agent harness. You are addressing feedback on a pull request you previously opened.
+
+# Context
+
+- **Repository:** {{repo}}
+- **PR:** #{{pr}}
+- **Issue:** #{{issue}} — {{title}}
+- **Branch:** `{{branch}}` — you are on it.
+- **Working directory:** {{cwd}}
+- **Round:** {{round}} of {{maxRounds}}
+
+# Feedback to address
+
+## Code review comments
+
+{{reviewBlock}}
+
+## CI failures (if any)
+
+{{ciBlock}}
+
+# Your job
+
+1. Address each blocking comment. Skim non-blocking nits and apply only the high-value ones.
+2. If a CI job failed, look at `{{ciLogPath}}` for the failure excerpt and fix the root cause. Do not paper over with skips.
+3. Run `bun lefthook run pre-commit` until it passes.
+4. Commit with a message starting with `fix:` and ending with `#{{issue}}` (e.g. `fix: address review feedback on validator #504`).
+5. Push the new commit(s): `git push`.
+6. Do NOT close review threads — the next review round decides.
+7. Do NOT comment on the PR or `@`-mention anyone.
+
+# Output
+
+End with a fenced JSON block:
+
+```json
+{ "status": "done", "addressed": <integer>, "skipped": <integer>, "summary": "<one line>" }
+```
+
+If you cannot resolve the feedback (e.g. it conflicts with the issue spec):
+
+```json
+{ "status": "blocked", "reason": "<short explanation>" }
+```
+
+# Constraints
+
+- Same CLAUDE.md rules as the implement phase.
+- Time budget: {{budgetMinutes}} minutes.

--- a/scripts/agent-harness/prompts/implement.md
+++ b/scripts/agent-harness/prompts/implement.md
@@ -1,0 +1,42 @@
+You are an autonomous engineer running inside an overnight agent harness. You are implementing a single GitHub issue end-to-end.
+
+# Issue
+
+- **Number:** #{{issue}}
+- **Title:** {{title}}
+- **Repository:** {{repo}}
+- **Working directory:** {{cwd}} (a git worktree dedicated to this issue)
+- **Branch:** `{{branch}}` (already created from `{{baseRef}}`)
+- **Previous PR in chain:** {{prevPrSummary}}
+
+# Issue body
+
+{{body}}
+
+# Your job
+
+1. Read any additional context you need with `gh issue view {{issue}} --comments` and by exploring the codebase.
+2. Implement the issue fully on the current branch. The branch already exists — DO NOT create a new branch.
+3. Run `bun lefthook run pre-commit` and fix anything it flags. The pre-commit must pass before you commit.
+4. Make one or more focused commits. Every commit message MUST end with `#{{issue}}` so it is auto-linked.
+5. **Do NOT push.** **Do NOT open a PR.** **Do NOT comment on the issue.** The harness handles those steps.
+6. When you are done, your last assistant message must be a fenced JSON block:
+
+```json
+{ "status": "done", "summary": "<one-line summary>", "filesChanged": <number>, "commits": <number> }
+```
+
+If you cannot complete the work (blocked by missing context, conflicting requirements, broken setup), end with:
+
+```json
+{ "status": "blocked", "reason": "<short explanation>" }
+```
+
+# Constraints
+
+- This is a chain of dependent PRs. Code from prior issues in the chain is already on this branch — read it carefully before duplicating work.
+- Stay scoped. Do not refactor unrelated code or add hypothetical-future abstractions.
+- Follow `/home/user/openstory/CLAUDE.md`. Especially: kebab-case files, named exports, `type` over `interface`, no `any`, no error fallbacks (throw or surface).
+- Tests: cover critical paths only; avoid excessive test generation.
+- If you delegate to a subagent (`backend-engineer`, `frontend-react-engineer`, etc.), still verify the result yourself.
+- Time budget: {{budgetMinutes}} minutes wall clock. Move efficiently.

--- a/scripts/agent-harness/prompts/review.md
+++ b/scripts/agent-harness/prompts/review.md
@@ -1,0 +1,40 @@
+You are a strict, senior code reviewer running inside an overnight agent harness. You are reviewing a pull request that an autonomous Claude instance opened minutes ago. Your job is to catch real defects, not nitpick.
+
+# Pull request
+
+- **Repository:** {{repo}}
+- **PR:** #{{pr}}
+- **Branch:** `{{branch}}` (base: `{{baseRef}}`)
+- **Implementing issue:** #{{issue}} — {{title}}
+- **Working directory:** {{cwd}} (a clean worktree at the PR head; read-only for you)
+- **Round:** {{round}} of {{maxRounds}}
+
+# Your job
+
+1. Use the `/review` skill to perform the review.
+2. Fetch the diff and existing reviews/comments:
+   - `gh pr diff {{pr}} --repo {{repo}}`
+   - `gh pr view {{pr}} --repo {{repo}} --json reviews,comments`
+3. Focus on: correctness bugs, missing error handling, security issues, broken invariants, type-safety violations, missing-test on new critical-path code, and CLAUDE.md violations.
+4. **Do NOT** comment on style or formatting (lefthook handles that). **Do NOT** request architectural rewrites at this stage. **Do NOT** mention `@claude` (it would re-trigger the workflow).
+5. Post specific, actionable comments via `gh pr review {{pr}} --repo {{repo}} --comment --body "..."` (one consolidated review). For inline comments use the GitHub MCP tool `mcp__github__pull_request_review_write` if available; otherwise post a single review comment that lists each issue with file:line references.
+
+# Output
+
+Your final assistant message MUST end with a fenced JSON block:
+
+```json
+{
+  "verdict": "clean" | "needs_changes",
+  "blockingCount": <integer>,
+  "summary": "<2-sentence overall assessment>"
+}
+```
+
+`clean` means there are zero blocking issues — the PR can be merged as-is.
+`needs_changes` means there are blocking issues that the next fix round must address.
+
+# Hard constraints
+
+- You may NOT edit files, push commits, or run `git push`. The harness denies those tools at this phase.
+- If you cannot fetch the diff or view the PR (auth/network), end with `verdict: "clean"` and a summary explaining the failure — the harness will treat the round as a no-op.

--- a/scripts/agent-harness/runner.ts
+++ b/scripts/agent-harness/runner.ts
@@ -1,0 +1,381 @@
+import type { CiCheck, Repo } from './lib/git';
+import type { Logger } from './lib/log';
+import { pollCi } from './phases/ci';
+import { runFixPhase } from './phases/fix';
+import { runImplementPhase } from './phases/implement';
+import { runReviewPhase } from './phases/review';
+import {
+  recordError,
+  saveState,
+  transition,
+  type HarnessState,
+  type IssueState,
+} from './lib/state';
+
+export type RunnerArgs = {
+  state: HarnessState;
+  statePath: string;
+  repo: Repo;
+  repoRoot: string;
+  runDir: string;
+  log: Logger;
+};
+
+function at<T>(arr: T[], i: number): T {
+  const v = arr[i];
+  if (v === undefined) {
+    throw new Error(`Index ${i} out of bounds (length ${arr.length})`);
+  }
+  return v;
+}
+
+function requirePr(issue: IssueState): number {
+  if (issue.prNumber === undefined) {
+    throw new Error(`Issue #${issue.issue} is missing a PR number`);
+  }
+  return issue.prNumber;
+}
+
+export async function runChain(args: RunnerArgs): Promise<HarnessState> {
+  let state = args.state;
+
+  for (let i = 0; i < state.chain.length; i++) {
+    let issue = at(state.chain, i);
+    args.log.info('issue.start', {
+      issue: issue.issue,
+      phase: issue.phase,
+      base: issue.baseRef,
+      branch: issue.branch,
+    });
+
+    if (issue.phase === 'DONE') {
+      args.log.info('issue.skip-done', { issue: issue.issue });
+      continue;
+    }
+
+    const issueDeadline = Date.now() + state.config.budgets.issueHardCapMs;
+    const update = (next: IssueState): void => {
+      issue = next;
+      state = persist(state, args.statePath, i, next);
+    };
+
+    try {
+      // ----- Implement -----
+      if (
+        issue.phase === 'PENDING' ||
+        issue.phase === 'PREPARING_BRANCH' ||
+        issue.phase === 'IMPLEMENTING'
+      ) {
+        update(transition(issue, 'IMPLEMENTING'));
+        update({
+          ...issue,
+          attempts: {
+            ...issue.attempts,
+            implement: issue.attempts.implement + 1,
+          },
+        });
+        const prevSummary =
+          i > 0
+            ? buildPrevSummary(at(state.chain, i - 1))
+            : 'None — first PR in chain.';
+        const result = await runImplementPhase({
+          issue,
+          repo: args.repo,
+          repoRoot: args.repoRoot,
+          runDir: args.runDir,
+          prevPrSummary: prevSummary,
+          budgetMs: state.config.budgets.implementMs,
+          log: args.log,
+        });
+        if (!result.ok) {
+          update(
+            recordError(
+              transition(issue, 'IMPL_FAILED', result.error),
+              result.error ?? 'unknown error',
+              result.transcriptPath
+            )
+          );
+          return finishOrContinue(state, args, i, 'implement failed');
+        }
+        update({ ...issue, prNumber: result.prNumber });
+        update(transition(issue, 'PR_OPEN'));
+      }
+
+      // ----- CI gate (after implement, before review) -----
+      if (issue.phase === 'PR_OPEN' || issue.phase === 'CI_PENDING') {
+        update(transition(issue, 'CI_PENDING'));
+        const ci = await pollCi({
+          pr: requirePr(issue),
+          repo: args.repo,
+          budgetMs: state.config.budgets.ciMs,
+          log: args.log,
+        });
+        if (ci.status === 'green') {
+          update(transition(issue, 'CI_GREEN'));
+        } else if (ci.status === 'red') {
+          update(transition(issue, 'CI_RED', ci.failureSummary));
+          state = await runFixCycle(state, args, i, issue, ci.checks);
+          issue = at(state.chain, i);
+          if (
+            issue.phase === 'IMPL_FAILED' ||
+            issue.phase === 'MAX_ROUNDS_EXCEEDED'
+          ) {
+            return finishOrContinue(
+              state,
+              args,
+              i,
+              'CI failures unrecoverable'
+            );
+          }
+        } else {
+          update(transition(issue, 'CI_RED', 'CI poll timeout'));
+          return finishOrContinue(state, args, i, 'CI timed out');
+        }
+      }
+
+      // ----- Review loop -----
+      if (
+        issue.phase === 'CI_GREEN' ||
+        issue.phase === 'REVIEWING' ||
+        issue.phase === 'HAS_FEEDBACK' ||
+        issue.phase === 'FIXING'
+      ) {
+        let round = issue.attempts.review;
+        while (round < state.config.maxRounds) {
+          if (Date.now() > issueDeadline) {
+            update(
+              transition(issue, 'REVIEW_FAILED', 'issue hard cap exceeded')
+            );
+            return finishOrContinue(state, args, i, 'issue hard cap');
+          }
+          round++;
+          update({
+            ...issue,
+            attempts: { ...issue.attempts, review: round },
+          });
+          update(transition(issue, 'REVIEWING'));
+          const verdict = await runReviewPhase({
+            issue,
+            repo: args.repo,
+            repoRoot: args.repoRoot,
+            runDir: args.runDir,
+            round,
+            maxRounds: state.config.maxRounds,
+            budgetMs: state.config.budgets.reviewMs,
+            log: args.log,
+          });
+          if (verdict.verdict === 'clean') {
+            update(transition(issue, 'CLEAN', verdict.summary));
+            break;
+          }
+          update(transition(issue, 'HAS_FEEDBACK', verdict.summary));
+
+          // Run a fix round.
+          update({
+            ...issue,
+            attempts: { ...issue.attempts, fix: issue.attempts.fix + 1 },
+          });
+          update(transition(issue, 'FIXING'));
+          const fixResult = await runFixPhase({
+            issue,
+            repo: args.repo,
+            runDir: args.runDir,
+            round,
+            maxRounds: state.config.maxRounds,
+            budgetMs: state.config.budgets.fixMs,
+            ciFailures: null,
+            log: args.log,
+          });
+          if (!fixResult.ok) {
+            update(
+              recordError(
+                transition(issue, 'REVIEW_FAILED', fixResult.error),
+                fixResult.error ?? 'unknown',
+                fixResult.transcriptPath
+              )
+            );
+            return finishOrContinue(state, args, i, 'fix phase failed');
+          }
+
+          // After fix: poll CI again.
+          update(transition(issue, 'CI_PENDING'));
+          const ci2 = await pollCi({
+            pr: requirePr(issue),
+            repo: args.repo,
+            budgetMs: state.config.budgets.ciMs,
+            log: args.log,
+          });
+          if (ci2.status === 'green') {
+            update(transition(issue, 'CI_GREEN'));
+          } else {
+            const reason =
+              ci2.status === 'red' ? ci2.failureSummary : 'timeout';
+            update(transition(issue, 'CI_RED', reason));
+            const ciChecks = ci2.status === 'red' ? ci2.checks : [];
+            state = await runFixCycle(state, args, i, issue, ciChecks);
+            issue = at(state.chain, i);
+            if (
+              issue.phase === 'IMPL_FAILED' ||
+              issue.phase === 'MAX_ROUNDS_EXCEEDED'
+            ) {
+              return finishOrContinue(state, args, i, 'fix CI failed');
+            }
+          }
+        }
+
+        if (issue.phase !== 'CLEAN') {
+          update(
+            transition(
+              issue,
+              'MAX_ROUNDS_EXCEEDED',
+              `hit ${String(state.config.maxRounds)} rounds`
+            )
+          );
+          return finishOrContinue(state, args, i, 'max rounds exceeded');
+        }
+      }
+
+      // ----- Done -----
+      update(transition(issue, 'DONE'));
+      args.log.info('issue.done', {
+        issue: issue.issue,
+        pr: issue.prNumber ?? null,
+      });
+
+      // Set the next issue's baseRef to this branch.
+      if (i + 1 < state.chain.length) {
+        const next = at(state.chain, i + 1);
+        const updated = { ...next, baseRef: issue.branch };
+        state = {
+          ...state,
+          chain: state.chain.map((s, idx) => (idx === i + 1 ? updated : s)),
+        };
+        saveState(args.statePath, state);
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      args.log.error('issue.exception', { issue: issue.issue, msg });
+      update(recordError(transition(issue, 'IMPL_FAILED', msg), msg));
+      return finishOrContinue(state, args, i, 'exception');
+    }
+  }
+
+  return state;
+}
+
+function persist(
+  state: HarnessState,
+  statePath: string,
+  index: number,
+  next: IssueState
+): HarnessState {
+  const updated: HarnessState = {
+    ...state,
+    chain: state.chain.map((s, i) => (i === index ? next : s)),
+  };
+  saveState(statePath, updated);
+  return updated;
+}
+
+async function runFixCycle(
+  state: HarnessState,
+  args: RunnerArgs,
+  index: number,
+  issue: IssueState,
+  ciFailures: CiCheck[]
+): Promise<HarnessState> {
+  const round = issue.attempts.fix + 1;
+  if (round > state.config.maxRounds) {
+    return persist(
+      state,
+      args.statePath,
+      index,
+      transition(issue, 'MAX_ROUNDS_EXCEEDED', 'CI fix cycle hit max rounds')
+    );
+  }
+  let working = persist(state, args.statePath, index, {
+    ...transition(issue, 'FIXING_CI'),
+    attempts: { ...issue.attempts, fix: round },
+  });
+
+  const fixResult = await runFixPhase({
+    issue: at(working.chain, index),
+    repo: args.repo,
+    runDir: args.runDir,
+    round,
+    maxRounds: state.config.maxRounds,
+    budgetMs: state.config.budgets.fixMs,
+    ciFailures,
+    log: args.log,
+  });
+
+  if (!fixResult.ok) {
+    return persist(
+      working,
+      args.statePath,
+      index,
+      recordError(
+        transition(at(working.chain, index), 'IMPL_FAILED', fixResult.error),
+        fixResult.error ?? 'unknown',
+        fixResult.transcriptPath
+      )
+    );
+  }
+
+  const ci = await pollCi({
+    pr: requirePr(at(working.chain, index)),
+    repo: args.repo,
+    budgetMs: state.config.budgets.ciMs,
+    log: args.log,
+  });
+  const next = at(working.chain, index);
+  if (ci.status === 'green') {
+    working = persist(
+      working,
+      args.statePath,
+      index,
+      transition(next, 'CI_GREEN')
+    );
+  } else {
+    const reason = ci.status === 'red' ? ci.failureSummary : 'timeout';
+    working = persist(
+      working,
+      args.statePath,
+      index,
+      transition(next, 'MAX_ROUNDS_EXCEEDED', reason)
+    );
+  }
+  return working;
+}
+
+function finishOrContinue(
+  state: HarnessState,
+  args: RunnerArgs,
+  index: number,
+  reason: string
+): HarnessState {
+  args.log.warn('issue.terminal-failure', { index, reason });
+  if (state.config.onFailure === 'stop') {
+    args.log.warn('chain.stop', { reason });
+    return state;
+  }
+  if (state.config.onFailure === 'skip') {
+    args.log.warn('chain.skip', { reason });
+    return state;
+  }
+  args.log.warn('chain.stop-on-prompt', { reason });
+  return state;
+}
+
+function buildPrevSummary(prev: IssueState): string {
+  const prLine =
+    prev.prNumber === undefined
+      ? 'No PR yet.'
+      : `PR: #${String(prev.prNumber)}`;
+  return [
+    `Issue #${String(prev.issue)}: ${prev.title}`,
+    `Branch: ${prev.branch}`,
+    prLine,
+    `Status: ${prev.phase}`,
+  ].join('\n');
+}

--- a/scripts/agent-harness/runner.ts
+++ b/scripts/agent-harness/runner.ts
@@ -282,69 +282,84 @@ async function runFixCycle(
   args: RunnerArgs,
   index: number,
   issue: IssueState,
-  ciFailures: CiCheck[]
+  initialFailures: CiCheck[]
 ): Promise<HarnessState> {
-  const round = issue.attempts.fix + 1;
-  if (round > state.config.maxRounds) {
-    return persist(
-      state,
-      args.statePath,
-      index,
-      transition(issue, 'MAX_ROUNDS_EXCEEDED', 'CI fix cycle hit max rounds')
-    );
-  }
-  let working = persist(state, args.statePath, index, {
-    ...transition(issue, 'FIXING_CI'),
-    attempts: { ...issue.attempts, fix: round },
-  });
+  let working = state;
+  let current = issue;
+  let failures = initialFailures;
 
-  const fixResult = await runFixPhase({
-    issue: at(working.chain, index),
-    repo: args.repo,
-    runDir: args.runDir,
-    round,
-    maxRounds: state.config.maxRounds,
-    budgetMs: state.config.budgets.fixMs,
-    ciFailures,
-    log: args.log,
-  });
+  while (current.attempts.fix < state.config.maxRounds) {
+    const round = current.attempts.fix + 1;
+    working = persist(working, args.statePath, index, {
+      ...transition(current, 'FIXING_CI'),
+      attempts: { ...current.attempts, fix: round },
+    });
+    current = at(working.chain, index);
 
-  if (!fixResult.ok) {
-    return persist(
-      working,
-      args.statePath,
-      index,
-      recordError(
-        transition(at(working.chain, index), 'IMPL_FAILED', fixResult.error),
-        fixResult.error ?? 'unknown',
-        fixResult.transcriptPath
-      )
-    );
-  }
+    const fixResult = await runFixPhase({
+      issue: current,
+      repo: args.repo,
+      runDir: args.runDir,
+      round,
+      maxRounds: state.config.maxRounds,
+      budgetMs: state.config.budgets.fixMs,
+      ciFailures: failures,
+      log: args.log,
+    });
 
-  const ci = await pollCi({
-    pr: requirePr(at(working.chain, index)),
-    repo: args.repo,
-    budgetMs: state.config.budgets.ciMs,
-    log: args.log,
-  });
-  const next = at(working.chain, index);
-  if (ci.status === 'green') {
+    if (!fixResult.ok) {
+      working = persist(
+        working,
+        args.statePath,
+        index,
+        recordError(
+          transition(current, 'IMPL_FAILED', fixResult.error),
+          fixResult.error ?? 'unknown',
+          fixResult.transcriptPath
+        )
+      );
+      return working;
+    }
+
+    const ci = await pollCi({
+      pr: requirePr(at(working.chain, index)),
+      repo: args.repo,
+      budgetMs: state.config.budgets.ciMs,
+      log: args.log,
+    });
+    current = at(working.chain, index);
+
+    if (ci.status === 'green') {
+      working = persist(
+        working,
+        args.statePath,
+        index,
+        transition(current, 'CI_GREEN')
+      );
+      return working;
+    }
+    const reason = ci.status === 'red' ? ci.failureSummary : 'CI poll timeout';
     working = persist(
       working,
       args.statePath,
       index,
-      transition(next, 'CI_GREEN')
+      transition(current, 'CI_RED', reason)
     );
-  } else {
-    const reason = ci.status === 'red' ? ci.failureSummary : 'timeout';
-    working = persist(
-      working,
-      args.statePath,
-      index,
-      transition(next, 'MAX_ROUNDS_EXCEEDED', reason)
-    );
+    current = at(working.chain, index);
+    failures = ci.status === 'red' ? ci.checks : [];
   }
+
+  // Exhausted the budget.
+  working = persist(
+    working,
+    args.statePath,
+    index,
+    transition(
+      current,
+      'MAX_ROUNDS_EXCEEDED',
+      `CI still red after ${String(state.config.maxRounds)} fix rounds`
+    )
+  );
   return working;
 }
 


### PR DESCRIPTION
Bun TypeScript runner that takes an ordered list of GitHub issue numbers
and walks each one through implement → CI → review → fix → repeat,
spawning the Claude Code CLI per phase. Each PR is stacked on the
previous one's branch so squash-merging the head auto-retargets the next.

State (`.claude-harness/state.json`) is crash-safe and `--resume`-able;
per-phase wall-clock budgets and tool allowlists are enforced via
AbortController and `--allowedTools`/`--disallowedTools`. Reviewer runs
in a read-only worktree at the PR head with Edit/Write/git-push denied,
emits a verdict JSON that gates the fix loop.

Usage: `bun agent-harness --issues 504,505,506`.