### PR TITLE
fix(dev): raise vite dev idleTimeout under Bun (#681)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,28 @@ const isE2EBuild = process.env.BUILD_E2E === '1';
 const e2eConditions = isE2EBuild ? ['e2e'] : [];
 
 /**
+ * Bun's node:http shim wraps Bun.serve, whose idleTimeout defaults to 10s.
+ * Bun maps Node's server.timeout (ms) onto Bun.serve idleTimeout (sec), so
+ * setting it on the vite dev server lifts the dev-only "Bun.serve: request
+ * timed out after 10 seconds." footgun without touching production. #681
+ */
+function bunDevIdleTimeout(): import('vite').Plugin {
+  return {
+    name: 'bun-dev-idle-timeout',
+    apply: 'serve',
+    configureServer(server) {
+      const isBun =
+        typeof (globalThis as { Bun?: unknown }).Bun !== 'undefined';
+      if (!isBun) return;
+      server.httpServer?.once('listening', () => {
+        const httpServer = server.httpServer;
+        if (httpServer && 'timeout' in httpServer) httpServer.timeout = 240_000;
+      });
+    },
+  };
+}
+
+/**
  * Rolldown reorders CJS-to-ESM wrappers: tsyringe checks for
  * Reflect.getMetadata before reflect-metadata's factory runs.
  * This plugin moves the require_Reflect() call before the check.
@@ -72,6 +94,7 @@ export default defineConfig({
     contentCollections(),
     isDev && devtools(),
     reflectMetadataPolyfill(),
+    bunDevIdleTimeout(),
     tailwindcss(),
     process.env.BUILD_CLOUDFLARE
       ? cloudflare({ viteEnvironment: { name: 'ssr' } })


### PR DESCRIPTION
## Summary

- Adds a serve-only Vite plugin in `vite.config.ts` that bumps the dev HTTP server's `timeout` to 240s when running under Bun.
- Bun's `node:http` shim wraps `Bun.serve`, whose `idleTimeout` defaults to **10s** — slow handlers in dev (SSR, AI proxies, DB) were aborting with `Bun.serve: request timed out after 10 seconds.` Bun maps Node's `server.timeout` (ms) onto `Bun.serve` `idleTimeout` (sec), so this raises the ceiling without touching production.
- No-op when not running under Bun. `apply: 'serve'` keeps build/preview/prod untouched.

## Test plan

- [x] `bun typecheck` passes
- [x] `bun --bun vite dev` boots cleanly with the plugin in place
- [ ] Hit a path that previously hung past 10s during dev — confirm it now completes
- [ ] (optional) Add a temporary `await Bun.sleep(15000)` handler and curl it; should return ~15s instead of erroring at 10s

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)