### PR TITLE
feat: browser-side mediabunny merge pipeline

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "html-react-parser": "^6.0.1",
         "input-otp": "^1.4.2",
         "lucide-react": "^1.8.0",
+        "mediabunny": "^1.42.0",
         "mermaid": "^11.14.0",
         "nitro": "^3.0.260415-beta",
         "partial-json": "^0.1.7",
@@ -1410,6 +1411,10 @@
 
     "@types/doctrine": ["@types/doctrine@0.0.9", "", {}, "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA=="],
 
+    "@types/dom-mediacapture-transform": ["@types/dom-mediacapture-transform@0.1.11", "", { "dependencies": { "@types/dom-webcodecs": "*" } }, "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ=="],
+
+    "@types/dom-webcodecs": ["@types/dom-webcodecs@0.1.13", "", {}, "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
@@ -2275,6 +2280,8 @@
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "mediabunny": ["mediabunny@1.42.0", "", { "dependencies": { "@types/dom-mediacapture-transform": "^0.1.11", "@types/dom-webcodecs": "0.1.13" } }, "sha512-s9ypTqLi6kbh95gC+YaJlG0PkLvMxu37Q/wO/pFZx0fUCA5Ym5mp+2dWoa83mKQ3Uo18aNlgev5iJ5ESZqWwgQ=="],
 
     "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "html-react-parser": "^6.0.1",
     "input-otp": "^1.4.2",
     "lucide-react": "^1.8.0",
+    "mediabunny": "^1.42.0",
     "mermaid": "^11.14.0",
     "nitro": "^3.0.260415-beta",
     "partial-json": "^0.1.7",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -292,6 +292,82 @@ function bucketHasDomain(bucket: string, domain: string): boolean {
   }
 }
 
+type CorsRule = {
+  allowed: { origins: string[]; methods: string[]; headers: string[] };
+  expose?: string[];
+  maxAge?: number;
+};
+
+function configureBucketCors(bucketName: string, rules: CorsRule[]): boolean {
+  const tmpFile = resolve(process.cwd(), '.cors-tmp.json');
+  try {
+    writeFileSync(tmpFile, JSON.stringify({ rules }, null, 2));
+    execFileSync(
+      'bunx',
+      [
+        'wrangler',
+        'r2',
+        'bucket',
+        'cors',
+        'set',
+        bucketName,
+        '--file',
+        tmpFile,
+        '--force',
+      ],
+      { stdio: 'pipe' }
+    );
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+async function getCloudflareWorkersSubdomain(
+  accountId: string,
+  apiToken: string
+): Promise<string | undefined> {
+  try {
+    const res = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/workers/subdomain`,
+      { headers: { Authorization: `Bearer ${apiToken}` } }
+    );
+    const data: { success?: boolean; result?: { name?: string } } =
+      await res.json();
+    if (data.success && data.result?.name) return data.result.name;
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
+// Wildcard origin patterns matching each hosting platform's PR preview URLs.
+// PR preview URLs are ephemeral and unique per PR, so we use platform-specific
+// wildcards to cover all of them with a single CORS rule.
+function derivePreviewOriginPatterns(opts: {
+  platform: string | undefined;
+  workersSubdomain?: string;
+}): string[] {
+  switch (opts.platform) {
+    case 'cloudflare':
+      return opts.workersSubdomain
+        ? [`https://pr-*.${opts.workersSubdomain}.workers.dev`]
+        : [];
+    case 'vercel':
+      return ['https://*.vercel.app'];
+    case 'railway':
+      return ['https://*.up.railway.app'];
+    default:
+      return [];
+  }
+}
+
 async function prPreviewSetup() {
   p.intro(chalk.bold('OpenStory PR Preview Setup'));
   p.log.info(
@@ -568,6 +644,99 @@ async function prPreviewSetup() {
         }
       } else {
         p.log.warn('No zone ID — skipping domain attachment.');
+      }
+    }
+  }
+
+  // 6c. Configure CORS on the staging bucket. Each PR deploy gets a unique
+  // URL so we use a wildcard origin matching the hosting platform's preview
+  // pattern. GET/HEAD only — staging buckets don't accept browser uploads.
+  const stgBucketName = merged.get('R2_BUCKET_NAME');
+  if (stgBucketName) {
+    const platform =
+      merged.get('DEPLOY_PLATFORM') ??
+      (merged.has('CLOUDFLARE_API_TOKEN') ? 'cloudflare' : undefined);
+
+    let workersSubdomain: string | undefined;
+    if (platform === 'cloudflare') {
+      const accountId = merged.get('CLOUDFLARE_ACCOUNT_ID');
+      const apiToken = merged.get('CLOUDFLARE_API_TOKEN');
+      if (accountId && apiToken) {
+        const subSpinner = p.spinner();
+        subSpinner.start('Looking up Cloudflare Workers subdomain');
+        workersSubdomain = await getCloudflareWorkersSubdomain(
+          accountId,
+          apiToken
+        );
+        if (workersSubdomain) {
+          subSpinner.stop(`Workers subdomain: ${workersSubdomain}`);
+        } else {
+          subSpinner.stop('Could not auto-detect Workers subdomain');
+        }
+      }
+
+      if (!workersSubdomain) {
+        const manual = await p.text({
+          message:
+            'Workers subdomain (the part before .workers.dev in your preview URL)',
+          placeholder: 'e.g. myaccount',
+        });
+        if (!p.isCancel(manual) && manual.trim()) {
+          workersSubdomain = manual.trim();
+        }
+      }
+    }
+
+    const previewOrigins = derivePreviewOriginPatterns({
+      platform,
+      workersSubdomain,
+    });
+
+    if (previewOrigins.length === 0) {
+      p.log.warn(
+        `No preview origin pattern available for platform "${platform ?? 'unknown'}".\n` +
+          `Configure CORS manually in Cloudflare Dashboard:\n` +
+          `  R2 → ${stgBucketName} → Settings → CORS Policy`
+      );
+    } else {
+      const setupStgCors = await p.confirm({
+        message: `Configure CORS on staging bucket ${chalk.bold(stgBucketName)}?`,
+        initialValue: true,
+      });
+
+      if (p.isCancel(setupStgCors)) {
+        p.cancel('PR preview setup cancelled.');
+        process.exit(0);
+      }
+
+      if (setupStgCors) {
+        const rules: CorsRule[] = [
+          {
+            allowed: {
+              origins: previewOrigins,
+              methods: ['GET', 'HEAD'],
+              headers: ['content-type', 'range'],
+            },
+            expose: ['ETag', 'Content-Length'],
+            maxAge: 3600,
+          },
+        ];
+
+        const corsSpinner = p.spinner();
+        corsSpinner.start(`Configuring CORS on ${stgBucketName}`);
+
+        if (configureBucketCors(stgBucketName, rules)) {
+          corsSpinner.stop(
+            `CORS configured on ${stgBucketName} (${previewOrigins.join(', ')})`
+          );
+        } else {
+          corsSpinner.stop('CORS configuration failed');
+          p.log.warn(
+            'Configure manually in Cloudflare Dashboard:\n' +
+              `  R2 → ${stgBucketName} → Settings → CORS Policy\n\n` +
+              JSON.stringify({ rules }, null, 2)
+          );
+        }
       }
     }
   }
@@ -1473,33 +1642,6 @@ async function main() {
           p.log.warn(`Could not attach ${domain} to ${bucket}`);
         }
       }
-    } else {
-      const enableDevUrl = checkCancel(
-        await p.confirm({
-          message:
-            'Enable r2.dev public URLs instead? (rate-limited, dev only)',
-          initialValue: false,
-        })
-      );
-
-      if (enableDevUrl) {
-        const storageBucket = vars.get('R2_BUCKET_NAME') ?? 'openstory-storage';
-        const assetsBucket =
-          vars.get('R2_PUBLIC_ASSETS_BUCKET') ?? 'openstory-public-assets';
-
-        for (const bucket of [storageBucket, assetsBucket]) {
-          try {
-            execFileSync(
-              'bunx',
-              ['wrangler', 'r2', 'bucket', 'dev-url', 'enable', bucket],
-              { stdio: 'inherit' }
-            );
-            p.log.success(`Enabled r2.dev URL for ${bucket}`);
-          } catch {
-            p.log.warn(`Could not enable r2.dev URL for ${bucket}`);
-          }
-        }
-      }
     }
   }
 
@@ -2084,6 +2226,18 @@ async function main() {
         `VITE_R2_PUBLIC_ASSETS_DOMAIN  = ${vars.get('VITE_R2_PUBLIC_ASSETS_DOMAIN')}`
       );
     }
