### PR TITLE
Stage 1.5: per-frame snapshot validation + frame_variants divergence in generateImageWorkflow #647

### DIFF
--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -57,6 +57,21 @@ export interface ImageWorkflowInput extends SequenceWorkflowContext {
   referenceImages?: ReferenceImageDescription[];
   /** Skip R2 upload and store fal.ai CDN URL directly (for ephemeral preview images) */
   skipStorage?: boolean;
+  /**
+   * Per-scene snapshot for divergence detection. When present, the workflow
+   * re-resolves character/location/element sheet hashes at write time and
+   * routes divergent results into `frame_variants` instead of overwriting
+   * the primary thumbnail. Optional: omit for callers that handle their own
+   * divergence (e.g. `regenerateFramesWorkflow`) or for preview-mode runs.
+   */
+  sceneSnapshot?: FrameImageSceneSnapshot;
+  /**
+   * Aspect ratio frozen at trigger time. Required when `sceneSnapshot` is
+   * present so write-time hash recomputation matches the trigger-time hash.
+   */
+  aspectRatio?: AspectRatio;
+  /** Hash over `(prompt, model, aspectRatio, sceneSnapshot)`; validated at start. */
+  snapshotInputHash?: string;
 }
 
 /**

--- a/src/lib/workflows/divergence-writes.ts
+++ b/src/lib/workflows/divergence-writes.ts
@@ -1,0 +1,34 @@
+import type { NewFrame, NewFrameVariant } from '@/lib/db/schema';
+
+/**
+ * Reverts to apply when a snapshot-pattern image workflow detects divergence
+ * after speculatively writing the primary `frames` + primary `frame_variants`
+ * row at start. Each consumer pairs this with its own divergent-alternate
+ * INSERT payload.
+ */
+export function buildDivergentRevertWrites(): {
+  frame: Partial<NewFrame>;
+  primaryRevert: Partial<NewFrameVariant>;
+} {
+  return {
+    frame: {
+      thumbnailUrl: null,
+      thumbnailPath: null,
+      thumbnailStatus: 'pending',
+      thumbnailWorkflowRunId: null,
+      thumbnailGeneratedAt: null,
+      thumbnailError: null,
+      thumbnailInputHash: null,
+    },
+    primaryRevert: {
+      url: null,
+      storagePath: null,
+      previewUrl: null,
+      status: 'pending',
+      workflowRunId: null,
+      generatedAt: null,
+      error: null,
+      inputHash: null,
+    },
+  };
+}

--- a/src/lib/workflows/frame-images-workflow.ts
+++ b/src/lib/workflows/frame-images-workflow.ts
@@ -28,6 +28,7 @@ import {
   matchLocationsToScene,
 } from './scene-matching';
 import {
+  computeFrameImageSceneHash,
   computeFrameImagesHashFromDto,
   type FrameImageSceneSnapshot,
 } from './sheet-snapshots';
@@ -139,9 +140,27 @@ export const frameImagesWorkflow = createScopedWorkflow<
           ...elementRefs,
         ];
 
