### PR TITLE
Stage 1: realtime stale:detected event + UI surface #616

### DIFF
--- a/src/components/scenes/frame-staleness-banners.tsx
+++ b/src/components/scenes/frame-staleness-banners.tsx
@@ -1,0 +1,103 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+import { DivergentAlternateBanner } from '@/components/staleness/divergent-alternate-banner';
+import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
+import {
+  getFrameStalenessFn,
+  getSequenceImageVariantsFn,
+} from '@/functions/frames';
+import type { FrameVariant } from '@/lib/db/schema';
+
+type FrameStalenessBannersProps = {
+  frameId?: string;
+  sequenceId: string;
+  onRegenerate: () => void;
+  onCompareDivergent?: (variantId: string) => void;
+  onPromoteDivergent?: (variantId: string) => void;
+  onDiscardDivergent?: (variantId: string) => void;
+};
+
+/**
+ * Surfaces Stage 1 divergence + staleness signals for the currently selected
+ * frame. The divergent banner is driven by `frame_variants` rows with
+ * `divergedAt IS NOT NULL` (refreshed in real time by `stale:detected`); the
+ * staleness indicator queries the scoped `isStale` helper. Both render at most
+ * once per frame so the panel stays calm — only the most recent divergent
+ * alternate is offered.
+ *
+ * Compare/promote/discard handlers are intentionally optional: this PR ships
+ * the surfacing primitive; the variant resolution UI lands in a follow-up.
+ */
+export const FrameStalenessBanners: React.FC<FrameStalenessBannersProps> = ({
+  frameId,
+  sequenceId,
+  onRegenerate,
+  onCompareDivergent,
+  onPromoteDivergent,
+  onDiscardDivergent,
+}) => {
+  const { data: staleness } = useQuery({
+    queryKey: ['frame-staleness', frameId],
+    queryFn: () => {
+      if (!frameId) throw new Error('frameId required');
+      return getFrameStalenessFn({ data: { sequenceId, frameId } });
+    },
+    enabled: !!frameId,
+    staleTime: 30_000,
+  });
+
+  // Same key as `scenes-view`; sharing it means the cache invalidation fired
+  // by `stale:detected` reaches both the variant grid and this banner with one
+  // refetch.
+  const { data: variants } = useQuery<FrameVariant[]>({
+    queryKey: ['sequence-image-variants', sequenceId],
+    queryFn: () => getSequenceImageVariantsFn({ data: { sequenceId } }),
+    enabled: !!sequenceId && !!frameId,
+    staleTime: 30_000,
+  });
+
+  const latestDivergent = useMemo(() => {
+    if (!frameId || !variants) return undefined;
+    return variants
+      .filter(
+        (v) =>
+          v.frameId === frameId &&
+          v.variantType === 'image' &&
+          v.divergedAt !== null
+      )
+      .sort(
+        (a, b) =>
+          (b.divergedAt?.getTime() ?? 0) - (a.divergedAt?.getTime() ?? 0)
+      )[0];
+  }, [variants, frameId]);
+
+  if (!frameId) return null;
+
+  // Divergent alternate takes precedence: a brand-new alternate is a more
+  // actionable signal than a generic "inputs changed" hint, and showing both
+  // at once would crowd the panel header.
+  if (latestDivergent) {
+    return (
+      <DivergentAlternateBanner
+        variantId={latestDivergent.id}
+        artifact="thumbnail"
+        entityType="frame"
+        onCompare={() => onCompareDivergent?.(latestDivergent.id)}
+        onPromote={() => onPromoteDivergent?.(latestDivergent.id)}
+        onDiscard={() => onDiscardDivergent?.(latestDivergent.id)}
+      />
+    );
+  }
+
+  if (staleness?.thumbnail) {
+    return (
+      <StalenessIndicator
+        artifact="thumbnail"
+        entityType="frame"
+        onRegenerate={onRegenerate}
+      />
+    );
+  }
+
+  return null;
+};

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -42,6 +42,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { CopyIcon, Loader2, Minimize2 } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { FrameStalenessBanners } from './frame-staleness-banners';
 import { SceneCastTab } from './scene-cast-tab';
 import { SceneElementsTab } from './scene-elements-tab';
 import { SceneLocationTab } from './scene-location-tab';
@@ -578,6 +579,19 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       }}
       className="w-full"
     >