+
+    // Bucket names — needed for CORS configuration. Cloudflare runtime uses
+    // native bindings from wrangler.jsonc, but wrangler CLI commands like
+    // `r2 bucket cors set` need the bucket name explicitly.
+    if (!vars.has('R2_BUCKET_NAME')) {
+      vars.set('R2_BUCKET_NAME', 'openstory-storage');
+      saveProgress();
+    }
+    if (!vars.has('R2_PUBLIC_ASSETS_BUCKET')) {
+      vars.set('R2_PUBLIC_ASSETS_BUCKET', 'openstory-public-assets');
+      saveProgress();
+    }
   } else {
     const setupStorage = checkCancel(
       await p.confirm({
@@ -2129,7 +2283,12 @@ async function main() {
   //   - Browser-side fetches from JS (e.g. browser-merge in #638) on every
   //     deployment, including Cloudflare. Native HTML elements (<video>,
   //     <img>, <a>) load R2 cross-origin without CORS, but `fetch()` does not.
-  if (vars.has('R2_BUCKET_NAME') && vars.has('R2_ACCESS_KEY_ID')) {
+  // Wrangler authenticates via CLOUDFLARE_API_TOKEN (or global wrangler login);
+  // R2_ACCESS_KEY_ID is for runtime signed URLs, not for setting CORS.
+  if (
+    vars.has('R2_BUCKET_NAME') &&
+    (vars.has('CLOUDFLARE_API_TOKEN') || vars.has('R2_ACCESS_KEY_ID'))
+  ) {
     const setupCors = checkCancel(
       await p.confirm({
         message:
@@ -2148,55 +2307,30 @@ async function main() {
       const origins = new Set(['http://localhost:3000']);
       if (appUrl !== 'http://localhost:3000') origins.add(appUrl);
 
-      const corsConfig = {
-        rules: [
-          {
-            allowed: {
-              origins: [...origins],
-              methods: ['GET', 'PUT', 'HEAD'],
-              headers: ['content-type'],
-            },
-            expose: ['ETag'],
-            maxAge: 3600,
+      const rules: CorsRule[] = [
+        {
+          allowed: {
+            origins: [...origins],
+            methods: ['GET', 'PUT', 'HEAD'],
+            headers: ['content-type'],
           },
-        ],
-      };
+          expose: ['ETag'],
+          maxAge: 3600,
+        },
+      ];
 
       const corsSpinner = p.spinner();
       corsSpinner.start(`Configuring CORS on ${bucketName}`);
 
-      const tmpFile = resolve(process.cwd(), '.cors-tmp.json');
-      try {
-        writeFileSync(tmpFile, JSON.stringify(corsConfig, null, 2));
-        execFileSync(
-          'bunx',
-          [
-            'wrangler',
-            'r2',
-            'bucket',
-            'cors',
-            'set',
-            bucketName,
-            '--file',
-            tmpFile,
-            '--force',
-          ],
-          { stdio: 'pipe' }
-        );
+      if (configureBucketCors(bucketName, rules)) {
         corsSpinner.stop(`CORS configured on ${bucketName}`);
-      } catch {
+      } else {
         corsSpinner.stop('CORS configuration failed');
         p.log.warn(
           'Configure manually in Cloudflare Dashboard:\n' +
             `  R2 → ${bucketName} → Settings → CORS Policy\n\n` +
-            JSON.stringify(corsConfig, null, 2)
+            JSON.stringify({ rules }, null, 2)
         );
-      } finally {
-        try {
-          unlinkSync(tmpFile);
-        } catch {
-          // ignore
-        }
       }
     }
   }

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -2124,13 +2124,12 @@ async function main() {
     }
   }
 
-  // Configure CORS on R2 bucket for presigned uploads (local dev & non-CF deploys)
-  // Cloudflare Workers use R2 bindings server-side, so CORS is not needed there.
-  if (
-    vars.has('R2_BUCKET_NAME') &&
-    vars.has('R2_ACCESS_KEY_ID') &&
-    vars.get('DEPLOY_PLATFORM') !== 'cloudflare'
-  ) {
+  // Configure CORS on R2 bucket. Needed for:
+  //   - Presigned PUT uploads from the browser (S3-style deployments).
+  //   - Browser-side fetches from JS (e.g. browser-merge in #638) on every
+  //     deployment, including Cloudflare. Native HTML elements (<video>,
+  //     <img>, <a>) load R2 cross-origin without CORS, but `fetch()` does not.
+  if (vars.has('R2_BUCKET_NAME') && vars.has('R2_ACCESS_KEY_ID')) {
     const setupCors = checkCancel(
       await p.confirm({
         message:

--- a/src/components/theatre/theatre-view.tsx
+++ b/src/components/theatre/theatre-view.tsx
@@ -21,6 +21,8 @@ import {
   Link,
   Download,
 } from 'lucide-react';
+import { useBrowserMerge } from '@/components/theatre/use-browser-merge';
+import type { MergeProgress } from '@/lib/browser-merge';
 import { usePostHog } from '@posthog/react';
 import { useCallback } from 'react';
 import { toast } from 'sonner';
@@ -39,6 +41,7 @@ export const TheatreView: React.FC<TheatreViewProps> = ({
   const { mergedVideoStatus, mergedVideoUrl, mergedVideoError, aspectRatio } =
     sequence;
   const posthog = usePostHog();
+  const browserMerge = useBrowserMerge(sequence);
 
   const handleCopyVideoUrl = useCallback(async () => {
     if (!mergedVideoUrl) return;
@@ -72,7 +75,11 @@ export const TheatreView: React.FC<TheatreViewProps> = ({
     return (
       <div className="flex flex-col items-center justify-center gap-4 py-16">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-        <p className="text-muted-foreground">Merging video segments…</p>
+        <p className="text-muted-foreground">
+          {browserMerge.isRunning && browserMerge.progress
+            ? formatMergeProgress(browserMerge.progress)
+            : 'Merging video segments…'}
+        </p>
       </div>
     );
   }
@@ -101,6 +108,19 @@ export const TheatreView: React.FC<TheatreViewProps> = ({
               <Download className="h-4 w-4" />
               Download video
             </DropdownMenuItem>
+            {browserMerge.isEnabled && (
+              <DropdownMenuItem
+                onClick={browserMerge.start}
+                disabled={browserMerge.isRunning}
+              >
+                {browserMerge.isRunning ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Film className="h-4 w-4" />
+                )}
+                Re-merge in browser (beta)
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
         <VideoPlayer src={mergedVideoUrl} aspectRatio={aspectRatio} />
@@ -119,18 +139,36 @@ export const TheatreView: React.FC<TheatreViewProps> = ({
             {mergedVideoError}
           </p>
         )}
-        {onGenerateMergedVideo && (
-          <Button onClick={onGenerateMergedVideo} disabled={isGenerating}>
-            {isGenerating ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Retrying…
-              </>
-            ) : (
-              'Retry Merge'
-            )}
-          </Button>
-        )}
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {onGenerateMergedVideo && (
+            <Button onClick={onGenerateMergedVideo} disabled={isGenerating}>
+              {isGenerating ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Retrying…
+                </>
+              ) : (
+                'Retry Merge'
+              )}
+            </Button>
+          )}
+          {browserMerge.isEnabled && (
+            <Button
+              variant="outline"
+              onClick={browserMerge.start}
+              disabled={browserMerge.isRunning}
+            >
+              {browserMerge.isRunning ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Merging in browser…
+                </>
+              ) : (
+                'Merge in browser (beta)'
+              )}
+            </Button>
+          )}
+        </div>
       </div>
     );
   }
@@ -144,25 +182,62 @@ export const TheatreView: React.FC<TheatreViewProps> = ({
         The merged video will be generated automatically once all motion
         segments are complete.
       </p>
-      {onGenerateMergedVideo && (
-        <Button
-          variant="outline"
-          onClick={onGenerateMergedVideo}
-          disabled={isGenerating}
-        >
-          {isGenerating ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Generating…
-            </>
-          ) : (
-            'Generate Now'
-          )}
-        </Button>
-      )}
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {onGenerateMergedVideo && (
+          <Button
+            variant="outline"
+            onClick={onGenerateMergedVideo}
+            disabled={isGenerating}
+          >
+            {isGenerating ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Generating…
+              </>
+            ) : (
+              'Generate Now'
+            )}
+          </Button>
+        )}
+        {browserMerge.isEnabled && (
+          <Button
+            variant="outline"
+            onClick={browserMerge.start}
+            disabled={browserMerge.isRunning}
+          >
+            {browserMerge.isRunning ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Merging in browser…
+              </>
+            ) : (
+              'Merge in browser (beta)'
+            )}
+          </Button>
+        )}
+      </div>
     </div>
   );
 };
+
+function formatMergeProgress(progress: MergeProgress): string {
+  const phaseLabel: Record<MergeProgress['phase'], string> = {
+    fetch: 'Downloading scenes',
+    decode: 'Stitching video',
+    mix: 'Mixing audio',
+    encode: 'Encoding audio',
+    finalize: 'Finalizing',
+  };
+  const label = phaseLabel[progress.phase];
+  if (progress.total > 0) {
+    const pct = Math.min(
+      100,
+      Math.round((progress.completed / progress.total) * 100)
+    );
+    return `${label}… ${pct}%`;
+  }
+  return `${label}…`;
+}
 
 export const TheatreViewSkeleton: React.FC = () => (
   <Skeleton className="aspect-video w-full" />

--- a/src/components/theatre/use-browser-merge.ts
+++ b/src/components/theatre/use-browser-merge.ts
@@ -1,0 +1,150 @@
+/**
+ * Hook that drives the browser-side merge:
+ *   1. Reserve an upload URL via `requestMergedUploadUrlFn` (status → 'merging').
+ *   2. Run the Mediabunny pipeline against the team's frames + music URL.
+ *   3. PUT the resulting Blob to the reserved URL.
+ *   4. Commit via `commitMergedVideoFn` (status → 'completed', URL set).
+ *   5. On any failure, post via `failMergedVideoFn` and surface a toast.
+ *
+ * The hook returns the running state + a `start()` function. PostHog flag
+ * gating (`browserMerge`) is exposed as `isEnabled` so the caller can hide
+ * the entry point when the flag is off.
+ */
+
+import { useFramesBySequence } from '@/hooks/use-frames';
+import { sequenceKeys } from '@/hooks/use-sequences';
+import { mergeSequence, uploadMergedBlob } from '@/lib/browser-merge';
+import type { MergeProgress } from '@/lib/browser-merge';
+import {
+  commitMergedVideoFn,
+  failMergedVideoFn,
+  requestMergedUploadUrlFn,
+} from '@/functions/merged-video';
+import { useQueryClient } from '@tanstack/react-query';
+import { usePostHog } from '@posthog/react';
+import { useCallback, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import type { Sequence } from '@/types/database';
+
+export type BrowserMergeState = {
+  isEnabled: boolean;
+  isRunning: boolean;
+  progress: MergeProgress | null;
+  start: () => void;
+  abort: () => void;
+};
+
+const FLAG_NAME = 'browserMerge';
+
+export function useBrowserMerge(sequence: Sequence): BrowserMergeState {
+  const posthog = usePostHog();
+  const queryClient = useQueryClient();
+  const isEnabled = Boolean(posthog.isFeatureEnabled(FLAG_NAME));
+
+  const { data: frames } = useFramesBySequence(sequence.id);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [progress, setProgress] = useState<MergeProgress | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const start = useCallback(() => {
+    if (isRunning) return;
+    if (!frames || frames.length === 0) {
+      toast.error('Cannot merge: this sequence has no frames yet.');
+      return;
+    }
+    const scenes = frames
+      .filter((f): f is typeof f & { videoUrl: string } => Boolean(f.videoUrl))
+      .map((f) => ({ orderIndex: f.orderIndex, videoUrl: f.videoUrl }));
+    if (scenes.length === 0) {
+      toast.error('Cannot merge: no scene videos are ready.');
+      return;
+    }
+    if (scenes.length !== frames.length) {
+      toast.error(
+        `Cannot merge yet: ${frames.length - scenes.length} of ${frames.length} scenes are still generating.`
+      );
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsRunning(true);
+    setProgress(null);
+
+    void runMerge({
+      sequenceId: sequence.id,
+      musicUrl: sequence.musicUrl ?? null,
+      scenes,
+      signal: controller.signal,
+      onProgress: setProgress,
+    })
+      .then(() => {
+        toast.success('Merged video ready.');
+        posthog.capture('browser_merge_completed', {
+          sequence_id: sequence.id,
+          scene_count: scenes.length,
+        });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        const message =
+          error instanceof Error ? error.message : 'Browser merge failed';
+        toast.error(message);
+        posthog.captureException(error, { sequence_id: sequence.id });
+      })
+      .finally(() => {
+        setIsRunning(false);
+        setProgress(null);
+        abortRef.current = null;
+        void queryClient.invalidateQueries({
+          queryKey: sequenceKeys.detail(sequence.id),
+        });
+      });
+  }, [frames, isRunning, posthog, queryClient, sequence.id, sequence.musicUrl]);
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  return { isEnabled, isRunning, progress, start, abort };
+}
+
+async function runMerge(args: {
+  sequenceId: string;
+  musicUrl: string | null;
+  scenes: Array<{ orderIndex: number; videoUrl: string }>;
+  signal: AbortSignal;
+  onProgress: (p: MergeProgress) => void;
+}): Promise<void> {
+  const { sequenceId, musicUrl, scenes, signal, onProgress } = args;
+
+  const reservation = await requestMergedUploadUrlFn({ data: { sequenceId } });
+
+  try {
+    const { blob } = await mergeSequence({
+      scenes,
+      musicUrl,
+      onProgress,
+      signal,
+    });
+
+    await uploadMergedBlob({
+      blob,
+      uploadUrl: reservation.uploadUrl,
+      contentType: reservation.contentType,
+      signal,
+    });
+
+    await commitMergedVideoFn({
+      data: { sequenceId, path: reservation.path },
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Browser merge failed';
+    await failMergedVideoFn({ data: { sequenceId, error: message } }).catch(
+      () => {}
+    );
+    throw error;
+  }
+}

--- a/src/components/theatre/use-browser-merge.ts
+++ b/src/components/theatre/use-browser-merge.ts
@@ -88,9 +88,7 @@ export function useBrowserMerge(sequence: Sequence): BrowserMergeState {
       })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
-        const message =
-          error instanceof Error ? error.message : 'Browser merge failed';
-        toast.error(message);
+        toast.error(toMergeErrorMessage(error));
         posthog.captureException(error, { sequence_id: sequence.id });
       })
       .finally(() => {
@@ -140,11 +138,35 @@ async function runMerge(args: {
       data: { sequenceId, path: reservation.path },
     });
   } catch (error) {
-    const message =
-      error instanceof Error ? error.message : 'Browser merge failed';
-    await failMergedVideoFn({ data: { sequenceId, error: message } }).catch(
-      () => {}
-    );
+    const message = toMergeErrorMessage(error);
+    try {
+      await failMergedVideoFn({ data: { sequenceId, error: message } });
+    } catch (failError) {
+      // Server didn't accept the failure record — the DB row stays in
+      // 'merging' until something else clears it. Log so we can detect
+      // stranded reservations; rethrow the original error so the caller
+      // surfaces the *root* cause to the user, not the secondary failure.
+      console.error(
+        'failMergedVideoFn rejected; sequence may be stuck in "merging"',
+        { sequenceId, originalError: error, failError }
+      );
+    }
     throw error;
   }
+}
+
+const MAX_MERGE_ERROR_LENGTH = 500;
+
+function toMergeErrorMessage(error: unknown): string {
+  const raw =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : 'Browser merge failed';
+  // Server-side Zod schema caps error at 500 chars; truncate so the fail call
+  // doesn't bounce on stack-bearing or 4xx-body messages from R2/network.
+  return raw.length <= MAX_MERGE_ERROR_LENGTH
+    ? raw
+    : `${raw.slice(0, MAX_MERGE_ERROR_LENGTH - 1)}…`;
 }

--- a/src/functions/merged-video.ts
+++ b/src/functions/merged-video.ts
@@ -62,10 +62,10 @@ export const requestMergedUploadUrlFn = createServerFn({ method: 'POST' })
         mergedVideoError: null,
       });
 
-    void getGenerationChannel(context.sequence.id).emit(
-      'generation.merge:progress',
-      { step: 'video', status: 'merging' }
-    );
+    await emitMergeProgress(context.sequence.id, {
+      step: 'video',
+      status: 'merging',
+    });
 
     return {
       uploadUrl: upload.uploadUrl,
@@ -118,14 +118,11 @@ export const commitMergedVideoFn = createServerFn({ method: 'POST' })
         mergedVideoError: null,
       });
 
-    void getGenerationChannel(context.sequence.id).emit(
-      'generation.merge:progress',
-      {
-        step: 'audio-video',
-        status: 'completed',
-        mergedVideoUrl: publicUrl,
-      }
-    );
+    await emitMergeProgress(context.sequence.id, {
+      step: 'audio-video',
+      status: 'completed',
+      mergedVideoUrl: publicUrl,
+    });
 
     return { mergedVideoUrl: publicUrl, mergedVideoPath: data.path };
   });
@@ -134,6 +131,10 @@ export const commitMergedVideoFn = createServerFn({ method: 'POST' })
  * Record a browser-merge failure (capability probe failure, network error
  * mid-upload, encode failure, abort, etc.) and emit the matching realtime
  * event so the existing `theatre-view.tsx` failure branch can render.
+ *
+ * Guarded so a stale call cannot clobber a row that already reached
+ * `'completed'` (e.g. server-side ffmpeg merge finished while the browser-side
+ * pipeline was still attempting and then errored).
  */
 export const failMergedVideoFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
@@ -146,6 +147,17 @@ export const failMergedVideoFn = createServerFn({ method: 'POST' })
     )
   )
   .handler(async ({ context, data }) => {
+    if (context.sequence.mergedVideoStatus !== 'merging') {
+      console.warn(
+        `failMergedVideoFn: ignoring failure for sequence ${context.sequence.id} in status "${context.sequence.mergedVideoStatus}"`
+      );
+      return { ok: false, reason: 'not-merging' as const };
+    }
+
+    console.error(
+      `Browser merge failed for sequence ${context.sequence.id}: ${data.error}`
+    );
+
     await context.scopedDb
       .sequence(context.sequence.id)
       .updateMergedVideoFields({
@@ -153,10 +165,41 @@ export const failMergedVideoFn = createServerFn({ method: 'POST' })
         mergedVideoError: data.error,
       });
 
-    void getGenerationChannel(context.sequence.id).emit(
-      'generation.merge:progress',
-      { step: 'video', status: 'failed' }
-    );
+    await emitMergeProgress(context.sequence.id, {
+      step: 'video',
+      status: 'failed',
+    });
 
-    return { ok: true };
+    return { ok: true as const };
   });
+
+type MergeProgressEvent =
+  | { step: 'video'; status: 'merging' | 'failed' }
+  | {
+      step: 'audio-video';
+      status: 'completed';
+      mergedVideoUrl: string;
+    };
+
+/**
+ * Emit a merge-progress event and surface (rather than swallow) realtime
+ * failures: a silent emit failure leaves the client UI hung in 'merging' even
+ * when the DB row is correct, so the only safe behavior is to log and let the
+ * caller treat it as a hard error if they need at-least-once delivery.
+ */
+async function emitMergeProgress(
+  sequenceId: string,
+  event: MergeProgressEvent
+): Promise<void> {
+  try {
+    await getGenerationChannel(sequenceId).emit(
+      'generation.merge:progress',
+      event
+    );
+  } catch (error) {
+    console.error(
+      `Failed to emit merge:progress for sequence ${sequenceId}`,
+      error
+    );
+  }
+}

--- a/src/functions/merged-video.ts
+++ b/src/functions/merged-video.ts
@@ -1,0 +1,162 @@
+/**
+ * Server functions backing the browser-side merge pipeline.
+ *
+ * Phase 1 of GitHub issue #638. The browser orchestrates the actual merge,
+ * but the server still owns:
+ *   - Authoritative status transitions on `sequences.mergedVideo*` columns.
+ *   - Realtime `merge:progress` event emission (Upstash channel auth lives
+ *     on the server).
+ *   - Issuance of upload URLs scoped to the team's R2 path.
+ *
+ * Three thin handlers:
+ *   - `requestMergedUploadUrlFn`  → reserves a path, flips status to 'merging',
+ *                                   emits `step:'video', status:'merging'`.
+ *   - `commitMergedVideoFn`       → verifies the uploaded object exists, writes
+ *                                   the final URL/path, emits `step:'audio-video',
+ *                                   status:'completed'`.
+ *   - `failMergedVideoFn`         → records the failure + emits `status:'failed'`.
+ */
+
+import { getSignedUploadUrl } from '#storage';
+import { generateId } from '@/lib/db/id';
+import { ulidSchema } from '@/lib/schemas/id.schemas';
+import { STORAGE_BUCKETS, getPublicUrl } from '@/lib/storage/buckets';
+import { getGenerationChannel } from '@/lib/realtime';
+import { createServerFn } from '@tanstack/react-start';
+import { zodValidator } from '@tanstack/zod-adapter';
+import { z } from 'zod';
+import { sequenceAccessMiddleware } from './middleware';
+
+const MERGED_FILENAME_SUFFIX = '_openstory.mp4';
+const MERGED_CONTENT_TYPE = 'video/mp4';
+
+function buildMergedPath(teamId: string, sequenceId: string): string {
+  const shortHash = generateId().slice(-8);
+  return `teams/${teamId}/sequences/${sequenceId}/merged/${shortHash}${MERGED_FILENAME_SUFFIX}`;
+}
+
+function expectedPathPrefix(teamId: string, sequenceId: string): string {
+  return `teams/${teamId}/sequences/${sequenceId}/merged/`;
+}
+
+/**
+ * Reserve an R2 upload URL for the browser-merged MP4 and flip status to
+ * 'merging'. The browser uses the returned `uploadUrl` (presigned PUT on
+ * S3 deployments, same-origin proxy on Cloudflare) to stream the bytes.
+ */
+export const requestMergedUploadUrlFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .handler(async ({ context }) => {
+    const path = buildMergedPath(context.teamId, context.sequence.id);
+    const upload = await getSignedUploadUrl(
+      STORAGE_BUCKETS.VIDEOS,
+      path,
+      MERGED_CONTENT_TYPE
+    );
+
+    await context.scopedDb
+      .sequence(context.sequence.id)
+      .updateMergedVideoFields({
+        mergedVideoStatus: 'merging',
+        mergedVideoError: null,
+      });
+
+    void getGenerationChannel(context.sequence.id).emit(
+      'generation.merge:progress',
+      { step: 'video', status: 'merging' }
+    );
+
+    return {
+      uploadUrl: upload.uploadUrl,
+      publicUrl: upload.publicUrl,
+      path,
+      contentType: MERGED_CONTENT_TYPE,
+    };
+  });
+
+/**
+ * Commit a successfully-uploaded merged MP4: verify the team-scoped path,
+ * write the public URL into the sequence row, emit completion.
+ *
+ * `path` is the bucket-relative path returned from `requestMergedUploadUrlFn`
+ * (i.e. `teams/.../merged/<hash>_openstory.mp4`, NOT prefixed with the bucket
+ * name). We re-derive the public URL from the bucket + path on the server to
+ * avoid trusting the client's reported URL.
+ */
+export const commitMergedVideoFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        path: z.string().min(1),
+      })
+    )
+  )
+  .handler(async ({ context, data }) => {
+    const expectedPrefix = expectedPathPrefix(
+      context.teamId,
+      context.sequence.id
+    );
+    if (!data.path.startsWith(expectedPrefix)) {
+      throw new Error('Invalid merged-video path for this sequence/team');
+    }
+    if (!data.path.endsWith(MERGED_FILENAME_SUFFIX)) {
+      throw new Error('Merged-video path must end with _openstory.mp4');
+    }
+
+    const publicUrl = getPublicUrl(STORAGE_BUCKETS.VIDEOS, data.path);
+
+    await context.scopedDb
+      .sequence(context.sequence.id)
+      .updateMergedVideoFields({
+        mergedVideoUrl: publicUrl,
+        mergedVideoPath: data.path,
+        mergedVideoStatus: 'completed',
+        mergedVideoGeneratedAt: new Date(),
+        mergedVideoError: null,
+      });
+
+    void getGenerationChannel(context.sequence.id).emit(
+      'generation.merge:progress',
+      {
+        step: 'audio-video',
+        status: 'completed',
+        mergedVideoUrl: publicUrl,
+      }
+    );
+
+    return { mergedVideoUrl: publicUrl, mergedVideoPath: data.path };
+  });
+
+/**
+ * Record a browser-merge failure (capability probe failure, network error
+ * mid-upload, encode failure, abort, etc.) and emit the matching realtime
+ * event so the existing `theatre-view.tsx` failure branch can render.
+ */
+export const failMergedVideoFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        error: z.string().max(500),
+      })
+    )
+  )
+  .handler(async ({ context, data }) => {
+    await context.scopedDb
+      .sequence(context.sequence.id)
+      .updateMergedVideoFields({
+        mergedVideoStatus: 'failed',
+        mergedVideoError: data.error,
+      });
+
+    void getGenerationChannel(context.sequence.id).emit(
+      'generation.merge:progress',
+      { step: 'video', status: 'failed' }
+    );
+
+    return { ok: true };
+  });

--- a/src/lib/browser-merge/assemble-channel-data.test.ts
+++ b/src/lib/browser-merge/assemble-channel-data.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Regression test for the AAC priming/padding overflow fix in
+ * `mix-audio-tracks.ts`.
+ *
+ * The buffer must be sized from the *actual* sum of decoded frames, NOT from
+ * the muxed track duration. AAC priming and padding cause the decoder to emit
+ * up to ~2k more frames than `Input.computeDuration` reports; sizing from
+ * duration overflows the typed array and `Float32Array.set` then throws
+ * "offset is out of bounds" once writing crosses the pre-allocated length.
+ *
+ * If a future refactor reverts to `Math.ceil(duration * sampleRate)` sizing,
+ * the "primingPaddingScenario" assertion below will fail.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { assembleChannelData } from './mix-audio-tracks';
+
+type MockFrame = {
+  numberOfFrames: number;
+  numberOfChannels: number;
+  copyTo: (
+    dest: Float32Array,
+    opts: { planeIndex: number; format: 'f32-planar' }
+  ) => void;
+  close: () => void;
+};
+
+function makeFrame(framesPerChannel: number, channelFill: number[]): MockFrame {
+  let closed = false;
+  return {
+    numberOfFrames: framesPerChannel,
+    numberOfChannels: channelFill.length,
+    copyTo: (dest, opts) => {
+      const value = channelFill[opts.planeIndex] ?? 0;
+      for (let i = 0; i < framesPerChannel; i++) dest[i] = value;
+    },
+    close: () => {
+      closed = true;
+    },
+    // Exposed via closure for assertions; assigned below.
+    get _closed() {
+      return closed;
+    },
+  } as MockFrame & { _closed: boolean };
+}
+
+describe('assembleChannelData', () => {
+  test('empty input returns zero-length buffers', () => {
+    const { channelData, totalFrames } = assembleChannelData([], 2);
+    expect(totalFrames).toBe(0);
+    expect(channelData).toHaveLength(2);
+    expect(channelData[0].length).toBe(0);
+    expect(channelData[1].length).toBe(0);
+  });
+
+  test('single frame fills exactly numberOfFrames per channel', () => {
+    const frame = makeFrame(1024, [0.5, -0.5]);
+    const { channelData, totalFrames } = assembleChannelData([frame], 2);
+    expect(totalFrames).toBe(1024);
+    expect(channelData[0].length).toBe(1024);
+    expect(channelData[1].length).toBe(1024);
+    expect(channelData[0][0]).toBe(0.5);
+    expect(channelData[1][1023]).toBe(-0.5);
+  });
+
+  test('totalFrames is the actual sum across decoded frames', () => {
+    // Heterogeneous frame counts — typical of WebCodecs AudioDecoder output.
+    const frames = [
+      makeFrame(1024, [0.1, 0.2]),
+      makeFrame(1024, [0.3, 0.4]),
+      makeFrame(1024, [0.5, 0.6]),
+      makeFrame(2048, [0.7, 0.8]), // larger trailing frame
+    ];
+    const expectedTotal = 1024 + 1024 + 1024 + 2048;
+    const { channelData, totalFrames } = assembleChannelData(frames, 2);
+    expect(totalFrames).toBe(expectedTotal);
+    expect(channelData[0].length).toBe(expectedTotal);
+    expect(channelData[1].length).toBe(expectedTotal);
+  });
+
+  test('AAC priming/padding scenario: decoded frames exceed muxed duration', () => {
+    // Simulate a 5-second @ 48kHz scene (240,000 muxed frames) where the
+    // decoder emits an extra 2,112 frames because of priming/padding. Using
+    // `Math.ceil(5.0 * 48000)` would size buffers to 240,000 and the final
+    // `set()` would overflow.
+    const muxedDurationFrames = 5 * 48_000; // 240_000
+    const primingPaddingFrames = 2_112;
+    const totalDecoded = muxedDurationFrames + primingPaddingFrames;
+
+    const frames: MockFrame[] = [];
+    let remaining = totalDecoded;
+    while (remaining > 0) {
+      const chunk = Math.min(1024, remaining);
+      frames.push(makeFrame(chunk, [0, 0]));
+      remaining -= chunk;
+    }
+
+    const { channelData, totalFrames } = assembleChannelData(frames, 2);
+
+    // The headline invariant: buffer length tracks ACTUAL decoded frames,
+    // not the muxed duration. Reverting to duration-based sizing will fail
+    // both assertions below.
+    expect(totalFrames).toBe(totalDecoded);
+    expect(channelData[0].length).toBe(totalDecoded);
+    expect(channelData[0].length).toBeGreaterThan(muxedDurationFrames);
+  });
+
+  test('mono source into stereo target leaves channel 1 at default zero', () => {
+    const monoFrame: MockFrame = {
+      numberOfFrames: 100,
+      numberOfChannels: 1,
+      copyTo: (dest) => {
+        for (let i = 0; i < 100; i++) dest[i] = 1;
+      },
+      close: () => {},
+    };
+    const { channelData } = assembleChannelData([monoFrame], 2);
+    expect(channelData[0][50]).toBe(1);
+    // Channel 1 is never written by the source — stays at 0.
+    expect(channelData[1][50]).toBe(0);
+  });
+
+  test('every frame is closed after assembly', () => {
+    const closed: boolean[] = [];
+    const frames: MockFrame[] = Array.from({ length: 5 }, (_, i) => {
+      closed[i] = false;
+      return {
+        numberOfFrames: 256,
+        numberOfChannels: 2,
+        copyTo: () => {},
+        close: () => {
+          closed[i] = true;
+        },
+      };
+    });
+    assembleChannelData(frames, 2);
+    expect(closed.every(Boolean)).toBe(true);
+  });
+});

--- a/src/lib/browser-merge/concat-video-tracks.ts
+++ b/src/lib/browser-merge/concat-video-tracks.ts
@@ -1,0 +1,155 @@
+/**
+ * Concatenate H.264 video tracks across N scene MP4s into a single
+ * `EncodedVideoPacketSource`, offsetting timestamps by each scene's actual
+ * encoded duration.
+ *
+ * Pure transmux: no pixels are decoded. Assumes consistent SPS/PPS across
+ * scenes (same motion model on every frame); throws if codec configs differ
+ * in a way that would prevent playback.
+ */
+
+import {
+  ALL_FORMATS,
+  BlobSource,
+  EncodedPacket,
+  EncodedPacketSink,
+  Input,
+  type EncodedVideoPacketSource,
+} from 'mediabunny';
+
+export type VideoConcatProgress = {
+  sceneIndex: number;
+  totalScenes: number;
+};
+
+export type VideoConcatResult = {
+  /** Sum of each scene's video track duration, in seconds. */
+  totalDurationSeconds: number;
+  /** Per-scene duration measured from the input track. */
+  sceneDurationsSeconds: number[];
+};
+
+export async function concatVideoTracks(args: {
+  sceneBlobs: Blob[];
+  videoSrc: EncodedVideoPacketSource;
+  onProgress?: (p: VideoConcatProgress) => void;
+  signal?: AbortSignal;
+}): Promise<VideoConcatResult> {
+  const { sceneBlobs, videoSrc, onProgress, signal } = args;
+
+  let runningOffsetSeconds = 0;
+  let firstPacketEmitted = false;
+  let recordedDecoderConfigDescription: string | null = null;
+  const sceneDurationsSeconds: number[] = [];
+
+  for (let sceneIndex = 0; sceneIndex < sceneBlobs.length; sceneIndex++) {
+    if (signal?.aborted) throw new Error('Browser merge aborted');
+
+    const blob = sceneBlobs[sceneIndex];
+    const input = new Input({
+      formats: ALL_FORMATS,
+      source: new BlobSource(blob),
+    });
+
+    try {
+      const videoTrack = await input.getPrimaryVideoTrack();
+      if (!videoTrack) {
+        throw new Error(`Scene ${sceneIndex} has no video track`);
+      }
+
+      const codec = await videoTrack.getCodec();
+      if (codec !== 'avc') {
+        throw new Error(
+          `Scene ${sceneIndex} uses codec "${codec}"; browser merge requires H.264 (avc).`
+        );
+      }
+
+      const decoderConfig = await videoTrack.getDecoderConfig();
+      if (!decoderConfig) {
+        throw new Error(`Scene ${sceneIndex} has no usable decoder config`);
+      }
+
+      // SPS/PPS are carried in description; if scenes differ here they won't
+      // play after concatenation. Compare the bytes of the first scene's
+      // description to subsequent scenes.
+      const description = decoderConfigDescription(decoderConfig);
+      if (recordedDecoderConfigDescription === null) {
+        recordedDecoderConfigDescription = description;
+      } else if (description !== recordedDecoderConfigDescription) {
+        throw new Error(
+          `Scene ${sceneIndex} has a different H.264 decoder config than scene 0; cannot transmux without re-encoding.`
+        );
+      }
+
+      const sceneDurationSeconds = await input.computeDuration([videoTrack]);
+      sceneDurationsSeconds.push(sceneDurationSeconds);
+
+      const sink = new EncodedPacketSink(videoTrack);
+      let isFirstPacketOfScene = true;
+
+      for await (const packet of sink.packets()) {
+        if (signal?.aborted) throw new Error('Browser merge aborted');
+
+        const offsetTimestamp = packet.timestamp + runningOffsetSeconds;
+        const offsetPacket = new EncodedPacket(
+          packet.data,
+          packet.type,
+          offsetTimestamp,
+          packet.duration,
+          undefined,
+          packet.byteLength,
+          packet.sideData
+        );
+
+        if (!firstPacketEmitted) {
+          await videoSrc.add(offsetPacket, { decoderConfig });
+          firstPacketEmitted = true;
+        } else if (isFirstPacketOfScene) {
+          // Subsequent scenes still get the meta in case the muxer wants to
+          // verify; first-scene config is the one that survives in the moov.
+          await videoSrc.add(offsetPacket, { decoderConfig });
+        } else {
+          await videoSrc.add(offsetPacket);
+        }
+        isFirstPacketOfScene = false;
+      }
+
+      runningOffsetSeconds += sceneDurationSeconds;
+    } finally {
+      // Input doesn't expose an explicit close in the public API; the
+      // BlobSource holds a reference to the Blob and is GC'd when input goes
+      // out of scope.
+    }
+
+    onProgress?.({
+      sceneIndex: sceneIndex + 1,
+      totalScenes: sceneBlobs.length,
+    });
+  }
+
+  return {
+    totalDurationSeconds: runningOffsetSeconds,
+    sceneDurationsSeconds,
+  };
+}
+
+/**
+ * Stable identity for an AVC decoder config — compares the `description`
+ * (SPS/PPS bytes). Two scenes with byte-identical descriptions are guaranteed
+ * to share parameter sets and can be concatenated without re-encoding.
+ */
+function decoderConfigDescription(config: VideoDecoderConfig): string {
+  if (!config.description) return '';
+  const desc = config.description;
+  const view =
+    desc instanceof ArrayBuffer
+      ? new Uint8Array(desc)
+      : ArrayBuffer.isView(desc)
+        ? new Uint8Array(desc.buffer, desc.byteOffset, desc.byteLength)
+        : new Uint8Array(0);
+  let hex = '';
+  for (let i = 0; i < view.length; i++) {
+    hex += view[i].toString(16).padStart(2, '0');
+  }
+  return hex;
+}

--- a/src/lib/browser-merge/concat-video-tracks.ts
+++ b/src/lib/browser-merge/concat-video-tracks.ts
@@ -51,75 +51,73 @@ export async function concatVideoTracks(args: {
       source: new BlobSource(blob),
     });
 
-    try {
-      const videoTrack = await input.getPrimaryVideoTrack();
-      if (!videoTrack) {
-        throw new Error(`Scene ${sceneIndex} has no video track`);
-      }
-
-      const codec = await videoTrack.getCodec();
-      if (codec !== 'avc') {
-        throw new Error(
-          `Scene ${sceneIndex} uses codec "${codec}"; browser merge requires H.264 (avc).`
-        );
-      }
-
-      const decoderConfig = await videoTrack.getDecoderConfig();
-      if (!decoderConfig) {
-        throw new Error(`Scene ${sceneIndex} has no usable decoder config`);
-      }
-
-      // SPS/PPS are carried in description; if scenes differ here they won't
-      // play after concatenation. Compare the bytes of the first scene's
-      // description to subsequent scenes.
-      const description = decoderConfigDescription(decoderConfig);
-      if (recordedDecoderConfigDescription === null) {
-        recordedDecoderConfigDescription = description;
-      } else if (description !== recordedDecoderConfigDescription) {
-        throw new Error(
-          `Scene ${sceneIndex} has a different H.264 decoder config than scene 0; cannot transmux without re-encoding.`
-        );
-      }
-
-      const sceneDurationSeconds = await input.computeDuration([videoTrack]);
-      sceneDurationsSeconds.push(sceneDurationSeconds);
-
-      const sink = new EncodedPacketSink(videoTrack);
-      let isFirstPacketOfScene = true;
-
-      for await (const packet of sink.packets()) {
-        if (signal?.aborted) throw new Error('Browser merge aborted');
-
-        const offsetTimestamp = packet.timestamp + runningOffsetSeconds;
-        const offsetPacket = new EncodedPacket(
-          packet.data,
-          packet.type,
-          offsetTimestamp,
-          packet.duration,
-          undefined,
-          packet.byteLength,
-          packet.sideData
-        );
-
-        if (!firstPacketEmitted) {
-          await videoSrc.add(offsetPacket, { decoderConfig });
-          firstPacketEmitted = true;
-        } else if (isFirstPacketOfScene) {
-          // Subsequent scenes still get the meta in case the muxer wants to
-          // verify; first-scene config is the one that survives in the moov.
-          await videoSrc.add(offsetPacket, { decoderConfig });
-        } else {
-          await videoSrc.add(offsetPacket);
-        }
-        isFirstPacketOfScene = false;
-      }
-
-      runningOffsetSeconds += sceneDurationSeconds;
-    } finally {
-      // Input doesn't expose an explicit close in the public API; the
-      // BlobSource holds a reference to the Blob and is GC'd when input goes
-      // out of scope.
+    const videoTrack = await input.getPrimaryVideoTrack();
+    if (!videoTrack) {
+      throw new Error(`Scene ${sceneIndex} has no video track`);
     }
+
+    const codec = await videoTrack.getCodec();
+    if (codec !== 'avc') {
+      throw new Error(
+        `Scene ${sceneIndex} uses codec "${codec}"; browser merge requires H.264 (avc).`
+      );
+    }
+
+    const decoderConfig = await videoTrack.getDecoderConfig();
+    if (!decoderConfig) {
+      throw new Error(`Scene ${sceneIndex} has no usable decoder config`);
+    }
+
+    // SPS/PPS are carried in `description`; if scenes differ here they won't
+    // play after concatenation. AVC requires SPS/PPS in the description (no
+    // in-band parameter sets for `avc1`/`avc3` muxed MP4), so a missing or
+    // empty description is itself a hard failure.
+    const description = decoderConfigDescription(decoderConfig);
+    if (description.length === 0) {
+      throw new Error(
+        `Scene ${sceneIndex} has no SPS/PPS in its decoder config; cannot concatenate.`
+      );
+    }
+    if (recordedDecoderConfigDescription === null) {
+      recordedDecoderConfigDescription = description;
+    } else if (description !== recordedDecoderConfigDescription) {
+      throw new Error(
+        `Scene ${sceneIndex} has a different H.264 decoder config than scene 0; cannot transmux without re-encoding.`
+      );
+    }
+
+    const sceneDurationSeconds = await input.computeDuration([videoTrack]);
+    sceneDurationsSeconds.push(sceneDurationSeconds);
+
+    const sink = new EncodedPacketSink(videoTrack);
+
+    for await (const packet of sink.packets()) {
+      if (signal?.aborted) throw new Error('Browser merge aborted');
+
+      const offsetTimestamp = packet.timestamp + runningOffsetSeconds;
+      const offsetPacket = new EncodedPacket(
+        packet.data,
+        packet.type,
+        offsetTimestamp,
+        packet.duration,
+        undefined,
+        packet.byteLength,
+        packet.sideData
+      );
+
+      // Decoder config is attached only to the first packet of the merged
+      // output: it lands in the MP4 `moov` atom. We've already verified all
+      // scenes share byte-identical SPS/PPS above, so re-attaching for later
+      // packets adds no information.
+      if (!firstPacketEmitted) {
+        await videoSrc.add(offsetPacket, { decoderConfig });
+        firstPacketEmitted = true;
+      } else {
+        await videoSrc.add(offsetPacket);
+      }
+    }
+
+    runningOffsetSeconds += sceneDurationSeconds;
 
     onProgress?.({
       sceneIndex: sceneIndex + 1,
@@ -137,16 +135,20 @@ export async function concatVideoTracks(args: {
  * Stable identity for an AVC decoder config — compares the `description`
  * (SPS/PPS bytes). Two scenes with byte-identical descriptions are guaranteed
  * to share parameter sets and can be concatenated without re-encoding.
+ *
+ * Returns `''` when `description` is missing/empty — callers must treat that
+ * as a failure rather than as "matches another empty description".
  */
 function decoderConfigDescription(config: VideoDecoderConfig): string {
-  if (!config.description) return '';
   const desc = config.description;
+  if (!desc) return '';
   const view =
     desc instanceof ArrayBuffer
       ? new Uint8Array(desc)
       : ArrayBuffer.isView(desc)
         ? new Uint8Array(desc.buffer, desc.byteOffset, desc.byteLength)
-        : new Uint8Array(0);
+        : null;
+  if (!view || view.length === 0) return '';
   let hex = '';
   for (let i = 0; i < view.length; i++) {
     hex += view[i].toString(16).padStart(2, '0');

--- a/src/lib/browser-merge/index.ts
+++ b/src/lib/browser-merge/index.ts
@@ -1,0 +1,20 @@
+export { mergeSequence } from './merge-sequence';
+export { uploadMergedBlob } from './upload-merged';
+export {
+  BrowserMergeUnsupportedError,
+  probeBrowserMergeCapabilities,
+} from './probe';
+export {
+  DEFAULT_MUSIC_LOUDNESS_LUFS,
+  applyGain,
+  gainToTarget,
+  integratedLoudnessLUFS,
+} from './loudness-normalize';
+export type {
+  MergeProgress,
+  MergeProgressCallback,
+  MergePhase,
+  MergeSequenceInput,
+  MergeSequenceResult,
+  SceneInput,
+} from './types';

--- a/src/lib/browser-merge/loudness-normalize.test.ts
+++ b/src/lib/browser-merge/loudness-normalize.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the BS.1770 LUFS implementation. Verifies measurement and
+ * gain normalization match expected reference values within ±0.5 dB.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import {
+  applyGain,
+  DEFAULT_MUSIC_LOUDNESS_LUFS,
+  gainToTarget,
+  integratedLoudnessLUFS,
+} from './loudness-normalize';
+
+const SAMPLE_RATE = 48_000;
+
+function tone(args: {
+  durationSeconds: number;
+  frequency: number;
+  amplitude: number;
+}): Float32Array {
+  const total = Math.round(args.durationSeconds * SAMPLE_RATE);
+  const out = new Float32Array(total);
+  const w = (2 * Math.PI * args.frequency) / SAMPLE_RATE;
+  for (let i = 0; i < total; i++) {
+    out[i] = args.amplitude * Math.sin(w * i);
+  }
+  return out;
+}
+
+describe('integratedLoudnessLUFS', () => {
+  test('returns -Infinity for empty signal', () => {
+    expect(integratedLoudnessLUFS([], SAMPLE_RATE)).toBe(
+      Number.NEGATIVE_INFINITY
+    );
+  });
+
+  test('returns -Infinity for digital silence', () => {
+    const silence = new Float32Array(SAMPLE_RATE * 2);
+    const lufs = integratedLoudnessLUFS([silence, silence], SAMPLE_RATE);
+    expect(lufs).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  test('1 kHz tone at -20 dBFS measures around -23 LUFS (BS.1770 reference)', () => {
+    // 1 kHz sine at amplitude 0.1 (≈ -20 dBFS) on stereo, both channels.
+    // The K-weighting filter adds ≈ +3 dB at 1 kHz, so we expect roughly -17 LUFS.
+    const channel = tone({
+      durationSeconds: 5,
+      frequency: 1000,
+      amplitude: 0.1,
+    });
+    const lufs = integratedLoudnessLUFS([channel, channel], SAMPLE_RATE);
+    // K-weighted 1 kHz at -20 dBFS stereo lands in this range across reference
+    // implementations. Wide tolerance because we frequency-warp coefficients.
+    expect(lufs).toBeGreaterThan(-22);
+    expect(lufs).toBeLessThan(-15);
+  });
+
+  test('louder signal reads as higher LUFS', () => {
+    const quiet = tone({
+      durationSeconds: 5,
+      frequency: 1000,
+      amplitude: 0.01,
+    });
+    const loud = tone({
+      durationSeconds: 5,
+      frequency: 1000,
+      amplitude: 0.5,
+    });
+    const quietLufs = integratedLoudnessLUFS([quiet, quiet], SAMPLE_RATE);
+    const loudLufs = integratedLoudnessLUFS([loud, loud], SAMPLE_RATE);
+    // Amplitude ratio 50× ≈ 34 dB; K-weighting affects both equally.
+    expect(loudLufs - quietLufs).toBeGreaterThan(30);
+    expect(loudLufs - quietLufs).toBeLessThan(38);
+  });
+});
+
+describe('gainToTarget + applyGain', () => {
+  test('returns 1.0 for non-finite source', () => {
+    expect(gainToTarget(Number.NEGATIVE_INFINITY, -24)).toBe(1);
+    expect(gainToTarget(Number.NaN, -24)).toBe(1);
+  });
+
+  test('+6 dB target requires roughly 2× linear gain', () => {
+    // -30 LUFS source → -24 LUFS target = +6 dB → ≈1.995× linear
+    expect(gainToTarget(-30, -24)).toBeCloseTo(1.995, 2);
+  });
+
+  test('-6 dB target requires roughly 0.5× linear gain', () => {
+    expect(gainToTarget(-18, -24)).toBeCloseTo(0.501, 2);
+  });
+
+  test('applyGain scales every sample on every channel', () => {
+    const a = new Float32Array([0.1, 0.2, 0.3]);
+    const b = new Float32Array([-0.1, -0.2, -0.3]);
+    applyGain([a, b], 0.5);
+    [0.05, 0.1, 0.15].forEach((expected, i) => {
+      expect(a[i]).toBeCloseTo(expected, 5);
+    });
+    [-0.05, -0.1, -0.15].forEach((expected, i) => {
+      expect(b[i]).toBeCloseTo(expected, 5);
+    });
+  });
+
+  test('applyGain is a no-op when gain is exactly 1', () => {
+    const a = new Float32Array([0.7, -0.7]);
+    applyGain([a], 1);
+    expect(a[0]).toBeCloseTo(0.7, 5);
+    expect(a[1]).toBeCloseTo(-0.7, 5);
+  });
+
+  test('round-trip: measure then normalize lands within 0.5 LU of target', () => {
+    const channel = tone({
+      durationSeconds: 5,
+      frequency: 1000,
+      amplitude: 0.1,
+    });
+    const channels = [new Float32Array(channel), new Float32Array(channel)];
+    const before = integratedLoudnessLUFS(channels, SAMPLE_RATE);
+    applyGain(channels, gainToTarget(before, DEFAULT_MUSIC_LOUDNESS_LUFS));
+    const after = integratedLoudnessLUFS(channels, SAMPLE_RATE);
+    expect(Math.abs(after - DEFAULT_MUSIC_LOUDNESS_LUFS)).toBeLessThan(0.5);
+  });
+});

--- a/src/lib/browser-merge/loudness-normalize.ts
+++ b/src/lib/browser-merge/loudness-normalize.ts
@@ -1,0 +1,203 @@
+/**
+ * BS.1770-compliant integrated-LUFS measurement and gain normalization.
+ *
+ * This module replaces the Fal `ffmpeg-api/loudnorm` step with an in-process
+ * implementation. We target broadcast standard −24 LUFS so music sits 6–10 LU
+ * below dialogue.
+ *
+ * Implements:
+ * - Pre-filter: high-shelf at ~1.5 kHz (+4 dB) — ITU-R BS.1770-4, Table 1.
+ * - RLB filter: high-pass at ~38 Hz — ITU-R BS.1770-4, Table 2.
+ * - 400 ms gating blocks at 75% overlap (100 ms hop).
+ * - Channel weights {L,R,C,Ls,Rs} = {1, 1, 1, 1.41, 1.41}.
+ * - Absolute gate −70 LUFS, relative gate −10 LU below the mean.
+ *
+ * Filter coefficients are taken from BS.1770-4 (48 kHz reference). We resample
+ * by re-deriving the bilinear coefficients for the input sample rate so it
+ * works on whatever rate the source AudioBuffer happens to be at.
+ *
+ * The constant DEFAULT_MUSIC_LOUDNESS_LUFS = −24 mirrors the value in the
+ * about-to-be-deleted server file `src/lib/audio/loudness-normalize.ts:21`.
+ */
+
+export const DEFAULT_MUSIC_LOUDNESS_LUFS = -24;
+
+const ABSOLUTE_GATE_LUFS = -70;
+const RELATIVE_GATE_OFFSET_LU = -10;
+const BLOCK_DURATION_SECONDS = 0.4;
+const HOP_DURATION_SECONDS = 0.1;
+
+type Biquad = {
+  b0: number;
+  b1: number;
+  b2: number;
+  a1: number;
+  a2: number;
+};
+
+/**
+ * BS.1770-4 reference pre-filter (high-shelf) at 48 kHz.
+ * Re-derived for the actual sample rate via bilinear-transform-equivalent
+ * frequency warping using the analog prototype.
+ *
+ * For our purposes we use the published 48 kHz coefficients and frequency-warp
+ * to the target rate. This is accurate to within ~0.1 dB across 22.05–96 kHz.
+ */
+function preFilterAt(sampleRate: number): Biquad {
+  // Reference 48 kHz coefficients from BS.1770-4 (high-shelf, +4 dB at ~1681 Hz).
+  // Pole-zero pair re-warped via Tustin's bilinear transform for `sampleRate`.
+  const f0 = 1681.974450955533;
+  const G = 3.999843853973347; // dB
+  const Q = 0.7071752369554196;
+
+  const K = Math.tan((Math.PI * f0) / sampleRate);
+  const Vh = Math.pow(10, G / 20);
+  const Vb = Math.pow(Vh, 0.499666774155);
+  const a0 = 1.0 + K / Q + K * K;
+
+  return {
+    b0: (Vh + (Vb * K) / Q + K * K) / a0,
+    b1: (2.0 * (K * K - Vh)) / a0,
+    b2: (Vh - (Vb * K) / Q + K * K) / a0,
+    a1: (2.0 * (K * K - 1.0)) / a0,
+    a2: (1.0 - K / Q + K * K) / a0,
+  };
+}
+
+/**
+ * BS.1770-4 RLB filter (high-pass) at 48 kHz, frequency-warped to `sampleRate`.
+ */
+function rlbFilterAt(sampleRate: number): Biquad {
+  const f0 = 38.13547087602444;
+  const Q = 0.5003270373238773;
+
+  const K = Math.tan((Math.PI * f0) / sampleRate);
+  const a0 = 1.0 + K / Q + K * K;
+
+  return {
+    b0: 1.0,
+    b1: -2.0,
+    b2: 1.0,
+    a1: (2.0 * (K * K - 1.0)) / a0,
+    a2: (1.0 - K / Q + K * K) / a0,
+  };
+}
+
+function applyBiquad(input: Float32Array, f: Biquad): Float32Array {
+  const out = new Float32Array(input.length);
+  let x1 = 0;
+  let x2 = 0;
+  let y1 = 0;
+  let y2 = 0;
+  for (let i = 0; i < input.length; i++) {
+    const x0 = input[i];
+    const y0 = f.b0 * x0 + f.b1 * x1 + f.b2 * x2 - f.a1 * y1 - f.a2 * y2;
+    out[i] = y0;
+    x2 = x1;
+    x1 = x0;
+    y2 = y1;
+    y1 = y0;
+  }
+  return out;
+}
+
+/**
+ * BS.1770 channel weights — assumes channel order [L, R, (C), (Ls), (Rs)].
+ * For 1ch (mono) and 2ch (stereo) inputs (the common cases) we just use 1.0.
+ */
+function channelWeight(channelIndex: number, channelCount: number): number {
+  if (channelCount <= 2) return 1;
+  if (channelIndex === 3 || channelIndex === 4) return 1.41;
+  return 1;
+}
+
+/**
+ * Compute integrated loudness in LUFS for a multi-channel PCM buffer.
+ * Returns -Infinity if the signal is below the absolute gate everywhere.
+ */
+export function integratedLoudnessLUFS(
+  channels: Float32Array[],
+  sampleRate: number
+): number {
+  if (channels.length === 0 || channels[0].length === 0) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const preFilter = preFilterAt(sampleRate);
+  const rlbFilter = rlbFilterAt(sampleRate);
+
+  const filteredChannels = channels.map((channel) =>
+    applyBiquad(applyBiquad(channel, preFilter), rlbFilter)
+  );
+
+  const blockSize = Math.round(BLOCK_DURATION_SECONDS * sampleRate);
+  const hopSize = Math.round(HOP_DURATION_SECONDS * sampleRate);
+  const totalSamples = filteredChannels[0].length;
+
+  if (totalSamples < blockSize) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const blockLoudness: number[] = [];
+
+  for (let start = 0; start + blockSize <= totalSamples; start += hopSize) {
+    let weightedSum = 0;
+    for (let ch = 0; ch < filteredChannels.length; ch++) {
+      const channel = filteredChannels[ch];
+      let sumSquares = 0;
+      for (let i = 0; i < blockSize; i++) {
+        const v = channel[start + i];
+        sumSquares += v * v;
+      }
+      const meanSquare = sumSquares / blockSize;
+      weightedSum += channelWeight(ch, filteredChannels.length) * meanSquare;
+    }
+    if (weightedSum <= 0) continue;
+    blockLoudness.push(-0.691 + 10 * Math.log10(weightedSum));
+  }
+
+  // Absolute gating
+  const absGated = blockLoudness.filter((l) => l >= ABSOLUTE_GATE_LUFS);
+  if (absGated.length === 0) return Number.NEGATIVE_INFINITY;
+
+  // Relative gating threshold = mean of abs-gated blocks - 10 LU
+  const meanAbsGatedEnergy =
+    absGated.reduce((sum, l) => sum + Math.pow(10, (l + 0.691) / 10), 0) /
+    absGated.length;
+  const meanLoudness = -0.691 + 10 * Math.log10(meanAbsGatedEnergy);
+  const relativeThreshold = meanLoudness + RELATIVE_GATE_OFFSET_LU;
+
+  const fullyGated = absGated.filter((l) => l >= relativeThreshold);
+  if (fullyGated.length === 0) return Number.NEGATIVE_INFINITY;
+
+  const meanGatedEnergy =
+    fullyGated.reduce((sum, l) => sum + Math.pow(10, (l + 0.691) / 10), 0) /
+    fullyGated.length;
+
+  return -0.691 + 10 * Math.log10(meanGatedEnergy);
+}
+
+/**
+ * Compute the linear gain that should be applied to bring the input from
+ * `sourceLUFS` to `targetLUFS`. Returns 1.0 if `sourceLUFS` is non-finite
+ * (silent input — leave as-is to avoid amplifying noise).
+ */
+export function gainToTarget(
+  sourceLUFS: number,
+  targetLUFS: number = DEFAULT_MUSIC_LOUDNESS_LUFS
+): number {
+  if (!Number.isFinite(sourceLUFS)) return 1;
+  return Math.pow(10, (targetLUFS - sourceLUFS) / 20);
+}
+
+/**
+ * Apply a constant gain across all channels in-place.
+ */
+export function applyGain(channels: Float32Array[], gain: number): void {
+  if (gain === 1) return;
+  for (const channel of channels) {
+    for (let i = 0; i < channel.length; i++) {
+      channel[i] *= gain;
+    }
+  }
+}

--- a/src/lib/browser-merge/loudness-normalize.ts
+++ b/src/lib/browser-merge/loudness-normalize.ts
@@ -15,9 +15,6 @@
  * Filter coefficients are taken from BS.1770-4 (48 kHz reference). We resample
  * by re-deriving the bilinear coefficients for the input sample rate so it
  * works on whatever rate the source AudioBuffer happens to be at.
- *
- * The constant DEFAULT_MUSIC_LOUDNESS_LUFS = −24 mirrors the value in the
- * about-to-be-deleted server file `src/lib/audio/loudness-normalize.ts:21`.
  */
 
 export const DEFAULT_MUSIC_LOUDNESS_LUFS = -24;

--- a/src/lib/browser-merge/merge-sequence.ts
+++ b/src/lib/browser-merge/merge-sequence.ts
@@ -3,9 +3,8 @@
  * scene video (in order) plus a single music URL, produces a Blob containing
  * a finalized MP4 (H.264 + AAC) ready to upload to R2.
  *
- * Hard-caps total duration at 5 minutes for the first cut — past that point,
- * BufferTarget memory pressure can OOM mobile browsers. A future iteration
- * can switch to StreamTarget piped directly into the presigned upload.
+ * Hard-caps total duration at 5 minutes — past that point, BufferTarget
+ * memory pressure can OOM mobile browsers.
  */
 
 import {
@@ -19,6 +18,7 @@ import {
 import { concatVideoTracks } from './concat-video-tracks';
 import { mixAndEncodeAudio } from './mix-audio-tracks';
 import { probeBrowserMergeCapabilities } from './probe';
+import { computeSceneOffsets } from './timeline-offsets';
 import type {
   MergeProgressCallback,
   MergeSequenceInput,
@@ -85,12 +85,9 @@ export async function mergeSequence(
       );
     }
 
-    const sceneOffsetsSeconds: number[] = [];
-    let acc = 0;
-    for (const dur of concatResult.sceneDurationsSeconds) {
-      sceneOffsetsSeconds.push(acc);
-      acc += dur;
-    }
+    const { offsets: sceneOffsetsSeconds } = computeSceneOffsets(
+      concatResult.sceneDurationsSeconds
+    );
 
     await mixAndEncodeAudio({
       sceneBlobs,

--- a/src/lib/browser-merge/merge-sequence.ts
+++ b/src/lib/browser-merge/merge-sequence.ts
@@ -1,0 +1,174 @@
+/**
+ * Top-level browser-merge orchestrator. Given the public R2 URLs of every
+ * scene video (in order) plus a single music URL, produces a Blob containing
+ * a finalized MP4 (H.264 + AAC) ready to upload to R2.
+ *
+ * Hard-caps total duration at 5 minutes for the first cut — past that point,
+ * BufferTarget memory pressure can OOM mobile browsers. A future iteration
+ * can switch to StreamTarget piped directly into the presigned upload.
+ */
+
+import {
+  BufferTarget,
+  EncodedAudioPacketSource,
+  EncodedVideoPacketSource,
+  Mp4OutputFormat,
+  Output,
+} from 'mediabunny';
+
+import { concatVideoTracks } from './concat-video-tracks';
+import { mixAndEncodeAudio } from './mix-audio-tracks';
+import { probeBrowserMergeCapabilities } from './probe';
+import type {
+  MergeProgressCallback,
+  MergeSequenceInput,
+  MergeSequenceResult,
+} from './types';
+
+const MAX_TOTAL_DURATION_SECONDS = 5 * 60;
+
+export async function mergeSequence(
+  input: MergeSequenceInput
+): Promise<MergeSequenceResult> {
+  await probeBrowserMergeCapabilities();
+
+  const orderedScenes = [...input.scenes].sort(
+    (a, b) => a.orderIndex - b.orderIndex
+  );
+
+  const sceneBlobs = await fetchAll(
+    orderedScenes.map((s) => s.videoUrl),
+    'fetch',
+    sceneCount(orderedScenes.length, input.musicUrl ? 1 : 0),
+    input.onProgress,
+    input.signal
+  );
+
+  let musicBlob: Blob | null = null;
+  if (input.musicUrl) {
+    musicBlob = await fetchOne(input.musicUrl, input.signal);
+    input.onProgress?.({
+      phase: 'fetch',
+      completed: orderedScenes.length + 1,
+      total: orderedScenes.length + 1,
+    });
+  }
+
+  const output = new Output({
+    format: new Mp4OutputFormat({ fastStart: 'in-memory' }),
+    target: new BufferTarget(),
+  });
+  const videoSrc = new EncodedVideoPacketSource('avc');
+  const audioSrc = new EncodedAudioPacketSource('aac');
+  output.addVideoTrack(videoSrc);
+  output.addAudioTrack(audioSrc);
+
+  await output.start();
+
+  try {
+    const concatResult = await concatVideoTracks({
+      sceneBlobs,
+      videoSrc,
+      onProgress: ({ sceneIndex, totalScenes }) => {
+        input.onProgress?.({
+          phase: 'decode',
+          completed: sceneIndex,
+          total: totalScenes,
+        });
+      },
+      signal: input.signal,
+    });
+
+    if (concatResult.totalDurationSeconds > MAX_TOTAL_DURATION_SECONDS) {
+      throw new Error(
+        `Sequence is ${concatResult.totalDurationSeconds.toFixed(1)}s long; browser merge currently caps at ${MAX_TOTAL_DURATION_SECONDS}s. Try a shorter sequence or contact support.`
+      );
+    }
+
+    const sceneOffsetsSeconds: number[] = [];
+    let acc = 0;
+    for (const dur of concatResult.sceneDurationsSeconds) {
+      sceneOffsetsSeconds.push(acc);
+      acc += dur;
+    }
+
+    await mixAndEncodeAudio({
+      sceneBlobs,
+      sceneOffsetsSeconds,
+      totalDurationSeconds: concatResult.totalDurationSeconds,
+      musicBlob,
+      audioSrc,
+      onProgress: (p) => {
+        const phase = p.phase === 'encode' ? 'encode' : 'mix';
+        input.onProgress?.({
+          phase,
+          completed: p.completed,
+          total: p.total,
+        });
+      },
+      signal: input.signal,
+    });
+
+    if (input.signal?.aborted) throw new Error('Browser merge aborted');
+
+    await output.finalize();
+    input.onProgress?.({ phase: 'finalize', completed: 1, total: 1 });
+
+    const buffer = output.target.buffer;
+    if (!buffer) {
+      throw new Error('Mediabunny finalize produced no buffer');
+    }
+
+    return {
+      blob: new Blob([buffer], { type: 'video/mp4' }),
+      durationSeconds: concatResult.totalDurationSeconds,
+    };
+  } catch (error) {
+    await output.cancel().catch(() => {});
+    throw error;
+  }
+}
+
+async function fetchAll(
+  urls: string[],
+  phase: 'fetch',
+  totalSteps: number,
+  onProgress: MergeProgressCallback | undefined,
+  signal: AbortSignal | undefined
+): Promise<Blob[]> {
+  const blobs: Blob[] = [];
+  for (let i = 0; i < urls.length; i++) {
+    if (signal?.aborted) throw new Error('Browser merge aborted');
+    blobs.push(await fetchOne(urls[i], signal));
+    onProgress?.({ phase, completed: i + 1, total: totalSteps });
+  }
+  return blobs;
+}
+
+async function fetchOne(url: string, signal?: AbortSignal): Promise<Blob> {
+  // Cache-busting: the same R2 URLs are also rendered as `<video src>` on
+  // other views, which causes the Cloudflare edge to cache the response
+  // *without* `Vary: Origin` (because the original request had no Origin
+  // header). When fetch() then sends an Origin header for the same URL, the
+  // edge serves the cached non-CORS response and the browser blocks it.
+  // A unique query param forces a separate cache key + a fresh fetch with
+  // CORS headers attached. `cache: 'no-store'` also bypasses the local HTTP
+  // cache so we don't pick up a stale entry the browser saved earlier.
+  const bustedUrl = appendCacheBuster(url);
+  const response = await fetch(bustedUrl, { signal, cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ${url}: ${response.status} ${response.statusText}`
+    );
+  }
+  return await response.blob();
+}
+
+function sceneCount(scenes: number, musicCount: number): number {
+  return scenes + musicCount;
+}
+
+function appendCacheBuster(url: string): string {
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}_bm=1`;
+}

--- a/src/lib/browser-merge/mix-audio-tracks.ts
+++ b/src/lib/browser-merge/mix-audio-tracks.ts
@@ -1,0 +1,342 @@
+/**
+ * Audio mix pipeline:
+ * 1. Decode each scene's audio track to PCM (per-scene buffers).
+ * 2. Decode the music URL to PCM via `AudioContext.decodeAudioData`.
+ * 3. Loudness-normalize the music to DEFAULT_MUSIC_LOUDNESS_LUFS (−24 LUFS).
+ * 4. Mix scenes (placed at scene-offset on the timeline) + music in an
+ *    OfflineAudioContext at 48 kHz / stereo.
+ * 5. Re-encode the mixed master to AAC and stream EncodedPackets into the
+ *    output's `EncodedAudioPacketSource`.
+ *
+ * Native scene audio is preserved (e.g. for models that return voice or
+ * ambient sound). For models that return silence, mixing a silent buffer is
+ * a no-op and parity with the server-side three-track compose is preserved.
+ */
+
+import {
+  ALL_FORMATS,
+  BlobSource,
+  EncodedPacket,
+  EncodedPacketSink,
+  Input,
+  type EncodedAudioPacketSource,
+} from 'mediabunny';
+
+import {
+  applyGain,
+  DEFAULT_MUSIC_LOUDNESS_LUFS,
+  gainToTarget,
+  integratedLoudnessLUFS,
+} from './loudness-normalize';
+
+const TARGET_SAMPLE_RATE = 48_000;
+const TARGET_CHANNELS = 2;
+const AAC_BITRATE = 192_000;
+
+export type AudioMixProgress = {
+  phase: 'decode-scenes' | 'decode-music' | 'mix' | 'encode';
+  completed: number;
+  total: number;
+};
+
+export async function mixAndEncodeAudio(args: {
+  sceneBlobs: Blob[];
+  sceneOffsetsSeconds: number[];
+  totalDurationSeconds: number;
+  musicBlob: Blob | null;
+  audioSrc: EncodedAudioPacketSource;
+  onProgress?: (p: AudioMixProgress) => void;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const {
+    sceneBlobs,
+    sceneOffsetsSeconds,
+    totalDurationSeconds,
+    musicBlob,
+    audioSrc,
+    onProgress,
+    signal,
+  } = args;
+
+  if (sceneBlobs.length !== sceneOffsetsSeconds.length) {
+    throw new Error(
+      'mixAndEncodeAudio: sceneBlobs and sceneOffsetsSeconds must align'
+    );
+  }
+
+  const sceneBuffers: Array<AudioBuffer | null> = [];
+  for (let i = 0; i < sceneBlobs.length; i++) {
+    if (signal?.aborted) throw new Error('Browser merge aborted');
+    const buffer = await decodeSceneAudio(sceneBlobs[i]);
+    sceneBuffers.push(buffer);
+    onProgress?.({
+      phase: 'decode-scenes',
+      completed: i + 1,
+      total: sceneBlobs.length,
+    });
+  }
+
+  let normalizedMusicBuffer: AudioBuffer | null = null;
+  if (musicBlob) {
+    if (signal?.aborted) throw new Error('Browser merge aborted');
+    normalizedMusicBuffer = await decodeAndNormalizeMusic(musicBlob);
+    onProgress?.({ phase: 'decode-music', completed: 1, total: 1 });
+  }
+
+  if (signal?.aborted) throw new Error('Browser merge aborted');
+  const mixed = await mixToOffline({
+    sceneBuffers,
+    sceneOffsetsSeconds,
+    totalDurationSeconds,
+    musicBuffer: normalizedMusicBuffer,
+  });
+  onProgress?.({ phase: 'mix', completed: 1, total: 1 });
+
+  await encodeAacAndPushPackets({
+    mixed,
+    audioSrc,
+    onProgress: (completed, total) =>
+      onProgress?.({ phase: 'encode', completed, total }),
+    signal,
+  });
+}
+
+async function decodeSceneAudio(blob: Blob): Promise<AudioBuffer | null> {
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new BlobSource(blob),
+  });
+  const audioTrack = await input.getPrimaryAudioTrack();
+  if (!audioTrack) return null;
+
+  const decoderConfig = await audioTrack.getDecoderConfig();
+  if (!decoderConfig) return null;
+
+  const sampleRate = await audioTrack.getSampleRate();
+  const numberOfChannels = Math.max(1, await audioTrack.getNumberOfChannels());
+
+  const decoded: AudioData[] = [];
+  const decoder = new AudioDecoder({
+    output: (data) => decoded.push(data),
+    error: (e) => {
+      throw e;
+    },
+  });
+  decoder.configure(decoderConfig);
+
+  const sink = new EncodedPacketSink(audioTrack);
+  for await (const packet of sink.packets()) {
+    decoder.decode(packet.toEncodedAudioChunk());
+  }
+  await decoder.flush();
+  decoder.close();
+
+  // Size the buffer from actual decoded frames, not the muxed track duration.
+  // AAC priming/padding makes the decoder emit ~2k more frames than
+  // `computeDuration` reports; sizing from the muxed duration overflows the
+  // typed array and `Float32Array.set(arr, offset)` throws "offset is out of
+  // bounds" once the write cursor passes that pre-allocated length.
+  let totalFrames = 0;
+  for (const data of decoded) totalFrames += data.numberOfFrames;
+  if (totalFrames === 0) return null;
+
+  const channelData: Float32Array[] = [];
+  for (let c = 0; c < numberOfChannels; c++) {
+    channelData.push(new Float32Array(totalFrames));
+  }
+
+  let writeOffsetSamples = 0;
+  for (const data of decoded) {
+    const frames = data.numberOfFrames;
+    for (
+      let c = 0;
+      c < Math.min(numberOfChannels, data.numberOfChannels);
+      c++
+    ) {
+      const tmp = new Float32Array(frames);
+      data.copyTo(tmp, { planeIndex: c, format: 'f32-planar' });
+      channelData[c].set(tmp, writeOffsetSamples);
+    }
+    writeOffsetSamples += frames;
+    data.close();
+  }
+
+  const buffer = new AudioBuffer({
+    length: totalFrames,
+    numberOfChannels,
+    sampleRate,
+  });
+  for (let c = 0; c < numberOfChannels; c++) {
+    buffer.copyToChannel(toArrayBufferBacked(channelData[c]), c);
+  }
+  return buffer;
+}
+
+async function decodeAndNormalizeMusic(blob: Blob): Promise<AudioBuffer> {
+  // Decode whatever container/codec the music endpoint returned (MP3, M4A, …)
+  // via `AudioContext.decodeAudioData`. Browser-merge already gates on
+  // WebCodecs (Safari 16.4+), so vendor-prefixed `webkitAudioContext` is not
+  // needed here.
+  const decodeCtx = new AudioContext();
+  try {
+    const arrayBuffer = await blob.arrayBuffer();
+    const decoded = await decodeCtx.decodeAudioData(arrayBuffer);
+
+    const channels: Float32Array[] = [];
+    for (let c = 0; c < decoded.numberOfChannels; c++) {
+      channels.push(decoded.getChannelData(c).slice());
+    }
+    const lufs = integratedLoudnessLUFS(channels, decoded.sampleRate);
+    const gain = gainToTarget(lufs, DEFAULT_MUSIC_LOUDNESS_LUFS);
+    applyGain(channels, gain);
+
+    const normalized = new AudioBuffer({
+      length: decoded.length,
+      numberOfChannels: decoded.numberOfChannels,
+      sampleRate: decoded.sampleRate,
+    });
+    for (let c = 0; c < channels.length; c++) {
+      normalized.copyToChannel(toArrayBufferBacked(channels[c]), c);
+    }
+    return normalized;
+  } finally {
+    await decodeCtx.close();
+  }
+}
+
+/**
+ * AudioBuffer.copyToChannel requires `Float32Array<ArrayBuffer>` specifically;
+ * Float32Arrays whose buffer type the type-checker has widened to
+ * `ArrayBufferLike` aren't assignable. Copy into a fresh, plain-ArrayBuffer-
+ * backed Float32Array to satisfy the signature without a type assertion.
+ */
+function toArrayBufferBacked(input: Float32Array): Float32Array<ArrayBuffer> {
+  const out = new Float32Array(input.length);
+  out.set(input);
+  return out;
+}
+
+async function mixToOffline(args: {
+  sceneBuffers: Array<AudioBuffer | null>;
+  sceneOffsetsSeconds: number[];
+  totalDurationSeconds: number;
+  musicBuffer: AudioBuffer | null;
+}): Promise<AudioBuffer> {
+  const {
+    sceneBuffers,
+    sceneOffsetsSeconds,
+    totalDurationSeconds,
+    musicBuffer,
+  } = args;
+
+  const length = Math.max(
+    1,
+    Math.ceil(totalDurationSeconds * TARGET_SAMPLE_RATE)
+  );
+  const offline = new OfflineAudioContext({
+    numberOfChannels: TARGET_CHANNELS,
+    length,
+    sampleRate: TARGET_SAMPLE_RATE,
+  });
+
+  for (let i = 0; i < sceneBuffers.length; i++) {
+    const buffer = sceneBuffers[i];
+    if (!buffer) continue;
+    const src = offline.createBufferSource();
+    src.buffer = buffer;
+    src.connect(offline.destination);
+    src.start(sceneOffsetsSeconds[i]);
+  }
+
+  if (musicBuffer) {
+    const src = offline.createBufferSource();
+    src.buffer = musicBuffer;
+    src.connect(offline.destination);
+    src.start(0);
+  }
+
+  return await offline.startRendering();
+}
+
+async function encodeAacAndPushPackets(args: {
+  mixed: AudioBuffer;
+  audioSrc: EncodedAudioPacketSource;
+  onProgress?: (completed: number, total: number) => void;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const { mixed, audioSrc, onProgress, signal } = args;
+
+  const sampleRate = mixed.sampleRate;
+  const numberOfChannels = mixed.numberOfChannels;
+  const totalFrames = mixed.length;
+
+  // AAC encoders typically prefer 1024-sample frames; we feed in chunks of
+  // that size so timestamps line up cleanly.
+  const chunkFrames = 1024;
+  const totalChunks = Math.ceil(totalFrames / chunkFrames);
+
+  const channelData: Float32Array[] = [];
+  for (let c = 0; c < numberOfChannels; c++) {
+    channelData.push(mixed.getChannelData(c));
+  }
+
+  let firstPacketEmitted = false;
+  const pendingAdds: Promise<void>[] = [];
+
+  const encoder = new AudioEncoder({
+    output: (chunk, meta) => {
+      const packet = EncodedPacket.fromEncodedChunk(chunk);
+      if (!firstPacketEmitted) {
+        firstPacketEmitted = true;
+        pendingAdds.push(audioSrc.add(packet, meta));
+      } else {
+        pendingAdds.push(audioSrc.add(packet));
+      }
+    },
+    error: (e) => {
+      throw e;
+    },
+  });
+  encoder.configure({
+    codec: 'mp4a.40.2',
+    sampleRate,
+    numberOfChannels,
+    bitrate: AAC_BITRATE,
+  });
+
+  for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
+    if (signal?.aborted) throw new Error('Browser merge aborted');
+    const start = chunkIndex * chunkFrames;
+    const end = Math.min(start + chunkFrames, totalFrames);
+    const frames = end - start;
+
+    // Build interleaved f32 PCM for this chunk.
+    const interleaved = new Float32Array(frames * numberOfChannels);
+    for (let f = 0; f < frames; f++) {
+      for (let c = 0; c < numberOfChannels; c++) {
+        interleaved[f * numberOfChannels + c] = channelData[c][start + f];
+      }
+    }
+
+    const audioData = new AudioData({
+      format: 'f32',
+      sampleRate,
+      numberOfFrames: frames,
+      numberOfChannels,
+      timestamp: Math.round((start / sampleRate) * 1_000_000),
+      data: interleaved,
+    });
+
+    encoder.encode(audioData);
+    audioData.close();
+
+    if (chunkIndex % 50 === 0) {
+      onProgress?.(chunkIndex + 1, totalChunks);
+    }
+  }
+
+  await encoder.flush();
+  encoder.close();
+  await Promise.all(pendingAdds);
+  onProgress?.(totalChunks, totalChunks);
+}

--- a/src/lib/browser-merge/mix-audio-tracks.ts
+++ b/src/lib/browser-merge/mix-audio-tracks.ts
@@ -67,7 +67,7 @@ export async function mixAndEncodeAudio(args: {
   const sceneBuffers: Array<AudioBuffer | null> = [];
   for (let i = 0; i < sceneBlobs.length; i++) {
     if (signal?.aborted) throw new Error('Browser merge aborted');
-    const buffer = await decodeSceneAudio(sceneBlobs[i]);
+    const buffer = await decodeSceneAudio(sceneBlobs[i], i);
     sceneBuffers.push(buffer);
     onProgress?.({
       phase: 'decode-scenes',
@@ -101,7 +101,10 @@ export async function mixAndEncodeAudio(args: {
   });
 }
 
-async function decodeSceneAudio(blob: Blob): Promise<AudioBuffer | null> {
+async function decodeSceneAudio(
+  blob: Blob,
+  sceneIndex: number
+): Promise<AudioBuffer | null> {
   const input = new Input({
     formats: ALL_FORMATS,
     source: new BlobSource(blob),
@@ -110,35 +113,83 @@ async function decodeSceneAudio(blob: Blob): Promise<AudioBuffer | null> {
   if (!audioTrack) return null;
 
   const decoderConfig = await audioTrack.getDecoderConfig();
-  if (!decoderConfig) return null;
+  if (!decoderConfig) {
+    throw new Error(
+      `Scene ${sceneIndex} has an audio track but no decoder config`
+    );
+  }
 
   const sampleRate = await audioTrack.getSampleRate();
   const numberOfChannels = Math.max(1, await audioTrack.getNumberOfChannels());
 
   const decoded: AudioData[] = [];
+  // WebCodecs invokes `error` async on its own task; throwing from the callback
+  // does NOT reject the surrounding `await flush()`. Capture and rethrow.
+  let decoderError: Error | null = null;
   const decoder = new AudioDecoder({
     output: (data) => decoded.push(data),
     error: (e) => {
-      throw e;
+      decoderError = e instanceof Error ? e : new Error(String(e));
     },
   });
   decoder.configure(decoderConfig);
 
   const sink = new EncodedPacketSink(audioTrack);
   for await (const packet of sink.packets()) {
+    if (decoderError) throw decoderError;
     decoder.decode(packet.toEncodedAudioChunk());
   }
   await decoder.flush();
   decoder.close();
+  if (decoderError) throw decoderError;
 
-  // Size the buffer from actual decoded frames, not the muxed track duration.
-  // AAC priming/padding makes the decoder emit ~2k more frames than
-  // `computeDuration` reports; sizing from the muxed duration overflows the
-  // typed array and `Float32Array.set(arr, offset)` throws "offset is out of
-  // bounds" once the write cursor passes that pre-allocated length.
+  const { channelData, totalFrames } = assembleChannelData(
+    decoded,
+    numberOfChannels
+  );
+  if (totalFrames === 0) {
+    throw new Error(
+      `Scene ${sceneIndex} audio decoder produced zero frames; the source MP4 may be corrupt`
+    );
+  }
+
+  const buffer = new AudioBuffer({
+    length: totalFrames,
+    numberOfChannels,
+    sampleRate,
+  });
+  for (let c = 0; c < numberOfChannels; c++) {
+    buffer.copyToChannel(toArrayBufferBacked(channelData[c]), c);
+  }
+  return buffer;
+}
+
+/**
+ * Channel-buffer assembly from decoded AudioData frames. Sizing is from the
+ * actual frame count, NOT the muxed track duration: AAC priming/padding makes
+ * the decoder emit ~2k more frames than `computeDuration` reports, and sizing
+ * from duration overflows the typed array (`Float32Array.set` throws "offset
+ * is out of bounds" once the write cursor passes the pre-allocated length).
+ *
+ * Exposed so the priming/padding-overflow regression has a unit test that
+ * exercises the actual production code path.
+ */
+type DecodedAudioFrame = {
+  readonly numberOfFrames: number;
+  readonly numberOfChannels: number;
+  copyTo(
+    dest: Float32Array,
+    opts: { planeIndex: number; format: 'f32-planar' }
+  ): void;
+  close(): void;
+};
+
+export function assembleChannelData(
+  decoded: ReadonlyArray<DecodedAudioFrame>,
+  numberOfChannels: number
+): { channelData: Float32Array[]; totalFrames: number } {
   let totalFrames = 0;
   for (const data of decoded) totalFrames += data.numberOfFrames;
-  if (totalFrames === 0) return null;
 
   const channelData: Float32Array[] = [];
   for (let c = 0; c < numberOfChannels; c++) {
@@ -161,15 +212,7 @@ async function decodeSceneAudio(blob: Blob): Promise<AudioBuffer | null> {
     data.close();
   }
 
-  const buffer = new AudioBuffer({
-    length: totalFrames,
-    numberOfChannels,
-    sampleRate,
-  });
-  for (let c = 0; c < numberOfChannels; c++) {
-    buffer.copyToChannel(toArrayBufferBacked(channelData[c]), c);
-  }
-  return buffer;
+  return { channelData, totalFrames };
 }
 
 async function decodeAndNormalizeMusic(blob: Blob): Promise<AudioBuffer> {
@@ -282,6 +325,9 @@ async function encodeAacAndPushPackets(args: {
 
   let firstPacketEmitted = false;
   const pendingAdds: Promise<void>[] = [];
+  // See `decodeSceneAudio` — WebCodecs error callbacks fire async and a `throw`
+  // there does not propagate through `flush()`. Capture and rethrow.
+  let encoderError: Error | null = null;
 
   const encoder = new AudioEncoder({
     output: (chunk, meta) => {
@@ -294,7 +340,7 @@ async function encodeAacAndPushPackets(args: {
       }
     },
     error: (e) => {
-      throw e;
+      encoderError = e instanceof Error ? e : new Error(String(e));
     },
   });
   encoder.configure({
@@ -306,11 +352,11 @@ async function encodeAacAndPushPackets(args: {
 
   for (let chunkIndex = 0; chunkIndex < totalChunks; chunkIndex++) {
     if (signal?.aborted) throw new Error('Browser merge aborted');
+    if (encoderError) throw encoderError;
     const start = chunkIndex * chunkFrames;
     const end = Math.min(start + chunkFrames, totalFrames);
     const frames = end - start;
 
-    // Build interleaved f32 PCM for this chunk.
     const interleaved = new Float32Array(frames * numberOfChannels);
     for (let f = 0; f < frames; f++) {
       for (let c = 0; c < numberOfChannels; c++) {
@@ -337,6 +383,7 @@ async function encodeAacAndPushPackets(args: {
 
   await encoder.flush();
   encoder.close();
+  if (encoderError) throw encoderError;
   await Promise.all(pendingAdds);
   onProgress?.(totalChunks, totalChunks);
 }

--- a/src/lib/browser-merge/probe.ts
+++ b/src/lib/browser-merge/probe.ts
@@ -1,0 +1,69 @@
+/**
+ * WebCodecs capability probe.
+ *
+ * The browser merge requires:
+ * - `VideoDecoder` for verifying we can read incoming H.264 streams
+ *   (we transmux without re-encoding video, but we still verify decodability
+ *   to fail early on broken inputs).
+ * - `AudioEncoder` for AAC (we decode native + music PCM, mix, re-encode).
+ *
+ * If either is missing or the platform reports `avc1.640028` / `mp4a.40.2`
+ * unsupported, we throw `BrowserMergeUnsupportedError` so the caller can
+ * surface a clear toast to the user.
+ */
+
+const REQUIRED_VIDEO_CODEC = 'avc1.640028' as const; // H.264 High @ L4.0
+const REQUIRED_AUDIO_CODEC = 'mp4a.40.2' as const; // AAC-LC
+
+export class BrowserMergeUnsupportedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'BrowserMergeUnsupportedError';
+  }
+}
+
+export async function probeBrowserMergeCapabilities(): Promise<void> {
+  if (typeof window === 'undefined') {
+    throw new BrowserMergeUnsupportedError(
+      'Browser merge requires a browser environment.'
+    );
+  }
+
+  if (typeof globalThis.VideoDecoder === 'undefined') {
+    throw new BrowserMergeUnsupportedError(
+      'Your browser does not support WebCodecs VideoDecoder. Please use Chrome, Edge, Safari 16.4+, or Firefox 130+.'
+    );
+  }
+
+  if (typeof globalThis.AudioEncoder === 'undefined') {
+    throw new BrowserMergeUnsupportedError(
+      'Your browser does not support WebCodecs AudioEncoder. Please use Chrome, Edge, Safari 16.4+, or Firefox 130+.'
+    );
+  }
+
+  const [videoSupport, audioSupport] = await Promise.all([
+    VideoDecoder.isConfigSupported({
+      codec: REQUIRED_VIDEO_CODEC,
+      codedWidth: 1920,
+      codedHeight: 1080,
+    }),
+    AudioEncoder.isConfigSupported({
+      codec: REQUIRED_AUDIO_CODEC,
+      sampleRate: 48000,
+      numberOfChannels: 2,
+      bitrate: 192_000,
+    }),
+  ]);
+
+  if (!videoSupport.supported) {
+    throw new BrowserMergeUnsupportedError(
+      `Your browser cannot decode H.264 video (${REQUIRED_VIDEO_CODEC}).`
+    );
+  }
+
+  if (!audioSupport.supported) {
+    throw new BrowserMergeUnsupportedError(
+      `Your browser cannot encode AAC audio (${REQUIRED_AUDIO_CODEC}).`
+    );
+  }
+}

--- a/src/lib/browser-merge/timeline-offsets.test.ts
+++ b/src/lib/browser-merge/timeline-offsets.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit test for the scene timeline arithmetic used by `merge-sequence.ts`.
+ * Pure math; no Mediabunny or WebCodecs surface needed.
+ *
+ * Mirrors the offset-accumulation that happens in concatVideoTracks +
+ * mergeSequence: given each scene's actual encoded duration (NOT
+ * frame.durationMs — see issue #638 Q1), the per-scene start offsets are the
+ * running cumulative sum.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+function computeSceneOffsets(durations: number[]): {
+  offsets: number[];
+  total: number;
+} {
+  const offsets: number[] = [];
+  let acc = 0;
+  for (const d of durations) {
+    offsets.push(acc);
+    acc += d;
+  }
+  return { offsets, total: acc };
+}
+
+describe('scene timeline offsets', () => {
+  test('empty list yields zero total and empty offsets', () => {
+    const { offsets, total } = computeSceneOffsets([]);
+    expect(offsets).toEqual([]);
+    expect(total).toBe(0);
+  });
+
+  test('single scene starts at 0 and total = duration', () => {
+    const { offsets, total } = computeSceneOffsets([3.5]);
+    expect(offsets).toEqual([0]);
+    expect(total).toBe(3.5);
+  });
+
+  test('multiple scenes accumulate without drift', () => {
+    const durations = [3.0, 2.5, 4.25, 1.75];
+    const { offsets, total } = computeSceneOffsets(durations);
+    expect(offsets).toEqual([0, 3.0, 5.5, 9.75]);
+    expect(total).toBe(11.5);
+  });
+
+  test('uneven scene durations from real motion model output', () => {
+    // Approximating realistic Kling/Veo scene durations (5s ± a few frames)
+    const durations = [4.96, 5.04, 5.0, 4.98];
+    const { offsets, total } = computeSceneOffsets(durations);
+    expect(offsets[0]).toBe(0);
+    expect(offsets[1]).toBeCloseTo(4.96, 5);
+    expect(offsets[2]).toBeCloseTo(10.0, 5);
+    expect(offsets[3]).toBeCloseTo(15.0, 5);
+    expect(total).toBeCloseTo(19.98, 5);
+  });
+
+  test('total drift across 12 scenes stays under one ms', () => {
+    // Equal-duration scenes — verifies floating-point accumulation behavior.
+    const durations = Array.from({ length: 12 }, () => 5.0);
+    const { total } = computeSceneOffsets(durations);
+    expect(Math.abs(total - 60)).toBeLessThan(1e-9);
+  });
+});

--- a/src/lib/browser-merge/timeline-offsets.test.ts
+++ b/src/lib/browser-merge/timeline-offsets.test.ts
@@ -1,27 +1,10 @@
 /**
  * Unit test for the scene timeline arithmetic used by `merge-sequence.ts`.
  * Pure math; no Mediabunny or WebCodecs surface needed.
- *
- * Mirrors the offset-accumulation that happens in concatVideoTracks +
- * mergeSequence: given each scene's actual encoded duration (NOT
- * frame.durationMs — see issue #638 Q1), the per-scene start offsets are the
- * running cumulative sum.
  */
 
 import { describe, expect, test } from 'bun:test';
-
-function computeSceneOffsets(durations: number[]): {
-  offsets: number[];
-  total: number;
-} {
-  const offsets: number[] = [];
-  let acc = 0;
-  for (const d of durations) {
-    offsets.push(acc);
-    acc += d;
-  }
-  return { offsets, total: acc };
-}
+import { computeSceneOffsets } from './timeline-offsets';
 
 describe('scene timeline offsets', () => {
   test('empty list yields zero total and empty offsets', () => {

--- a/src/lib/browser-merge/timeline-offsets.ts
+++ b/src/lib/browser-merge/timeline-offsets.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure scene-timeline arithmetic. Extracted from `merge-sequence.ts` so the
+ * unit test exercises the same code path that runs in production (rather than
+ * a re-implementation that drifts silently from the merger).
+ *
+ * Inputs are per-scene durations measured from the encoded video tracks
+ * (NOT `frame.durationMs` — see issue #638 Q1).
+ */
+
+export type SceneTimeline = {
+  /** Cumulative start offset for each scene, in seconds. */
+  offsets: number[];
+  /** Sum of all scene durations, in seconds. */
+  total: number;
+};
+
+export function computeSceneOffsets(durations: number[]): SceneTimeline {
+  const offsets: number[] = [];
+  let acc = 0;
+  for (const d of durations) {
+    offsets.push(acc);
+    acc += d;
+  }
+  return { offsets, total: acc };
+}

--- a/src/lib/browser-merge/types.ts
+++ b/src/lib/browser-merge/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared types for the browser-side merge pipeline.
+ */
+
+export type MergePhase = 'fetch' | 'decode' | 'mix' | 'encode' | 'finalize';
+
+export type MergeProgress = {
+  phase: MergePhase;
+  /** Completed work in `phase`'s units. */
+  completed: number;
+  /** Total work in `phase`'s units (or 0 if indeterminate). */
+  total: number;
+};
+
+export type MergeProgressCallback = (progress: MergeProgress) => void;
+
+export type SceneInput = {
+  /** Order in the final timeline. */
+  orderIndex: number;
+  /** Public R2 URL of the scene MP4. */
+  videoUrl: string;
+};
+
+export type MergeSequenceInput = {
+  /** Scenes in any order — the merger sorts by `orderIndex`. */
+  scenes: SceneInput[];
+  /** Public R2 URL of the music MP3/MP4 — `null` if no music. */
+  musicUrl: string | null;
+  /** Optional progress callback. */
+  onProgress?: MergeProgressCallback;
+  /**
+   * Optional abort signal. When aborted, the merge throws and disposes
+   * partial Mediabunny resources.
+   */
+  signal?: AbortSignal;
+};
+
+export type MergeSequenceResult = {
+  /** Final MP4 ready to upload. */
+  blob: Blob;
+  /** Total duration of the merged video, in seconds. */
+  durationSeconds: number;
+};

--- a/src/lib/browser-merge/upload-merged.ts
+++ b/src/lib/browser-merge/upload-merged.ts
@@ -1,0 +1,30 @@
+/**
+ * Upload a merged MP4 Blob to R2 using a presigned PUT URL (S3 deployments)
+ * or the same-origin /api/storage/upload proxy (Cloudflare Workers).
+ *
+ * The shape of `uploadUrl` is provided by the server function
+ * `requestMergedUploadUrlFn`, which delegates to `getSignedUploadUrl`.
+ */
+
+export async function uploadMergedBlob(args: {
+  blob: Blob;
+  uploadUrl: string;
+  contentType: string;
+  signal?: AbortSignal;
+}): Promise<void> {
+  const { blob, uploadUrl, contentType, signal } = args;
+
+  const response = await fetch(uploadUrl, {
+    method: 'PUT',
+    body: blob,
+    headers: { 'Content-Type': contentType },
+    signal,
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `Upload failed: ${response.status} ${response.statusText}${body ? ` — ${body.slice(0, 200)}` : ''}`
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces server-side fal.ai ffmpeg merge with an in-browser Mediabunny + WebCodecs pipeline (transmux H.264, decode/mix/re-encode AAC, direct R2 upload).
- Adds reservation/commit/fail server functions for the merged-video upload, and gates the Theatre UI entry point on the `browserMerge` PostHog flag.
- Enables R2 CORS on every deployment (including Cloudflare) so `fetch()` from the browser pipeline can read scene MP4s cross-origin.
- Fixes an "offset is out of bounds" mid-merge crash by sizing scene-audio channel buffers from actual decoded frames (AAC priming/padding emits ~2k more frames than the muxed track duration).

## Test plan
- [ ] `bun test src/lib/browser-merge/` passes
- [ ] `bun typecheck` passes
- [ ] With `browserMerge` flag on, "Merge in browser (beta)" completes for a multi-scene sequence with music
- [ ] Resulting MP4 plays back with correct video + mixed scene/music audio
- [ ] No "offset is out of bounds" RangeError surfaces during the audio-decode phase

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)