### PR TITLE
fix(ci): remove accidentally tracked .claude/worktrees gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ scripts/schemas/
 
 # claude code local state
 .claude/*.lock
+.claude/worktrees/
 
 # agent harness
 .claude-harness/


### PR DESCRIPTION
## Summary

- Commit `485d59a2` (merged via #656) accidentally staged `.claude/worktrees/cranky-gauss-616c96` as a gitlink (mode `160000`). Claude Code worktrees contain a `.git` file, which makes git record the path as a submodule reference rather than walking into it.
- With no matching `.gitmodules` entry, GitHub Actions' **Post job cleanup** runs `git submodule foreach --recursive` against every checkout and fails:
  ```
  fatal: No url found for submodule path '.claude/worktrees/cranky-gauss-616c96' in .gitmodules
  Warning: The process '/usr/bin/git' failed with exit code 128
  ```
- This PR removes the gitlink from the index and adds `.claude/worktrees/` to `.gitignore` so it can't recur.

Branches based on the broken main will need to rebase past this fix to clear the same CI failure.

## Test plan

- [ ] CI runs to completion (no Post job cleanup failure) on this PR
- [ ] After merge, confirm subsequent pushes to main no longer hit the cleanup error