+      <FrameStalenessBanners
+        frameId={frame?.id}
+        sequenceId={sequenceId}
+        onRegenerate={() => {
+          onTabChange('image-prompt');
+          if (falNeedsBillingSetup) {
+            showFalGate();
+            return;
+          }
+          void handleRegenerate();
+        }}
+      />
+
       {/* Mobile: Select dropdown */}
       <div className="md:hidden">
         <Select

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
 import type { NewFrame } from '@/lib/db/schema';
 import { getVideoDownloadUrl } from '@/lib/motion/video-storage';
 import {
@@ -7,6 +8,7 @@ import {
 } from '@/lib/schemas/frame.schemas';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { reconcileStaleFrameStatuses } from '@/lib/workflow/reconcile';
+import { buildRegenerateFrameSnapshot } from '@/lib/workflows/regenerate-frames-snapshot';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -129,6 +131,50 @@ export const reorderFramesFn = createServerFn({ method: 'POST' })
     }));
     await context.scopedDb.frames.reorder(data.sequenceId, frameOrders);
     return { success: true };
+  });
+
+/**
+ * Returns staleness flags for a frame's artifacts. Stage 1 covers `thumbnail`
+ * only — that's the artifact whose input hash actually flows through the
+ * snapshot pipeline today. Other artifacts return `null` (= "unknown") so the
+ * UI can render them defensively without us pretending they're up to date.
+ *
+ * Computed by re-deriving the current input hash from live scoped state and
+ * comparing it to the stored `thumbnail_input_hash` via the scoped helper.
+ * A null stored hash means "legacy artifact, no opinion" — the helper returns
+ * false, which is the correct UX (don't push regenerate on something we never
+ * tracked inputs for).
+ */
+export const getFrameStalenessFn = createServerFn({ method: 'GET' })
+  .middleware([frameAccessMiddleware])
+  .inputValidator(zodValidator(frameIdInputSchema))
+  .handler(async ({ context }) => {
+    const { frame, sequence, scopedDb } = context;
+
+    if (!frame.imagePrompt) {
+      return { thumbnail: false };
+    }
+
+    const [characters, locations] = await Promise.all([
+      scopedDb.characters.listWithSheets(sequence.id),
+      scopedDb.sequenceLocations.listWithReferences(sequence.id),
+    ]);
+
+    const snapshot = await buildRegenerateFrameSnapshot({
+      frame,
+      characters,
+      locations,
+      imageModel: safeTextToImageModel(frame.imageModel, DEFAULT_IMAGE_MODEL),
+      aspectRatio: sequence.aspectRatio,
+    });
+
+    const thumbnail = await scopedDb.frames.isStale(
+      frame.id,
+      'thumbnail',
+      snapshot.snapshotInputHash
+    );
+
+    return { thumbnail };
   });
 
 /**

--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -263,10 +263,11 @@ describe('createFrameVariantsMethods', () => {
       inputHash: 'divergent-hash',
       divergedAt,
     });
-    expect(first).not.toBeNull();
+    expect(first.id).toBeDefined();
 
     // Second call — simulates a QStash retry of the reconcile step. Must not
-    // throw and must not create a second row.
+    // throw and must not create a second row, and must return the existing
+    // row so callers (e.g. realtime emitters) can reference its id.
     const second = await methods.insertDivergent({
       frameId,
       sequenceId,
@@ -277,7 +278,7 @@ describe('createFrameVariantsMethods', () => {
       inputHash: 'divergent-hash',
       divergedAt,
     });
-    expect(second).toBeNull();
+    expect(second.id).toBe(first.id);
 
     const rows = await db.select().from(frameVariants);
     expect(rows.filter((r) => r.divergedAt !== null)).toHaveLength(1);

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -153,8 +153,9 @@ export function createFrameVariantsMethods(db: Database) {
      * Insert a divergent alternate row. Idempotent on (frame, type, model,
      * inputHash) within the divergent partial unique index so QStash retries
      * of the same reconcile step don't collide on a row already inserted on a
-     * previous attempt. Returns null when the row already exists (caller has
-     * no use for the row beyond knowing the insert succeeded once).
+     * previous attempt. Returns the existing row on retry so callers can
+     * reference its id (e.g. when re-emitting the realtime `stale:detected`
+     * event after a step retry).
      *
      * Pre-checks existence rather than `onConflictDoNothing` because drizzle's
      * SQLite `onConflictDoNothing` does not emit the partial-index `WHERE`
@@ -164,7 +165,7 @@ export function createFrameVariantsMethods(db: Database) {
      */
     insertDivergent: async (
       data: NewFrameVariant & { inputHash: string; divergedAt: Date }
-    ): Promise<FrameVariant | null> => {
+    ): Promise<FrameVariant> => {
       const existing = await db
         .select()
         .from(frameVariants)
@@ -178,7 +179,7 @@ export function createFrameVariantsMethods(db: Database) {
           )
         );
       if (existing.length > 0) {
-        return null;
+        return existing[0];
       }
       const [variant] = await db.insert(frameVariants).values(data).returning();
       return variant;

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -203,6 +203,30 @@ export const realtimeSchema = {
       posterUrl: z.string(),
     }),
 
