### PR TITLE
Stage 1 UI: frame staleness + divergence wiring #625

### DIFF
--- a/drizzle/migrations/20260503055203_sticky_xorn/migration.sql
+++ b/drizzle/migrations/20260503055203_sticky_xorn/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `frame_variants` ADD `discarded_at` integer;

--- a/drizzle/migrations/20260503055203_sticky_xorn/snapshot.json
+++ b/drizzle/migrations/20260503055203_sticky_xorn/snapshot.json
@@ -1,0 +1,6525 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "9605b368-2d17-427f-a234-bd13adddf76a",
+  "prevIds": ["afc355d2-d8df-460a-a705-1e4363953231"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frames",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_thumbnail_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "variant_image_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "thumbnail_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "merged_video_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "merged_video_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frame_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frame_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frames_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_prompt_variants_pk",
+      "table": "frame_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_variants_pk",
+      "table": "frame_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frames_pk",
+      "table": "frames",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_prompt_variants_frame_type_created",
+      "entityType": "indexes",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_frame_type",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "frame_variants_primary_key",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "frame_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_order",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_sequence_id",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "frames_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": []
+}

--- a/src/components/scenes/divergence-compare-dialog.stories.tsx
+++ b/src/components/scenes/divergence-compare-dialog.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { Frame, FrameVariant } from '@/lib/db/schema';
+import { DivergenceCompareDialog } from './divergence-compare-dialog';
+
+const baseFrame = {
+  id: 'frame-1',
+  sequenceId: 'seq-1',
+  orderIndex: 0,
+  description: 'A wide shot.',
+  thumbnailUrl: 'https://images.unsplash.com/photo-1502872364588-894d7d6ddfab',
+  videoUrl: null,
+  audioUrl: null,
+  thumbnailStatus: 'completed',
+  videoStatus: 'pending',
+  thumbnailInputHash: 'live-hash',
+  videoInputHash: null,
+  audioInputHash: null,
+  variantImageInputHash: null,
+} as unknown as Frame;
+
+function makeVariant(
+  overrides: Partial<FrameVariant> & {
+    variantType: FrameVariant['variantType'];
+  }
+): FrameVariant {
+  return {
+    id: 'variant-1',
+    frameId: 'frame-1',
+    sequenceId: 'seq-1',
+    model: 'nano_banana_2',
+    url: 'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee',
+    storagePath: null,
+    previewUrl: null,
+    shotVariantUrl: null,
+    shotVariantPath: null,
+    shotVariantStatus: null,
+    shotVariantWorkflowRunId: null,
+    status: 'completed',
+    workflowRunId: null,
+    generatedAt: new Date(),
+    error: null,
+    promptHash: null,
+    inputHash: 'snapshot-hash',
+    divergedAt: new Date('2026-04-29T00:00:00Z'),
+    discardedAt: null,
+    durationMs: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+const meta: Meta<typeof DivergenceCompareDialog> = {
+  title: 'Scenes/DivergenceCompareDialog',
+  component: DivergenceCompareDialog,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof DivergenceCompareDialog>;
+
+export const ThumbnailVariant: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    frame: baseFrame,
+    variant: makeVariant({ variantType: 'image' }),
+    onPromote: () => {},
+    onDiscard: () => {},
+    upstreamChanges: [
+      'Character "Alex" — sheet regenerated',
+      'Location "Warehouse" — recast',
+    ],
+  },
+};
+
+export const VideoVariant: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    frame: {
+      ...baseFrame,
+      videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
+    } as Frame,
+    variant: makeVariant({
+      variantType: 'video',
+      url: 'https://www.w3schools.com/html/movie.mp4',
+    }),
+    onPromote: () => {},
+    onDiscard: () => {},
+  },
+};
+
+export const AudioVariant: Story = {
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    frame: baseFrame,
+    variant: makeVariant({
+      variantType: 'audio',
+      url: 'https://www.w3schools.com/html/horse.ogg',
+    }),
+    onPromote: () => {},
+    onDiscard: () => {},
+  },
+};
+
+export const Promoting: Story = {
+  args: {
+    ...ThumbnailVariant.args,
+    isPromoting: true,
+  } as Story['args'],
+};

--- a/src/components/scenes/divergence-compare-dialog.tsx
+++ b/src/components/scenes/divergence-compare-dialog.tsx
@@ -106,13 +106,14 @@ export const DivergenceCompareDialog: React.FC<
   const busy = isPromoting || isDiscarding;
 
   // Two-click confirm: promote replaces the live primary and (for image)
-  // clears downstream video. CLAUDE.md requires a confirmation step or undo
-  // window for destructive ops; two-click avoids nested modals here.
+  // clears downstream video. Destructive ops need a confirmation step or
+  // undo window; two-click avoids nested modals here.
   const [confirmingPromote, setConfirmingPromote] = useState(false);
-  // Reset the confirm state whenever the dialog re-opens or the variant
-  // changes, so a fresh open never starts mid-confirm.
+  // Reset whenever the dialog opens/closes or the variant swaps, so a
+  // fresh open (or a caller swapping variants while open) never starts
+  // mid-confirm.
   useEffect(() => {
-    if (!open) setConfirmingPromote(false);
+    setConfirmingPromote(false);
   }, [open, variant.id]);
 
   const handlePromoteClick = () => {

--- a/src/components/scenes/divergence-compare-dialog.tsx
+++ b/src/components/scenes/divergence-compare-dialog.tsx
@@ -66,7 +66,6 @@ const AssetPreview: React.FC<{
       // adds little here and the variant URL may already be a CDN-resized one.
       // Plain img keeps this simple and aligns with the existing variant
       // selector dialog.
-      // eslint-disable-next-line @next/next/no-img-element
       <img
         src={url}
         alt={alt}

--- a/src/components/scenes/divergence-compare-dialog.tsx
+++ b/src/components/scenes/divergence-compare-dialog.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Loader2 } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import type { Frame, FrameVariant } from '@/lib/db/schema';
 import type { VariantType } from '@/lib/db/schema/frame-variants';
 
@@ -104,6 +105,25 @@ export const DivergenceCompareDialog: React.FC<
   const label = ARTIFACT_LABEL[variant.variantType];
   const busy = isPromoting || isDiscarding;
 
+  // Two-click confirm: promote replaces the live primary and (for image)
+  // clears downstream video. CLAUDE.md requires a confirmation step or undo
+  // window for destructive ops; two-click avoids nested modals here.
+  const [confirmingPromote, setConfirmingPromote] = useState(false);
+  // Reset the confirm state whenever the dialog re-opens or the variant
+  // changes, so a fresh open never starts mid-confirm.
+  useEffect(() => {
+    if (!open) setConfirmingPromote(false);
+  }, [open, variant.id]);
+
+  const handlePromoteClick = () => {
+    if (confirmingPromote) {
+      onPromote();
+      setConfirmingPromote(false);
+      return;
+    }
+    setConfirmingPromote(true);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-3xl">
@@ -147,6 +167,18 @@ export const DivergenceCompareDialog: React.FC<
           </div>
         )}
 
+        {confirmingPromote && (
+          <div
+            className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+            role="alert"
+            aria-live="polite"
+          >
+            Promote replaces the current {label}
+            {variant.variantType === 'image' && ' and clears the live video'}.
+            Click Promote again to confirm.
+          </div>
+        )}
+
         <DialogFooter className="flex flex-row justify-end gap-2">
           <Button
             type="button"
@@ -165,9 +197,14 @@ export const DivergenceCompareDialog: React.FC<
           >
             Cancel
           </Button>
