### PR TITLE
Remove follow-to-get-credits promotion

### DIFF
--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -3,7 +3,6 @@
  * Prompts users to add credits or configure BYOK API keys
  */
 
-import { XIcon } from '@/components/icons/x-icon';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -16,7 +15,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 import { Link } from '@tanstack/react-router';
-import { ArrowRight, CreditCard, Gift, KeyRound, Sparkles } from 'lucide-react';
+import { ArrowRight, CreditCard, Gift, KeyRound } from 'lucide-react';
 
 const RETURN_KEY = 'openstory:billing-return';
 
@@ -181,27 +180,13 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
         </DialogHeader>
 
         <div className="flex flex-col gap-2 pt-1">
-          <OptionCard
-            href="https://x.com/openstory_so"
-            icon={<XIcon className="size-4" />}
-            title="Follow us on X"
-            description="Follow @openstory_so and DM us for a $10 gift code"
-            variant="primary"
-            badge={
-              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                <Sparkles className="size-2.5" />
-                Free credits
-              </span>
-            }
-          />
-
           {stripeEnabled && (
             <OptionCard
               to="/credits"
               icon={<CreditCard className="size-4" />}
               title="Add Credits"
               description="Pay as you go. Auto top-up keeps you generating."
-              variant="warm"
+              variant="primary"
               onClick={handleNav}
             />
           )}

--- a/src/components/settings/gift-code-settings.tsx
+++ b/src/components/settings/gift-code-settings.tsx
@@ -1,4 +1,3 @@
-import { XIcon } from '@/components/icons/x-icon';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -24,16 +23,7 @@ import {
 } from '@/functions/gift-tokens';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
-import { useBillingGateQuery } from '@/hooks/use-billing-gate';
-import {
-  Check,
-  Copy,
-  Gift,
-  Layers,
-  LinkIcon,
-  ShieldCheck,
-  Sparkles,
-} from 'lucide-react';
+import { Check, Copy, Gift, Layers, LinkIcon, ShieldCheck } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -45,11 +35,9 @@ export function GiftCodeSettings() {
     queryFn: () => isSystemAdminFn(),
     staleTime: 5 * 60 * 1000,
   });
-  const { data: gateStatus } = useBillingGateQuery();
 
   return (
     <div className="space-y-6">
-      {gateStatus && !gateStatus.hasRedeemedGift && <FollowOnXCard />}
       <RedeemSection />
       {adminLoading ? (
         <Skeleton className="h-48 w-full" />
@@ -57,43 +45,6 @@ export function GiftCodeSettings() {
         <AdminSection />
       ) : null}
     </div>
-  );
-}
-
-function FollowOnXCard() {
-  return (
-    <Card className="border-primary/20 bg-primary/[0.02]">
-      <CardHeader>
-        <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
-            <XIcon className="h-5 w-5 text-primary" />
-          </div>
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <CardTitle>Get $10 Free Credits</CardTitle>
-              <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
-                <Sparkles className="size-2.5" />
-                Free
-              </span>
-            </div>
-            <CardDescription>
-              Follow @openstory_so on X and DM us to get a gift code worth $10
-            </CardDescription>
-          </div>
-        </div>
-      </CardHeader>
-      <CardContent>
-        <Button asChild>
-          <a
-            href="https://x.com/openstory_so"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Follow @openstory_so on X
-          </a>
-        </Button>
-      </CardContent>
-    </Card>
   );
 }
 