+    // Divergence detected: a workflow finished but its inputs no longer match
+    // the snapshot it was triggered from. The divergent result has been parked
+    // (see workflow-snapshots-and-content-hash-staleness.md § "Divergence-on-completion")
+    // so the live primary artifact is preserved. The UI uses this to surface
+    // an "alternate available" affordance without polling.
+    'stale:detected': z.object({
+      entityType: z.enum([
+        'frame',
+        'character',
+        'location',
+        'library-location',
+        'talent',
+      ]),
+      entityId: z.string(),
+      artifact: z
+        .enum(['thumbnail', 'variant-image', 'video', 'audio', 'sheet'])
+        .optional(),
+      snapshotInputHash: z.string(),
+      // Populated for frame artifacts that landed in `frame_variants` as a
+      // divergent alternate; absent when the divergent result was discarded
+      // (e.g. sheets, sequence-level music) and merely re-queued.
+      divergedVariantId: z.string().optional(),
+    }),
+
     // Sequence events
     updated: z.object({
       title: z.string().optional(),

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -224,6 +224,34 @@ export function updateQueryCacheFromEvent(
       break;
     }
 
+    case 'generation.stale:detected': {
+      // A divergent regeneration parked its result in `frame_variants`. Refetch
+      // image variants so the new alternate row shows up; also refetch the
+      // frame so its reverted thumbnail status (pending) reaches the UI.
+      // Frame staleness query is keyed per-frame; invalidate it so the
+      // indicator reappears if the user just dismissed it.
+      const entityType = getString(data, 'entityType');
+      const entityId = getString(data, 'entityId');
+      if (entityType === 'frame' && entityId) {
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-image-variants', sequenceId],
+          `image-variants:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          frameKeys.list(sequenceId),
+          `frames:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          ['frame-staleness', entityId],
+          `frame-staleness:${entityId}`
+        );
+      }
+      break;
+    }
+
     case 'generation.preview:replaced':
       // Preview frames replaced by AI-analyzed frames — refetch frame list
       void queryClient.invalidateQueries({

--- a/src/lib/realtime/use-generation-stream.ts
+++ b/src/lib/realtime/use-generation-stream.ts
@@ -303,6 +303,7 @@ export function useGenerationStream(
       'generation.location:matched',
       'generation.poster:ready',
       'generation.preview:replaced',
+      'generation.stale:detected',
       'generation.complete',
       'generation.failed',
       'generation.updated',

--- a/src/lib/workflows/regenerate-frames-workflow.ts
+++ b/src/lib/workflows/regenerate-frames-workflow.ts
@@ -280,27 +280,34 @@ export const regenerateFramesWorkflow = createScopedWorkflow<
               };
             }
 
-            await scopedDb.frameVariants.insertDivergent({
+            const divergentVariant =
+              await scopedDb.frameVariants.insertDivergent({
+                frameId: result.frameId,
+                sequenceId,
+                variantType: 'image',
+                model: imageModel,
+                url: result.imageUrl,
+                storagePath: primaryVariant?.storagePath ?? null,
+                previewUrl: primaryVariant?.previewUrl ?? null,
+                shotVariantUrl: primaryVariant?.shotVariantUrl ?? null,
+                shotVariantPath: primaryVariant?.shotVariantPath ?? null,
+                ...writes.divergentRow,
+              });
+
+            const channel = getGenerationChannel(sequenceId);
+            await channel.emit('generation.image:progress', {
               frameId: result.frameId,
-              sequenceId,
-              variantType: 'image',
+              status: 'pending',
               model: imageModel,
-              url: result.imageUrl,
-              storagePath: primaryVariant?.storagePath ?? null,
-              previewUrl: primaryVariant?.previewUrl ?? null,
-              shotVariantUrl: primaryVariant?.shotVariantUrl ?? null,
-              shotVariantPath: primaryVariant?.shotVariantPath ?? null,
-              ...writes.divergentRow,
             });
 
-            await getGenerationChannel(sequenceId).emit(
-              'generation.image:progress',
-              {
-                frameId: result.frameId,
-                status: 'pending',
-                model: imageModel,
-              }
-            );
+            await channel.emit('generation.stale:detected', {
+              entityType: 'frame',
+              entityId: result.frameId,
+              artifact: 'thumbnail',
+              snapshotInputHash: snapshot.snapshotInputHash,
+              divergedVariantId: divergentVariant.id,
+            });
 
             console.log(
               '[RegenerateFramesWorkflow]',


### PR DESCRIPTION
## Related Issue
Closes #616

## Summary
Implemented Stage 1 stale:detected event + frame detail UI surface; pushed for CI + reviewer pass

## Notes
Opened by the agent-harness overnight runner. See the `harness-active` label.
