### PR TITLE
feat: add GPT Image 2 model (openai/gpt-image-2)

### DIFF
--- a/src/lib/ai/fal-pricing-data.ts
+++ b/src/lib/ai/fal-pricing-data.ts
@@ -142,6 +142,48 @@ export const IMAGE_PRICING: Record<string, ImagePricing> = {
     basePrice: micros(75_000),
     unit: 'per_image',
   },
+  'openai/gpt-image-2': {
+    basePrice: micros(220_000),
+    unit: 'per_image',
+    qualitySizeMatrix: {
+      low: {
+        '1024x1024': micros(10_000),
+        '1024x1536': micros(10_000),
+        '1536x1024': micros(10_000),
+      },
+      medium: {
+        '1024x1024': micros(60_000),
+        '1024x1536': micros(50_000),
+        '1536x1024': micros(40_000),
+      },
+      high: {
+        '1024x1024': micros(220_000),
+        '1024x1536': micros(170_000),
+        '1536x1024': micros(160_000),
+      },
+    },
+  },
+  'openai/gpt-image-2/edit': {
+    basePrice: micros(220_000),
+    unit: 'per_image',
+    qualitySizeMatrix: {
+      low: {
+        '1024x1024': micros(10_000),
+        '1024x1536': micros(10_000),
+        '1536x1024': micros(10_000),
+      },
+      medium: {
+        '1024x1024': micros(60_000),
+        '1024x1536': micros(50_000),
+        '1536x1024': micros(40_000),
+      },
+      high: {
+        '1024x1024': micros(220_000),
+        '1024x1536': micros(170_000),
+        '1536x1024': micros(160_000),
+      },
+    },
+  },
   'xai/grok-imagine-image': {
     basePrice: micros(20_000),
     unit: 'per_image',

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -189,6 +189,15 @@ export const IMAGE_MODELS = {
     description: 'Unified generation and editing',
     maxPromptLength: 2000,
   },
+  gpt_image_2: {
+    id: 'openai/gpt-image-2' as const,
+    name: 'GPT Image 2',
+    provider: 'OpenAI',
+    license: 'proprietary' as const,
+    qualityRank: 2.5,
+    description: 'Extremely detailed images with fine typography',
+    maxPromptLength: 32000,
+  },
   flux_2_turbo: {
     id: 'fal-ai/flux-2/turbo' as const,
     name: 'FLUX.2 Turbo',
@@ -586,6 +595,7 @@ export const EDIT_ENDPOINTS: Partial<Record<TextToImageModel, string>> = {
   flux_2_turbo: 'fal-ai/flux-2/turbo/edit',
   qwen_image: 'fal-ai/qwen-image-2/pro/edit',
   seedream_v5: 'fal-ai/bytedance/seedream/v5/lite/edit',
+  gpt_image_2: 'openai/gpt-image-2/edit',
 };
 
 /**

--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -36,6 +36,7 @@ export type ImageGenerationParams = {
   embeddings?: Array<{ path: string; tokens: string[] }>;
 
   // Model-specific
+  quality?: 'low' | 'medium' | 'high';
   style?: string;
   colors?: Array<{ r: number; g: number; b: number }>;
   resolution?: '1K' | '2K' | '4K';
@@ -192,6 +193,7 @@ async function generateImageInternal(
     heightPx: dims.height,
     resolution: params.resolution,
     style: params.style,
+    quality: params.quality,
     imageSize: sizeMap[imageSize],
   });
 
@@ -357,6 +359,18 @@ function buildFalModelOptions(
         enable_safety_checker: true,
         ...(params.seed !== undefined && { seed: params.seed }),
         ...(params.numImages !== undefined && { num_images: params.numImages }),
+        ...(params.referenceImageUrls?.length && {
+          image_urls: params.referenceImageUrls,
+        }),
+        sync_mode: false,
+      };
+
+    case 'gpt_image_2':
+      return {
+        image_size: params.imageSize ?? DEFAULT_IMAGE_SIZE,
+        quality: params.quality ?? 'high',
+        ...(params.numImages !== undefined && { num_images: params.numImages }),
+        ...(params.outputFormat && { output_format: params.outputFormat }),
         ...(params.referenceImageUrls?.length && {
           image_urls: params.referenceImageUrls,
         }),


### PR DESCRIPTION
## Summary

- Adds OpenAI's GPT Image 2 to the image model catalog
- Supports text-to-image, reference image editing, quality tiers, and per-quality cost estimation
- Recovered from an abandoned worktree (`claude/flamboyant-meitner-8c16ae`, commit 31c2985c, dated 2026-04-23) — opening as draft so the work isn't lost

## Files

- src/lib/ai/fal-pricing-data.ts
- src/lib/ai/models.ts
- src/lib/image/image-generation.ts

## Test plan

- [ ] Confirm GPT Image 2 still belongs in the catalog (vs. anything added since 2026-04-23)
- [ ] Smoke-test text-to-image generation with the new model
- [ ] Smoke-test reference image editing
- [ ] Verify cost estimates match the quality tiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)