### PR TITLE
fix(workflows): prevent duplicate merge-video on parallel motion completion

### DIFF
--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -240,6 +240,7 @@ export const smartRetryFn = createServerFn({ method: 'POST' })
           model: videoModel,
           aspectRatio: sequence.aspectRatio,
           duration: frame.durationMs ? frame.durationMs / 1000 : undefined,
+          triggerMergeOnComplete: true,
         };
 
         await triggerWorkflow('/motion', workflowInput, {

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -196,6 +196,15 @@ export interface MotionWorkflowInput extends SequenceWorkflowContext {
    * the workflow appends a `user-edit` variant row.
    */
   userEditedPrompt?: boolean;
+  /**
+   * When `true`, the workflow's final step checks whether *all* sequence
+   * frames now have completed videos and, if so, triggers `/merge-video`.
+   * Only callers that fan out motion without their own subsequent merge
+   * invocation (e.g. `smart-retry`'s motion-retry path) should set this.
+   * The batch orchestrator (`motionBatchWorkflow`) invokes merge itself and
+   * leaves this unset to avoid redundant triggers.
+   */
+  triggerMergeOnComplete?: boolean;
 }
 
 /**

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -65,6 +65,8 @@ export const motionBatchWorkflow =
             motionBucket: frame.motionBucket,
             aspectRatio: frame.aspectRatio,
             userEditedPrompt: frame.userEditedPrompt,
+            // motion-batch invokes merge itself at step 3
+            triggerMergeOnComplete: false,
           } satisfies MotionWorkflowInput,
           retries: 3,
           retryDelay: 'pow(2, retried) * 1000',

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -397,14 +397,15 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
         }
       });
 
-      // Step 6: Check if all frames are complete and trigger merge.
-      // N parallel motion workflows can each reach this point near-
-      // simultaneously after the last frame lands; we rely on QStash to
-      // dedup the duplicate triggers via a content-derived workflowRunId.
-      // Same merge inputs → same hash → same id → QStash collapses the
-      // duplicates. Regenerating any frame's video changes the hash and
+      // Step 6: Opt-in merge auto-trigger for callers that fan out motion
+      // without their own subsequent merge invocation (e.g. smart-retry's
+      // motion-retry path). N parallel motion workflows can each reach this
+      // step near-simultaneously after the last frame lands; the content-
+      // derived dedup ID makes QStash collapse the duplicates into a single
+      // workflowRunId. Regenerating any frame's video changes the hash and
       // re-arms a fresh merge. See issue #690.
       await context.run('check-merge-trigger', async () => {
+        if (!input.triggerMergeOnComplete) return;
         if (!input.sequenceId || !input.teamId || !input.userId) return;
 
         const allFrames = await scopedDb.frames.listBySequence(


### PR DESCRIPTION
## Summary

- Makes the in-motion merge auto-trigger **opt-in** via a new `triggerMergeOnComplete` flag on `MotionWorkflowInput`. The batch path (`motionBatchWorkflow`) invokes merge itself at step 3 and now opts out, eliminating the N+1 redundant trigger attempts per sequence. `smart-retry`'s motion-retry path opts in.
- Switches the dedup ID from `Date.now()` to a content-derived hash (`computeSequenceVideoHashFromDto(...).slice(0, 16)`) so that any remaining parallel completions (e.g. smart-retry running multiple motion frames concurrently) collapse to a single `workflowRunId` at QStash. Regeneration still re-merges because the hash changes when a frame's `videoUrl` changes.
- Inlines `sourceFrameVideoHashes` on the auto-trigger payload so `mergeVideoWorkflow`'s divergence check works the same way as the manual path in `motion-functions.ts`.

Root cause was `motion-workflow.ts:check-merge-trigger` baking a millisecond timestamp into the dedup ID — two near-simultaneous frame completions both passed the all-complete check before either reached QStash, so dedup never collapsed them. Result was two billed Fal merge jobs, two uploads, and a non-deterministic last-write race on `sequences.mergedVideoUrl`.

Closes #690

## Test plan

- [x] `bun typecheck`
- [x] `bun test src/lib/workflows/sequence-snapshots.test.ts src/lib/workflows/merge-variant-resolution.test.ts` (31/31 pass)
- [ ] Manual: `bun dev` + `bun qstash:dev`, generate a ≥3-frame sequence — expect zero `[MotionWorkflow] All N frames complete, triggering merge workflow` lines (batch path doesn't auto-trigger) and exactly one `[Merge Videos] Job submitted` from `motionBatchWorkflow` step 3
- [ ] Manual: simulate a failed motion frame on a sequence, run smart-retry — expect one `[MotionWorkflow] All N frames complete, triggering merge workflow` line and exactly one `[Merge Videos] Job submitted`; if multiple frames are retried, the content hash should collapse them to one merge
- [ ] Manual: regenerate one frame's motion via the UI — new `videoUrl` should produce a new dedup ID so the merge re-runs (sequence isn't permanently locked out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)