### PR TITLE
feat: improve server function logging #669

### DIFF
--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -302,9 +302,8 @@ export const stripeWebhookMiddleware = createMiddleware().server(
  * Basic auth middleware - requires authenticated user
  * Adds user and session to context
  */
-export const authMiddleware = createMiddleware({ type: 'function' })
-  .middleware([loggerMiddleware])
-  .server(async ({ next }) => {
+export const authMiddleware = createMiddleware({ type: 'function' }).server(
+  async ({ next }) => {
     const request = getRequest();
     const auth = getAuth();
     const session = await auth.api.getSession({ headers: request.headers });
@@ -319,7 +318,8 @@ export const authMiddleware = createMiddleware({ type: 'function' })
         session,
       },
     });
-  });
+  }
+);
 
 /**
  * Tracing middleware — wraps the request in an OTel trace-context with the

--- a/src/lib/observability/structured-log.ts
+++ b/src/lib/observability/structured-log.ts
@@ -61,7 +61,7 @@ const DIM = '\x1b[2m';
 function emitDevLog(log: StructuredLog): void {
   const { label, color } = LEVEL_STYLES[log.level];
   const method = log.method ?? '';
-  const path = log.path ?? log.name;
+  const path = log.source === 'serverFn' ? log.name : (log.path ?? log.name);
   const ms = `${DIM}${log.durationMs}ms${RESET}`;
 
   let line = `${color}${label}${RESET} ${method} ${path} ${ms}`;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -1160,10 +1160,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
     router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,0 +1,6 @@
+import { createStart } from '@tanstack/react-start';
+import { loggerMiddleware } from '@/functions/middleware';
+
+export const startInstance = createStart(() => ({
+  functionMiddleware: [loggerMiddleware],
+}));


### PR DESCRIPTION
## Summary
- Register `loggerMiddleware` as global `functionMiddleware` via new `src/start.ts` so every `createServerFn` logs automatically (previously only chains through `authMiddleware` did).
- Fix `emitDevLog` to display the function name for `serverFn` source instead of the opaque `/_serverFn/<hash>` path; `api`/`workflow` sources keep showing the URL path.
- Drop the now-redundant `.middleware([loggerMiddleware])` from `authMiddleware` so logs aren't emitted twice.

## Test plan
- [ ] `bun tsgo --noEmit` clean
- [ ] `bun test src/functions src/lib/observability` passes
- [ ] `bun dev`, trigger a server fn from the UI — console shows `INFO POST getCurrentUserFn 12ms` (not `/_serverFn/<hash>`)
- [ ] Trigger an unauthed fn (e.g. `getCurrentUserFn`) — confirm it now logs (previously bypassed)
- [ ] Trigger an authed fn — confirm exactly one log line, not two
- [ ] Hit `/api/workflows/...` — confirm `withApiLogging` output unchanged (still URL-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)