+        // Locate the per-scene snapshot inlined into our payload. Bound to
+        // sceneId rather than index so a re-ordered `sceneSnapshots` array
+        // (e.g. analyze-script sorts by sceneId; we don't) still maps right.
+        const sceneSnapshot = input.sceneSnapshots?.find(
+          (s) => s.sceneId === scene.sceneId
+        );
+
         // Generate with each selected model in parallel
         const modelResults = await Promise.all(
           imageModels.map(async (model) => {
+            // Compute the per-frame hash here (rather than at trigger time)
+            // because each model gets its own image-workflow invocation, and
+            // `computeFrameImageSceneHash` is keyed on the model.
+            const perFrameSnapshotInputHash = sceneSnapshot
+              ? await computeFrameImageSceneHash(
+                  sceneSnapshot,
+                  model,
+                  aspectRatio
+                )
+              : undefined;
+
             const result = await context.invoke(
               `image-${scene.sceneId}-${model}`,
               {
@@ -153,11 +172,14 @@ export const frameImagesWorkflow = createScopedWorkflow<
                   prompt: visualPrompt,
                   model,
                   imageSize,
+                  aspectRatio,
                   numImages: 1,
                   frameId: matchedFrame?.frameId,
                   sequenceId,
                   referenceImages:
                     allReferences.length > 0 ? allReferences : undefined,
+                  sceneSnapshot,
+                  snapshotInputHash: perFrameSnapshotInputHash,
                 } satisfies ImageWorkflowInput,
                 retries: 3,
                 retryDelay: 'pow(2, retried) * 1000',

--- a/src/lib/workflows/frame-images-workflow.ts
+++ b/src/lib/workflows/frame-images-workflow.ts
@@ -108,6 +108,12 @@ export const frameImagesWorkflow = createScopedWorkflow<
 
     const imageSize = aspectRatioToImageSize(aspectRatio);
 
+    // Build a sceneId→snapshot index once so the per-(scene, model) inner loop
+    // doesn't repeat O(snapshots) `find` work for every frame × model combo.
+    const sceneSnapshotsById = new Map<string, FrameImageSceneSnapshot>(
+      (input.sceneSnapshots ?? []).map((s) => [s.sceneId, s])
+    );
+
     // Generate frame images in parallel (for each scene, for each model)
     const imageUrls = await Promise.all(
       scenesWithVisualPrompts.map(async (scene) => {
@@ -140,12 +146,10 @@ export const frameImagesWorkflow = createScopedWorkflow<
           ...elementRefs,
         ];
 
-        // Locate the per-scene snapshot inlined into our payload. Bound to
-        // sceneId rather than index so a re-ordered `sceneSnapshots` array
-        // (e.g. analyze-script sorts by sceneId; we don't) still maps right.
-        const sceneSnapshot = input.sceneSnapshots?.find(
-          (s) => s.sceneId === scene.sceneId
-        );
+        // Bound to sceneId rather than index so a re-ordered `sceneSnapshots`
+        // array (e.g. analyze-script sorts by sceneId; we don't) still maps
+        // right.
+        const sceneSnapshot = sceneSnapshotsById.get(scene.sceneId);
 
         // Generate with each selected model in parallel
         const modelResults = await Promise.all(

--- a/src/lib/workflows/image-workflow-snapshot.test.ts
+++ b/src/lib/workflows/image-workflow-snapshot.test.ts
@@ -11,7 +11,8 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import type { ScopedDb } from '@/lib/db/scoped';
+import type { NewFrame, NewFrameVariant } from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
 import type {
   FrameImageSceneSnapshot,
   ImageWorkflowInput,
@@ -21,13 +22,11 @@ import {
   buildImageDivergentWrites,
   computeImageWorkflowHashCurrent,
   computeImageWorkflowHashFromDto,
+  type ImageHashScopedDb,
+  type PersistImageScopedDb,
   persistImageResult,
+  type SceneForHash,
 } from './image-workflow-snapshot';
-
-function asScopedDb<T>(stub: T): ScopedDb {
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
-  return stub as unknown as ScopedDb;
-}
 
 const baseScene: FrameImageSceneSnapshot = {
   sceneId: 's1',
@@ -48,29 +47,28 @@ const baseInput: ImageWorkflowInput = {
   sceneSnapshot: baseScene,
 };
 
-function buildScopedDbStub(opts: {
+const DEFAULT_SCENE: SceneForHash = {
+  continuity: {
+    characterTags: ['jack'],
+    environmentTag: 'docks',
+    elementTags: [],
+  },
+  metadata: { location: 'Docks' },
+  originalScript: { extract: '' },
+};
+
+function buildHashScopedDb(opts: {
   characterSheetHash?: string | null;
   locationReferenceHash?: string | null;
-  elementImageUrl?: string | null;
-  frameMetadata?: unknown;
-}) {
-  const defaultMetadata = {
-    sceneId: 's1',
-    continuity: {
-      characterTags: ['jack'],
-      environmentTag: 'docks',
-      elementTags: [],
-    },
-    metadata: { location: 'Docks' },
-    originalScript: { extract: '' },
-  };
-  // Use `in` check so an explicit `frameMetadata: null` flows through (data
-  // corruption case) rather than collapsing to the default via `??`.
+  elementImageUrl?: string;
+  frameMetadata?: SceneForHash | null;
+}): ImageHashScopedDb {
+  // `in` check distinguishes explicit `null` (data-corruption case) from omitted (default).
   const metadata =
-    'frameMetadata' in opts ? opts.frameMetadata : defaultMetadata;
-  return asScopedDb({
+    'frameMetadata' in opts ? (opts.frameMetadata ?? null) : DEFAULT_SCENE;
+  return {
     frames: {
-      getById: async () => ({ id: 'f1', metadata }),
+      getById: async () => ({ metadata }),
     },
     characters: {
       listWithSheets: async () =>
@@ -79,11 +77,12 @@ function buildScopedDbStub(opts: {
           : [
               {
                 id: 'c1',
-                sequenceId: 'seq1',
                 characterId: 'jack',
                 consistencyTag: 'jack',
                 name: 'Jack',
+                physicalDescription: null,
                 sheetImageUrl: 'https://example.com/jack.png',
+                sheetStatus: 'completed',
                 sheetInputHash: opts.characterSheetHash,
               },
             ],
@@ -95,11 +94,12 @@ function buildScopedDbStub(opts: {
           : [
               {
                 id: 'l1',
-                sequenceId: 'seq1',
                 locationId: 'docks',
+                description: null,
                 consistencyTag: 'docks',
                 name: 'Docks',
                 referenceImageUrl: 'https://example.com/docks.png',
+                referenceStatus: 'completed',
                 referenceInputHash: opts.locationReferenceHash,
               },
             ],
@@ -118,8 +118,33 @@ function buildScopedDbStub(opts: {
               },
             ],
     },
-  });
+  };
 }
+
+const unreachableHashScopedDb: ImageHashScopedDb = {
+  frames: {
+    getById: async () => {
+      throw new Error('frames.getById should not be called in this test');
+    },
+  },
+  characters: {
+    listWithSheets: async () => {
+      throw new Error('characters.listWithSheets should not be called');
+    },
+  },
+  sequenceLocations: {
+    listWithReferences: async () => {
+      throw new Error(
+        'sequenceLocations.listWithReferences should not be called'
+      );
+    },
+  },
+  sequenceElements: {
+    list: async () => {
+      throw new Error('sequenceElements.list should not be called');
+    },
+  },
+};
 
 describe('computeImageWorkflowHashFromDto', () => {
   it('returns the inlined hash sentinel when no snapshot is opted in', async () => {
@@ -165,7 +190,7 @@ describe('computeImageWorkflowHashCurrent', () => {
     const dtoHash = await computeImageWorkflowHashFromDto(baseInput);
     const currentHash = await computeImageWorkflowHashCurrent(
       baseInput,
-      buildScopedDbStub({
+      buildHashScopedDb({
         characterSheetHash: 'jack-hash-v1',
         locationReferenceHash: 'docks-hash-v1',
       })
@@ -177,7 +202,7 @@ describe('computeImageWorkflowHashCurrent', () => {
     const dtoHash = await computeImageWorkflowHashFromDto(baseInput);
     const currentHash = await computeImageWorkflowHashCurrent(
       baseInput,
-      buildScopedDbStub({
+      buildHashScopedDb({
         characterSheetHash: 'jack-hash-v2',
         locationReferenceHash: 'docks-hash-v1',
       })
@@ -193,12 +218,11 @@ describe('computeImageWorkflowHashCurrent', () => {
         elementReferenceHashes: ['https://example.com/logo-v1.png'],
       },
     };
-    const stub = buildScopedDbStub({
+    const stub = buildHashScopedDb({
       characterSheetHash: 'jack-hash-v1',
       locationReferenceHash: 'docks-hash-v1',
       elementImageUrl: 'https://example.com/logo-v2.png',
       frameMetadata: {
-        sceneId: 's1',
         continuity: {
           characterTags: ['jack'],
           environmentTag: 'docks',
@@ -217,10 +241,9 @@ describe('computeImageWorkflowHashCurrent', () => {
   });
 
   it('returns the inlined hash sentinel when no snapshot is opted in', async () => {
-    const stub = asScopedDb({});
     const result = await computeImageWorkflowHashCurrent(
       { ...baseInput, sceneSnapshot: undefined, snapshotInputHash: undefined },
-      stub
+      unreachableHashScopedDb
     );
     expect(result).toBe('');
   });
@@ -229,7 +252,7 @@ describe('computeImageWorkflowHashCurrent', () => {
     expect(
       computeImageWorkflowHashCurrent(
         { ...baseInput, aspectRatio: undefined },
-        buildScopedDbStub({
+        buildHashScopedDb({
           characterSheetHash: 'jack-hash-v1',
           locationReferenceHash: 'docks-hash-v1',
         })
@@ -238,7 +261,7 @@ describe('computeImageWorkflowHashCurrent', () => {
   });
 
   it('throws when the frame exists but has null metadata (data corruption)', () => {
-    const stub = buildScopedDbStub({
+    const stub = buildHashScopedDb({
       characterSheetHash: 'jack-hash-v1',
       locationReferenceHash: 'docks-hash-v1',
       frameMetadata: null,
@@ -275,7 +298,6 @@ describe('buildImageConvergentWrites', () => {
       generatedAt,
     });
 
-    // Frame: new thumbnail + reset video lifecycle (regen invalidates motion).
     expect(writes.frame).toEqual({
       thumbnailPath: upload.path,
       thumbnailUrl: upload.url,
@@ -291,8 +313,6 @@ describe('buildImageConvergentWrites', () => {
       videoError: null,
     });
 
-    // Variant: new thumbnail + previewUrl cleared (no stale preview-mode
-    // pointer left attached after the converged primary write).
     expect(writes.variant).toEqual({
       url: upload.url,
       storagePath: upload.path,
@@ -329,9 +349,8 @@ describe('buildImageDivergentWrites', () => {
       divergedAt,
     });
 
-    // Frame: fully revert primary thumbnail. Critically, thumbnailUrl AND
-    // thumbnailPath are both nulled so an already-completed frame doesn't
-    // get left at status=pending while a stale URL persists.
+    // Critically: thumbnailUrl AND thumbnailPath are both nulled so an
+    // already-completed frame doesn't carry a stale URL into pending state.
     expect(writes.frame).toEqual({
       thumbnailUrl: null,
       thumbnailPath: null,
@@ -342,8 +361,6 @@ describe('buildImageDivergentWrites', () => {
       thumbnailInputHash: null,
     });
 
-    // Primary variant row: speculative URL/status cleared so the primary
-    // slot stops pointing at diverged work.
     expect(writes.primaryRevert).toEqual({
       url: null,
       storagePath: null,
@@ -355,9 +372,8 @@ describe('buildImageDivergentWrites', () => {
       inputHash: null,
     });
 
-    // Divergent alternate: full content payload incl. divergence keys
-    // (inputHash + divergedAt) so insertDivergent can match the partial
-    // unique index for idempotency on QStash retry.
+    // inputHash + divergedAt key the divergent partial unique index for
+    // insertDivergent idempotency on QStash retry.
     expect(writes.divergentRow).toEqual({
       url: upload.url,
       storagePath: upload.path,
@@ -372,54 +388,78 @@ describe('buildImageDivergentWrites', () => {
 });
 
 describe('persistImageResult — orchestration', () => {
-  type Call = { method: string; args: unknown[] };
   const upload = { url: 'https://r2/jack.png', path: 'team/seq/jack.png' };
   const NOW = new Date('2026-05-04T00:00:00Z');
 
+  type FrameUpdateCall = {
+    frameId: string;
+    data: Partial<NewFrame>;
+  };
+  type VariantUpdateCall = {
+    frameId: string;
+    variantType: VariantType;
+    model: string;
+    data: Partial<NewFrameVariant>;
+  };
+  type InsertDivergentCall = NewFrameVariant & {
+    inputHash: string;
+    divergedAt: Date;
+  };
+  type CallOrder =
+    | 'frames.update'
+    | 'frameVariants.updateByFrameAndModel'
+    | 'frameVariants.insertDivergent';
+
   function buildScopedDbSpy(opts: { frameMissing?: boolean } = {}): {
-    scopedDb: ScopedDb;
-    calls: Call[];
+    scopedDb: PersistImageScopedDb;
+    framesUpdates: FrameUpdateCall[];
+    variantsUpdates: VariantUpdateCall[];
+    variantsInserts: InsertDivergentCall[];
+    callOrder: CallOrder[];
   } {
-    const calls: Call[] = [];
-    const scopedDb = asScopedDb({
+    const framesUpdates: FrameUpdateCall[] = [];
+    const variantsUpdates: VariantUpdateCall[] = [];
+    const variantsInserts: InsertDivergentCall[] = [];
+    const callOrder: CallOrder[] = [];
+    const scopedDb: PersistImageScopedDb = {
       frames: {
-        update: async (
-          frameId: string,
-          data: unknown,
-          options: { throwOnMissing: boolean }
-        ) => {
-          calls.push({
-            method: 'frames.update',
-            args: [frameId, data, options],
-          });
-          if (opts.frameMissing) return null;
+        update: async (frameId, data) => {
+          framesUpdates.push({ frameId, data });
+          callOrder.push('frames.update');
+          if (opts.frameMissing) return undefined;
           return { id: frameId };
         },
       },
       frameVariants: {
-        updateByFrameAndModel: async (
-          frameId: string,
-          variantType: string,
-          model: string,
-          data: unknown
-        ) => {
-          calls.push({
-            method: 'frameVariants.updateByFrameAndModel',
-            args: [frameId, variantType, model, data],
-          });
+        updateByFrameAndModel: async (frameId, variantType, model, data) => {
+          variantsUpdates.push({ frameId, variantType, model, data });
+          callOrder.push('frameVariants.updateByFrameAndModel');
           return { id: 'v1' };
         },
-        insertDivergent: async (data: unknown) => {
-          calls.push({ method: 'frameVariants.insertDivergent', args: [data] });
+        insertDivergent: async (data) => {
+          variantsInserts.push(data);
+          callOrder.push('frameVariants.insertDivergent');
           return { id: 'v2' };
         },
       },
-    });
-    return { scopedDb, calls };
+    };
+    return {
+      scopedDb,
+      framesUpdates,
+      variantsUpdates,
+      variantsInserts,
+      callOrder,
+    };
   }
 
   it('divergent path: reverts primary frames row, reverts primary variant, inserts divergent alternate, emits pending', async () => {
-    const { scopedDb, calls } = buildScopedDbSpy();
+    const {
+      scopedDb,
+      framesUpdates,
+      variantsUpdates,
+      variantsInserts,
+      callOrder,
+    } = buildScopedDbSpy();
     const emits: Array<{ event: string; payload: unknown }> = [];
 
     const outcome = await persistImageResult({
@@ -437,31 +477,31 @@ describe('persistImageResult — orchestration', () => {
       now: () => NOW,
     });
 
-    expect(outcome).toEqual({ status: 'divergent', imageUrl: upload.url });
+    expect(outcome).toEqual({
+      status: 'divergent',
+      imageUrl: upload.url,
+      snapshotHash: 'snapshot-abc',
+    });
 
-    // Frame revert was called first with the divergent revert payload
-    // (incl. nulled url/path so an already-completed frame doesn't carry
-    // a stale URL into pending state).
-    expect(calls[0].method).toBe('frames.update');
-    const frameUpdateData = calls[0].args[1] as Record<string, unknown>;
-    expect(frameUpdateData.thumbnailUrl).toBeNull();
-    expect(frameUpdateData.thumbnailPath).toBeNull();
-    expect(frameUpdateData.thumbnailStatus).toBe('pending');
-    expect(frameUpdateData.thumbnailInputHash).toBeNull();
+    expect(callOrder).toEqual([
+      'frames.update',
+      'frameVariants.updateByFrameAndModel',
+      'frameVariants.insertDivergent',
+    ]);
 
-    // Primary variant reverted (cleared) — primary slot must stop pointing at
-    // diverged work.
-    expect(calls[1].method).toBe('frameVariants.updateByFrameAndModel');
-    const variantRevert = calls[1].args[3] as Record<string, unknown>;
+    const frameUpdate = framesUpdates[0].data;
+    expect(frameUpdate.thumbnailUrl).toBeNull();
+    expect(frameUpdate.thumbnailPath).toBeNull();
+    expect(frameUpdate.thumbnailStatus).toBe('pending');
+    expect(frameUpdate.thumbnailInputHash).toBeNull();
+
+    const variantRevert = variantsUpdates[0].data;
     expect(variantRevert.url).toBeNull();
     expect(variantRevert.previewUrl).toBeNull();
     expect(variantRevert.status).toBe('pending');
     expect(variantRevert.inputHash).toBeNull();
 
-    // Divergent alternate inserted with snapshot hash + divergedAt for the
-    // partial-unique-index idempotency key.
-    expect(calls[2].method).toBe('frameVariants.insertDivergent');
-    const divergentRow = calls[2].args[0] as Record<string, unknown>;
+    const divergentRow = variantsInserts[0];
     expect(divergentRow.frameId).toBe('f1');
     expect(divergentRow.sequenceId).toBe('seq1');
     expect(divergentRow.variantType).toBe('image');
@@ -471,8 +511,6 @@ describe('persistImageResult — orchestration', () => {
     expect(divergentRow.divergedAt).toBe(NOW);
     expect(divergentRow.status).toBe('completed');
 
-    // Emit signals "pending" so the UI doesn't briefly show a completed
-    // primary while the alternate is being routed.
     expect(emits).toEqual([
       {
         event: 'generation.image:progress',
@@ -482,7 +520,13 @@ describe('persistImageResult — orchestration', () => {
   });
 
   it('convergent path: stamps primary frames row + primary variant with snapshot hash, emits completed, NO insertDivergent call', async () => {
-    const { scopedDb, calls } = buildScopedDbSpy();
+    const {
+      scopedDb,
+      framesUpdates,
+      variantsUpdates,
+      variantsInserts,
+      callOrder,
+    } = buildScopedDbSpy();
     const emits: Array<{ event: string; payload: unknown }> = [];
 
     const outcome = await persistImageResult({
@@ -492,7 +536,7 @@ describe('persistImageResult — orchestration', () => {
       model: 'nano_banana_2',
       upload,
       snapshotHash: 'snapshot-abc',
-      currentHash: 'snapshot-abc', // matches → convergent
+      currentHash: 'snapshot-abc',
       promptHash: 'prompt-1',
       emit: async (event, payload) => {
         emits.push({ event, payload });
@@ -502,25 +546,23 @@ describe('persistImageResult — orchestration', () => {
 
     expect(outcome).toEqual({ status: 'convergent', imageUrl: upload.url });
 
-    // Frame primary write with snapshot hash recorded.
-    expect(calls[0].method).toBe('frames.update');
-    const frameUpdateData = calls[0].args[1] as Record<string, unknown>;
-    expect(frameUpdateData.thumbnailUrl).toBe(upload.url);
-    expect(frameUpdateData.thumbnailStatus).toBe('completed');
-    expect(frameUpdateData.thumbnailInputHash).toBe('snapshot-abc');
+    expect(callOrder).toEqual([
+      'frames.update',
+      'frameVariants.updateByFrameAndModel',
+    ]);
 
-    // Variant primary write with snapshot hash recorded + previewUrl cleared.
-    expect(calls[1].method).toBe('frameVariants.updateByFrameAndModel');
-    const variantWrite = calls[1].args[3] as Record<string, unknown>;
+    const frameUpdate = framesUpdates[0].data;
+    expect(frameUpdate.thumbnailUrl).toBe(upload.url);
+    expect(frameUpdate.thumbnailStatus).toBe('completed');
+    expect(frameUpdate.thumbnailInputHash).toBe('snapshot-abc');
+
+    const variantWrite = variantsUpdates[0].data;
     expect(variantWrite.url).toBe(upload.url);
     expect(variantWrite.status).toBe('completed');
     expect(variantWrite.inputHash).toBe('snapshot-abc');
     expect(variantWrite.previewUrl).toBeNull();
 
-    // Critically: no insertDivergent call on the convergent path.
-    expect(
-      calls.some((c) => c.method === 'frameVariants.insertDivergent')
-    ).toBe(false);
+    expect(variantsInserts).toEqual([]);
 
     expect(emits).toEqual([
       {
@@ -536,7 +578,8 @@ describe('persistImageResult — orchestration', () => {
   });
 
   it('non-snapshot mode (snapshotHash null): convergent write with null inputHash, NO insertDivergent', async () => {
-    const { scopedDb, calls } = buildScopedDbSpy();
+    const { scopedDb, framesUpdates, variantsUpdates, variantsInserts } =
+      buildScopedDbSpy();
     const emits: Array<{ event: string; payload: unknown }> = [];
 
     const outcome = await persistImageResult({
@@ -555,17 +598,14 @@ describe('persistImageResult — orchestration', () => {
     });
 
     expect(outcome.status).toBe('convergent');
-    const frameUpdateData = calls[0].args[1] as Record<string, unknown>;
-    expect(frameUpdateData.thumbnailInputHash).toBeNull();
-    const variantWrite = calls[1].args[3] as Record<string, unknown>;
-    expect(variantWrite.inputHash).toBeNull();
-    expect(
-      calls.some((c) => c.method === 'frameVariants.insertDivergent')
-    ).toBe(false);
+    expect(framesUpdates[0].data.thumbnailInputHash).toBeNull();
+    expect(variantsUpdates[0].data.inputHash).toBeNull();
+    expect(variantsInserts).toEqual([]);
   });
 
   it('frame deleted mid-flight: short-circuits without touching frame_variants', async () => {
-    const { scopedDb, calls } = buildScopedDbSpy({ frameMissing: true });
+    const { scopedDb, framesUpdates, variantsUpdates, variantsInserts } =
+      buildScopedDbSpy({ frameMissing: true });
 
     const outcome = await persistImageResult({
       scopedDb,
@@ -581,9 +621,8 @@ describe('persistImageResult — orchestration', () => {
     });
 
     expect(outcome).toEqual({ status: 'frame-deleted' });
-    // Only the initial frames.update was attempted; bail out before any
-    // variant writes when the frame is gone.
-    expect(calls.length).toBe(1);
-    expect(calls[0].method).toBe('frames.update');
+    expect(framesUpdates.length).toBe(1);
+    expect(variantsUpdates).toEqual([]);
+    expect(variantsInserts).toEqual([]);
   });
 });

--- a/src/lib/workflows/image-workflow-snapshot.test.ts
+++ b/src/lib/workflows/image-workflow-snapshot.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Behavioural tests for the per-frame image-workflow snapshot helpers.
+ *
+ * `generateImageWorkflow` opts into the snapshot pattern so it can detect
+ * drift between trigger-time and write-time and route divergent results into
+ * `frame_variants`. These tests pin the two contract paths the workflow
+ * branches on:
+ *
+ *   - convergent: live state matches the inlined snapshot → primary write
+ *   - divergent: a character sheet was re-hashed mid-flight → alternate write
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { ScopedDb } from '@/lib/db/scoped';
+import type {
+  FrameImageSceneSnapshot,
+  ImageWorkflowInput,
+} from '@/lib/workflow/types';
+import {
+  computeImageWorkflowHashCurrent,
+  computeImageWorkflowHashFromDto,
+} from './image-workflow-snapshot';
+
+function asScopedDb<T>(stub: T): ScopedDb {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
+  return stub as unknown as ScopedDb;
+}
+
+const baseScene: FrameImageSceneSnapshot = {
+  sceneId: 's1',
+  visualPrompt: 'A wide establishing shot of Jack at the docks at dusk',
+  characterSheetHashes: ['jack-hash-v1'],
+  locationSheetHashes: ['docks-hash-v1'],
+  elementReferenceHashes: [],
+};
+
+const baseInput: ImageWorkflowInput = {
+  userId: 'u1',
+  teamId: 't1',
+  sequenceId: 'seq1',
+  frameId: 'f1',
+  prompt: baseScene.visualPrompt,
+  model: 'nano_banana_2',
+  aspectRatio: '16:9',
+  sceneSnapshot: baseScene,
+};
+
+function buildScopedDbStub(opts: {
+  characterSheetHash?: string | null;
+  locationReferenceHash?: string | null;
+  elementImageUrl?: string | null;
+  frameMetadata?: unknown;
+}) {
+  return asScopedDb({
+    frames: {
+      getById: async () => ({
+        id: 'f1',
+        metadata: opts.frameMetadata ?? {
+          sceneId: 's1',
+          continuity: {
+            characterTags: ['jack'],
+            environmentTag: 'docks',
+            elementTags: [],
+          },
+          metadata: { location: 'Docks' },
+          originalScript: { extract: '' },
+        },
+      }),
+    },
+    characters: {
+      listWithSheets: async () =>
+        opts.characterSheetHash === undefined
+          ? []
+          : [
+              {
+                id: 'c1',
+                sequenceId: 'seq1',
+                characterId: 'jack',
+                consistencyTag: 'jack',
+                name: 'Jack',
+                sheetImageUrl: 'https://example.com/jack.png',
+                sheetInputHash: opts.characterSheetHash,
+              },
+            ],
+    },
+    sequenceLocations: {
+      listWithReferences: async () =>
+        opts.locationReferenceHash === undefined
+          ? []
+          : [
+              {
+                id: 'l1',
+                sequenceId: 'seq1',
+                locationId: 'docks',
+                consistencyTag: 'docks',
+                name: 'Docks',
+                referenceImageUrl: 'https://example.com/docks.png',
+                referenceInputHash: opts.locationReferenceHash,
+              },
+            ],
+    },
+    sequenceElements: {
+      list: async () =>
+        opts.elementImageUrl === undefined
+          ? []
+          : [
+              {
+                id: 'e1',
+                token: 'LOGO',
+                description: null,
+                consistencyTag: 'logo',
+                imageUrl: opts.elementImageUrl,
+              },
+            ],
+    },
+  });
+}
+
+describe('computeImageWorkflowHashFromDto', () => {
+  it('returns the inlined hash sentinel when no snapshot is opted in', async () => {
+    const result = await computeImageWorkflowHashFromDto({
+      ...baseInput,
+      sceneSnapshot: undefined,
+      snapshotInputHash: undefined,
+    });
+    expect(result).toBe('');
+  });
+
+  it('produces a deterministic hash for identical snapshots', async () => {
+    const a = await computeImageWorkflowHashFromDto(baseInput);
+    const b = await computeImageWorkflowHashFromDto(baseInput);
+    expect(a).toBe(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+
+  it('changes the hash when the model changes', async () => {
+    const a = await computeImageWorkflowHashFromDto(baseInput);
+    const b = await computeImageWorkflowHashFromDto({
+      ...baseInput,
+      model: 'seedream_v5',
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it('changes the hash when a character sheet hash changes', async () => {
+    const a = await computeImageWorkflowHashFromDto(baseInput);
+    const b = await computeImageWorkflowHashFromDto({
+      ...baseInput,
+      sceneSnapshot: {
+        ...baseScene,
+        characterSheetHashes: ['jack-hash-v2'],
+      },
+    });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('computeImageWorkflowHashCurrent', () => {
+  it('matches the DTO hash on the convergent path (live state == snapshot)', async () => {
+    const dtoHash = await computeImageWorkflowHashFromDto(baseInput);
+    const currentHash = await computeImageWorkflowHashCurrent(
+      baseInput,
+      buildScopedDbStub({
+        characterSheetHash: 'jack-hash-v1',
+        locationReferenceHash: 'docks-hash-v1',
+      })
+    );
+    expect(currentHash).toBe(dtoHash);
+  });
+
+  it('diverges from the DTO hash when a character sheet was re-hashed mid-flight', async () => {
+    const dtoHash = await computeImageWorkflowHashFromDto(baseInput);
+    const currentHash = await computeImageWorkflowHashCurrent(
+      baseInput,
+      buildScopedDbStub({
+        characterSheetHash: 'jack-hash-v2',
+        locationReferenceHash: 'docks-hash-v1',
+      })
+    );
+    expect(currentHash).not.toBe(dtoHash);
+  });
+
+  it('diverges when an element reference image was swapped', async () => {
+    const inputWithElement: ImageWorkflowInput = {
+      ...baseInput,
+      sceneSnapshot: {
+        ...baseScene,
+        elementReferenceHashes: ['https://example.com/logo-v1.png'],
+      },
+    };
+    const stub = buildScopedDbStub({
+      characterSheetHash: 'jack-hash-v1',
+      locationReferenceHash: 'docks-hash-v1',
+      elementImageUrl: 'https://example.com/logo-v2.png',
+      frameMetadata: {
+        sceneId: 's1',
+        continuity: {
+          characterTags: ['jack'],
+          environmentTag: 'docks',
+          elementTags: ['LOGO'],
+        },
+        metadata: { location: 'Docks' },
+        originalScript: { extract: 'see LOGO at the door' },
+      },
+    });
+    const dtoHash = await computeImageWorkflowHashFromDto(inputWithElement);
+    const currentHash = await computeImageWorkflowHashCurrent(
+      inputWithElement,
+      stub
+    );
+    expect(currentHash).not.toBe(dtoHash);
+  });
+
+  it('returns the inlined hash sentinel when no snapshot is opted in', async () => {
+    const stub = asScopedDb({});
+    const result = await computeImageWorkflowHashCurrent(
+      { ...baseInput, sceneSnapshot: undefined, snapshotInputHash: undefined },
+      stub
+    );
+    expect(result).toBe('');
+  });
+});

--- a/src/lib/workflows/image-workflow-snapshot.test.ts
+++ b/src/lib/workflows/image-workflow-snapshot.test.ts
@@ -17,8 +17,11 @@ import type {
   ImageWorkflowInput,
 } from '@/lib/workflow/types';
 import {
+  buildImageConvergentWrites,
+  buildImageDivergentWrites,
   computeImageWorkflowHashCurrent,
   computeImageWorkflowHashFromDto,
+  persistImageResult,
 } from './image-workflow-snapshot';
 
 function asScopedDb<T>(stub: T): ScopedDb {
@@ -51,21 +54,23 @@ function buildScopedDbStub(opts: {
   elementImageUrl?: string | null;
   frameMetadata?: unknown;
 }) {
+  const defaultMetadata = {
+    sceneId: 's1',
+    continuity: {
+      characterTags: ['jack'],
+      environmentTag: 'docks',
+      elementTags: [],
+    },
+    metadata: { location: 'Docks' },
+    originalScript: { extract: '' },
+  };
+  // Use `in` check so an explicit `frameMetadata: null` flows through (data
+  // corruption case) rather than collapsing to the default via `??`.
+  const metadata =
+    'frameMetadata' in opts ? opts.frameMetadata : defaultMetadata;
   return asScopedDb({
     frames: {
-      getById: async () => ({
-        id: 'f1',
-        metadata: opts.frameMetadata ?? {
-          sceneId: 's1',
-          continuity: {
-            characterTags: ['jack'],
-            environmentTag: 'docks',
-            elementTags: [],
-          },
-          metadata: { location: 'Docks' },
-          originalScript: { extract: '' },
-        },
-      }),
+      getById: async () => ({ id: 'f1', metadata }),
     },
     characters: {
       listWithSheets: async () =>
@@ -218,5 +223,367 @@ describe('computeImageWorkflowHashCurrent', () => {
       stub
     );
     expect(result).toBe('');
+  });
+
+  it('throws when sceneSnapshot is present but aspectRatio is missing', () => {
+    expect(
+      computeImageWorkflowHashCurrent(
+        { ...baseInput, aspectRatio: undefined },
+        buildScopedDbStub({
+          characterSheetHash: 'jack-hash-v1',
+          locationReferenceHash: 'docks-hash-v1',
+        })
+      )
+    ).rejects.toThrow(/aspectRatio is required/);
+  });
+
+  it('throws when the frame exists but has null metadata (data corruption)', () => {
+    const stub = buildScopedDbStub({
+      characterSheetHash: 'jack-hash-v1',
+      locationReferenceHash: 'docks-hash-v1',
+      frameMetadata: null,
+    });
+    expect(computeImageWorkflowHashCurrent(baseInput, stub)).rejects.toThrow(
+      /null metadata/
+    );
+  });
+});
+
+describe('computeImageWorkflowHashFromDto — aspectRatio guard', () => {
+  it('throws when sceneSnapshot is present but aspectRatio is missing', () => {
+    expect(() =>
+      computeImageWorkflowHashFromDto({
+        ...baseInput,
+        aspectRatio: undefined,
+      })
+    ).toThrow(/aspectRatio is required/);
+  });
+});
+
+describe('buildImageConvergentWrites', () => {
+  const upload = {
+    url: 'https://r2/jack-final.png',
+    path: 'team/seq/jack.png',
+  };
+  const generatedAt = new Date('2026-05-04T00:00:00Z');
+
+  it('stamps the new thumbnail + records snapshot hash + clears stale preview/video', () => {
+    const writes = buildImageConvergentWrites({
+      upload,
+      snapshotHash: 'hash-abc',
+      promptHash: 'prompt-xyz',
+      generatedAt,
+    });
+
+    // Frame: new thumbnail + reset video lifecycle (regen invalidates motion).
+    expect(writes.frame).toEqual({
+      thumbnailPath: upload.path,
+      thumbnailUrl: upload.url,
+      thumbnailStatus: 'completed',
+      thumbnailGeneratedAt: generatedAt,
+      thumbnailError: null,
+      thumbnailInputHash: 'hash-abc',
+      videoUrl: null,
+      videoPath: null,
+      videoStatus: 'pending',
+      videoWorkflowRunId: null,
+      videoGeneratedAt: null,
+      videoError: null,
+    });
+
+    // Variant: new thumbnail + previewUrl cleared (no stale preview-mode
+    // pointer left attached after the converged primary write).
+    expect(writes.variant).toEqual({
+      url: upload.url,
+      storagePath: upload.path,
+      previewUrl: null,
+      status: 'completed',
+      generatedAt,
+      error: null,
+      promptHash: 'prompt-xyz',
+      inputHash: 'hash-abc',
+    });
+  });
+
+  it('writes a null inputHash when the workflow did not opt into snapshots', () => {
+    const writes = buildImageConvergentWrites({
+      upload,
+      snapshotHash: null,
+      promptHash: null,
+      generatedAt,
+    });
+    expect(writes.frame.thumbnailInputHash).toBeNull();
+    expect(writes.variant.inputHash).toBeNull();
+  });
+});
+
+describe('buildImageDivergentWrites', () => {
+  const upload = { url: 'https://r2/jack-alt.png', path: 'team/seq/alt.png' };
+  const divergedAt = new Date('2026-05-04T00:00:00Z');
+
+  it('reverts the speculative primary (incl. thumbnailUrl/Path) and emits an alternate row', () => {
+    const writes = buildImageDivergentWrites({
+      upload,
+      snapshotHash: 'hash-xyz',
+      promptHash: 'prompt-pqr',
+      divergedAt,
+    });
+
+    // Frame: fully revert primary thumbnail. Critically, thumbnailUrl AND
+    // thumbnailPath are both nulled so an already-completed frame doesn't
+    // get left at status=pending while a stale URL persists.
+    expect(writes.frame).toEqual({
+      thumbnailUrl: null,
+      thumbnailPath: null,
+      thumbnailStatus: 'pending',
+      thumbnailWorkflowRunId: null,
+      thumbnailGeneratedAt: null,
+      thumbnailError: null,
+      thumbnailInputHash: null,
+    });
+
+    // Primary variant row: speculative URL/status cleared so the primary
+    // slot stops pointing at diverged work.
+    expect(writes.primaryRevert).toEqual({
+      url: null,
+      storagePath: null,
+      previewUrl: null,
+      status: 'pending',
+      workflowRunId: null,
+      generatedAt: null,
+      error: null,
+      inputHash: null,
+    });
+
+    // Divergent alternate: full content payload incl. divergence keys
+    // (inputHash + divergedAt) so insertDivergent can match the partial
+    // unique index for idempotency on QStash retry.
+    expect(writes.divergentRow).toEqual({
+      url: upload.url,
+      storagePath: upload.path,
+      status: 'completed',
+      generatedAt: divergedAt,
+      error: null,
+      promptHash: 'prompt-pqr',
+      inputHash: 'hash-xyz',
+      divergedAt,
+    });
+  });
+});
+
+describe('persistImageResult — orchestration', () => {
+  type Call = { method: string; args: unknown[] };
+  const upload = { url: 'https://r2/jack.png', path: 'team/seq/jack.png' };
+  const NOW = new Date('2026-05-04T00:00:00Z');
+
+  function buildScopedDbSpy(opts: { frameMissing?: boolean } = {}): {
+    scopedDb: ScopedDb;
+    calls: Call[];
+  } {
+    const calls: Call[] = [];
+    const scopedDb = asScopedDb({
+      frames: {
+        update: async (
+          frameId: string,
+          data: unknown,
+          options: { throwOnMissing: boolean }
+        ) => {
+          calls.push({
+            method: 'frames.update',
+            args: [frameId, data, options],
+          });
+          if (opts.frameMissing) return null;
+          return { id: frameId };
+        },
+      },
+      frameVariants: {
+        updateByFrameAndModel: async (
+          frameId: string,
+          variantType: string,
+          model: string,
+          data: unknown
+        ) => {
+          calls.push({
+            method: 'frameVariants.updateByFrameAndModel',
+            args: [frameId, variantType, model, data],
+          });
+          return { id: 'v1' };
+        },
+        insertDivergent: async (data: unknown) => {
+          calls.push({ method: 'frameVariants.insertDivergent', args: [data] });
+          return { id: 'v2' };
+        },
+      },
+    });
+    return { scopedDb, calls };
+  }
+
+  it('divergent path: reverts primary frames row, reverts primary variant, inserts divergent alternate, emits pending', async () => {
+    const { scopedDb, calls } = buildScopedDbSpy();
+    const emits: Array<{ event: string; payload: unknown }> = [];
+
+    const outcome = await persistImageResult({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'nano_banana_2',
+      upload,
+      snapshotHash: 'snapshot-abc',
+      currentHash: 'current-xyz',
+      promptHash: 'prompt-1',
+      emit: async (event, payload) => {
+        emits.push({ event, payload });
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'divergent', imageUrl: upload.url });
+
+    // Frame revert was called first with the divergent revert payload
+    // (incl. nulled url/path so an already-completed frame doesn't carry
+    // a stale URL into pending state).
+    expect(calls[0].method).toBe('frames.update');
+    const frameUpdateData = calls[0].args[1] as Record<string, unknown>;
+    expect(frameUpdateData.thumbnailUrl).toBeNull();
+    expect(frameUpdateData.thumbnailPath).toBeNull();
+    expect(frameUpdateData.thumbnailStatus).toBe('pending');
+    expect(frameUpdateData.thumbnailInputHash).toBeNull();
+
+    // Primary variant reverted (cleared) — primary slot must stop pointing at
+    // diverged work.
+    expect(calls[1].method).toBe('frameVariants.updateByFrameAndModel');
+    const variantRevert = calls[1].args[3] as Record<string, unknown>;
+    expect(variantRevert.url).toBeNull();
+    expect(variantRevert.previewUrl).toBeNull();
+    expect(variantRevert.status).toBe('pending');
+    expect(variantRevert.inputHash).toBeNull();
+
+    // Divergent alternate inserted with snapshot hash + divergedAt for the
+    // partial-unique-index idempotency key.
+    expect(calls[2].method).toBe('frameVariants.insertDivergent');
+    const divergentRow = calls[2].args[0] as Record<string, unknown>;
+    expect(divergentRow.frameId).toBe('f1');
+    expect(divergentRow.sequenceId).toBe('seq1');
+    expect(divergentRow.variantType).toBe('image');
+    expect(divergentRow.model).toBe('nano_banana_2');
+    expect(divergentRow.url).toBe(upload.url);
+    expect(divergentRow.inputHash).toBe('snapshot-abc');
+    expect(divergentRow.divergedAt).toBe(NOW);
+    expect(divergentRow.status).toBe('completed');
+
+    // Emit signals "pending" so the UI doesn't briefly show a completed
+    // primary while the alternate is being routed.
+    expect(emits).toEqual([
+      {
+        event: 'generation.image:progress',
+        payload: { frameId: 'f1', status: 'pending', model: 'nano_banana_2' },
+      },
+    ]);
+  });
+
+  it('convergent path: stamps primary frames row + primary variant with snapshot hash, emits completed, NO insertDivergent call', async () => {
+    const { scopedDb, calls } = buildScopedDbSpy();
+    const emits: Array<{ event: string; payload: unknown }> = [];
+
+    const outcome = await persistImageResult({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'nano_banana_2',
+      upload,
+      snapshotHash: 'snapshot-abc',
+      currentHash: 'snapshot-abc', // matches → convergent
+      promptHash: 'prompt-1',
+      emit: async (event, payload) => {
+        emits.push({ event, payload });
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'convergent', imageUrl: upload.url });
+
+    // Frame primary write with snapshot hash recorded.
+    expect(calls[0].method).toBe('frames.update');
+    const frameUpdateData = calls[0].args[1] as Record<string, unknown>;
+    expect(frameUpdateData.thumbnailUrl).toBe(upload.url);
+    expect(frameUpdateData.thumbnailStatus).toBe('completed');
+    expect(frameUpdateData.thumbnailInputHash).toBe('snapshot-abc');
+
+    // Variant primary write with snapshot hash recorded + previewUrl cleared.
+    expect(calls[1].method).toBe('frameVariants.updateByFrameAndModel');
+    const variantWrite = calls[1].args[3] as Record<string, unknown>;
+    expect(variantWrite.url).toBe(upload.url);
+    expect(variantWrite.status).toBe('completed');
+    expect(variantWrite.inputHash).toBe('snapshot-abc');
+    expect(variantWrite.previewUrl).toBeNull();
+
+    // Critically: no insertDivergent call on the convergent path.
+    expect(
+      calls.some((c) => c.method === 'frameVariants.insertDivergent')
+    ).toBe(false);
+
+    expect(emits).toEqual([
+      {
+        event: 'generation.image:progress',
+        payload: {
+          frameId: 'f1',
+          status: 'completed',
+          thumbnailUrl: upload.url,
+          model: 'nano_banana_2',
+        },
+      },
+    ]);
+  });
+
+  it('non-snapshot mode (snapshotHash null): convergent write with null inputHash, NO insertDivergent', async () => {
+    const { scopedDb, calls } = buildScopedDbSpy();
+    const emits: Array<{ event: string; payload: unknown }> = [];
+
+    const outcome = await persistImageResult({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'nano_banana_2',
+      upload,
+      snapshotHash: null,
+      currentHash: null,
+      promptHash: null,
+      emit: async (event, payload) => {
+        emits.push({ event, payload });
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome.status).toBe('convergent');
+    const frameUpdateData = calls[0].args[1] as Record<string, unknown>;
+    expect(frameUpdateData.thumbnailInputHash).toBeNull();
+    const variantWrite = calls[1].args[3] as Record<string, unknown>;
+    expect(variantWrite.inputHash).toBeNull();
+    expect(
+      calls.some((c) => c.method === 'frameVariants.insertDivergent')
+    ).toBe(false);
+  });
+
+  it('frame deleted mid-flight: short-circuits without touching frame_variants', async () => {
+    const { scopedDb, calls } = buildScopedDbSpy({ frameMissing: true });
+
+    const outcome = await persistImageResult({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'nano_banana_2',
+      upload,
+      snapshotHash: 'snapshot-abc',
+      currentHash: 'current-xyz',
+      promptHash: null,
+      emit: async () => {},
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'frame-deleted' });
+    // Only the initial frames.update was attempted; bail out before any
+    // variant writes when the frame is gone.
+    expect(calls.length).toBe(1);
+    expect(calls[0].method).toBe('frames.update');
   });
 });

--- a/src/lib/workflows/image-workflow-snapshot.ts
+++ b/src/lib/workflows/image-workflow-snapshot.ts
@@ -1,5 +1,5 @@
 /**
- * Snapshot DTO hashers for `generateImageWorkflow`.
+ * Snapshot DTO hashers + persist orchestration for `generateImageWorkflow`.
  *
  * `computeFromDto` hashes the inlined per-scene snapshot for the start-time
  * tamper check. `computeCurrent` re-resolves the live character / location /
@@ -12,13 +12,20 @@
  */
 
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
-import type { NewFrame, NewFrameVariant } from '@/lib/db/schema';
-import type { ScopedDb } from '@/lib/db/scoped';
+import type {
+  CharacterMinimal,
+  NewFrame,
+  NewFrameVariant,
+  SequenceElementMinimal,
+  SequenceLocationMinimal,
+} from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
   FrameImageSceneSnapshot,
   ImageWorkflowInput,
 } from '@/lib/workflow/types';
+import { buildDivergentRevertWrites } from './divergence-writes';
 import { computeFrameImageSceneHash } from './sheet-snapshots';
 import {
   matchCharactersToScene,
@@ -27,6 +34,66 @@ import {
 } from './scene-matching';
 
 export type ImageStorageResult = { url: string; path: string };
+
+/**
+ * Subset of `Scene` actually read by `computeImageWorkflowHashCurrent` —
+ * keeping the narrow shape declared here so production `Scene` (a superset)
+ * assigns cleanly while test stubs can build small literals.
+ */
+export type SceneForHash = {
+  continuity?: {
+    characterTags?: string[];
+    environmentTag?: string;
+    elementTags?: string[];
+  } | null;
+  metadata?: { location?: string } | null;
+  originalScript?: { extract?: string } | null;
+};
+
+/**
+ * Minimum scopedDb surface for `computeImageWorkflowHashCurrent`. Production
+ * `ScopedDb` is a structural superset and assigns cleanly; tests can build
+ * literal objects against this type without casting.
+ */
+export type ImageHashScopedDb = {
+  frames: {
+    getById: (id: string) => Promise<{ metadata: SceneForHash | null } | null>;
+  };
+  characters: {
+    listWithSheets: (seqId: string) => Promise<CharacterMinimal[]>;
+  };
+  sequenceLocations: {
+    listWithReferences: (seqId: string) => Promise<SequenceLocationMinimal[]>;
+  };
+  sequenceElements: {
+    list: (seqId: string) => Promise<SequenceElementMinimal[]>;
+  };
+};
+
+/**
+ * Minimum scopedDb surface for `persistImageResult`. Same pattern as
+ * `ImageHashScopedDb` — production `ScopedDb` satisfies it structurally.
+ */
+export type PersistImageScopedDb = {
+  frames: {
+    update: (
+      id: string,
+      data: Partial<NewFrame>,
+      opts?: { throwOnMissing?: boolean }
+    ) => Promise<{ id: string } | undefined>;
+  };
+  frameVariants: {
+    updateByFrameAndModel: (
+      frameId: string,
+      type: VariantType,
+      model: string,
+      data: Partial<NewFrameVariant>
+    ) => Promise<{ id: string } | null>;
+    insertDivergent: (
+      data: NewFrameVariant & { inputHash: string; divergedAt: Date }
+    ) => Promise<{ id: string }>;
+  };
+};
 
 const NO_SNAPSHOT_SENTINEL = '';
 
@@ -51,10 +118,6 @@ export function computeImageWorkflowHashFromDto(
   input: ImageWorkflowInput
 ): Promise<string> | string {
   if (!input.sceneSnapshot) {
-    // No snapshot opted in. The body must not call `validate()` in this path;
-    // returning the inlined hash (or empty sentinel) keeps validate() honest
-    // for callers that *do* opt in via a missing snapshotInputHash (which
-    // would mismatch and throw).
     return input.snapshotInputHash ?? NO_SNAPSHOT_SENTINEL;
   }
   return computeFrameImageSceneHash(
@@ -64,16 +127,9 @@ export function computeImageWorkflowHashFromDto(
   );
 }
 
-/**
- * Re-resolve the live sheet hashes for the frame's scene and recompute the
- * snapshot hash. Falls back to the DTO hash when the workflow has no scene
- * snapshot or the frame has been deleted — the caller treats matching hashes
- * as "convergent" so a missing frame collapses to the convergent path
- * (image-workflow already short-circuits on deleted frames upstream).
- */
 export async function computeImageWorkflowHashCurrent(
   input: ImageWorkflowInput,
-  scopedDb: ScopedDb
+  scopedDb: ImageHashScopedDb
 ): Promise<string> {
   if (!input.sceneSnapshot)
     return input.snapshotInputHash ?? NO_SNAPSHOT_SENTINEL;
@@ -86,15 +142,12 @@ export async function computeImageWorkflowHashCurrent(
   }
 
   const frame = await scopedDb.frames.getById(input.frameId);
-  // Deleted mid-flight: fall back to DTO hash so the divergence check returns
-  // "convergent". image-workflow's storage step already returns early on
-  // deleted frames, so this branch is just belt-and-braces.
+  // Deleted mid-flight: collapse to convergent so the workflow's
+  // deleted-frame short-circuit handles the cleanup. Distinct from a frame
+  // that exists with null metadata, which is data corruption — refuse.
   if (!frame) {
     return computeFrameImageSceneHash(input.sceneSnapshot, model, aspectRatio);
   }
-  // Frame exists but its scene metadata is gone — that's data corruption,
-  // not a deletion race. Refuse to write a thumbnail to a row whose scene we
-  // can't re-hash.
   if (!frame.metadata) {
     throw new WorkflowValidationError(
       `Frame ${input.frameId} exists but has null metadata; snapshot recompute requires scene metadata`
@@ -141,13 +194,9 @@ export async function computeImageWorkflowHashCurrent(
 }
 
 /**
- * Writes to apply when the per-frame snapshot hash matches between trigger
- * and write time: stamp the new thumbnail onto the primary frame row + primary
- * frame_variants row and record the snapshot hash so downstream staleness
- * reads compare against it.
- *
- * Clears `previewUrl` on the variant row so a prior preview-mode run can't
- * leave a stale preview pointer attached to the converged primary.
+ * Convergent write also clears `variant.previewUrl` so a prior preview-mode
+ * run can't leave a stale preview pointer attached to the converged primary.
+ * Resets video lifecycle because a new thumbnail invalidates dependent motion.
  */
 export function buildImageConvergentWrites(opts: {
   upload: ImageStorageResult;
@@ -188,19 +237,10 @@ export function buildImageConvergentWrites(opts: {
 }
 
 /**
- * Writes to apply when current inputs no longer match the snapshot.
- *
- *   - `frame`: revert the speculative primary thumbnail back to `pending` and
- *     fully clear url/path so an already-completed frame doesn't end up with
- *     `status=pending` while a stale URL persists.
- *   - `primaryRevert`: clear the speculative URL/status that the start-step
- *     pre-wrote to the primary variant row, so the primary slot stops pointing
- *     at the diverged work.
- *   - `divergentRow`: full payload for an INSERT that preserves the diverged
- *     result as an alternate. The caller supplies the workflow context fields
- *     (frameId/sequenceId/variantType/model); this helper supplies the
- *     content fields including the divergence-specific `inputHash` +
- *     `divergedAt` that key the divergent partial unique index.
+ * `divergentRow` is the full INSERT payload for the divergent alternate. The
+ * caller supplies frameId/sequenceId/variantType/model; this helper supplies
+ * the content fields including the `inputHash` + `divergedAt` keys that match
+ * the `frame_variants` divergent partial unique index.
  */
 export function buildImageDivergentWrites(opts: {
   upload: ImageStorageResult;
@@ -220,25 +260,7 @@ export function buildImageDivergentWrites(opts: {
 } {
   const { upload, snapshotHash, promptHash, divergedAt } = opts;
   return {
-    frame: {
-      thumbnailUrl: null,
-      thumbnailPath: null,
-      thumbnailStatus: 'pending',
-      thumbnailWorkflowRunId: null,
-      thumbnailGeneratedAt: null,
-      thumbnailError: null,
-      thumbnailInputHash: null,
-    },
-    primaryRevert: {
-      url: null,
-      storagePath: null,
-      previewUrl: null,
-      status: 'pending',
-      workflowRunId: null,
-      generatedAt: null,
-      error: null,
-      inputHash: null,
-    },
+    ...buildDivergentRevertWrites(),
     divergentRow: {
       url: upload.url,
       storagePath: upload.path,
@@ -253,28 +275,23 @@ export function buildImageDivergentWrites(opts: {
 }
 
 export type PersistImageOutcome =
-  | { status: 'divergent'; imageUrl: string }
+  | { status: 'divergent'; imageUrl: string; snapshotHash: string }
   | { status: 'convergent'; imageUrl: string }
   | { status: 'frame-deleted' };
 
 /**
- * Orchestrates the divergence branch + DB writes for the image workflow.
- *
- * Pulled out of the workflow body so the call sequence (which scopedDb
- * methods get called, in what order, with what payload) is testable without
+ * Pulled out of the workflow body so the call sequence is testable without
  * bootstrapping `createWorkflow`. The workflow remains responsible for the
  * `context.run` boundary and for resolving `currentHash` via
- * `context.snapshot.computeCurrent()` — that lets retries re-resolve the
- * live state cheaply without re-running this orchestration on a successful
- * step.
+ * `context.snapshot.computeCurrent()` so retries re-resolve live state
+ * cheaply without re-running this orchestration on a successful step.
  *
- * Idempotent on retry:
- *   - `frames.update` is last-write-wins,
- *   - `frameVariants.updateByFrameAndModel` is last-write-wins,
- *   - `frameVariants.insertDivergent` pre-checks `(frame, type, model, hash)`.
+ * Idempotent on retry: `frames.update` and
+ * `frameVariants.updateByFrameAndModel` are last-write-wins, and
+ * `frameVariants.insertDivergent` pre-checks `(frame, type, model, hash)`.
  */
 export async function persistImageResult(opts: {
-  scopedDb: ScopedDb;
+  scopedDb: PersistImageScopedDb;
   frameId: string;
   sequenceId: string;
   model: string;
@@ -306,9 +323,7 @@ export async function persistImageResult(opts: {
     now = () => new Date(),
   } = opts;
 
-  const divergent = !!snapshotHash && currentHash !== snapshotHash;
-
-  if (divergent && snapshotHash) {
+  if (snapshotHash && currentHash !== snapshotHash) {
     const writes = buildImageDivergentWrites({
       upload,
       snapshotHash,
@@ -342,7 +357,7 @@ export async function persistImageResult(opts: {
       model,
     });
 
-    return { status: 'divergent', imageUrl: upload.url };
+    return { status: 'divergent', imageUrl: upload.url, snapshotHash };
   }
 
   const writes = buildImageConvergentWrites({

--- a/src/lib/workflows/image-workflow-snapshot.ts
+++ b/src/lib/workflows/image-workflow-snapshot.ts
@@ -1,0 +1,119 @@
+/**
+ * Snapshot DTO hashers for `generateImageWorkflow`.
+ *
+ * `computeFromDto` hashes the inlined per-scene snapshot for the start-time
+ * tamper check. `computeCurrent` re-resolves the live character / location /
+ * element sheet hashes from the scoped DB so the workflow can detect upstream
+ * drift between trigger and write time and route divergent results into
+ * `frame_variants` instead of overwriting the primary thumbnail.
+ *
+ * See docs/architecture/workflow-snapshots-and-content-hash-staleness.md
+ * § "Pillar 3: Divergence-on-completion".
+ */
+
+import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
+import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
+import type { ScopedDb } from '@/lib/db/scoped';
+import type {
+  FrameImageSceneSnapshot,
+  ImageWorkflowInput,
+} from '@/lib/workflow/types';
+import { computeFrameImageSceneHash } from './sheet-snapshots';
+import {
+  matchCharactersToScene,
+  matchElementsToScene,
+  matchLocationsToScene,
+} from './scene-matching';
+
+const NO_SNAPSHOT_SENTINEL = '';
+
+function sortedHashes(values: Array<string | null | undefined>): string[] {
+  return values
+    .filter((v): v is string => typeof v === 'string' && v.length > 0)
+    .sort();
+}
+
+export function computeImageWorkflowHashFromDto(
+  input: ImageWorkflowInput
+): Promise<string> | string {
+  if (!input.sceneSnapshot) {
+    // No snapshot opted in. The body must not call `validate()` in this path;
+    // returning the inlined hash (or empty sentinel) keeps validate() honest
+    // for callers that *do* opt in via a missing snapshotInputHash (which
+    // would mismatch and throw).
+    return input.snapshotInputHash ?? NO_SNAPSHOT_SENTINEL;
+  }
+  return computeFrameImageSceneHash(
+    input.sceneSnapshot,
+    input.model ?? DEFAULT_IMAGE_MODEL,
+    input.aspectRatio ?? DEFAULT_ASPECT_RATIO
+  );
+}
+
+/**
+ * Re-resolve the live sheet hashes for the frame's scene and recompute the
+ * snapshot hash. Falls back to the DTO hash when the workflow has no scene
+ * snapshot or the frame has been deleted — the caller treats matching hashes
+ * as "convergent" so a missing frame collapses to the convergent path
+ * (image-workflow already short-circuits on deleted frames upstream).
+ */
+export async function computeImageWorkflowHashCurrent(
+  input: ImageWorkflowInput,
+  scopedDb: ScopedDb
+): Promise<string> {
+  if (!input.sceneSnapshot)
+    return input.snapshotInputHash ?? NO_SNAPSHOT_SENTINEL;
+
+  const model = input.model ?? DEFAULT_IMAGE_MODEL;
+  const aspectRatio = input.aspectRatio ?? DEFAULT_ASPECT_RATIO;
+
+  if (!input.sequenceId || !input.frameId) {
+    return computeFrameImageSceneHash(input.sceneSnapshot, model, aspectRatio);
+  }
+
+  const frame = await scopedDb.frames.getById(input.frameId);
+  // Deleted mid-flight: fall back to DTO hash so the divergence check returns
+  // "convergent". image-workflow's storage step already returns early on
+  // deleted frames, so this branch is just belt-and-braces.
+  if (!frame?.metadata) {
+    return computeFrameImageSceneHash(input.sceneSnapshot, model, aspectRatio);
+  }
+
+  const [characters, locations, elements] = await Promise.all([
+    scopedDb.characters.listWithSheets(input.sequenceId),
+    scopedDb.sequenceLocations.listWithReferences(input.sequenceId),
+    scopedDb.sequenceElements.list(input.sequenceId),
+  ]);
+
+  const scene = frame.metadata;
+  const matchedCharacters = matchCharactersToScene(
+    characters,
+    scene.continuity?.characterTags ?? []
+  );
+  const matchedLocations = matchLocationsToScene(
+    locations,
+    scene.continuity?.environmentTag ?? '',
+    scene.metadata?.location ?? ''
+  );
+  const matchedElements = matchElementsToScene(
+    elements,
+    scene.continuity?.elementTags ?? [],
+    scene.originalScript?.extract ?? ''
+  );
+
+  const currentSnapshot: FrameImageSceneSnapshot = {
+    sceneId: input.sceneSnapshot.sceneId,
+    visualPrompt: input.sceneSnapshot.visualPrompt,
+    characterSheetHashes: sortedHashes(
+      matchedCharacters.map((c) => c.sheetInputHash)
+    ),
+    locationSheetHashes: sortedHashes(
+      matchedLocations.map((l) => l.referenceInputHash)
+    ),
+    elementReferenceHashes: sortedHashes(
+      matchedElements.map((e) => e.imageUrl)
+    ),
+  };
+
+  return computeFrameImageSceneHash(currentSnapshot, model, aspectRatio);
+}

--- a/src/lib/workflows/image-workflow-snapshot.ts
+++ b/src/lib/workflows/image-workflow-snapshot.ts
@@ -12,8 +12,9 @@
  */
 
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
-import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
+import type { NewFrame, NewFrameVariant } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
+import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
   FrameImageSceneSnapshot,
   ImageWorkflowInput,
@@ -25,12 +26,25 @@ import {
   matchLocationsToScene,
 } from './scene-matching';
 
+export type ImageStorageResult = { url: string; path: string };
+
 const NO_SNAPSHOT_SENTINEL = '';
 
 function sortedHashes(values: Array<string | null | undefined>): string[] {
   return values
     .filter((v): v is string => typeof v === 'string' && v.length > 0)
     .sort();
+}
+
+function requireAspectRatio(
+  input: ImageWorkflowInput
+): NonNullable<ImageWorkflowInput['aspectRatio']> {
+  if (!input.aspectRatio) {
+    throw new WorkflowValidationError(
+      'aspectRatio is required when sceneSnapshot is present; trigger-time and write-time hashes would otherwise diverge'
+    );
+  }
+  return input.aspectRatio;
 }
 
 export function computeImageWorkflowHashFromDto(
@@ -46,7 +60,7 @@ export function computeImageWorkflowHashFromDto(
   return computeFrameImageSceneHash(
     input.sceneSnapshot,
     input.model ?? DEFAULT_IMAGE_MODEL,
-    input.aspectRatio ?? DEFAULT_ASPECT_RATIO
+    requireAspectRatio(input)
   );
 }
 
@@ -65,7 +79,7 @@ export async function computeImageWorkflowHashCurrent(
     return input.snapshotInputHash ?? NO_SNAPSHOT_SENTINEL;
 
   const model = input.model ?? DEFAULT_IMAGE_MODEL;
-  const aspectRatio = input.aspectRatio ?? DEFAULT_ASPECT_RATIO;
+  const aspectRatio = requireAspectRatio(input);
 
   if (!input.sequenceId || !input.frameId) {
     return computeFrameImageSceneHash(input.sceneSnapshot, model, aspectRatio);
@@ -75,8 +89,16 @@ export async function computeImageWorkflowHashCurrent(
   // Deleted mid-flight: fall back to DTO hash so the divergence check returns
   // "convergent". image-workflow's storage step already returns early on
   // deleted frames, so this branch is just belt-and-braces.
-  if (!frame?.metadata) {
+  if (!frame) {
     return computeFrameImageSceneHash(input.sceneSnapshot, model, aspectRatio);
+  }
+  // Frame exists but its scene metadata is gone — that's data corruption,
+  // not a deletion race. Refuse to write a thumbnail to a row whose scene we
+  // can't re-hash.
+  if (!frame.metadata) {
+    throw new WorkflowValidationError(
+      `Frame ${input.frameId} exists but has null metadata; snapshot recompute requires scene metadata`
+    );
   }
 
   const [characters, locations, elements] = await Promise.all([
@@ -116,4 +138,238 @@ export async function computeImageWorkflowHashCurrent(
   };
 
   return computeFrameImageSceneHash(currentSnapshot, model, aspectRatio);
+}
+
+/**
+ * Writes to apply when the per-frame snapshot hash matches between trigger
+ * and write time: stamp the new thumbnail onto the primary frame row + primary
+ * frame_variants row and record the snapshot hash so downstream staleness
+ * reads compare against it.
+ *
+ * Clears `previewUrl` on the variant row so a prior preview-mode run can't
+ * leave a stale preview pointer attached to the converged primary.
+ */
+export function buildImageConvergentWrites(opts: {
+  upload: ImageStorageResult;
+  snapshotHash: string | null;
+  promptHash: string | null;
+  generatedAt: Date;
+}): {
+  frame: Partial<NewFrame>;
+  variant: Partial<NewFrameVariant>;
+} {
+  const { upload, snapshotHash, promptHash, generatedAt } = opts;
+  return {
+    frame: {
+      thumbnailPath: upload.path,
+      thumbnailUrl: upload.url,
+      thumbnailStatus: 'completed',
+      thumbnailGeneratedAt: generatedAt,
+      thumbnailError: null,
+      thumbnailInputHash: snapshotHash,
+      videoUrl: null,
+      videoPath: null,
+      videoStatus: 'pending',
+      videoWorkflowRunId: null,
+      videoGeneratedAt: null,
+      videoError: null,
+    },
+    variant: {
+      url: upload.url,
+      storagePath: upload.path,
+      previewUrl: null,
+      status: 'completed',
+      generatedAt,
+      error: null,
+      promptHash,
+      inputHash: snapshotHash,
+    },
+  };
+}
+
+/**
+ * Writes to apply when current inputs no longer match the snapshot.
+ *
+ *   - `frame`: revert the speculative primary thumbnail back to `pending` and
+ *     fully clear url/path so an already-completed frame doesn't end up with
+ *     `status=pending` while a stale URL persists.
+ *   - `primaryRevert`: clear the speculative URL/status that the start-step
+ *     pre-wrote to the primary variant row, so the primary slot stops pointing
+ *     at the diverged work.
+ *   - `divergentRow`: full payload for an INSERT that preserves the diverged
+ *     result as an alternate. The caller supplies the workflow context fields
+ *     (frameId/sequenceId/variantType/model); this helper supplies the
+ *     content fields including the divergence-specific `inputHash` +
+ *     `divergedAt` that key the divergent partial unique index.
+ */
+export function buildImageDivergentWrites(opts: {
+  upload: ImageStorageResult;
+  snapshotHash: string;
+  promptHash: string | null;
+  divergedAt: Date;
+}): {
+  frame: Partial<NewFrame>;
+  primaryRevert: Partial<NewFrameVariant>;
+  divergentRow: Partial<NewFrameVariant> & {
+    url: string;
+    storagePath: string;
+    inputHash: string;
+    divergedAt: Date;
+    status: 'completed';
+  };
+} {
+  const { upload, snapshotHash, promptHash, divergedAt } = opts;
+  return {
+    frame: {
+      thumbnailUrl: null,
+      thumbnailPath: null,
+      thumbnailStatus: 'pending',
+      thumbnailWorkflowRunId: null,
+      thumbnailGeneratedAt: null,
+      thumbnailError: null,
+      thumbnailInputHash: null,
+    },
+    primaryRevert: {
+      url: null,
+      storagePath: null,
+      previewUrl: null,
+      status: 'pending',
+      workflowRunId: null,
+      generatedAt: null,
+      error: null,
+      inputHash: null,
+    },
+    divergentRow: {
+      url: upload.url,
+      storagePath: upload.path,
+      status: 'completed',
+      generatedAt: divergedAt,
+      error: null,
+      promptHash,
+      inputHash: snapshotHash,
+      divergedAt,
+    },
+  };
+}
+
+export type PersistImageOutcome =
+  | { status: 'divergent'; imageUrl: string }
+  | { status: 'convergent'; imageUrl: string }
+  | { status: 'frame-deleted' };
+
+/**
+ * Orchestrates the divergence branch + DB writes for the image workflow.
+ *
+ * Pulled out of the workflow body so the call sequence (which scopedDb
+ * methods get called, in what order, with what payload) is testable without
+ * bootstrapping `createWorkflow`. The workflow remains responsible for the
+ * `context.run` boundary and for resolving `currentHash` via
+ * `context.snapshot.computeCurrent()` — that lets retries re-resolve the
+ * live state cheaply without re-running this orchestration on a successful
+ * step.
+ *
+ * Idempotent on retry:
+ *   - `frames.update` is last-write-wins,
+ *   - `frameVariants.updateByFrameAndModel` is last-write-wins,
+ *   - `frameVariants.insertDivergent` pre-checks `(frame, type, model, hash)`.
+ */
+export async function persistImageResult(opts: {
+  scopedDb: ScopedDb;
+  frameId: string;
+  sequenceId: string;
+  model: string;
+  upload: ImageStorageResult;
+  snapshotHash: string | null;
+  currentHash: string | null;
+  promptHash: string | null;
+  emit: (
+    event: 'generation.image:progress',
+    payload: {
+      frameId: string;
+      status: 'pending' | 'completed';
+      model: string;
+      thumbnailUrl?: string;
+    }
+  ) => Promise<void>;
+  now?: () => Date;
+}): Promise<PersistImageOutcome> {
+  const {
+    scopedDb,
+    frameId,
+    sequenceId,
+    model,
+    upload,
+    snapshotHash,
+    currentHash,
+    promptHash,
+    emit,
+    now = () => new Date(),
+  } = opts;
+
+  const divergent = !!snapshotHash && currentHash !== snapshotHash;
+
+  if (divergent && snapshotHash) {
+    const writes = buildImageDivergentWrites({
+      upload,
+      snapshotHash,
+      promptHash,
+      divergedAt: now(),
+    });
+
+    const updatedFrame = await scopedDb.frames.update(frameId, writes.frame, {
+      throwOnMissing: false,
+    });
+    if (!updatedFrame) return { status: 'frame-deleted' };
+
+    await scopedDb.frameVariants.updateByFrameAndModel(
+      frameId,
+      'image',
+      model,
+      writes.primaryRevert
+    );
+
+    await scopedDb.frameVariants.insertDivergent({
+      frameId,
+      sequenceId,
+      variantType: 'image',
+      model,
+      ...writes.divergentRow,
+    });
+
+    await emit('generation.image:progress', {
+      frameId,
+      status: 'pending',
+      model,
+    });
+
+    return { status: 'divergent', imageUrl: upload.url };
+  }
+
+  const writes = buildImageConvergentWrites({
+    upload,
+    snapshotHash,
+    promptHash,
+    generatedAt: now(),
+  });
+
+  const updatedFrame = await scopedDb.frames.update(frameId, writes.frame, {
+    throwOnMissing: false,
+  });
+  if (!updatedFrame) return { status: 'frame-deleted' };
+
+  await scopedDb.frameVariants.updateByFrameAndModel(
+    frameId,
+    'image',
+    model,
+    writes.variant
+  );
+
+  await emit('generation.image:progress', {
+    frameId,
+    status: 'completed',
+    thumbnailUrl: upload.url,
+    model,
+  });
+
+  return { status: 'convergent', imageUrl: upload.url };
 }

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -16,6 +16,7 @@ import type { ImageWorkflowInput } from '@/lib/workflow/types';
 import {
   computeImageWorkflowHashCurrent,
   computeImageWorkflowHashFromDto,
+  persistImageResult,
 } from './image-workflow-snapshot';
 
 type ImageWorkflowResult = {
@@ -35,14 +36,22 @@ export const generateImageWorkflow = createScopedWorkflow<
     // runStarted-middleware throws to console.error, so payload-tamper
     // detection only halts the run when the throw originates inside
     // `context.run`. Skipped when the caller did not opt into the snapshot.
-    const snapshotOpted = !!input.sceneSnapshot;
-    if (snapshotOpted) {
+    if (input.sceneSnapshot) {
       await context.run('validate-snapshot', async () => {
         if (context.snapshot) {
           await context.snapshot.validate();
         }
       });
     }
+
+    // Source of truth for whether this run opted into the snapshot pattern.
+    // After `validate-snapshot`, a non-null hash is guaranteed when
+    // `sceneSnapshot` is present (the validator throws otherwise), so the
+    // type narrows to `string | null` without needing `?? null` at use sites.
+    const snapshotHash: string | null =
+      input.sceneSnapshot && input.snapshotInputHash
+        ? input.snapshotInputHash
+        : null;
 
     const generationParams = await context.run(
       'set-generating-status',
@@ -155,164 +164,69 @@ export const generateImageWorkflow = createScopedWorkflow<
     let imageUrl: string = imageResult.imageUrls[0];
 
     if (imageUrl && frameId && sequenceId && teamId && !input.skipStorage) {
-      const writeResult = await context.run(
-        'persist-result',
-        async (): Promise<{ imageUrl: string } | null> => {
-          const upload = await uploadImageToStorage({
-            imageUrl,
-            teamId,
-            sequenceId,
-            frameId,
-          });
+      // Step 1: durable R2 upload. Isolated so a transient failure in the
+      // downstream divergence/persist step doesn't re-upload (and leak) the
+      // R2 object on QStash retry. Upstash persists the return value so
+      // retries of any later step see the same url+path.
+      const upload = await context.run('upload-image', async () => {
+        return uploadImageToStorage({
+          imageUrl,
+          teamId,
+          sequenceId,
+          frameId,
+        });
+      });
 
-          if (!upload.url) {
-            throw new Error('Failed to upload image to storage');
-          }
+      // Step 2: divergence check + DB writes + emit. Idempotent on retry —
+      // frame.update + variants.updateByFrameAndModel are last-write-wins,
+      // and insertDivergent pre-checks (frame, type, model, inputHash).
+      const writeResult = await context.run('persist-result', async () => {
+        const promptHash = input.prompt ? simpleHash(input.prompt) : null;
+        const { model } = generationParams;
 
-          // Re-resolve current sheet hashes when the caller opted into the
-          // snapshot pattern. A divergence between the trigger-time snapshot
-          // and the current state means the references that produced this
-          // image are no longer authoritative — preserve the result as a
-          // divergent alternate instead of overwriting the primary thumbnail.
-          const snapshotHash = input.snapshotInputHash;
-          let divergent = false;
-          if (snapshotOpted && context.snapshot && snapshotHash) {
-            const currentHash = await context.snapshot.computeCurrent();
-            divergent = currentHash !== snapshotHash;
-          }
+        // Re-resolve current sheet hashes when the caller opted into the
+        // snapshot pattern. A divergence between the trigger-time snapshot
+        // and the current state means the references that produced this
+        // image are no longer authoritative — preserve the result as a
+        // divergent alternate instead of overwriting the primary thumbnail.
+        const currentHash =
+          snapshotHash && context.snapshot
+            ? await context.snapshot.computeCurrent()
+            : null;
 
-          if (divergent && snapshotHash) {
-            // Revert the speculative primary status we set at start so the
-            // primary thumbnail goes back to `pending`. The frame row never
-            // held a URL (storage write happens here), so we only roll back
-            // the lifecycle fields.
-            const updatedFrame = await scopedDb.frames.update(
-              frameId,
-              {
-                thumbnailStatus: 'pending',
-                thumbnailWorkflowRunId: null,
-                thumbnailGeneratedAt: null,
-                thumbnailError: null,
-                thumbnailInputHash: null,
-              },
-              { throwOnMissing: false }
-            );
+        const outcome = await persistImageResult({
+          scopedDb,
+          frameId,
+          sequenceId,
+          model,
+          upload,
+          snapshotHash,
+          currentHash,
+          promptHash,
+          emit: async (event, payload) => {
+            await getGenerationChannel(sequenceId).emit(event, payload);
+          },
+        });
 
-            if (!updatedFrame) {
-              console.log(
-                '[ImageWorkflow]',
-                `Frame ${frameId} was deleted, skipping divergent write`
-              );
-              return null;
-            }
-
-            // Revert the speculative primary frame_variants row so the
-            // primary slot stops pointing at diverged work.
-            await scopedDb.frameVariants.updateByFrameAndModel(
-              frameId,
-              'image',
-              generationParams.model,
-              {
-                url: null,
-                storagePath: null,
-                previewUrl: null,
-                status: 'pending',
-                workflowRunId: null,
-                generatedAt: null,
-                error: null,
-                inputHash: null,
-              }
-            );
-
-            // Insert (or no-op on retry) a divergent alternate preserving
-            // the diverged result for comparison/promotion.
-            const divergedAt = new Date();
-            await scopedDb.frameVariants.insertDivergent({
-              frameId,
-              sequenceId,
-              variantType: 'image',
-              model: generationParams.model,
-              url: upload.url,
-              storagePath: upload.path || null,
-              status: 'completed',
-              generatedAt: divergedAt,
-              error: null,
-              promptHash: input.prompt ? simpleHash(input.prompt) : null,
-              inputHash: snapshotHash,
-              divergedAt,
-            });
-
-            await getGenerationChannel(sequenceId).emit(
-              'generation.image:progress',
-              { frameId, status: 'pending', model: generationParams.model }
-            );
-
-            console.log(
-              '[ImageWorkflow]',
-              `Diverged frame ${frameId}: snapshot=${snapshotHash.slice(0, 8)}; routed alternate to frame_variants`
-            );
-
-            return { imageUrl: upload.url };
-          }
-
-          // Convergent path (or no snapshot opted in): primary write.
-          const updatedFrame = await scopedDb.frames.update(
-            frameId,
-            {
-              thumbnailPath: upload.path || null,
-              thumbnailUrl: upload.url,
-              thumbnailStatus: 'completed',
-              thumbnailGeneratedAt: new Date(),
-              thumbnailError: null,
-              thumbnailInputHash: snapshotOpted ? (snapshotHash ?? null) : null,
-              videoUrl: null,
-              videoPath: null,
-              videoStatus: 'pending',
-              videoWorkflowRunId: null,
-              videoGeneratedAt: null,
-              videoError: null,
-            },
-            { throwOnMissing: false }
+        if (outcome.status === 'frame-deleted') {
+          console.log(
+            '[ImageWorkflow]',
+            `Frame ${frameId} was deleted, skipping persist`
           );
-
-          if (!updatedFrame) {
-            console.log(
-              '[ImageWorkflow]',
-              `Frame ${frameId} was deleted, skipping final update`
-            );
-            return null;
-          }
-
-          await scopedDb.frameVariants.updateByFrameAndModel(
-            frameId,
-            'image',
-            generationParams.model,
-            {
-              url: upload.url,
-              storagePath: upload.path || null,
-              status: 'completed',
-              generatedAt: new Date(),
-              error: null,
-              promptHash: input.prompt ? simpleHash(input.prompt) : null,
-              inputHash: snapshotOpted ? (snapshotHash ?? null) : null,
-            }
-          );
-
-          await getGenerationChannel(sequenceId).emit(
-            'generation.image:progress',
-            {
-              frameId,
-              status: 'completed',
-              thumbnailUrl: upload.url,
-              model: generationParams.model,
-            }
-          );
-
-          console.log('[ImageWorkflow]', `Uploaded to storage: ${upload.path}`);
-
-          return { imageUrl: upload.url };
+          return null;
         }
-      );
+
+        if (outcome.status === 'divergent' && snapshotHash) {
+          console.log(
+            '[ImageWorkflow]',
+            `Diverged frame ${frameId}: snapshot=${snapshotHash.slice(0, 8)} current=${currentHash?.slice(0, 8)}; routed alternate to frame_variants`
+          );
+        } else {
+          console.log('[ImageWorkflow]', `Uploaded to storage: ${upload.path}`);
+        }
+
+        return { imageUrl: outcome.imageUrl };
+      });
       if (writeResult) imageUrl = writeResult.imageUrl;
     } else if (imageUrl && frameId && input.skipStorage) {
       // Preview mode: store fal.ai CDN URL in dedicated preview field

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -32,10 +32,8 @@ export const generateImageWorkflow = createScopedWorkflow<
   async (context, scopedDb) => {
     const input = context.requestPayload;
 
-    // Validate the inlined snapshot inside the body. Upstash swallows
-    // runStarted-middleware throws to console.error, so payload-tamper
-    // detection only halts the run when the throw originates inside
-    // `context.run`. Skipped when the caller did not opt into the snapshot.
+    // Upstash swallows runStarted-middleware throws to console.error, so
+    // payload-tamper detection only halts the run from inside `context.run`.
     if (input.sceneSnapshot) {
       await context.run('validate-snapshot', async () => {
         if (context.snapshot) {
@@ -44,10 +42,8 @@ export const generateImageWorkflow = createScopedWorkflow<
       });
     }
 
-    // Source of truth for whether this run opted into the snapshot pattern.
-    // After `validate-snapshot`, a non-null hash is guaranteed when
-    // `sceneSnapshot` is present (the validator throws otherwise), so the
-    // type narrows to `string | null` without needing `?? null` at use sites.
+    // After validate-snapshot, snapshotInputHash is guaranteed when
+    // sceneSnapshot is present, so this narrows to `string | null` cleanly.
     const snapshotHash: string | null =
       input.sceneSnapshot && input.snapshotInputHash
         ? input.snapshotInputHash

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -13,6 +13,10 @@ import { WorkflowValidationError } from '@/lib/workflow/errors';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type { ImageWorkflowInput } from '@/lib/workflow/types';
+import {
+  computeImageWorkflowHashCurrent,
+  computeImageWorkflowHashFromDto,
+} from './image-workflow-snapshot';
 
 type ImageWorkflowResult = {
   imageUrl: string;
@@ -26,6 +30,19 @@ export const generateImageWorkflow = createScopedWorkflow<
 >(
   async (context, scopedDb) => {
     const input = context.requestPayload;
+
+    // Validate the inlined snapshot inside the body. Upstash swallows
+    // runStarted-middleware throws to console.error, so payload-tamper
+    // detection only halts the run when the throw originates inside
+    // `context.run`. Skipped when the caller did not opt into the snapshot.
+    const snapshotOpted = !!input.sceneSnapshot;
+    if (snapshotOpted) {
+      await context.run('validate-snapshot', async () => {
+        if (context.snapshot) {
+          await context.snapshot.validate();
+        }
+      });
+    }
 
     const generationParams = await context.run(
       'set-generating-status',
@@ -138,74 +155,165 @@ export const generateImageWorkflow = createScopedWorkflow<
     let imageUrl: string = imageResult.imageUrls[0];
 
     if (imageUrl && frameId && sequenceId && teamId && !input.skipStorage) {
-      const storageUrl = await context.run('upload-to-storage', async () => {
-        const result = await uploadImageToStorage({
-          imageUrl,
-          teamId,
-          sequenceId,
-          frameId,
-        });
-
-        if (!result.url) {
-          throw new Error('Failed to upload image to storage');
-        }
-
-        const updatedFrame = await scopedDb.frames.update(
-          frameId,
-          {
-            thumbnailPath: result.path || null,
-            thumbnailUrl: result.url,
-            thumbnailStatus: 'completed',
-            thumbnailGeneratedAt: new Date(),
-            thumbnailError: null,
-            videoUrl: null,
-            videoPath: null,
-            videoStatus: 'pending',
-            videoWorkflowRunId: null,
-            videoGeneratedAt: null,
-            videoError: null,
-          },
-          { throwOnMissing: false }
-        );
-
-        if (!updatedFrame) {
-          console.log(
-            '[ImageWorkflow]',
-            `Frame ${frameId} was deleted, skipping final update`
-          );
-          return;
-        }
-
-        // Dual-write: update frame_variants row (returns null if row doesn't exist)
-        await scopedDb.frameVariants.updateByFrameAndModel(
-          frameId,
-          'image',
-          generationParams.model,
-          {
-            url: result.url,
-            storagePath: result.path || null,
-            status: 'completed',
-            generatedAt: new Date(),
-            error: null,
-            promptHash: input.prompt ? simpleHash(input.prompt) : null,
-          }
-        );
-
-        await getGenerationChannel(sequenceId).emit(
-          'generation.image:progress',
-          {
+      const writeResult = await context.run(
+        'persist-result',
+        async (): Promise<{ imageUrl: string } | null> => {
+          const upload = await uploadImageToStorage({
+            imageUrl,
+            teamId,
+            sequenceId,
             frameId,
-            status: 'completed',
-            thumbnailUrl: result.url,
-            model: generationParams.model,
+          });
+
+          if (!upload.url) {
+            throw new Error('Failed to upload image to storage');
           }
-        );
 
-        console.log('[ImageWorkflow]', `Uploaded to storage: ${result.path}`);
+          // Re-resolve current sheet hashes when the caller opted into the
+          // snapshot pattern. A divergence between the trigger-time snapshot
+          // and the current state means the references that produced this
+          // image are no longer authoritative — preserve the result as a
+          // divergent alternate instead of overwriting the primary thumbnail.
+          const snapshotHash = input.snapshotInputHash;
+          let divergent = false;
+          if (snapshotOpted && context.snapshot && snapshotHash) {
+            const currentHash = await context.snapshot.computeCurrent();
+            divergent = currentHash !== snapshotHash;
+          }
 
-        return result.url;
-      });
-      if (storageUrl) imageUrl = storageUrl;
+          if (divergent && snapshotHash) {
+            // Revert the speculative primary status we set at start so the
+            // primary thumbnail goes back to `pending`. The frame row never
+            // held a URL (storage write happens here), so we only roll back
+            // the lifecycle fields.
+            const updatedFrame = await scopedDb.frames.update(
+              frameId,
+              {
+                thumbnailStatus: 'pending',
+                thumbnailWorkflowRunId: null,
+                thumbnailGeneratedAt: null,
+                thumbnailError: null,
+                thumbnailInputHash: null,
+              },
+              { throwOnMissing: false }
+            );
+
+            if (!updatedFrame) {
+              console.log(
+                '[ImageWorkflow]',
+                `Frame ${frameId} was deleted, skipping divergent write`
+              );
+              return null;
+            }
+
+            // Revert the speculative primary frame_variants row so the
+            // primary slot stops pointing at diverged work.
+            await scopedDb.frameVariants.updateByFrameAndModel(
+              frameId,
+              'image',
+              generationParams.model,
+              {
+                url: null,
+                storagePath: null,
+                previewUrl: null,
+                status: 'pending',
+                workflowRunId: null,
+                generatedAt: null,
+                error: null,
+                inputHash: null,
+              }
+            );
+
+            // Insert (or no-op on retry) a divergent alternate preserving
+            // the diverged result for comparison/promotion.
+            const divergedAt = new Date();
+            await scopedDb.frameVariants.insertDivergent({
+              frameId,
+              sequenceId,
+              variantType: 'image',
+              model: generationParams.model,
+              url: upload.url,
+              storagePath: upload.path || null,
+              status: 'completed',
+              generatedAt: divergedAt,
+              error: null,
+              promptHash: input.prompt ? simpleHash(input.prompt) : null,
+              inputHash: snapshotHash,
+              divergedAt,
+            });
+
+            await getGenerationChannel(sequenceId).emit(
+              'generation.image:progress',
+              { frameId, status: 'pending', model: generationParams.model }
+            );
+
+            console.log(
+              '[ImageWorkflow]',
+              `Diverged frame ${frameId}: snapshot=${snapshotHash.slice(0, 8)}; routed alternate to frame_variants`
+            );
+
+            return { imageUrl: upload.url };
+          }
+
+          // Convergent path (or no snapshot opted in): primary write.
+          const updatedFrame = await scopedDb.frames.update(
+            frameId,
+            {
+              thumbnailPath: upload.path || null,
+              thumbnailUrl: upload.url,
+              thumbnailStatus: 'completed',
+              thumbnailGeneratedAt: new Date(),
+              thumbnailError: null,
+              thumbnailInputHash: snapshotOpted ? (snapshotHash ?? null) : null,
+              videoUrl: null,
+              videoPath: null,
+              videoStatus: 'pending',
+              videoWorkflowRunId: null,
+              videoGeneratedAt: null,
+              videoError: null,
+            },
+            { throwOnMissing: false }
+          );
+
+          if (!updatedFrame) {
+            console.log(
+              '[ImageWorkflow]',
+              `Frame ${frameId} was deleted, skipping final update`
+            );
+            return null;
+          }
+
+          await scopedDb.frameVariants.updateByFrameAndModel(
+            frameId,
+            'image',
+            generationParams.model,
+            {
+              url: upload.url,
+              storagePath: upload.path || null,
+              status: 'completed',
+              generatedAt: new Date(),
+              error: null,
+              promptHash: input.prompt ? simpleHash(input.prompt) : null,
+              inputHash: snapshotOpted ? (snapshotHash ?? null) : null,
+            }
+          );
+
+          await getGenerationChannel(sequenceId).emit(
+            'generation.image:progress',
+            {
+              frameId,
+              status: 'completed',
+              thumbnailUrl: upload.url,
+              model: generationParams.model,
+            }
+          );
+
+          console.log('[ImageWorkflow]', `Uploaded to storage: ${upload.path}`);
+
+          return { imageUrl: upload.url };
+        }
+      );
+      if (writeResult) imageUrl = writeResult.imageUrl;
     } else if (imageUrl && frameId && input.skipStorage) {
       // Preview mode: store fal.ai CDN URL in dedicated preview field
       await context.run('store-preview-url', async () => {
@@ -286,6 +394,11 @@ export const generateImageWorkflow = createScopedWorkflow<
       }
 
       return `Image generation failed for frame ${input.frameId}`;
+    },
+    snapshot: {
+      computeFromDto: (input) => computeImageWorkflowHashFromDto(input),
+      computeCurrent: (input, scopedDb) =>
+        computeImageWorkflowHashCurrent(input, scopedDb),
     },
   }
 );

--- a/src/lib/workflows/regenerate-frames-snapshot.ts
+++ b/src/lib/workflows/regenerate-frames-snapshot.ts
@@ -24,6 +24,7 @@ import type {
   SequenceLocation,
 } from '@/lib/db/schema';
 import { matchLocationsToFrame } from '@/lib/db/scoped/sequence-locations';
+import { buildDivergentRevertWrites } from './divergence-writes';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
 import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
@@ -208,19 +209,11 @@ export function buildConvergentWrites(snapshotInputHash: string): {
 }
 
 /**
- * Writes to apply when current inputs no longer match the snapshot.
- *
- *   - `frame`: revert the speculative primary thumbnail on the frame row
- *     back to `pending` so the next reconciliation regenerates from current
- *     inputs.
- *   - `primaryRevert`: clear the speculative URL/status that image-workflow
- *     pre-wrote to the primary variant row, so the primary slot stops
- *     pointing at diverged work.
- *   - `divergentRow`: partial payload for an INSERT that preserves the
- *     diverged result as an alternate. The workflow supplies frameId,
- *     sequenceId, variantType, model, and the speculative url; this helper
- *     supplies the divergence-specific fields so the alternate is
- *     identifiable in the divergent partial unique index.
+ * `divergentRow` is a partial payload for an INSERT that preserves the
+ * diverged result as an alternate. The workflow supplies frameId, sequenceId,
+ * variantType, model, and the speculative url; this helper supplies the
+ * divergence-specific fields so the alternate is identifiable in the
+ * divergent partial unique index.
  */
 export function buildDivergentWrites(
   snapshotInputHash: string,
@@ -234,25 +227,7 @@ export function buildDivergentWrites(
   };
 } {
   return {
-    frame: {
-      thumbnailUrl: null,
-      thumbnailPath: null,
-      thumbnailStatus: 'pending',
-      thumbnailWorkflowRunId: null,
-      thumbnailGeneratedAt: null,
-      thumbnailError: null,
-      thumbnailInputHash: null,
-    },
-    primaryRevert: {
-      url: null,
-      storagePath: null,
-      previewUrl: null,
-      status: 'pending',
-      workflowRunId: null,
-      generatedAt: null,
-      error: null,
-      inputHash: null,
-    },
+    ...buildDivergentRevertWrites(),
     divergentRow: {
       inputHash: snapshotInputHash,
       divergedAt,


### PR DESCRIPTION
## Related Issue
Closes #647

## Summary
Implemented per-frame snapshot validation and frame_variants divergence routing in generateImageWorkflow; pushed branch for PR + CI/review.

## Notes
Opened by the agent-harness overnight runner. See the `harness-active` label.