@@ -196,7 +147,7 @@ function AdminSection() {
 const INITIAL_BATCH_FORM = {
   count: '100',
   amount: '10',
-  note: 'X follow reward',
+  note: '',
   expiresInDays: '',
 };
 
@@ -261,7 +212,7 @@ function BatchCreateCard() {
           <div>
             <CardTitle>Batch Create Gift Codes</CardTitle>
             <CardDescription>
-              Generate multiple single-use codes for X follow rewards
+              Generate multiple single-use codes (e.g. for promotions)
             </CardDescription>
           </div>
         </div>
@@ -322,7 +273,7 @@ function BatchCreateCard() {
               <Label htmlFor="batch-note">Note</Label>
               <Input
                 id="batch-note"
-                placeholder="e.g. X follow reward…"
+                placeholder="e.g. Promo batch…"
                 value={form.note}
                 onChange={(e) => updateField('note', e.target.value)}
                 autoComplete="off"

--- a/src/functions/billing-gate.ts
+++ b/src/functions/billing-gate.ts
@@ -23,14 +23,12 @@ export const getBillingGateStatusFn = createServerFn({ method: 'GET' })
       hasOpenRouterKey,
       openRouterKeyInvalid,
       billingSettings,
-      hasRedeemedGift,
     ] = await Promise.all([
       scopedDb.billing.getBalance(),
       scopedDb.apiKeys.hasKey('fal'),
       scopedDb.apiKeys.hasKey('openrouter'),
       scopedDb.apiKeys.hasInvalidKey('openrouter'),
       scopedDb.billing.getBillingSettings(),
-      scopedDb.billing.hasRedeemedGiftCode(),
     ]);
 
     return {
@@ -42,6 +40,5 @@ export const getBillingGateStatusFn = createServerFn({ method: 'GET' })
       hasAutoTopUp:
         billingSettings.autoTopUpEnabled && !!billingSettings.stripeCustomerId,
       stripeEnabled: isStripeEnabled(),
-      hasRedeemedGift,
     };
   });

--- a/src/hooks/use-billing-gate.ts
+++ b/src/hooks/use-billing-gate.ts
@@ -18,7 +18,6 @@ type BillingGateStatus = {
   balance: number;
   hasAutoTopUp: boolean;
   stripeEnabled: boolean;
-  hasRedeemedGift: boolean;
 };
 
 export function useBillingGateQuery() {
@@ -77,7 +76,6 @@ export function useBillingGate(mode: 'all' | 'fal' = 'all') {
     hasCredits: data?.hasCredits ?? true,
     hasAutoTopUp: data?.hasAutoTopUp ?? false,
     stripeEnabled: data?.stripeEnabled ?? true,
-    hasRedeemedGift: data?.hasRedeemedGift ?? false,
     showGate,
     gateProps: { open, onOpenChange: setOpen },
     isLoading: query.isLoading,

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -159,22 +159,11 @@ export function createBillingReadMethods(db: Database, teamId: string) {
     return existing;
   }
 
-  async function hasRedeemedGiftCode(): Promise<boolean> {
-    const [row] = await db
-      .select({ id: giftTokenRedemptions.id })
-      .from(giftTokenRedemptions)
-      .where(eq(giftTokenRedemptions.teamId, teamId))
-      .limit(1);
-
-    return !!row;
-  }
-
   return {
     getBalance,
     hasEnoughCredits,
     getTransactionHistory,
     getBillingSettings,
-    hasRedeemedGiftCode,
   };
 }
 


### PR DESCRIPTION
## Summary
- Removes the "Follow @openstory_so on X for a \$10 gift code" cards from `BillingGateDialog` and `gift-code-settings.tsx`
- Drops the now-dead `hasRedeemedGift` field (and the `hasRedeemedGiftCode()` scoped-DB query that backed it) across the hook → server fn → scoped DB stack — its only consumer was the removed FollowOnXCard
- Generic-izes batch-create copy (no more "X follow reward" defaults/placeholders/description)
- Keeps the gift code system intact: `/gift/\$code` route, admin batch/create/list UI, redeem form, and DB tables all still work, so already-issued codes continue to redeem

## Test plan
- [x] `bun test` — 711 pass / 0 fail
- [x] `bun typecheck` — clean
- [ ] `bun dev` → visit `/sequences/new` as a no-credit user: BillingGateDialog shows Add Credits → Redeem Gift Code → BYOK (no Follow on X option)
- [ ] `/credits?tab=gift-codes`: no FollowOnXCard banner; Redeem form still works
- [ ] As admin: BatchCreate description reads "Generate multiple single-use codes (e.g. for promotions)"; create a code, redeem at `/gift/<code>`, balance increases

Closes #693

🤖 Generated with [Claude Code](https://claude.com/claude-code)