### PR TITLE
fix: slug-normalize character/frame-tag matching

### DIFF
--- a/src/components/scenes/scene-cast-tab.tsx
+++ b/src/components/scenes/scene-cast-tab.tsx
@@ -6,6 +6,7 @@
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSequenceCharacters } from '@/hooks/use-sequence-characters';
 import type { Character } from '@/lib/db/schema';
+import { matchCharactersToScene } from '@/lib/workflows/scene-matching';
 import type { Frame } from '@/types/database';
 import { Link } from '@tanstack/react-router';
 import { Film, User } from 'lucide-react';
@@ -14,36 +15,6 @@ type SceneCastTabProps = {
   frame?: Frame;
   sequenceId: string;
 };
-
-/**
- * Match characters to frame's characterTags
- * Replicates logic from character.service.ts getCharactersForScene
- */
-function matchCharactersToTags(
-  characters: Character[],
-  characterTags: string[]
-): Character[] {
-  if (characterTags.length === 0) return [];
-
-  return characters.filter((char) => {
-    const consistencyTag = (char.consistencyTag ?? '').toLowerCase();
-    const charName = char.name.toLowerCase();
-    const charId = char.characterId.toLowerCase();
-
-    return characterTags.some((tag) => {
-      const tagLower = tag.toLowerCase();
-      // Match by consistency tag (either direction — tag may be a substring of the full tag or vice versa)
-      if (consistencyTag && tagLower.includes(consistencyTag)) return true;
-      if (consistencyTag && consistencyTag.includes(tagLower)) return true;
-      // Match by character name (either direction)
-      if (tagLower.includes(charName)) return true;
-      if (charName.includes(tagLower) && tagLower.length >= 3) return true;
-      // Match by character ID (e.g., "char_001")
-      if (tagLower.includes(charId)) return true;
-      return false;
-    });
-  });
-}
 
 type CastCardProps = {
   character: Character;
@@ -127,7 +98,7 @@ export const SceneCastTab: React.FC<SceneCastTabProps> = ({
 
   // Match characters to this frame
   const frameCast = characters
-    ? matchCharactersToTags(characters, characterTags)
+    ? matchCharactersToScene(characters, characterTags)
     : [];
 
   // Loading state

--- a/src/functions/frame-image.ts
+++ b/src/functions/frame-image.ts
@@ -13,7 +13,7 @@ import {
   aspectRatioToImageSize,
   getVariantGridConfig,
 } from '@/lib/constants/aspect-ratios';
-import type { Character, SequenceLocation } from '@/lib/db/schema';
+import type { SequenceLocation } from '@/lib/db/schema';
 import { locationMatchesTag } from '@/lib/db/scoped/sequence-locations';
 import { cropTileFromGrid } from '@/lib/image/image-crop';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
@@ -33,7 +33,10 @@ import type {
   UpscaleVariantWorkflowInput,
   VariantWorkflowInput,
 } from '@/lib/workflow/types';
-import { matchElementsToScene } from '@/lib/workflows/scene-matching';
+import {
+  matchCharactersToScene,
+  matchElementsToScene,
+} from '@/lib/workflows/scene-matching';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -42,30 +45,6 @@ import { frameAccessMiddleware, sequenceAccessMiddleware } from './middleware';
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/** Match characters by continuity tags and return their reference sheet images. */
-function getSceneCharacterReferenceImages(
-  allCharacters: Character[],
-  characterTags: string[]
-): ReferenceImageDescription[] {
-  if (characterTags.length === 0) return [];
-
-  const matchedCharacters = allCharacters.filter((char) => {
-    const consistencyTag = (char.consistencyTag ?? '').toLowerCase();
-    const charName = char.name.toLowerCase();
-
-    return characterTags.some((tag) => {
-      const tagLower = tag.toLowerCase();
-      return (
-        (consistencyTag && tagLower.includes(consistencyTag)) ||
-        tagLower.includes(charName) ||
-        tagLower.includes(char.characterId.toLowerCase())
-      );
-    });
-  });
-
-  return buildCharacterReferenceImages(matchedCharacters);
-}
 
 /** Match locations by environmentTag or scene location and return reference images. */
 function getSceneLocationReferenceImages(
@@ -163,9 +142,8 @@ export const generateFrameImageFn = createServerFn({ method: 'POST' })
       sequence.id
     );
     const characterTags = frame.metadata?.continuity?.characterTags ?? [];
-    const characterReferences = getSceneCharacterReferenceImages(
-      allCharacters,
-      characterTags
+    const characterReferences = buildCharacterReferenceImages(
+      matchCharactersToScene(allCharacters, characterTags)
     );
 
     const allLocations =
@@ -243,9 +221,8 @@ export const generateFrameVariantsFn = createServerFn({ method: 'POST' })
       sequence.id
     );
     const characterTags = frame.metadata?.continuity?.characterTags ?? [];
-    const characterReferences = getSceneCharacterReferenceImages(
-      allCharacters,
-      characterTags
+    const characterReferences = buildCharacterReferenceImages(
+      matchCharactersToScene(allCharacters, characterTags)
     );
 
     const allLocations =
@@ -368,9 +345,8 @@ export const selectFrameVariantFn = createServerFn({ method: 'POST' })
       sequence.id
     );
     const characterTags = frame.metadata?.continuity?.characterTags ?? [];
-    const characterReferences = getSceneCharacterReferenceImages(
-      allCharacters,
-      characterTags
+    const characterReferences = buildCharacterReferenceImages(
+      matchCharactersToScene(allCharacters, characterTags)
     );
 
     const allLocations =

--- a/src/lib/ai/scene-analysis.schema.ts
+++ b/src/lib/ai/scene-analysis.schema.ts
@@ -556,7 +556,8 @@ export const audioDesignSchema = z.object({
 
 export const continuitySchema = z.object({
   characterTags: z.array(z.string()).catch([]).meta({
-    description: 'List of character consistency tags appearing in this scene',
+    description:
+      "Snake_case slug of each character's name as written in the script (e.g., 'GIRL ONE' → 'girl_one'). Optional descriptive context may be appended after the name slug (e.g., 'girl_one_bathroom_morning'). One entry per character appearing in the scene.",
   }),
   environmentTag: z
     .string()

--- a/src/lib/db/scoped/characters.ts
+++ b/src/lib/db/scoped/characters.ts
@@ -13,26 +13,7 @@ import type {
   SheetStatus,
 } from '@/lib/db/schema';
 import { characters, frames, talent } from '@/lib/db/schema';
-
-/**
- * Match a character to a scene's characterTags (private helper)
- */
-function characterMatchesTags(
-  character: Character,
-  characterTags: string[]
-): boolean {
-  const consistencyTag = (character.consistencyTag ?? '').toLowerCase();
-  const charName = character.name.toLowerCase();
-  const charId = character.characterId.toLowerCase();
-
-  return characterTags.some((tag) => {
-    const tagLower = tag.toLowerCase();
-    if (consistencyTag && tagLower.includes(consistencyTag)) return true;
-    if (tagLower.includes(charName)) return true;
-    if (tagLower.includes(charId)) return true;
-    return false;
-  });
-}
+import { matchCharacterToFrameTags } from '@/lib/workflows/scene-matching';
 
 export function createCharactersMethods(db: Database) {
   // Private update helper used by updateSheetStatus and updateSheet
@@ -284,7 +265,7 @@ export function createCharactersMethods(db: Database) {
       // Filter frames that contain this character
       return (allFrames as Frame[]).filter((frame) => {
         const characterTags = frame.metadata?.continuity?.characterTags ?? [];
-        return characterMatchesTags(character, characterTags);
+        return matchCharacterToFrameTags(character, characterTags);
       });
     },
 
@@ -313,7 +294,7 @@ export function createCharactersMethods(db: Database) {
       return (allFrames as Frame[])
         .filter((frame) => {
           const characterTags = frame.metadata?.continuity?.characterTags ?? [];
-          return characterMatchesTags(character, characterTags);
+          return matchCharacterToFrameTags(character, characterTags);
         })
         .map((f) => f.id);
     },

--- a/src/lib/workflows/regenerate-frames-workflow.ts
+++ b/src/lib/workflows/regenerate-frames-workflow.ts
@@ -7,7 +7,6 @@
 
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
-import type { CharacterMinimal } from '@/lib/db/schema';
 import { matchLocationsToFrame } from '@/lib/db/scoped/sequence-locations';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
 import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
@@ -19,33 +18,7 @@ import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type { RegenerateFramesWorkflowInput } from '@/lib/workflow/types';
 import { getFalFlowControl } from './constants';
 import { generateImageWorkflow } from './image-workflow';
-
-/**
- * Match characters to a frame by their continuity tags.
- * Pure function that works in-memory without DB queries.
- */
-function matchCharactersToFrame(
-  allCharacters: CharacterMinimal[],
-  characterTags: string[]
-): CharacterMinimal[] {
-  if (characterTags.length === 0) return [];
-
-  return allCharacters.filter((char) => {
-    const consistencyTag = (char.consistencyTag ?? '').toLowerCase();
-    const charName = char.name.toLowerCase();
-
-    return characterTags.some((tag) => {
-      const tagLower = tag.toLowerCase();
-      return (
-        (consistencyTag && tagLower.includes(consistencyTag)) ||
-        (consistencyTag && consistencyTag.includes(tagLower)) ||
-        tagLower.includes(charName) ||
-        (charName.includes(tagLower) && tagLower.length >= 3) ||
-        tagLower.includes(char.characterId.toLowerCase())
-      );
-    });
-  });
-}
+import { matchCharactersToScene } from './scene-matching';
 
 type FrameResult = {
   frameId: string;
@@ -133,7 +106,7 @@ export const regenerateFramesWorkflow = createScopedWorkflow<
         }
 
         const characterTags = frame.metadata?.continuity?.characterTags ?? [];
-        const frameCharacters = matchCharactersToFrame(
+        const frameCharacters = matchCharactersToScene(
           allCharacters,
           characterTags
         );

--- a/src/lib/workflows/scene-matching.test.ts
+++ b/src/lib/workflows/scene-matching.test.ts
@@ -105,6 +105,27 @@ describe('matchCharacterToFrameTags', () => {
     });
     expect(matchCharacterToFrameTags(c, ['char_001_in_doorway'])).toBe(true);
   });
+
+  // Regression for sequence 01KQDZ5AY370HAPX736RHRWN0E — the LLM emitted
+  // tokens in reversed order from the character's `name`.
+  it('matches when the LLM reorders the name tokens in the tag', () => {
+    const subject = makeCharacter({
+      name: 'Subject (Anonymous)',
+      characterId: 'char_001',
+      consistencyTag: 'char_001_ben_affleck',
+    });
+    expect(
+      matchCharacterToFrameTags(subject, [
+        'anonymous_subject_tattooed_gold_nosering_vintage_tee',
+      ])
+    ).toBe(true);
+  });
+
+  it('does not false-match when the name is a substring of a different word', () => {
+    const jack = makeCharacter({ name: 'JACK', characterId: 'char_jack' });
+    // Substring matcher would match "jack" inside "jacket"; token matcher must not.
+    expect(matchCharacterToFrameTags(jack, ['jacket_of_doom'])).toBe(false);
+  });
 });
 
 describe('matchCharactersToScene', () => {

--- a/src/lib/workflows/scene-matching.test.ts
+++ b/src/lib/workflows/scene-matching.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import type { SequenceElementMinimal } from '@/lib/db/schema';
-import { matchElementsToScene } from './scene-matching';
+import type { CharacterMinimal, SequenceElementMinimal } from '@/lib/db/schema';
+import {
+  matchCharacterToFrameTags,
+  matchCharactersToScene,
+  matchElementsToScene,
+} from './scene-matching';
 
 const elements: SequenceElementMinimal[] = [
   {
@@ -18,6 +22,113 @@ const elements: SequenceElementMinimal[] = [
     consistencyTag: 'silver-bottle',
   },
 ];
+
+// Helper: build a CharacterMinimal with sane defaults so tests can override
+// just the fields they care about.
+function makeCharacter(
+  overrides: Partial<CharacterMinimal> & {
+    name: string;
+    characterId: string;
+  }
+): CharacterMinimal {
+  return {
+    id: 'id_' + overrides.characterId,
+    sheetImageUrl: null,
+    sheetStatus: 'completed',
+    physicalDescription: null,
+    consistencyTag: null,
+    ...overrides,
+  };
+}
+
+describe('matchCharacterToFrameTags', () => {
+  // Regression for sequence 01KQE5DTXJ93PB463JNW85TJV5: name "GIRL ONE" must
+  // match snake_case tag emitted by the LLM.
+  it('matches a spaced uppercase name against a snake_case tag', () => {
+    const girlOne = makeCharacter({
+      name: 'GIRL ONE',
+      characterId: 'char_girl_one',
+      consistencyTag: 'char_girl_one_scarlett_johansson',
+    });
+    expect(
+      matchCharacterToFrameTags(girlOne, [
+        'girl_one_late_teens_bathroom_morning',
+      ])
+    ).toBe(true);
+  });
+
+  it('matches when the tag is exactly the name slug', () => {
+    const girlOne = makeCharacter({
+      name: 'GIRL ONE',
+      characterId: 'char_girl_one',
+    });
+    expect(matchCharacterToFrameTags(girlOne, ['girl_one'])).toBe(true);
+  });
+
+  it('is invariant to hyphens and other punctuation in the name', () => {
+    const girlOne = makeCharacter({
+      name: 'GIRL-ONE',
+      characterId: 'char_girl_one',
+    });
+    expect(matchCharacterToFrameTags(girlOne, ['girl_one'])).toBe(true);
+  });
+
+  it('does not match unrelated sibling characters', () => {
+    const girlOne = makeCharacter({
+      name: 'GIRL ONE',
+      characterId: 'char_girl_one',
+    });
+    expect(matchCharacterToFrameTags(girlOne, ['boy_two_running'])).toBe(false);
+  });
+
+  it('returns false for an empty tags array', () => {
+    const girlOne = makeCharacter({
+      name: 'GIRL ONE',
+      characterId: 'char_girl_one',
+    });
+    expect(matchCharacterToFrameTags(girlOne, [])).toBe(false);
+  });
+
+  it('rejects very short tags on the reverse direction', () => {
+    const girlOne = makeCharacter({
+      name: 'GIRL ONE',
+      characterId: 'char_girl_one',
+    });
+    // Slugifies to "a" — would match "girl_one" reverse-direction without the floor
+    expect(matchCharacterToFrameTags(girlOne, ['a'])).toBe(false);
+  });
+
+  it('matches via characterId fallback when name slug differs', () => {
+    const c = makeCharacter({
+      name: 'Unnamed Stranger',
+      characterId: 'char_001',
+    });
+    expect(matchCharacterToFrameTags(c, ['char_001_in_doorway'])).toBe(true);
+  });
+});
+
+describe('matchCharactersToScene', () => {
+  it('agrees with the singular matcher for the same input', () => {
+    const cast = [
+      makeCharacter({ name: 'GIRL ONE', characterId: 'char_girl_one' }),
+      makeCharacter({ name: 'GIRL TWO', characterId: 'char_girl_two' }),
+      makeCharacter({ name: 'BOY ONE', characterId: 'char_boy_one' }),
+    ];
+    const tags = ['girl_one_bathroom', 'girl_two_lip_gloss'];
+    const matched = matchCharactersToScene(cast, tags);
+    expect(matched.map((c) => c.name).sort()).toEqual(['GIRL ONE', 'GIRL TWO']);
+    for (const c of cast) {
+      expect(matched.includes(c)).toBe(matchCharacterToFrameTags(c, tags));
+    }
+  });
+
+  it('returns an empty array when there are no tags', () => {
+    const cast = [
+      makeCharacter({ name: 'GIRL ONE', characterId: 'char_girl_one' }),
+    ];
+    expect(matchCharactersToScene(cast, [])).toEqual([]);
+  });
+});
 
 describe('matchElementsToScene', () => {
   it('matches by elementTags primary path', () => {

--- a/src/lib/workflows/scene-matching.ts
+++ b/src/lib/workflows/scene-matching.ts
@@ -16,21 +16,33 @@ type CharacterMatchInput = Pick<
   'name' | 'characterId' | 'consistencyTag'
 >;
 
-// Normalizes any cased/spaced/punctuated form to a snake_case slug so
-// `"GIRL ONE"` and `"girl_one"` compare equal.
-function slugify(s: string): string {
+// Tokenizes any cased/spaced/punctuated form into a set of snake_case-style
+// word tokens, so `"Subject (Anonymous)"` and `"anonymous_subject_..."`
+// share the {subject, anonymous} tokens regardless of order.
+function tokenize(s: string): string[] {
   return s
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function isSubset(needle: string[], haystack: Set<string>): boolean {
+  if (needle.length === 0) return false;
+  return needle.every((t) => haystack.has(t));
 }
 
 /**
  * Boolean: does any tag in `characterTags` refer to this character?
  *
- * Authoritative match key is the slugified `name` — it's stable across
- * recast and is what the LLM is told to emit. `characterId` and
- * `consistencyTag` remain as fallbacks.
+ * Token-subset match: the character's `name` tokens must be a subset of
+ * the tag's tokens (or vice versa for partial references). This is
+ * invariant to case, spaces, punctuation, and word order — so
+ * `"Subject (Anonymous)"` matches `"anonymous_subject_tattooed_..."`,
+ * and `"jack"` no longer accidentally matches `"jacket_of_doom"`.
+ *
+ * `name` is the authoritative match key (stable across recast and what
+ * the LLM is told to emit). `characterId` and `consistencyTag` are
+ * fallbacks for legacy frames whose tags pre-date the prompt fix.
  */
 export function matchCharacterToFrameTags(
   character: CharacterMatchInput,
@@ -38,27 +50,31 @@ export function matchCharacterToFrameTags(
 ): boolean {
   if (characterTags.length === 0) return false;
 
-  const nameSlug = slugify(character.name);
-  const idSlug = slugify(character.characterId);
-  const consistencySlug = character.consistencyTag
-    ? slugify(character.consistencyTag)
-    : '';
+  const nameTokens = tokenize(character.name);
+  const idTokens = tokenize(character.characterId);
+  const consistencyTokens = character.consistencyTag
+    ? tokenize(character.consistencyTag)
+    : [];
 
   return characterTags.some((rawTag) => {
-    const tagSlug = slugify(rawTag);
-    if (!tagSlug) return false;
+    const tagTokens = tokenize(rawTag);
+    if (tagTokens.length === 0) return false;
+    const tagSet = new Set(tagTokens);
 
-    if (nameSlug && tagSlug.includes(nameSlug)) return true;
-    if (nameSlug && tagSlug.length >= 3 && nameSlug.includes(tagSlug))
-      return true;
-    if (idSlug && tagSlug.includes(idSlug)) return true;
-    if (consistencySlug && tagSlug.includes(consistencySlug)) return true;
-    if (
-      consistencySlug &&
-      tagSlug.length >= 3 &&
-      consistencySlug.includes(tagSlug)
-    )
-      return true;
+    // Authoritative: name tokens
+    if (isSubset(nameTokens, tagSet)) return true;
+    // Reverse (partial name reference): tag is just part of the name
+    const nameSet = new Set(nameTokens);
+    if (isSubset(tagTokens, nameSet)) return true;
+
+    // Fallback: characterId — tag must contain every characterId token
+    if (isSubset(idTokens, tagSet)) return true;
+
+    // Fallback: consistencyTag — both directions
+    if (isSubset(consistencyTokens, tagSet)) return true;
+    const consistencySet = new Set(consistencyTokens);
+    if (isSubset(tagTokens, consistencySet)) return true;
+
     return false;
   });
 }

--- a/src/lib/workflows/scene-matching.ts
+++ b/src/lib/workflows/scene-matching.ts
@@ -11,32 +11,70 @@ import type {
   SequenceLocationMinimal,
 } from '@/lib/db/schema';
 
+type CharacterMatchInput = Pick<
+  CharacterMinimal,
+  'name' | 'characterId' | 'consistencyTag'
+>;
+
+// Normalizes any cased/spaced/punctuated form to a snake_case slug so
+// `"GIRL ONE"` and `"girl_one"` compare equal.
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Boolean: does any tag in `characterTags` refer to this character?
+ *
+ * Authoritative match key is the slugified `name` — it's stable across
+ * recast and is what the LLM is told to emit. `characterId` and
+ * `consistencyTag` remain as fallbacks.
+ */
+export function matchCharacterToFrameTags(
+  character: CharacterMatchInput,
+  characterTags: string[]
+): boolean {
+  if (characterTags.length === 0) return false;
+
+  const nameSlug = slugify(character.name);
+  const idSlug = slugify(character.characterId);
+  const consistencySlug = character.consistencyTag
+    ? slugify(character.consistencyTag)
+    : '';
+
+  return characterTags.some((rawTag) => {
+    const tagSlug = slugify(rawTag);
+    if (!tagSlug) return false;
+
+    if (nameSlug && tagSlug.includes(nameSlug)) return true;
+    if (nameSlug && tagSlug.length >= 3 && nameSlug.includes(tagSlug))
+      return true;
+    if (idSlug && tagSlug.includes(idSlug)) return true;
+    if (consistencySlug && tagSlug.includes(consistencySlug)) return true;
+    if (
+      consistencySlug &&
+      tagSlug.length >= 3 &&
+      consistencySlug.includes(tagSlug)
+    )
+      return true;
+    return false;
+  });
+}
+
 /**
  * Match characters to a scene by their continuity tags.
  * Pure function that works in-memory without DB queries.
  */
-export function matchCharactersToScene(
-  allCharacters: CharacterMinimal[],
+export function matchCharactersToScene<T extends CharacterMatchInput>(
+  allCharacters: T[],
   characterTags: string[]
-): CharacterMinimal[] {
+): T[] {
   if (characterTags.length === 0) return [];
-
-  return allCharacters.filter((char) => {
-    const consistencyTag = (char.consistencyTag ?? '').toLowerCase();
-    const charName = char.name.toLowerCase();
-    const charId = char.characterId.toLowerCase();
-
-    return characterTags.some((tag) => {
-      const tagLower = tag.toLowerCase();
-      return (
-        (consistencyTag && tagLower.includes(consistencyTag)) ||
-        (consistencyTag && consistencyTag.includes(tagLower)) ||
-        tagLower.includes(charName) ||
-        (charName.includes(tagLower) && tagLower.length >= 3) ||
-        tagLower.includes(charId)
-      );
-    });
-  });
+  return allCharacters.filter((c) =>
+    matchCharacterToFrameTags(c, characterTags)
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Recast regenerated zero frames when the LLM emitted snake_case character tags (e.g. `girl_one_bathroom`) against a `name` stored in screenplay form (`GIRL ONE`) — slug-normalize both sides so `"GIRL ONE"` matches `"girl_one_..."`.
- Consolidate five duplicated matchers into one shared pair (`matchCharacterToFrameTags` singular + `matchCharactersToScene` plural) in `src/lib/workflows/scene-matching.ts`. Replaced inline copies in `src/lib/db/scoped/characters.ts`, `src/lib/workflows/regenerate-frames-workflow.ts`, `src/components/scenes/scene-cast-tab.tsx`, and three call sites in `src/functions/frame-image.ts`.
- Tighten the `characterTags` `.meta` description in `src/lib/ai/scene-analysis.schema.ts` so the LLM is explicitly told to emit name slugs (`'GIRL ONE' → 'girl_one'`), locking the matcher's contract in place.

The authoritative match key is now the slugified `name` — stable across recast and what the LLM is told to emit. `characterId` and `consistencyTag` remain as fallbacks (the latter is regenerated by `buildCastingAttributes` on every recast and shouldn't be the primary key).

Closes #634

## Test plan

- [x] `bun typecheck` clean
- [x] `bun test` — 453 pass, 0 fail (7 new cases in `scene-matching.test.ts` covering the GIRL ONE regression, name-slug-only tag, hyphen invariance, no-overlap, empty tags, length floor, and singular/plural agreement)
- [ ] Manual against `local.db` sequence `01KQE5DTXJ93PB463JNW85TJV5`: Cast tab shows GIRL ONE / GIRL TWO with sheet thumbnails (was empty)
- [ ] Manual: triggering character recast on GIRL ONE returns non-zero `affectedFrameIds` and recast frames reflect the assigned talent

🤖 Generated with [Claude Code](https://claude.com/claude-code)