-          <Button type="button" onClick={onPromote} disabled={busy}>
+          <Button
+            type="button"
+            onClick={handlePromoteClick}
+            disabled={busy}
+            variant={confirmingPromote ? 'destructive' : 'default'}
+          >
             {isPromoting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-            Promote
+            {confirmingPromote ? 'Confirm Promote' : 'Promote'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/components/scenes/divergence-compare-dialog.tsx
+++ b/src/components/scenes/divergence-compare-dialog.tsx
@@ -1,0 +1,177 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Loader2 } from 'lucide-react';
+import type { Frame, FrameVariant } from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
+
+type DivergenceCompareDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  frame: Frame;
+  variant: FrameVariant;
+  onPromote: () => void;
+  onDiscard: () => void;
+  isPromoting?: boolean;
+  isDiscarding?: boolean;
+  /**
+   * Optional list of upstream entity changes between the snapshot and live
+   * inputs. Stage 1 surfaces this as a flat string list; field-level diffs
+   * land in stage 4.
+   */
+  upstreamChanges?: string[];
+};
+
+const ARTIFACT_LABEL: Record<VariantType, string> = {
+  image: 'image',
+  video: 'video',
+  audio: 'audio',
+};
+
+function liveAssetForVariant(
+  frame: Frame,
+  variantType: VariantType
+): { url: string | null; kind: 'image' | 'video' | 'audio' } {
+  switch (variantType) {
+    case 'image':
+      return { url: frame.thumbnailUrl, kind: 'image' };
+    case 'video':
+      return { url: frame.videoUrl, kind: 'video' };
+    case 'audio':
+      return { url: frame.audioUrl, kind: 'audio' };
+  }
+}
+
+const AssetPreview: React.FC<{
+  url: string | null | undefined;
+  kind: 'image' | 'video' | 'audio';
+  alt: string;
+}> = ({ url, kind, alt }) => {
+  if (!url) {
+    return (
+      <div className="flex aspect-video items-center justify-center rounded-md border border-dashed border-muted-foreground/40 text-xs text-muted-foreground">
+        No asset
+      </div>
+    );
+  }
+  if (kind === 'image') {
+    return (
+      // Compare-dialog is a transient surface; the unpic optimisation pipeline
+      // adds little here and the variant URL may already be a CDN-resized one.
+      // Plain img keeps this simple and aligns with the existing variant
+      // selector dialog.
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={url}
+        alt={alt}
+        className="aspect-video w-full rounded-md object-cover"
+      />
+    );
+  }
+  if (kind === 'video') {
+    return (
+      // eslint-disable-next-line jsx-a11y/media-has-caption -- Compare-dialog renders user-supplied generated assets that have no caption track.
+      <video
+        src={url}
+        controls
+        className="aspect-video w-full rounded-md bg-black"
+      />
+    );
+  }
+  // eslint-disable-next-line jsx-a11y/media-has-caption -- Compare-dialog renders user-supplied generated audio without captions.
+  return <audio src={url} controls className="w-full" />;
+};
+
+export const DivergenceCompareDialog: React.FC<
+  DivergenceCompareDialogProps
+> = ({
+  open,
+  onOpenChange,
+  frame,
+  variant,
+  onPromote,
+  onDiscard,
+  isPromoting = false,
+  isDiscarding = false,
+  upstreamChanges,
+}) => {
+  const live = liveAssetForVariant(frame, variant.variantType);
+  const label = ARTIFACT_LABEL[variant.variantType];
+  const busy = isPromoting || isDiscarding;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Compare alternate {label}</DialogTitle>
+          <DialogDescription>
+            An alternate {label} was generated from the inputs you had at the
+            time. Compare it against the live version, then promote or discard.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium">Live (current inputs)</span>
+            <AssetPreview
+              url={live.url}
+              kind={live.kind}
+              alt={`Live ${label}`}
+            />
+          </div>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium">
+              Alternate (older inputs)
+            </span>
+            <AssetPreview
+              url={variant.url}
+              kind={live.kind}
+              alt={`Alternate ${label}`}
+            />
+          </div>
+        </div>
+
+        {upstreamChanges && upstreamChanges.length > 0 && (
+          <div className="flex flex-col gap-2 rounded-md border bg-muted/30 p-3">
+            <span className="text-sm font-medium">What changed</span>
+            <ul className="flex flex-col gap-1 text-sm text-muted-foreground">
+              {upstreamChanges.map((change) => (
+                <li key={change}>• {change}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <DialogFooter className="flex flex-row justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onDiscard}
+            disabled={busy}
+          >
+            {isDiscarding && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Discard
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={onPromote} disabled={busy}>
+            {isPromoting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Promote
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/scenes/scene-list-item.tsx
+++ b/src/components/scenes/scene-list-item.tsx
@@ -60,16 +60,21 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
     ? undefined
     : (metadata?.originalScript.extract ?? frame.description ?? '');
 
+  // Skeleton state (no frame): suppress click handling and pointer cursor so
+  // a click during the loading window does not invoke the (now-undefined)
+  // onSelect callback or appear interactive.
+  const isSkeleton = !frame;
   return (
     <Card
       className={cn(
-        '@container/scene relative cursor-pointer transition-all',
+        '@container/scene relative transition-all',
+        isSkeleton ? 'pointer-events-none' : 'cursor-pointer',
         isActive ? 'border-primary bg-primary/5' : 'hover:bg-muted/50',
         variant === 'responsive' && '@[280px]/scene:py-3',
         variant === 'horizontal' && 'py-3',
         'py-3'
       )}
-      onClick={onSelect}
+      onClick={isSkeleton ? undefined : onSelect}
     >
       {showDivergentDot && (
         <div

--- a/src/components/scenes/scene-list-item.tsx
+++ b/src/components/scenes/scene-list-item.tsx
@@ -1,5 +1,4 @@
 import { DivergentAlternateBanner } from '@/components/staleness/divergent-alternate-banner';
-import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import {
   Card,
   CardDescription,
@@ -29,10 +28,7 @@ type SceneListItemProps = {
    * spec — promoting the alternate resolves both states.
    */
   divergentVariantId?: string;
-  /** True when the live thumbnail's input hash no longer matches upstream. */
-  isThumbnailStale?: boolean;
   onCompareDivergent?: () => void;
-  onRegenerateThumbnail?: () => void;
 };
 
 const SceneListItemComponent: React.FC<SceneListItemProps> = ({
@@ -45,16 +41,12 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
   isRegeneratingImage = false,
   isRegeneratingMotion = false,
   divergentVariantId,
-  isThumbnailStale = false,
   onCompareDivergent,
-  onRegenerateThumbnail,
 }) => {
   // Divergent alternate takes precedence: promoting it resolves staleness too.
   const showDivergentDot = !!divergentVariantId;
-  const showStalenessDot = !showDivergentDot && isThumbnailStale;
   const showStatusIndicator =
     !showDivergentDot &&
-    !showStalenessDot &&
     (isCompleted ||
       (frame && (isRegeneratingImage || isRegeneratingMotion || !isCompleted)));
   // Extract scene data from frame metadata
@@ -98,24 +90,6 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
             // Compare-only entry from the corner; promote/discard live in the dialog.
             onPromote={() => onCompareDivergent?.()}
             onDiscard={() => onCompareDivergent?.()}
-          />
-        </div>
-      )}
-      {showStalenessDot && (
-        <div
-          className="absolute right-3 top-3 z-10"
-          // The corner indicator is itself a focusable button; this wrapper
-          // exists only to halt click propagation so opening the dot doesn't
-          // also select the scene card behind it.
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-          role="presentation"
-        >
-          <StalenessIndicator
-            density="corner-dot"
-            artifact="thumbnail"
-            entityType="frame"
-            onRegenerate={() => onRegenerateThumbnail?.()}
           />
         </div>
       )}
@@ -206,8 +180,7 @@ const areEqual = (
     prevProps.variant !== nextProps.variant ||
     prevProps.isRegeneratingImage !== nextProps.isRegeneratingImage ||
     prevProps.isRegeneratingMotion !== nextProps.isRegeneratingMotion ||
-    prevProps.divergentVariantId !== nextProps.divergentVariantId ||
-    prevProps.isThumbnailStale !== nextProps.isThumbnailStale
+    prevProps.divergentVariantId !== nextProps.divergentVariantId
   ) {
     return false;
   }

--- a/src/components/scenes/scene-list-item.tsx
+++ b/src/components/scenes/scene-list-item.tsx
@@ -1,3 +1,5 @@
+import { DivergentAlternateBanner } from '@/components/staleness/divergent-alternate-banner';
+import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import {
   Card,
   CardDescription,
@@ -21,6 +23,16 @@ type SceneListItemProps = {
   variant?: 'stacked' | 'horizontal' | 'responsive';
   isRegeneratingImage?: boolean;
   isRegeneratingMotion?: boolean;
+  /**
+   * Set when the frame has a divergent alternate thumbnail awaiting review.
+   * Takes precedence over the staleness dot per the divergence-resolution
+   * spec — promoting the alternate resolves both states.
+   */
+  divergentVariantId?: string;
+  /** True when the live thumbnail's input hash no longer matches upstream. */
+  isThumbnailStale?: boolean;
+  onCompareDivergent?: () => void;
+  onRegenerateThumbnail?: () => void;
 };
 
 const SceneListItemComponent: React.FC<SceneListItemProps> = ({
@@ -32,7 +44,19 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
   variant = 'responsive',
   isRegeneratingImage = false,
   isRegeneratingMotion = false,
+  divergentVariantId,
+  isThumbnailStale = false,
+  onCompareDivergent,
+  onRegenerateThumbnail,
 }) => {
+  // Divergent alternate takes precedence: promoting it resolves staleness too.
+  const showDivergentDot = !!divergentVariantId;
+  const showStalenessDot = !showDivergentDot && isThumbnailStale;
+  const showStatusIndicator =
+    !showDivergentDot &&
+    !showStalenessDot &&
+    (isCompleted ||
+      (frame && (isRegeneratingImage || isRegeneratingMotion || !isCompleted)));
   // Extract scene data from frame metadata
   const metadata = frame?.metadata;
 
@@ -55,7 +79,47 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
       )}
       onClick={onSelect}
     >
-      {isCompleted && (
+      {showDivergentDot && (
+        <div
+          className="absolute right-3 top-3 z-10"
+          // The corner indicator is itself a focusable button; this wrapper
+          // exists only to halt click propagation so opening the dot doesn't
+          // also select the scene card behind it.
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          role="presentation"
+        >
+          <DivergentAlternateBanner
+            density="corner-dot"
+            variantId={divergentVariantId ?? ''}
+            artifact="thumbnail"
+            entityType="frame"
+            onCompare={() => onCompareDivergent?.()}
+            // Compare-only entry from the corner; promote/discard live in the dialog.
+            onPromote={() => onCompareDivergent?.()}
+            onDiscard={() => onCompareDivergent?.()}
+          />
+        </div>
+      )}
+      {showStalenessDot && (
+        <div
+          className="absolute right-3 top-3 z-10"
+          // The corner indicator is itself a focusable button; this wrapper
+          // exists only to halt click propagation so opening the dot doesn't
+          // also select the scene card behind it.
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+          role="presentation"
+        >
+          <StalenessIndicator
+            density="corner-dot"
+            artifact="thumbnail"
+            entityType="frame"
+            onRegenerate={() => onRegenerateThumbnail?.()}
+          />
+        </div>
+      )}
+      {showStatusIndicator && isCompleted && (
         <Check
           className={cn(
             'absolute right-4 top-4 z-10 h-6 w-6 p-1 rounded-full',
@@ -63,7 +127,8 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
           )}
         />
       )}
-      {frame &&
+      {showStatusIndicator &&
+        frame &&
         !isCompleted &&
         (isRegeneratingImage || isRegeneratingMotion) && (
           <Loader2
@@ -73,7 +138,8 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
             )}
           />
         )}
-      {frame &&
+      {showStatusIndicator &&
+        frame &&
         !isCompleted &&
         !isRegeneratingImage &&
         !isRegeneratingMotion && (
@@ -139,7 +205,9 @@ const areEqual = (
     prevProps.isCompleted !== nextProps.isCompleted ||
     prevProps.variant !== nextProps.variant ||
     prevProps.isRegeneratingImage !== nextProps.isRegeneratingImage ||
-    prevProps.isRegeneratingMotion !== nextProps.isRegeneratingMotion
+    prevProps.isRegeneratingMotion !== nextProps.isRegeneratingMotion ||
+    prevProps.divergentVariantId !== nextProps.divergentVariantId ||
+    prevProps.isThumbnailStale !== nextProps.isThumbnailStale
   ) {
     return false;
   }

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -123,9 +123,6 @@ const SceneListComponent: React.FC<SceneListProps> = ({
                 aspectRatio={aspectRatio}
                 isActive={false}
                 isCompleted={false}
-                onSelect={function (): void {
-                  throw new Error('Function not implemented.');
-                }}
               />
             ))}
 

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -20,10 +20,7 @@ type SceneListProps = {
   hideBatchButton?: boolean;
   /** Live divergent alternates for the current sequence (filtered per-frame). */
   divergentVariants?: FrameVariant[];
-  /** Frame ids whose live thumbnail is stale (no divergent alternate yet). */
-  staleThumbnailFrameIds?: Set<string>;
   onCompareDivergent?: (variant: FrameVariant) => void;
-  onRegenerateThumbnail?: (frameId: string) => void;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -43,9 +40,7 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   musicPromptsReady,
   hideBatchButton = false,
   divergentVariants,
-  staleThumbnailFrameIds,
   onCompareDivergent,
-  onRegenerateThumbnail,
 }) => {
   const divergentByFrameId = useMemo(() => {
     const map = new Map<string, FrameVariant>();
@@ -148,16 +143,10 @@ const SceneListComponent: React.FC<SceneListProps> = ({
                   isRegeneratingImage={regeneratingImages.has(frame.id)}
                   isRegeneratingMotion={regeneratingMotion.has(frame.id)}
                   divergentVariantId={divergent?.id}
-                  isThumbnailStale={
-                    !divergent && !!staleThumbnailFrameIds?.has(frame.id)
-                  }
                   onCompareDivergent={
                     divergent
                       ? () => onCompareDivergent?.(divergent)
                       : undefined
-                  }
-                  onRegenerateThumbnail={() =>
-                    onRegenerateThumbnail?.(frame.id)
                   }
                 />
               );
@@ -241,7 +230,17 @@ const areEqual = (
   }
 
   // Compare callback references
-  if (prevProps.onBatchGenerateMotion !== nextProps.onBatchGenerateMotion) {
+  if (
+    prevProps.onBatchGenerateMotion !== nextProps.onBatchGenerateMotion ||
+    prevProps.onCompareDivergent !== nextProps.onCompareDivergent
+  ) {
+    return false;
+  }
+
+  // Divergent / staleness inputs drive corner-dot indicators on each row.
+  // TanStack Query structural sharing keeps the array reference stable when
+  // contents are unchanged, so reference equality is sufficient here.
+  if (prevProps.divergentVariants !== nextProps.divergentVariants) {
     return false;
   }
 

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
-import type { Frame } from '@/types/database';
+import type { Frame, FrameVariant } from '@/lib/db/schema';
 import { Loader2, Video } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { SceneListItem } from './scene-list-item';
@@ -18,6 +18,12 @@ type SceneListProps = {
   musicPromptsReady: boolean;
   /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
   hideBatchButton?: boolean;
+  /** Live divergent alternates for the current sequence (filtered per-frame). */
+  divergentVariants?: FrameVariant[];
+  /** Frame ids whose live thumbnail is stale (no divergent alternate yet). */
+  staleThumbnailFrameIds?: Set<string>;
+  onCompareDivergent?: (variant: FrameVariant) => void;
+  onRegenerateThumbnail?: (frameId: string) => void;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -36,7 +42,22 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   onBatchGenerateMotion,
   musicPromptsReady,
   hideBatchButton = false,
+  divergentVariants,
+  staleThumbnailFrameIds,
+  onCompareDivergent,
+  onRegenerateThumbnail,
 }) => {
+  const divergentByFrameId = useMemo(() => {
+    const map = new Map<string, FrameVariant>();
+    for (const v of divergentVariants ?? []) {
+      // Image variant is what surfaces on the card. Other variant types
+      // live on their respective tabs per the spec's surfacing matrix.
+      if (v.variantType !== 'image') continue;
+      if (!map.has(v.frameId)) map.set(v.frameId, v);
+    }
+    return map;
+  }, [divergentVariants]);
+
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
 
@@ -114,18 +135,33 @@ const SceneListComponent: React.FC<SceneListProps> = ({
             ))}
 
           {frames &&
-            frames.map((frame) => (
-              <SceneListItem
-                key={frame.id}
-                frame={frame}
-                aspectRatio={aspectRatio}
-                isActive={frame.id === selectedFrameId}
-                isCompleted={isCompleted(frame)}
-                onSelect={() => onSelectFrame(frame.id)}
-                isRegeneratingImage={regeneratingImages.has(frame.id)}
-                isRegeneratingMotion={regeneratingMotion.has(frame.id)}
-              />
-            ))}
+            frames.map((frame) => {
+              const divergent = divergentByFrameId.get(frame.id);
+              return (
+                <SceneListItem
+                  key={frame.id}
+                  frame={frame}
+                  aspectRatio={aspectRatio}
+                  isActive={frame.id === selectedFrameId}
+                  isCompleted={isCompleted(frame)}
+                  onSelect={() => onSelectFrame(frame.id)}
+                  isRegeneratingImage={regeneratingImages.has(frame.id)}
+                  isRegeneratingMotion={regeneratingMotion.has(frame.id)}
+                  divergentVariantId={divergent?.id}
+                  isThumbnailStale={
+                    !divergent && !!staleThumbnailFrameIds?.has(frame.id)
+                  }
+                  onCompareDivergent={
+                    divergent
+                      ? () => onCompareDivergent?.(divergent)
+                      : undefined
+                  }
+                  onRegenerateThumbnail={() =>
+                    onRegenerateThumbnail?.(frame.id)
+                  }
+                />
+              );
+            })}
         </div>
       </ScrollArea>
 

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1,6 +1,7 @@
 import { BillingGateDialog } from '@/components/billing/billing-gate-dialog';
 import { ImageModelSelector } from '@/components/model/image-model-selector';
 import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { DivergentAlternateBanner } from '@/components/staleness/divergent-alternate-banner';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import {
@@ -96,6 +97,9 @@ type SceneScriptPromptsProps = {
   onImageModelChange?: (model: string) => void;
   /** Current style category, used to show/hide style-restricted motion models */
   styleCategory?: string;
+  /** Live divergent alternates for the current frame across variant types. */
+  frameDivergentVariants?: FrameVariant[];
+  onCompareDivergent?: (variant: FrameVariant) => void;
 };
 
 type PromptTabContentProps = {
@@ -171,7 +175,17 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   variantForSelectedModel,
   onImageModelChange,
   styleCategory,
+  frameDivergentVariants,
+  onCompareDivergent,
 }) => {
+  const divergentImageVariant = useMemo(
+    () => frameDivergentVariants?.find((v) => v.variantType === 'image'),
+    [frameDivergentVariants]
+  );
+  const divergentVideoVariant = useMemo(
+    () => frameDivergentVariants?.find((v) => v.variantType === 'video'),
+    [frameDivergentVariants]
+  );
   const [copiedTab, setCopiedTab] = useState<string | null>(null);
   const [shortenStatus, setShortenStatus] = useState<{
     loading: boolean;
@@ -709,6 +723,18 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
             {shortenStatus.loading ? 'Shortening…' : 'Shorten Prompt'}
           </Button>
 
+          {/* Divergent alternate / staleness banners (issue #625) */}
+          {divergentImageVariant && (
+            <DivergentAlternateBanner
+              variantId={divergentImageVariant.id}
+              artifact="thumbnail"
+              entityType="frame"
+              onCompare={() => onCompareDivergent?.(divergentImageVariant)}
+              onPromote={() => onCompareDivergent?.(divergentImageVariant)}
+              onDiscard={() => onCompareDivergent?.(divergentImageVariant)}
+            />
+          )}
+
           {/* Image action button — variant-aware */}
           {variantIsCompleted && !variantAlreadySet ? (
             <Button
@@ -831,6 +857,18 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 {assembledPrompt}
               </p>
             </div>
+          )}
+
+          {/* Divergent alternate banner for video variant */}
+          {divergentVideoVariant && (
+            <DivergentAlternateBanner
+              variantId={divergentVideoVariant.id}
+              artifact="video"
+              entityType="frame"
+              onCompare={() => onCompareDivergent?.(divergentVideoVariant)}
+              onPromote={() => onCompareDivergent?.(divergentVideoVariant)}
+              onDiscard={() => onCompareDivergent?.(divergentVideoVariant)}
+            />
           )}
 
           {/* Regenerate button */}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -12,7 +12,17 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { batchGenerateMotionFn } from '@/functions/motion-functions';
 import { smartRetryFn } from '@/functions/smart-retry';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
-import { frameKeys, useFramesBySequence } from '@/hooks/use-frames';
+import {
+  frameKeys,
+  useDiscardVariant,
+  useDivergentVariants,
+  useFramesBySequence,
+  usePromoteVariantToPrimary,
+  useUndiscardVariant,
+} from '@/hooks/use-frames';
+import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
+import { generateFrameImageFn } from '@/functions/frame-image';
+import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-dialog';
 import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
 import { useStyle } from '@/hooks/use-styles';
 import { safeTextToImageModel, DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
@@ -165,6 +175,82 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     staleTime: 30_000,
     enabled: !!sequenceId,
   });
+
+  // Divergent alternates + realtime stale:detected wiring (issue #625).
+  const { data: divergentVariants } = useDivergentVariants(sequenceId);
+  useStaleDetected(sequenceId);
+  const promoteVariant = usePromoteVariantToPrimary();
+  const discardVariant = useDiscardVariant();
+  const undiscardVariant = useUndiscardVariant();
+  const [compareVariant, setCompareVariant] = useState<FrameVariant | null>(
+    null
+  );
+
+  const handleDiscardWithUndo = useCallback(
+    (variant: FrameVariant) => {
+      const restore = () => {
+        undiscardVariant.mutate({
+          sequenceId,
+          frameId: variant.frameId,
+          variantId: variant.id,
+        });
+      };
+      discardVariant.mutate(
+        { sequenceId, frameId: variant.frameId, variantId: variant.id },
+        {
+          onSuccess: () => {
+            toast('Alternate discarded', {
+              action: { label: 'Undo', onClick: restore },
+            });
+          },
+          onError: (error) => {
+            toast.error('Failed to discard alternate', {
+              description:
+                error instanceof Error ? error.message : 'Unknown error',
+            });
+          },
+        }
+      );
+    },
+    [sequenceId, discardVariant, undiscardVariant]
+  );
+
+  const handlePromote = useCallback(
+    (variant: FrameVariant) => {
+      promoteVariant.mutate(
+        { sequenceId, frameId: variant.frameId, variantId: variant.id },
+        {
+          onSuccess: () => {
+            setCompareVariant(null);
+            toast.success('Alternate promoted');
+          },
+          onError: (error) => {
+            toast.error('Failed to promote alternate', {
+              description:
+                error instanceof Error ? error.message : 'Unknown error',
+            });
+          },
+        }
+      );
+    },
+    [sequenceId, promoteVariant]
+  );
+
+  const handleRegenerateThumbnail = useCallback(
+    async (frameId: string) => {
+      try {
+        await generateFrameImageFn({
+          data: { sequenceId, frameId, regenerateThumbnail: true },
+        });
+        setRegeneratingImages((prev) => addToSet(prev, frameId));
+      } catch (error) {
+        toast.error('Failed to start regeneration', {
+          description: error instanceof Error ? error.message : 'Unknown error',
+        });
+      }
+    },
+    [sequenceId]
+  );
 
   const curSelectedFrameId = selectedFrameId || frames?.[0]?.id;
   const selectedFrame = useMemo(
@@ -490,6 +576,11 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             hideBatchButton={
               phaseConfig.autoGenerateMotion && isGenerationActive
             }
+            divergentVariants={divergentVariants}
+            onCompareDivergent={(variant) => setCompareVariant(variant)}
+            onRegenerateThumbnail={(frameId) =>
+              void handleRegenerateThumbnail(frameId)
+            }
           />
         </div>
 
@@ -543,9 +634,38 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             variantForSelectedModel={variantForSelectedModel}
             onImageModelChange={setImageModelOverride}
             styleCategory={styleCategory}
+            frameDivergentVariants={divergentVariants?.filter(
+              (v) => v.frameId === curSelectedFrameId
+            )}
+            onCompareDivergent={(variant) => setCompareVariant(variant)}
           />
         </ScrollArea>
       </div>
+
+      {compareVariant &&
+        (() => {
+          const targetFrame = frames?.find(
+            (f) => f.id === compareVariant.frameId
+          );
+          if (!targetFrame) return null;
+          return (
+            <DivergenceCompareDialog
+              open={true}
+              onOpenChange={(open) => {
+                if (!open) setCompareVariant(null);
+              }}
+              frame={targetFrame}
+              variant={compareVariant}
+              onPromote={() => handlePromote(compareVariant)}
+              onDiscard={() => {
+                handleDiscardWithUndo(compareVariant);
+                setCompareVariant(null);
+              }}
+              isPromoting={promoteVariant.isPending}
+              isDiscarding={discardVariant.isPending}
+            />
+          );
+        })()}
     </div>
   );
 };

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -176,7 +176,12 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   });
 
   // Divergent alternates + realtime stale:detected wiring (issue #625).
-  const { data: divergentVariants } = useDivergentVariants(sequenceId);
+  // Mirror the frames-list polling fallback so the corner-dot still updates
+  // when realtime is down.
+  const { data: divergentVariants } = useDivergentVariants(
+    sequenceId,
+    shouldPoll ? { refetchInterval: 2000 } : undefined
+  );
   useStaleDetected(sequenceId);
   const promoteVariant = usePromoteVariantToPrimary();
   const discardVariant = useDiscardVariant();
@@ -188,11 +193,21 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   const handleDiscardWithUndo = useCallback(
     (variant: FrameVariant) => {
       const restore = () => {
-        undiscardVariant.mutate({
-          sequenceId,
-          frameId: variant.frameId,
-          variantId: variant.id,
-        });
+        undiscardVariant.mutate(
+          {
+            sequenceId,
+            frameId: variant.frameId,
+            variantId: variant.id,
+          },
+          {
+            onError: (error) => {
+              toast.error('Failed to restore alternate', {
+                description:
+                  error instanceof Error ? error.message : 'Unknown error',
+              });
+            },
+          }
+        );
       };
       discardVariant.mutate(
         { sequenceId, frameId: variant.frameId, variantId: variant.id },
@@ -216,6 +231,18 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     },
     [sequenceId, discardVariant, undiscardVariant]
   );
+
+  // If the frame backing the open compare dialog disappears (e.g. concurrent
+  // delete from another tab), close the dialog explicitly with a toast rather
+  // than silently null-rendering it.
+  useEffect(() => {
+    if (!compareVariant || !frames) return;
+    const stillExists = frames.some((f) => f.id === compareVariant.frameId);
+    if (!stillExists) {
+      toast.info('Scene was removed.');
+      setCompareVariant(null);
+    }
+  }, [compareVariant, frames]);
 
   const handlePromote = useCallback(
     (variant: FrameVariant) => {

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -21,7 +21,6 @@ import {
   useUndiscardVariant,
 } from '@/hooks/use-frames';
 import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
-import { generateFrameImageFn } from '@/functions/frame-image';
 import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-dialog';
 import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
 import { useStyle } from '@/hooks/use-styles';
@@ -199,6 +198,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         { sequenceId, frameId: variant.frameId, variantId: variant.id },
         {
           onSuccess: () => {
+            // Only close the dialog after the mutation succeeds — on failure
+            // the user keeps the dialog open and can retry from there.
+            setCompareVariant(null);
             toast('Alternate discarded', {
               action: { label: 'Undo', onClick: restore },
             });
@@ -234,22 +236,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
       );
     },
     [sequenceId, promoteVariant]
-  );
-
-  const handleRegenerateThumbnail = useCallback(
-    async (frameId: string) => {
-      try {
-        await generateFrameImageFn({
-          data: { sequenceId, frameId, regenerateThumbnail: true },
-        });
-        setRegeneratingImages((prev) => addToSet(prev, frameId));
-      } catch (error) {
-        toast.error('Failed to start regeneration', {
-          description: error instanceof Error ? error.message : 'Unknown error',
-        });
-      }
-    },
-    [sequenceId]
   );
 
   const curSelectedFrameId = selectedFrameId || frames?.[0]?.id;
@@ -578,9 +564,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             }
             divergentVariants={divergentVariants}
             onCompareDivergent={(variant) => setCompareVariant(variant)}
-            onRegenerateThumbnail={(frameId) =>
-              void handleRegenerateThumbnail(frameId)
-            }
           />
         </div>
 
@@ -657,10 +640,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
               frame={targetFrame}
               variant={compareVariant}
               onPromote={() => handlePromote(compareVariant)}
-              onDiscard={() => {
-                handleDiscardWithUndo(compareVariant);
-                setCompareVariant(null);
-              }}
+              onDiscard={() => handleDiscardWithUndo(compareVariant)}
               isPromoting={promoteVariant.isPending}
               isDiscarding={discardVariant.isPending}
             />

--- a/src/functions/__tests__/frames.test.ts
+++ b/src/functions/__tests__/frames.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the promote/discard server-fn orchestration.
+ *
+ * The TanStack server-fn middleware chain (auth, frame access, scoped DB)
+ * is exercised end-to-end by the e2e suite; here we cover the new logic
+ * added in #625:
+ *   - The pure per-variantType update builder (buildPromoteUpdate).
+ *   - The atomic frame-update + variant-discard pair via the new scoped
+ *     `promoteAtomically` method, including its all-or-nothing semantics.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'bun:test';
+import { type Client, createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { eq } from 'drizzle-orm';
+import { generateId } from '@/lib/db/id';
+import {
+  frameVariants,
+  frames,
+  sequences,
+  styles,
+  teams,
+  user,
+} from '@/lib/db/schema';
+import type { FrameVariant } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import type { Database } from '@/lib/db/client';
+import { createFrameVariantsMethods } from '@/lib/db/scoped/frame-variants';
+import { buildPromoteUpdate } from '@/functions/frames';
+
+const baseVariant = (overrides: Partial<FrameVariant> = {}): FrameVariant => ({
+  id: 'v1',
+  frameId: 'f1',
+  sequenceId: 's1',
+  variantType: 'image',
+  model: 'flux',
+  url: 'https://example.com/v1.png',
+  storagePath: 'variants/v1.png',
+  previewUrl: null,
+  shotVariantUrl: null,
+  shotVariantPath: null,
+  shotVariantStatus: 'pending',
+  shotVariantWorkflowRunId: null,
+  status: 'completed',
+  workflowRunId: null,
+  generatedAt: new Date(),
+  error: null,
+  promptHash: null,
+  inputHash: 'hash-abc',
+  divergedAt: new Date('2026-04-01T00:00:00Z'),
+  discardedAt: null,
+  durationMs: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe('buildPromoteUpdate', () => {
+  it('image variant: copies thumbnail fields, clears downstream video, sets imageModel', () => {
+    const variant = baseVariant({ variantType: 'image' });
+    const { update, progressEvent, progressUrlField } =
+      buildPromoteUpdate(variant);
+
+    expect(update.thumbnailUrl).toBe(variant.url);
+    expect(update.thumbnailPath).toBe(variant.storagePath);
+    expect(update.thumbnailStatus).toBe('completed');
+    expect(update.thumbnailError).toBeNull();
+    expect(update.thumbnailInputHash).toBe(variant.inputHash);
+    expect(update.imageModel).toBe(variant.model);
+    // Critical: image promote must clear the downstream video so it doesn't
+    // sit there mismatched against the new image.
+    expect(update.videoUrl).toBeNull();
+    expect(update.videoPath).toBeNull();
+    expect(update.videoStatus).toBe('pending');
+    expect(update.videoWorkflowRunId).toBeNull();
+    expect(update.videoGeneratedAt).toBeNull();
+    expect(update.videoError).toBeNull();
+
+    expect(progressEvent).toBe('image:progress');
+    expect(progressUrlField).toBe('thumbnailUrl');
+  });
+
+  it('video variant: copies video fields only, leaves image intact', () => {
+    const variant = baseVariant({ variantType: 'video' });
+    const { update, progressEvent, progressUrlField } =
+      buildPromoteUpdate(variant);
+
+    expect(update.videoUrl).toBe(variant.url);
+    expect(update.videoPath).toBe(variant.storagePath);
+    expect(update.videoStatus).toBe('completed');
+    expect(update.videoError).toBeNull();
+    expect(update.videoInputHash).toBe(variant.inputHash);
+
+    expect(update.thumbnailUrl).toBeUndefined();
+    expect(update.imageModel).toBeUndefined();
+    expect(update.audioUrl).toBeUndefined();
+
+    expect(progressEvent).toBe('video:progress');
+    expect(progressUrlField).toBe('videoUrl');
+  });
+
+  it('audio variant: copies audio fields only', () => {
+    const variant = baseVariant({ variantType: 'audio' });
+    const { update, progressEvent, progressUrlField } =
+      buildPromoteUpdate(variant);
+
+    expect(update.audioUrl).toBe(variant.url);
+    expect(update.audioPath).toBe(variant.storagePath);
+    expect(update.audioStatus).toBe('completed');
+    expect(update.audioError).toBeNull();
+    expect(update.audioInputHash).toBe(variant.inputHash);
+
+    expect(update.thumbnailUrl).toBeUndefined();
+    expect(update.videoUrl).toBeUndefined();
+
+    expect(progressEvent).toBe('audio:progress');
+    expect(progressUrlField).toBe('audioUrl');
+  });
+});
+
+let client: Client;
+let db: Database;
+const team = { id: '', name: 'T', slug: 't' };
+const userRow = { id: '', name: 'U', email: 'u@example.com' };
+let sequenceId = '';
+let frameId = '';
+
+async function seed() {
+  await db.delete(frameVariants);
+  await db.delete(frames);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await db.delete(user);
+
+  team.id = generateId();
+  userRow.id = generateId();
+  sequenceId = generateId();
+
+  await db.insert(user).values([userRow]);
+  await db.insert(teams).values([team]);
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId: team.id,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  await db
+    .insert(sequences)
+    .values([
+      { id: sequenceId, teamId: team.id, title: 'S', styleId: style.id },
+    ]);
+  const [frame] = await db
+    .insert(frames)
+    .values({ sequenceId, orderIndex: 0, thumbnailUrl: 'https://live/old.png' })
+    .returning();
+  frameId = frame.id;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations, casing: 'snake_case' });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('frameVariants.promoteAtomically', () => {
+  async function insertDivergent(opts: {
+    inputHash: string;
+    url: string;
+    variantType?: 'image' | 'video' | 'audio';
+  }) {
+    const [variant] = await db
+      .insert(frameVariants)
+      .values({
+        frameId,
+        sequenceId,
+        variantType: opts.variantType ?? 'image',
+        model: 'm1',
+        url: opts.url,
+        status: 'completed',
+        inputHash: opts.inputHash,
+        divergedAt: new Date('2026-04-29T00:00:00Z'),
+      })
+      .returning();
+    return variant;
+  }
+
+  it('promotes image: updates frame thumbnail and discards variant in one batch', async () => {
+    const variant = await insertDivergent({
+      inputHash: 'h1',
+      url: 'https://alt/v1.png',
+    });
+    const methods = createFrameVariantsMethods(db);
+
+    const { update } = buildPromoteUpdate(variant);
+    const result = await methods.promoteAtomically(frameId, update, variant.id);
+
+    expect(result.frame.thumbnailUrl).toBe('https://alt/v1.png');
+    expect(result.frame.videoStatus).toBe('pending');
+    expect(result.discardedAt).toBeInstanceOf(Date);
+
+    const after = await methods.getById(variant.id);
+    expect(after?.discardedAt).toBeInstanceOf(Date);
+    // Variant falls out of the divergent listing once discardedAt is set.
+    const stillDivergent = await methods.listDivergentByFrame(frameId, 'image');
+    expect(stillDivergent.map((r) => r.id)).not.toContain(variant.id);
+  });
+
+  it('throws when frame does not exist; variant is not soft-deleted', async () => {
+    const variant = await insertDivergent({
+      inputHash: 'h2',
+      url: 'https://alt/v2.png',
+    });
+    const methods = createFrameVariantsMethods(db);
+
+    expect(
+      methods.promoteAtomically(generateId(), { thumbnailUrl: 'x' }, variant.id)
+    ).rejects.toThrow('not found');
+
+    // Both writes go through db.batch, so a missing frame must roll back the
+    // variant discard — promote is all-or-nothing.
+    const after = await methods.getById(variant.id);
+    expect(after?.discardedAt).toBeNull();
+  });
+
+  it('throws when variant does not exist; frame is not updated', async () => {
+    const methods = createFrameVariantsMethods(db);
+
+    expect(
+      methods.promoteAtomically(
+        frameId,
+        { thumbnailUrl: 'should-not-stick' },
+        generateId()
+      )
+    ).rejects.toThrow('not found');
+
+    const [frameAfter] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    expect(frameAfter.thumbnailUrl).toBe('https://live/old.png');
+  });
+});

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
 import type { NewFrame } from '@/lib/db/schema';
+import { getGenerationChannel } from '@/lib/realtime';
 import { getVideoDownloadUrl } from '@/lib/motion/video-storage';
 import {
   bulkFrameSchema,
@@ -47,6 +48,173 @@ export const getSequenceImageModelsFn = createServerFn({ method: 'GET' })
       context.sequence.id,
       'image'
     );
+  });
+
+export const getDivergentVariantsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.frameVariants.listDivergentBySequence(
+      context.sequence.id
+    );
+  });
+
+/**
+ * Promote a divergent alternate to be the live primary for its variant type.
+ * Copies the variant's url/path into the matching frames column, updates the
+ * matching `*_input_hash` so the live row reflects the alternate's inputs,
+ * soft-deletes the variant, and emits a synthetic `*:progress` event so any
+ * listeners refresh.
+ */
+export const promoteVariantFn = createServerFn({ method: 'POST' })
+  .middleware([frameAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        frameId: ulidSchema,
+        variantId: ulidSchema,
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
+    const { frame, scopedDb } = context;
+    const variant = await scopedDb.frameVariants.getById(data.variantId);
+    if (!variant || variant.frameId !== frame.id) {
+      throw new Error('Variant not found for this frame');
+    }
+    if (variant.divergedAt === null || variant.discardedAt !== null) {
+      throw new Error('Variant is not a live divergent alternate');
+    }
+    if (!variant.url) {
+      throw new Error('Variant has no asset to promote');
+    }
+
+    const update: Partial<NewFrame> = {};
+    let progressEvent:
+      | 'image:progress'
+      | 'video:progress'
+      | 'audio:progress'
+      | null = null;
+    let progressUrlField: 'thumbnailUrl' | 'videoUrl' | 'audioUrl' | null =
+      null;
+
+    switch (variant.variantType) {
+      case 'image':
+        update.thumbnailUrl = variant.url;
+        update.thumbnailPath = variant.storagePath;
+        update.thumbnailStatus = 'completed';
+        update.thumbnailError = null;
+        update.thumbnailInputHash = variant.inputHash;
+        update.imageModel = variant.model;
+        // Downstream video is now misaligned with the new image — mark stale
+        // by clearing it; the user will regenerate.
+        update.videoUrl = null;
+        update.videoPath = null;
+        update.videoStatus = 'pending';
+        update.videoWorkflowRunId = null;
+        update.videoGeneratedAt = null;
+        update.videoError = null;
+        progressEvent = 'image:progress';
+        progressUrlField = 'thumbnailUrl';
+        break;
+      case 'video':
+        update.videoUrl = variant.url;
+        update.videoPath = variant.storagePath;
+        update.videoStatus = 'completed';
+        update.videoError = null;
+        update.videoInputHash = variant.inputHash;
+        progressEvent = 'video:progress';
+        progressUrlField = 'videoUrl';
+        break;
+      case 'audio':
+        update.audioUrl = variant.url;
+        update.audioPath = variant.storagePath;
+        update.audioInputHash = variant.inputHash;
+        progressEvent = 'audio:progress';
+        progressUrlField = 'audioUrl';
+        break;
+    }
+
+    const updatedFrame = await scopedDb.frames.update(frame.id, update);
+    if (!updatedFrame) {
+      throw new Error(`Frame ${frame.id} not found`);
+    }
+    // Soft-delete the promoted variant so it disappears from the alternate
+    // listing without losing recovery audit trail.
+    await scopedDb.frameVariants.discard(variant.id);
+
+    if (progressEvent && progressUrlField) {
+      const url = updatedFrame[progressUrlField] ?? variant.url;
+      await getGenerationChannel(data.sequenceId).emit(
+        `generation.${progressEvent}`,
+        progressEvent === 'audio:progress'
+          ? {
+              frameId: frame.id,
+              status: 'completed',
+              audioUrl: url ?? undefined,
+            }
+          : progressEvent === 'video:progress'
+            ? {
+                frameId: frame.id,
+                status: 'completed',
+                videoUrl: url ?? undefined,
+              }
+            : {
+                frameId: frame.id,
+                status: 'completed',
+                thumbnailUrl: url ?? undefined,
+                model: variant.model,
+              }
+      );
+    }
+
+    return { frame: updatedFrame, variantId: variant.id };
+  });
+
+export const discardVariantFn = createServerFn({ method: 'POST' })
+  .middleware([frameAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        frameId: ulidSchema,
+        variantId: ulidSchema,
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
+    const variant = await context.scopedDb.frameVariants.getById(
+      data.variantId
+    );
+    if (!variant || variant.frameId !== context.frame.id) {
+      throw new Error('Variant not found for this frame');
+    }
+    const discardedAt = await context.scopedDb.frameVariants.discard(
+      variant.id
+    );
+    return { variantId: variant.id, discardedAt };
+  });
+
+export const undiscardVariantFn = createServerFn({ method: 'POST' })
+  .middleware([frameAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        frameId: ulidSchema,
+        variantId: ulidSchema,
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
+    const variant = await context.scopedDb.frameVariants.getById(
+      data.variantId
+    );
+    if (!variant || variant.frameId !== context.frame.id) {
+      throw new Error('Variant not found for this frame');
+    }
+    await context.scopedDb.frameVariants.undiscard(variant.id);
+    return { variantId: variant.id };
   });
 
 export const getSequenceImageVariantsFn = createServerFn({ method: 'GET' })

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -129,6 +129,8 @@ export const promoteVariantFn = createServerFn({ method: 'POST' })
       case 'audio':
         update.audioUrl = variant.url;
         update.audioPath = variant.storagePath;
+        update.audioStatus = 'completed';
+        update.audioError = null;
         update.audioInputHash = variant.inputHash;
         progressEvent = 'audio:progress';
         progressUrlField = 'audioUrl';

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
-import type { NewFrame } from '@/lib/db/schema';
+import type { FrameVariant, NewFrame } from '@/lib/db/schema';
 import { getGenerationChannel } from '@/lib/realtime';
 import { getVideoDownloadUrl } from '@/lib/motion/video-storage';
 import {
@@ -58,6 +58,69 @@ export const getDivergentVariantsFn = createServerFn({ method: 'GET' })
     );
   });
 
+type PromoteProgressEvent =
+  | 'image:progress'
+  | 'video:progress'
+  | 'audio:progress';
+type PromoteProgressUrlField = 'thumbnailUrl' | 'videoUrl' | 'audioUrl';
+
+/**
+ * Build the per-variantType `frames` update payload and matching realtime
+ * progress event metadata for a promote-variant operation. Exported (and
+ * pure) for unit testing — the server-fn handler wraps this in auth +
+ * persistence.
+ */
+export function buildPromoteUpdate(variant: FrameVariant): {
+  update: Partial<NewFrame>;
+  progressEvent: PromoteProgressEvent;
+  progressUrlField: PromoteProgressUrlField;
+} {
+  const update: Partial<NewFrame> = {};
+  let progressEvent: PromoteProgressEvent;
+  let progressUrlField: PromoteProgressUrlField;
+
+  switch (variant.variantType) {
+    case 'image':
+      update.thumbnailUrl = variant.url;
+      update.thumbnailPath = variant.storagePath;
+      update.thumbnailStatus = 'completed';
+      update.thumbnailError = null;
+      update.thumbnailInputHash = variant.inputHash;
+      update.imageModel = variant.model;
+      // Downstream video is now misaligned with the new image — mark stale
+      // by clearing it; the user will regenerate.
+      update.videoUrl = null;
+      update.videoPath = null;
+      update.videoStatus = 'pending';
+      update.videoWorkflowRunId = null;
+      update.videoGeneratedAt = null;
+      update.videoError = null;
+      progressEvent = 'image:progress';
+      progressUrlField = 'thumbnailUrl';
+      break;
+    case 'video':
+      update.videoUrl = variant.url;
+      update.videoPath = variant.storagePath;
+      update.videoStatus = 'completed';
+      update.videoError = null;
+      update.videoInputHash = variant.inputHash;
+      progressEvent = 'video:progress';
+      progressUrlField = 'videoUrl';
+      break;
+    case 'audio':
+      update.audioUrl = variant.url;
+      update.audioPath = variant.storagePath;
+      update.audioStatus = 'completed';
+      update.audioError = null;
+      update.audioInputHash = variant.inputHash;
+      progressEvent = 'audio:progress';
+      progressUrlField = 'audioUrl';
+      break;
+  }
+
+  return { update, progressEvent, progressUrlField };
+}
+
 /**
  * Promote a divergent alternate to be the live primary for its variant type.
  * Copies the variant's url/path into the matching frames column, updates the
@@ -89,65 +152,25 @@ export const promoteVariantFn = createServerFn({ method: 'POST' })
       throw new Error('Variant has no asset to promote');
     }
 
-    const update: Partial<NewFrame> = {};
-    let progressEvent:
-      | 'image:progress'
-      | 'video:progress'
-      | 'audio:progress'
-      | null = null;
-    let progressUrlField: 'thumbnailUrl' | 'videoUrl' | 'audioUrl' | null =
-      null;
+    const { update, progressEvent, progressUrlField } =
+      buildPromoteUpdate(variant);
 
-    switch (variant.variantType) {
-      case 'image':
-        update.thumbnailUrl = variant.url;
-        update.thumbnailPath = variant.storagePath;
-        update.thumbnailStatus = 'completed';
-        update.thumbnailError = null;
-        update.thumbnailInputHash = variant.inputHash;
-        update.imageModel = variant.model;
-        // Downstream video is now misaligned with the new image — mark stale
-        // by clearing it; the user will regenerate.
-        update.videoUrl = null;
-        update.videoPath = null;
-        update.videoStatus = 'pending';
-        update.videoWorkflowRunId = null;
-        update.videoGeneratedAt = null;
-        update.videoError = null;
-        progressEvent = 'image:progress';
-        progressUrlField = 'thumbnailUrl';
-        break;
-      case 'video':
-        update.videoUrl = variant.url;
-        update.videoPath = variant.storagePath;
-        update.videoStatus = 'completed';
-        update.videoError = null;
-        update.videoInputHash = variant.inputHash;
-        progressEvent = 'video:progress';
-        progressUrlField = 'videoUrl';
-        break;
-      case 'audio':
-        update.audioUrl = variant.url;
-        update.audioPath = variant.storagePath;
-        update.audioStatus = 'completed';
-        update.audioError = null;
-        update.audioInputHash = variant.inputHash;
-        progressEvent = 'audio:progress';
-        progressUrlField = 'audioUrl';
-        break;
-    }
+    // Atomic: a partial failure can't leave the live primary updated with the
+    // variant still appearing in the divergent list (or vice versa).
+    const { frame: updatedFrame } =
+      await scopedDb.frameVariants.promoteAtomically(
+        frame.id,
+        update,
+        variant.id
+      );
 
-    const updatedFrame = await scopedDb.frames.update(frame.id, update);
-    if (!updatedFrame) {
-      throw new Error(`Frame ${frame.id} not found`);
-    }
-    // Soft-delete the promoted variant so it disappears from the alternate
-    // listing without losing recovery audit trail.
-    await scopedDb.frameVariants.discard(variant.id);
-
-    if (progressEvent && progressUrlField) {
+    // Realtime emit is purely cache-busting — TanStack Query refetches on the
+    // mutation onSuccess invalidation regardless. A failed emit must not
+    // surface to the user as "promote failed" when the DB already committed.
+    const channel = getGenerationChannel(data.sequenceId);
+    try {
       const url = updatedFrame[progressUrlField] ?? variant.url;
-      await getGenerationChannel(data.sequenceId).emit(
+      await channel.emit(
         `generation.${progressEvent}`,
         progressEvent === 'audio:progress'
           ? {
@@ -168,6 +191,18 @@ export const promoteVariantFn = createServerFn({ method: 'POST' })
                 model: variant.model,
               }
       );
+      // Promoting an image clears the downstream video — emit a paired
+      // video:progress event so listeners deriving motion-banner state from
+      // realtime (not just cache) reset immediately.
+      if (variant.variantType === 'image') {
+        await channel.emit('generation.video:progress', {
+          frameId: frame.id,
+          status: 'pending',
+          videoUrl: undefined,
+        });
+      }
+    } catch (error) {
+      console.error('[promoteVariantFn] realtime emit failed', error);
     }
 
     return { frame: updatedFrame, variantId: variant.id };

--- a/src/hooks/use-frames.ts
+++ b/src/hooks/use-frames.ts
@@ -83,15 +83,19 @@ export const frameKeys = {
 
 // Hook to fetch the live (non-discarded) divergent alternates for a sequence.
 // The corner-dot indicator and inline banner both filter this list per frame.
-export function useDivergentVariants(sequenceId?: string) {
+export function useDivergentVariants(
+  sequenceId?: string,
+  options?: { refetchInterval?: number | false }
+) {
   return useQuery<FrameVariant[]>({
     queryKey: frameKeys.divergentVariants(sequenceId ?? ''),
     queryFn: async () => {
-      if (!sequenceId) return [];
+      if (!sequenceId) throw new Error('sequenceId is required');
       return getDivergentVariantsFn({ data: { sequenceId } });
     },
     enabled: !!sequenceId,
     staleTime: 30_000,
+    refetchInterval: options?.refetchInterval ?? false,
   });
 }
 

--- a/src/hooks/use-frames.ts
+++ b/src/hooks/use-frames.ts
@@ -1,6 +1,7 @@
 import type { Frame } from '@/types/database';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import type { FrameVariant } from '@/lib/db/schema';
 import {
   getFramesFn,
   getFrameFn,
@@ -10,6 +11,10 @@ import {
   deleteFrameFn,
   deleteFramesBySequenceFn,
   reorderFramesFn,
+  getDivergentVariantsFn,
+  promoteVariantFn,
+  discardVariantFn,
+  undiscardVariantFn,
 } from '@/functions/frames';
 import {
   generateFramesFn,
@@ -72,7 +77,86 @@ export const frameKeys = {
   detail: (id: string) => [...frameKeys.details(), id] as const,
   imageModels: (sequenceId: string) =>
     [...frameKeys.all, 'image-models', sequenceId] as const,
+  divergentVariants: (sequenceId: string) =>
+    [...frameKeys.all, 'divergent-variants', sequenceId] as const,
 };
+
+// Hook to fetch the live (non-discarded) divergent alternates for a sequence.
+// The corner-dot indicator and inline banner both filter this list per frame.
+export function useDivergentVariants(sequenceId?: string) {
+  return useQuery<FrameVariant[]>({
+    queryKey: frameKeys.divergentVariants(sequenceId ?? ''),
+    queryFn: async () => {
+      if (!sequenceId) return [];
+      return getDivergentVariantsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
+
+// Promote a divergent alternate to the live primary slot.
+export function usePromoteVariantToPrimary() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { frame: Frame; variantId: string },
+    Error,
+    { sequenceId: string; frameId: string; variantId: string }
+  >({
+    mutationFn: async (input) => {
+      const result = await promoteVariantFn({ data: input });
+      return result;
+    },
+    onSuccess: async ({ frame }, { sequenceId }) => {
+      queryClient.setQueryData(frameKeys.detail(frame.id), frame);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: frameKeys.list(sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: frameKeys.divergentVariants(sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['sequence-image-variants', sequenceId],
+        }),
+      ]);
+    },
+  });
+}
+
+// Discard a divergent alternate (sets discarded_at). Pairs with useUndiscard
+// for the toast Undo action.
+export function useDiscardVariant() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { variantId: string; discardedAt: Date },
+    Error,
+    { sequenceId: string; frameId: string; variantId: string }
+  >({
+    mutationFn: async (input) => discardVariantFn({ data: input }),
+    onSuccess: async (_, { sequenceId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: frameKeys.divergentVariants(sequenceId),
+      });
+    },
+  });
+}
+
+export function useUndiscardVariant() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { variantId: string },
+    Error,
+    { sequenceId: string; frameId: string; variantId: string }
+  >({
+    mutationFn: async (input) => undiscardVariantFn({ data: input }),
+    onSuccess: async (_, { sequenceId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: frameKeys.divergentVariants(sequenceId),
+      });
+    },
+  });
+}
 
 // Hook for listing frames by sequence with optional auto-refresh
 export function useFramesBySequence(

--- a/src/lib/db/schema/frame-variants.ts
+++ b/src/lib/db/schema/frame-variants.ts
@@ -99,12 +99,9 @@ export const frameVariants = sqliteTable(
       .where(sql`${table.divergedAt} IS NULL`),
     // Divergent alternates: distinguished by input_hash, so multiple
     // divergences of the same model can coexist without overwriting each other.
-    // Invariant (enforced at application layer in scoped methods): a primary
-    // variant — divergedAt IS NULL — must never have discardedAt set;
-    // discardedAt is the user-dismissal marker for divergent alternates only.
-    // A schema-level CHECK constraint is a planned follow-up (the table
-    // rebuild required to add it post-hoc was deferred to keep this PR's
-    // migration clean).
+    // Invariant (enforced in the scoped methods): a primary variant —
+    // divergedAt IS NULL — must never have discardedAt set; discardedAt is
+    // the user-dismissal marker for divergent alternates only.
     uniqueIndex('frame_variants_divergent_key')
       .on(table.frameId, table.variantType, table.model, table.inputHash)
       .where(sql`${table.divergedAt} IS NOT NULL`),

--- a/src/lib/db/schema/frame-variants.ts
+++ b/src/lib/db/schema/frame-variants.ts
@@ -71,6 +71,10 @@ export const frameVariants = sqliteTable(
     // Set when the variant was saved as a divergence (inputs changed between
     // workflow snapshot and write time) rather than as the primary artifact.
     divergedAt: integer('diverged_at', { mode: 'timestamp' }),
+    // Soft-delete marker for divergent alternates the user has dismissed.
+    // Kept (rather than hard-deleted) so the artifact stays addressable for
+    // recovery via the toast Undo action.
+    discardedAt: integer('discarded_at', { mode: 'timestamp' }),
 
     // Duration (relevant for video/audio variants)
     durationMs: integer('duration_ms'),

--- a/src/lib/db/schema/frame-variants.ts
+++ b/src/lib/db/schema/frame-variants.ts
@@ -99,6 +99,12 @@ export const frameVariants = sqliteTable(
       .where(sql`${table.divergedAt} IS NULL`),
     // Divergent alternates: distinguished by input_hash, so multiple
     // divergences of the same model can coexist without overwriting each other.
+    // Invariant (enforced at application layer in scoped methods): a primary
+    // variant — divergedAt IS NULL — must never have discardedAt set;
+    // discardedAt is the user-dismissal marker for divergent alternates only.
+    // A schema-level CHECK constraint is a planned follow-up (the table
+    // rebuild required to add it post-hoc was deferred to keep this PR's
+    // migration clean).
     uniqueIndex('frame_variants_divergent_key')
       .on(table.frameId, table.variantType, table.model, table.inputHash)
       .where(sql`${table.divergedAt} IS NOT NULL`),

--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -309,7 +309,7 @@ describe('frame_variants discard / undiscard / listDivergent', () => {
       inputHash: 'h1',
       divergedAt: new Date('2026-04-29T00:00:00Z'),
     });
-    const methods = createFrameVariantsMethods(asDatabase(db));
+    const methods = createFrameVariantsMethods(db);
 
     const ts = await methods.discard(v.id);
     expect(ts).toBeInstanceOf(Date);
@@ -339,7 +339,7 @@ describe('frame_variants discard / undiscard / listDivergent', () => {
       discardedAt: new Date('2026-05-02T00:00:00Z'),
     });
 
-    const methods = createFrameVariantsMethods(asDatabase(db));
+    const methods = createFrameVariantsMethods(db);
     const rows = await methods.listDivergentByFrame(frameId, 'image');
     const ids = rows.map((r) => r.id);
     expect(ids).toEqual([a.id, b.id]);

--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -280,3 +280,69 @@ describe('createFrameVariantsMethods', () => {
     expect(rows.filter((r) => r.divergedAt !== null)).toHaveLength(1);
   });
 });
+
+describe('frame_variants discard / undiscard / listDivergent', () => {
+  async function insertDivergent(opts: {
+    inputHash: string;
+    divergedAt: Date;
+    discardedAt?: Date;
+  }) {
+    const [variant] = await db
+      .insert(frameVariants)
+      .values({
+        frameId,
+        sequenceId,
+        variantType: 'image',
+        model: 'm1',
+        url: `https://example.com/${opts.inputHash}.png`,
+        status: 'completed',
+        inputHash: opts.inputHash,
+        divergedAt: opts.divergedAt,
+        discardedAt: opts.discardedAt ?? null,
+      })
+      .returning();
+    return variant;
+  }
+
+  it('discard sets discardedAt; undiscard clears it', async () => {
+    const v = await insertDivergent({
+      inputHash: 'h1',
+      divergedAt: new Date('2026-04-29T00:00:00Z'),
+    });
+    const methods = createFrameVariantsMethods(asDatabase(db));
+
+    const ts = await methods.discard(v.id);
+    expect(ts).toBeInstanceOf(Date);
+    const after = await methods.getById(v.id);
+    // SQLite timestamp(0) drops sub-second precision on round-trip, so compare seconds.
+    expect(Math.floor((after?.discardedAt?.getTime() ?? 0) / 1000)).toBe(
+      Math.floor(ts.getTime() / 1000)
+    );
+
+    await methods.undiscard(v.id);
+    const restored = await methods.getById(v.id);
+    expect(restored?.discardedAt).toBeNull();
+  });
+
+  it('listDivergentByFrame excludes discarded rows and orders by divergedAt', async () => {
+    const a = await insertDivergent({
+      inputHash: 'h-a',
+      divergedAt: new Date('2026-04-29T00:00:00Z'),
+    });
+    const b = await insertDivergent({
+      inputHash: 'h-b',
+      divergedAt: new Date('2026-04-30T00:00:00Z'),
+    });
+    const c = await insertDivergent({
+      inputHash: 'h-c',
+      divergedAt: new Date('2026-05-01T00:00:00Z'),
+      discardedAt: new Date('2026-05-02T00:00:00Z'),
+    });
+
+    const methods = createFrameVariantsMethods(asDatabase(db));
+    const rows = await methods.listDivergentByFrame(frameId, 'image');
+    const ids = rows.map((r) => r.id);
+    expect(ids).toEqual([a.id, b.id]);
+    expect(ids).not.toContain(c.id);
+  });
+});

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -265,14 +265,14 @@ export function createFrameVariantsMethods(db: Database) {
 
     /**
      * Atomically replace the live primary on `frames` with the variant's
-     * fields and soft-delete the variant. Both writes go through a single
-     * `db.batch()` so a partial failure cannot leave the live primary updated
-     * while the variant still appears in the divergent list (or vice versa).
+     * fields and soft-delete the variant. Both writes run in a single
+     * `db.batch()` (one libSQL transaction) so partial failure isn't
+     * possible at the SQL layer.
      *
-     * Pre-checks existence rather than relying on returning(), because
-     * libSQL `batch()` commits both UPDATEs even when the WHERE matches no
-     * rows — a JS-side throw after commit would still leave one side
-     * mutated.
+     * Pre-checks existence so a missing frame or variant fails fast with a
+     * specific error before the batch runs. Without the pre-check, a
+     * zero-row UPDATE silently succeeds inside the batch, forcing ambiguous
+     * post-batch reasoning about which side was missing.
      */
     promoteAtomically: async (
       frameId: string,
@@ -305,11 +305,19 @@ export function createFrameVariantsMethods(db: Database) {
         .set({ discardedAt: now, updatedAt: now })
         .where(eq(frameVariants.id, variantId))
         .returning();
-      const [frameRows] = await db.batch([updateFrame, discardVariant]);
-      // Existence was checked above; an empty result here would mean the row
-      // was deleted between the pre-check and the batch — surface it.
+      const [frameRows, variantRows] = await db.batch([
+        updateFrame,
+        discardVariant,
+      ]);
+      // Existence was checked above. A zero-row result on either side means
+      // the row was deleted between the pre-check and the batch — surface
+      // it so the caller sees the inconsistency rather than silently
+      // discarding a nonexistent variant or "promoting" with no live frame.
       if (frameRows.length === 0) {
         throw new Error(`Frame ${frameId} disappeared during promote`);
+      }
+      if (variantRows.length === 0) {
+        throw new Error(`FrameVariant ${variantId} disappeared during promote`);
       }
       return { frame: frameRows[0], discardedAt: now };
     },

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -201,6 +201,91 @@ export function createFrameVariantsMethods(db: Database) {
       return currentHash !== stored;
     },
 
+    /**
+     * List divergent alternates for a frame (or all frames in a sequence) that
+     * have not been discarded. Ordered oldest-first by divergedAt so the UI
+     * surfaces the longest-pending alternate consistently.
+     */
+    listDivergentByFrame: async (
+      frameId: string,
+      variantType?: VariantType
+    ): Promise<FrameVariant[]> => {
+      const conditions = [
+        eq(frameVariants.frameId, frameId),
+        sql`${frameVariants.divergedAt} IS NOT NULL`,
+        sql`${frameVariants.discardedAt} IS NULL`,
+      ];
+      if (variantType) {
+        conditions.push(eq(frameVariants.variantType, variantType));
+      }
+      return db
+        .select()
+        .from(frameVariants)
+        .where(and(...conditions))
+        .orderBy(frameVariants.divergedAt);
+    },
+
+    listDivergentBySequence: async (
+      sequenceId: string
+    ): Promise<FrameVariant[]> => {
+      return db
+        .select()
+        .from(frameVariants)
+        .where(
+          and(
+            eq(frameVariants.sequenceId, sequenceId),
+            sql`${frameVariants.divergedAt} IS NOT NULL`,
+            sql`${frameVariants.discardedAt} IS NULL`
+          )
+        )
+        .orderBy(frameVariants.divergedAt);
+    },
+
+    /**
+     * Mark a divergent alternate as discarded. Idempotent; returns the
+     * timestamp set so the caller can stash it for an Undo action.
+     */
+    discard: async (variantId: string): Promise<Date> => {
+      const discardedAt = new Date();
+      const result = await db
+        .update(frameVariants)
+        .set({ discardedAt, updatedAt: discardedAt })
+        .where(eq(frameVariants.id, variantId))
+        .returning();
+      if (result.length === 0) {
+        throw new Error(`FrameVariant ${variantId} not found`);
+      }
+      return discardedAt;
+    },
+
+    /**
+     * Undo a previous discard by clearing discardedAt. Used by the sonner
+     * toast Undo action.
+     */
+    undiscard: async (variantId: string): Promise<void> => {
+      const result = await db
+        .update(frameVariants)
+        .set({ discardedAt: null, updatedAt: new Date() })
+        .where(eq(frameVariants.id, variantId))
+        .returning();
+      if (result.length === 0) {
+        throw new Error(`FrameVariant ${variantId} not found`);
+      }
+    },
+
+    /**
+     * Look up a divergent variant by id. Used by the promote/discard server
+     * functions to confirm the row exists and is still divergent before
+     * acting.
+     */
+    getById: async (variantId: string): Promise<FrameVariant | null> => {
+      const result = await db
+        .select()
+        .from(frameVariants)
+        .where(eq(frameVariants.id, variantId));
+      return result[0] ?? null;
+    },
+
     deleteByFrame: async (frameId: string): Promise<number> => {
       const result = await db
         .delete(frameVariants)

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -4,8 +4,13 @@
  */
 
 import type { Database } from '@/lib/db/client';
-import type { FrameVariant, NewFrameVariant } from '@/lib/db/schema';
-import { frameVariants } from '@/lib/db/schema';
+import type {
+  Frame,
+  FrameVariant,
+  NewFrame,
+  NewFrameVariant,
+} from '@/lib/db/schema';
+import { frameVariants, frames } from '@/lib/db/schema';
 import type { VariantType } from '@/lib/db/schema/frame-variants';
 import { and, eq, sql } from 'drizzle-orm';
 
@@ -256,6 +261,57 @@ export function createFrameVariantsMethods(db: Database) {
         throw new Error(`FrameVariant ${variantId} not found`);
       }
       return discardedAt;
+    },
+
+    /**
+     * Atomically replace the live primary on `frames` with the variant's
+     * fields and soft-delete the variant. Both writes go through a single
+     * `db.batch()` so a partial failure cannot leave the live primary updated
+     * while the variant still appears in the divergent list (or vice versa).
+     *
+     * Pre-checks existence rather than relying on returning(), because
+     * libSQL `batch()` commits both UPDATEs even when the WHERE matches no
+     * rows — a JS-side throw after commit would still leave one side
+     * mutated.
+     */
+    promoteAtomically: async (
+      frameId: string,
+      frameUpdate: Partial<NewFrame>,
+      variantId: string
+    ): Promise<{ frame: Frame; discardedAt: Date }> => {
+      const [existingFrame] = await db
+        .select({ id: frames.id })
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      if (!existingFrame) {
+        throw new Error(`Frame ${frameId} not found`);
+      }
+      const [existingVariant] = await db
+        .select({ id: frameVariants.id })
+        .from(frameVariants)
+        .where(eq(frameVariants.id, variantId));
+      if (!existingVariant) {
+        throw new Error(`FrameVariant ${variantId} not found`);
+      }
+
+      const now = new Date();
+      const updateFrame = db
+        .update(frames)
+        .set({ ...frameUpdate, updatedAt: now })
+        .where(eq(frames.id, frameId))
+        .returning();
+      const discardVariant = db
+        .update(frameVariants)
+        .set({ discardedAt: now, updatedAt: now })
+        .where(eq(frameVariants.id, variantId))
+        .returning();
+      const [frameRows] = await db.batch([updateFrame, discardVariant]);
+      // Existence was checked above; an empty result here would mean the row
+      // was deleted between the pre-check and the batch — surface it.
+      if (frameRows.length === 0) {
+        throw new Error(`Frame ${frameId} disappeared during promote`);
+      }
+      return { frame: frameRows[0], discardedAt: now };
     },
 
     /**

--- a/src/lib/realtime/__tests__/use-stale-detected.test.ts
+++ b/src/lib/realtime/__tests__/use-stale-detected.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for the testable pieces of `useStaleDetected`. The hook itself is
+ * React-lifecycle-bound and not exercised here (the codebase has no DOM
+ * environment configured for `bun:test`); behavior such as cross-sequence
+ * attribution and timer cleanup is covered by manual smoke testing in the
+ * scenes view.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { formatStaleToastMessage } from '@/lib/realtime/use-stale-detected';
+
+describe('formatStaleToastMessage', () => {
+  it('uses the singular phrasing for exactly one alternate', () => {
+    expect(formatStaleToastMessage(1)).toBe(
+      'An alternate version is available.'
+    );
+  });
+
+  it('pluralizes for counts greater than one', () => {
+    expect(formatStaleToastMessage(2)).toBe(
+      '2 alternate versions are available.'
+    );
+    expect(formatStaleToastMessage(7)).toBe(
+      '7 alternate versions are available.'
+    );
+  });
+
+  // Zero is a guard for completeness — the debounce only schedules a timer
+  // when at least one event has been counted, so this branch should not
+  // appear in practice; surfaced as plural to avoid the impression of a
+  // single alternate.
+  it('treats zero as plural', () => {
+    expect(formatStaleToastMessage(0)).toBe(
+      '0 alternate versions are available.'
+    );
+  });
+});

--- a/src/lib/realtime/use-stale-detected.ts
+++ b/src/lib/realtime/use-stale-detected.ts
@@ -6,6 +6,17 @@ import { toast } from 'sonner';
 
 const TOAST_DEBOUNCE_MS = 5_000;
 
+/**
+ * Format the debounced "alternates available" toast message.
+ * Exported for unit testing (the hook itself is not directly testable
+ * without a DOM environment).
+ */
+export function formatStaleToastMessage(count: number): string {
+  return count === 1
+    ? 'An alternate version is available.'
+    : `${count} alternate versions are available.`;
+}
+
 type StaleDetectedEvent = {
   event: string;
   data: {
@@ -44,10 +55,14 @@ export function useStaleDetected(sequenceId: string | undefined) {
   const queryClient = useQueryClient();
   const debounceRef = useRef<DebounceState>({ count: 0, timeout: null });
 
+  // Track the sequenceId the timer was scheduled for so a navigation within
+  // the 5s debounce window cannot credit late-arriving events to the wrong
+  // sequence's toast.
   const handleEvent = useCallback(
     (event: StaleDetectedEvent) => {
       if (event.event !== 'generation.stale:detected') return;
       if (!sequenceId) return;
+      const scheduledFor = sequenceId;
 
       void queryClient.invalidateQueries({
         queryKey: frameKeys.list(sequenceId),
@@ -63,22 +78,39 @@ export function useStaleDetected(sequenceId: string | undefined) {
         const count = state.count;
         state.count = 0;
         state.timeout = null;
-        toast.info(
-          count === 1
-            ? 'An alternate version is available.'
-            : `${count} alternate versions are available.`
-        );
+        // Bail if the user navigated away while the timer was pending — the
+        // count belongs to the previous sequence and the new view will get
+        // its own subscription + toast.
+        if (scheduledFor !== sequenceIdRef.current) return;
+        toast.info(formatStaleToastMessage(count));
       }, TOAST_DEBOUNCE_MS);
     },
     [queryClient, sequenceId]
   );
 
-  useRealtime({
+  const sequenceIdRef = useRef(sequenceId);
+  useEffect(() => {
+    sequenceIdRef.current = sequenceId;
+  }, [sequenceId]);
+
+  const { status } = useRealtime({
     channels: sequenceId ? [sequenceId] : [],
     events: ['generation.stale:detected'] as const,
     onData: handleEvent,
     enabled: !!sequenceId,
   });
+
+  // Surface realtime subscription failures so silent disconnects show up in
+  // logs — without this the divergent banner can stay stale forever with no
+  // signal. Polling fallback in `useDivergentVariants` covers UX recovery.
+  useEffect(() => {
+    if (!sequenceId) return;
+    if (status === 'error') {
+      console.error('[useStaleDetected] realtime channel error', {
+        sequenceId,
+      });
+    }
+  }, [status, sequenceId]);
 
   // Cancel any pending toast when the sequence changes or the view unmounts —
   // otherwise a navigation within the 5s debounce window fires a toast for a

--- a/src/lib/realtime/use-stale-detected.ts
+++ b/src/lib/realtime/use-stale-detected.ts
@@ -1,0 +1,82 @@
+import { frameKeys } from '@/hooks/use-frames';
+import { useRealtime } from '@/lib/realtime/client';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef } from 'react';
+import { toast } from 'sonner';
+
+const TOAST_DEBOUNCE_MS = 5_000;
+
+type StaleDetectedEvent = {
+  event: string;
+  data: {
+    entityType:
+      | 'frame'
+      | 'character'
+      | 'location'
+      | 'library-location'
+      | 'talent';
+    entityId: string;
+    artifact?: 'thumbnail' | 'variant-image' | 'video' | 'audio' | 'sheet';
+    snapshotInputHash: string;
+    divergedVariantId?: string;
+  };
+};
+
+type DebounceState = {
+  count: number;
+  timeout: ReturnType<typeof setTimeout> | null;
+};
+
+/**
+ * Subscribes to `generation.stale:detected` for the current sequence channel.
+ *
+ * Two responsibilities:
+ *  1. Show a sonner toast announcing the alternate. Debounced to one toast
+ *     per sequence per 5s with a count, so a recast that lands many divergent
+ *     variants in quick succession doesn't spam the user.
+ *  2. Invalidate TanStack Query caches so the divergent banner / corner dot
+ *     appear inline without a manual refresh.
+ *
+ * Returns nothing — this is a fire-and-forget subscription kept alive for the
+ * scenes view's lifetime.
+ */
+export function useStaleDetected(sequenceId: string | undefined) {
+  const queryClient = useQueryClient();
+  const debounceRef = useRef<DebounceState>({ count: 0, timeout: null });
+
+  const handleEvent = useCallback(
+    (event: StaleDetectedEvent) => {
+      if (event.event !== 'generation.stale:detected') return;
+      if (!sequenceId) return;
+
+      void queryClient.invalidateQueries({
+        queryKey: frameKeys.list(sequenceId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: frameKeys.divergentVariants(sequenceId),
+      });
+
+      const state = debounceRef.current;
+      state.count += 1;
+      if (state.timeout) return;
+      state.timeout = setTimeout(() => {
+        const count = state.count;
+        state.count = 0;
+        state.timeout = null;
+        toast.info(
+          count === 1
+            ? 'An alternate version is available.'
+            : `${count} alternate versions are available.`
+        );
+      }, TOAST_DEBOUNCE_MS);
+    },
+    [queryClient, sequenceId]
+  );
+
+  useRealtime({
+    channels: sequenceId ? [sequenceId] : [],
+    events: ['generation.stale:detected'] as const,
+    onData: handleEvent,
+    enabled: !!sequenceId,
+  });
+}

--- a/src/lib/realtime/use-stale-detected.ts
+++ b/src/lib/realtime/use-stale-detected.ts
@@ -1,7 +1,7 @@
 import { frameKeys } from '@/hooks/use-frames';
 import { useRealtime } from '@/lib/realtime/client';
 import { useQueryClient } from '@tanstack/react-query';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
 const TOAST_DEBOUNCE_MS = 5_000;
@@ -79,4 +79,18 @@ export function useStaleDetected(sequenceId: string | undefined) {
     onData: handleEvent,
     enabled: !!sequenceId,
   });
+
+  // Cancel any pending toast when the sequence changes or the view unmounts —
+  // otherwise a navigation within the 5s debounce window fires a toast for a
+  // sequence the user has already left.
+  useEffect(() => {
+    const state = debounceRef.current;
+    return () => {
+      if (state.timeout) {
+        clearTimeout(state.timeout);
+        state.timeout = null;
+        state.count = 0;
+      }
+    };
+  }, [sequenceId]);
 }


### PR DESCRIPTION
## Related Issue
Closes #625

> Stacked on `618-stage-2-sheet-variants-for-character-location-talent`. Merge the parent PR first; GitHub will auto-retarget this one.

## Summary
Implemented stage 1 staleness/divergence UI: discardedAt column + migration, scoped methods, promote/discard server fns + hooks, useStaleDetected realtime hook, DivergenceCompareDialog, scene-list-item corner dot, inline banners, scenes-view wiring with Undo toast; tests + story added; typecheck/lint clean; pushed.

## Notes
Opened by the agent-harness overnight runner. See the `harness-active` label.
