### PR TITLE
fix: race-safe billing bootstrap + Generate button loading state

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -785,8 +785,12 @@ export const ScriptView: FC<{
                   className="group relative px-6 bg-linear-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-primary-foreground font-semibold tracking-wide shadow-lg shadow-primary/20 hover:shadow-primary/30 overflow-hidden"
                 >
                   <span className="relative z-10 flex items-center justify-center gap-2">
-                    <GenerateSequenceIcon className="size-4" />
-                    Generate
+                    {isSubmitting ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <GenerateSequenceIcon className="size-4" />
+                    )}
+                    {isSubmitting ? 'Generating…' : 'Generate'}
                   </span>
                   {/* Shine effect */}
                   <div className="absolute inset-0 bg-linear-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700 pointer-events-none" />

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -61,7 +61,10 @@ export function createBillingReadMethods(db: Database, teamId: string) {
 
     // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard: DB query may return undefined
     if (!row) {
-      await db.insert(credits).values({ teamId, balance: 0 });
+      await db
+        .insert(credits)
+        .values({ teamId, balance: 0 })
+        .onConflictDoNothing();
       return ZERO_MICROS;
     }
 
@@ -132,15 +135,23 @@ export function createBillingReadMethods(db: Database, teamId: string) {
       .limit(1);
 
     // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard: DB query may return undefined
-    if (!row) {
-      const [created] = await db
-        .insert(teamBillingSettings)
-        .values({ teamId })
-        .returning();
-      return created;
-    }
+    if (row) return row;
 
-    return row;
+    const [inserted] = await db
+      .insert(teamBillingSettings)
+      .values({ teamId })
+      .onConflictDoNothing()
+      .returning();
+
+    if (inserted) return inserted;
+
+    // Lost the race — peer inserted between our SELECT and INSERT.
+    const [existing] = await db
+      .select()
+      .from(teamBillingSettings)
+      .where(eq(teamBillingSettings.teamId, teamId))
+      .limit(1);
+    return existing;
   }
 
   async function hasRedeemedGiftCode(): Promise<boolean> {

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -64,7 +64,7 @@ export function createBillingReadMethods(db: Database, teamId: string) {
       await db
         .insert(credits)
         .values({ teamId, balance: 0 })
-        .onConflictDoNothing();
+        .onConflictDoNothing({ target: credits.teamId });
       return ZERO_MICROS;
     }
 
@@ -140,7 +140,7 @@ export function createBillingReadMethods(db: Database, teamId: string) {
     const [inserted] = await db
       .insert(teamBillingSettings)
       .values({ teamId })
-      .onConflictDoNothing()
+      .onConflictDoNothing({ target: teamBillingSettings.teamId })
       .returning();
 
     if (inserted) return inserted;

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -151,6 +151,11 @@ export function createBillingReadMethods(db: Database, teamId: string) {
       .from(teamBillingSettings)
       .where(eq(teamBillingSettings.teamId, teamId))
       .limit(1);
+    if (!existing) {
+      throw new Error(
+        `getBillingSettings: row missing for team ${teamId} after onConflictDoNothing`
+      );
+    }
     return existing;
   }
 


### PR DESCRIPTION
## Summary
- Fix UNIQUE-constraint race in `getBalance` and `getBillingSettings` (`src/lib/db/scoped/billing.ts`) — both bootstrap inserts now use `.onConflictDoNothing()`; `getBillingSettings` re-selects when a peer wins the race so it always returns a row.
- Make Generate button (`src/components/script/script-view.tsx`) visibly in-flight: swap `GenerateSequenceIcon` for `Loader2` spinner and label to "Generating…" while `createSequenceMutation.isPending`.

## Why
On prod, brand-new teams hit a transient 500 from `getBillingGateStatusFn` because SSR + client refetch race the first inserts into `credits` / `team_billing_settings`. Even on healthy slow requests, the disabled-but-unchanged Generate button looked like nothing happened. Together those produced the "silent hang" UX in #632.

## Test plan
- [x] `bun typecheck` clean.
- [ ] Load `/sequences/new`, click Generate; spinner + "Generating…" should appear immediately. Verify with DevTools "Slow 3G" throttling.
- [ ] Clear `team_billing_settings` row for a test team; hit `/sequences/new` repeatedly with hard reloads — first request should not 500.

Closes #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)