### PR TITLE
feat(scenes): auto-link element/cast/location tags from edited prompts #683

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -17,6 +17,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps['theme']}
       className="toaster group"
+      richColors
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,

--- a/src/functions/frame-image.ts
+++ b/src/functions/frame-image.ts
@@ -25,6 +25,7 @@ import {
   regenerateFrameSchema,
 } from '@/lib/schemas/frame.schemas';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
+import { rescanContinuityFromPrompt } from '@/lib/scenes/rescan-continuity-from-prompt';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import type {
@@ -138,19 +139,41 @@ export const generateFrameImageFn = createServerFn({ method: 'POST' })
       throw new Error('Frame has no prompt or description to regenerate from');
     }
 
+    // Auto-link any element/cast/location tags the user mentioned in their
+    // edited prompt before computing reference attachment, so a freshly-
+    // mentioned LOGO gets its reference image attached to THIS regeneration.
+    // updateFrameFn does the same rescan, but the UI never calls it — the
+    // regenerate buttons are the only persistence path for prompts today.
+    const userEditedPrompt = data.prompt !== undefined;
+    const baseContinuity = frame.metadata?.continuity;
+    let continuity = baseContinuity;
+    if (userEditedPrompt && frame.metadata && baseContinuity) {
+      const rescan = await rescanContinuityFromPrompt({
+        scopedDb: context.scopedDb,
+        sequenceId: sequence.id,
+        existing: baseContinuity,
+        promptText: prompt,
+      });
+      if (rescan.changed) {
+        continuity = rescan.continuity;
+        await context.scopedDb.frames.update(frame.id, {
+          metadata: { ...frame.metadata, continuity: rescan.continuity },
+        });
+      }
+    }
+
     const allCharacters = await context.scopedDb.characters.listWithSheets(
       sequence.id
     );
-    const characterTags = frame.metadata?.continuity?.characterTags ?? [];
     const characterReferences = buildCharacterReferenceImages(
-      matchCharactersToScene(allCharacters, characterTags)
+      matchCharactersToScene(allCharacters, continuity?.characterTags ?? [])
     );
 
     const allLocations =
       await context.scopedDb.sequenceLocations.listWithReferences(sequence.id);
     const locationReferences = getSceneLocationReferenceImages(
       allLocations,
-      frame.metadata?.continuity?.environmentTag ?? '',
+      continuity?.environmentTag ?? '',
       frame.metadata?.metadata?.location ?? ''
     );
 
@@ -160,7 +183,7 @@ export const generateFrameImageFn = createServerFn({ method: 'POST' })
     const elementReferences = buildElementReferenceImages(
       matchElementsToScene(
         allElements,
-        frame.metadata?.continuity?.elementTags ?? [],
+        continuity?.elementTags ?? [],
         frame.metadata?.originalScript.extract ?? ''
       )
     );
@@ -188,7 +211,7 @@ export const generateFrameImageFn = createServerFn({ method: 'POST' })
         ...locationReferences,
         ...elementReferences,
       ],
-      userEditedPrompt: data.prompt !== undefined,
+      userEditedPrompt,
     };
 
     const workflowRunId = await triggerWorkflow('/image', workflowInput, {

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -14,11 +14,7 @@ import {
 } from '@/lib/schemas/frame.schemas';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { reconcileStaleFrameStatuses } from '@/lib/workflow/reconcile';
-import {
-  extractContinuityFromPrompt,
-  hasContinuityAdditions,
-  mergeContinuityAdditions,
-} from '@/lib/workflows/extract-continuity-from-prompt';
+import { rescanContinuityFromPrompt } from '@/lib/scenes/rescan-continuity-from-prompt';
 import { buildRegenerateFrameSnapshot } from '@/lib/workflows/regenerate-frames-snapshot';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
@@ -326,36 +322,25 @@ export const updateFrameFn = createServerFn({ method: 'POST' })
       (imagePromptChanged || motionPromptChanged) &&
       frameMetadata?.continuity
     ) {
-      const existingContinuity = frameMetadata.continuity;
-      const newImagePrompt = imagePromptChanged ? updateData.imagePrompt : null;
-      const newMotionPrompt = motionPromptChanged
-        ? updateData.motionPrompt
-        : null;
-      const promptText = [newImagePrompt, newMotionPrompt]
+      const promptText = [
+        imagePromptChanged ? updateData.imagePrompt : null,
+        motionPromptChanged ? updateData.motionPrompt : null,
+      ]
         .filter((s): s is string => typeof s === 'string' && s.length > 0)
         .join('\n');
 
-      if (promptText.length > 0) {
-        const [characters, elements, locations] = await Promise.all([
-          context.scopedDb.characters.list(sequenceId),
-          context.scopedDb.sequenceElements.list(sequenceId),
-          context.scopedDb.sequenceLocations.list(sequenceId),
-        ]);
+      const rescan = await rescanContinuityFromPrompt({
+        scopedDb: context.scopedDb,
+        sequenceId,
+        existing: frameMetadata.continuity,
+        promptText,
+      });
 
-        const additions = extractContinuityFromPrompt({
-          promptText,
-          characters,
-          elements,
-          locations,
-          existing: existingContinuity,
-        });
-
-        if (hasContinuityAdditions(additions)) {
-          updateData.metadata = {
-            ...frameMetadata,
-            continuity: mergeContinuityAdditions(existingContinuity, additions),
-          };
-        }
+      if (rescan.changed) {
+        updateData.metadata = {
+          ...frameMetadata,
+          continuity: rescan.continuity,
+        };
       }
     }
 

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -14,6 +14,11 @@ import {
 } from '@/lib/schemas/frame.schemas';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { reconcileStaleFrameStatuses } from '@/lib/workflow/reconcile';
+import {
+  extractContinuityFromPrompt,
+  hasContinuityAdditions,
+  mergeContinuityAdditions,
+} from '@/lib/workflows/extract-continuity-from-prompt';
 import { buildRegenerateFrameSnapshot } from '@/lib/workflows/regenerate-frames-snapshot';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
@@ -303,7 +308,57 @@ export const updateFrameFn = createServerFn({ method: 'POST' })
     )
   )
   .handler(async ({ data, context }) => {
-    const { sequenceId: _, frameId, ...updateData } = data;
+    const { sequenceId, frameId, ...updateData } = data;
+
+    // When a user edits a prompt, auto-link any element/cast/location tags
+    // they mentioned by additively merging them into frame.metadata.continuity
+    // so the next generation pulls those references in (#683). Skip when the
+    // prompt value hasn't actually changed, so plain saves stay a single
+    // UPDATE with no extra reads.
+    const imagePromptChanged =
+      updateData.imagePrompt !== undefined &&
+      updateData.imagePrompt !== context.frame.imagePrompt;
+    const motionPromptChanged =
+      updateData.motionPrompt !== undefined &&
+      updateData.motionPrompt !== context.frame.motionPrompt;
+    const frameMetadata = context.frame.metadata;
+    if (
+      (imagePromptChanged || motionPromptChanged) &&
+      frameMetadata?.continuity
+    ) {
+      const existingContinuity = frameMetadata.continuity;
+      const newImagePrompt = imagePromptChanged ? updateData.imagePrompt : null;
+      const newMotionPrompt = motionPromptChanged
+        ? updateData.motionPrompt
+        : null;
+      const promptText = [newImagePrompt, newMotionPrompt]
+        .filter((s): s is string => typeof s === 'string' && s.length > 0)
+        .join('\n');
+
+      if (promptText.length > 0) {
+        const [characters, elements, locations] = await Promise.all([
+          context.scopedDb.characters.list(sequenceId),
+          context.scopedDb.sequenceElements.list(sequenceId),
+          context.scopedDb.sequenceLocations.list(sequenceId),
+        ]);
+
+        const additions = extractContinuityFromPrompt({
+          promptText,
+          characters,
+          elements,
+          locations,
+          existing: existingContinuity,
+        });
+
+        if (hasContinuityAdditions(additions)) {
+          updateData.metadata = {
+            ...frameMetadata,
+            continuity: mergeContinuityAdditions(existingContinuity, additions),
+          };
+        }
+      }
+    }
+
     return context.scopedDb.frames.update(frameId, updateData);
   });
 

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -3,7 +3,7 @@ import {
   computeMotionPromptInputHash,
   computeVisualPromptInputHash,
 } from '@/lib/ai/input-hash';
-import { loadFramePromptContext } from '@/lib/ai/prompt-context';
+import { loadNarrowFramePromptContext } from '@/lib/ai/prompt-context';
 import type { FrameVariant, NewFrame } from '@/lib/db/schema';
 import { getGenerationChannel } from '@/lib/realtime';
 import { getVideoDownloadUrl } from '@/lib/motion/video-storage';
@@ -454,7 +454,7 @@ export const getFrameStalenessFn = createServerFn({ method: 'GET' })
           frame.id,
           'visual'
         );
-        const ctx = await loadFramePromptContext({
+        const ctx = await loadNarrowFramePromptContext({
           scopedDb,
           sequence,
           scene: frame.metadata,
@@ -479,7 +479,7 @@ export const getFrameStalenessFn = createServerFn({ method: 'GET' })
           frame.id,
           'motion'
         );
-        const ctx = await loadFramePromptContext({
+        const ctx = await loadNarrowFramePromptContext({
           scopedDb,
           sequence,
           scene: frame.metadata,

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -22,6 +22,7 @@ import type {
 } from '@/lib/workflow/types';
 
 import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
+import { rescanContinuityFromPrompt } from '@/lib/scenes/rescan-continuity-from-prompt';
 import { buildMergeVideoSourcesFromFrames } from '@/lib/workflows/sequence-snapshots';
 
 import { frameAccessMiddleware, sequenceAccessMiddleware } from './middleware';
@@ -50,6 +51,25 @@ export const generateFrameMotionFn = createServerFn({ method: 'POST' })
 
     const userEditedPrompt = Boolean(data.prompt);
     const prompt = data.prompt || resolveMotionPrompt(frame, model);
+
+    // Auto-link any element/cast/location tags the user mentioned in their
+    // edited motion prompt into frame.metadata.continuity, so downstream
+    // consumers (next image regenerate, frame-image reference attachment)
+    // see the new references. Motion itself uses image-to-video and doesn't
+    // re-attach references here, but persisting keeps the data consistent.
+    if (userEditedPrompt && frame.metadata?.continuity) {
+      const rescan = await rescanContinuityFromPrompt({
+        scopedDb: context.scopedDb,
+        sequenceId: sequence.id,
+        existing: frame.metadata.continuity,
+        promptText: prompt,
+      });
+      if (rescan.changed) {
+        await context.scopedDb.frames.update(frame.id, {
+          metadata: { ...frame.metadata, continuity: rescan.continuity },
+        });
+      }
+    }
 
     const duration = data.duration ?? snapDuration(undefined, model);
 

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -7,7 +7,10 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
-import { loadFramePromptContext } from '@/lib/ai/prompt-context';
+import {
+  loadFramePromptContext,
+  narrowFramePromptContext,
+} from '@/lib/ai/prompt-context';
 import {
   FRAME_PROMPT_TYPES,
   type FramePromptVariant,
@@ -193,11 +196,14 @@ export const regenerateFramePromptFn = createServerFn({ method: 'POST' })
 
     // Bail if the cached input hash already matches the live recompute —
     // otherwise every double-click enqueues a duplicate workflow run and
-    // appends a no-op `'regenerated'` history row.
+    // appends a no-op `'regenerated'` history row. Hash inputs are narrowed
+    // to what this frame's continuity actually references; the workflow
+    // downstream still gets the full bibles for LLM context.
+    const narrowed = narrowFramePromptContext(ctx);
     const liveHash =
       data.promptType === 'visual'
-        ? await computeVisualPromptInputHash(ctx)
-        : await computeMotionPromptInputHash(ctx);
+        ? await computeVisualPromptInputHash(narrowed)
+        : await computeMotionPromptInputHash(narrowed);
     const storedHash =
       data.promptType === 'visual'
         ? frame.visualPromptInputHash

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -38,16 +38,36 @@ async function triggerElementVision(
 }
 
 // ============================================================================
-// Presign upload
+// Presign upload — drafts go under the user's default team's `temp/` folder
+// and are later relocated via `promoteTempElements`. Persisted uploads
+// (existing sequence) must use the *sequence's* teamId in the path so the
+// finalize check passes for users whose default team differs from the
+// sequence's team (multi-team members and system admins).
 // ============================================================================
 
-export const presignElementUploadFn = createServerFn({ method: 'POST' })
+export const presignDraftElementUploadFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
+  .inputValidator(zodValidator(z.object({ filename: z.string().min(1) })))
+  .handler(async ({ context, data }) => {
+    const ext = getExtensionFromUrl(data.filename);
+    const uploadId = generateId();
+    const contentType = getMimeTypeFromExtension(ext);
+    const storagePath = `${context.teamId}/temp/${uploadId}.${ext}`;
+
+    return getSignedUploadUrl(
+      STORAGE_BUCKETS.ELEMENTS,
+      storagePath,
+      contentType
+    );
+  });
+
+export const presignElementUploadFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
   .inputValidator(
     zodValidator(
       z.object({
+        sequenceId: ulidSchema,
         filename: z.string().min(1),
-        sequenceId: ulidSchema.optional(),
       })
     )
   )
@@ -55,10 +75,7 @@ export const presignElementUploadFn = createServerFn({ method: 'POST' })
     const ext = getExtensionFromUrl(data.filename);
     const uploadId = generateId();
     const contentType = getMimeTypeFromExtension(ext);
-
-    const storagePath = data.sequenceId
-      ? `${context.teamId}/${data.sequenceId}/${uploadId}.${ext}`
-      : `${context.teamId}/temp/${uploadId}.${ext}`;
+    const storagePath = `${context.teamId}/${data.sequenceId}/${uploadId}.${ext}`;
 
     return getSignedUploadUrl(
       STORAGE_BUCKETS.ELEMENTS,

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -3,6 +3,7 @@ import {
   deleteSequenceElementFn,
   finalizeElementUploadFn,
   listSequenceElementsFn,
+  presignDraftElementUploadFn,
   presignElementUploadFn,
   renameSequenceElementTokenFn,
 } from '@/functions/sequence-elements';
@@ -107,7 +108,7 @@ export function useUploadDraftElement() {
       onProgress?: (percent: number) => void;
       onAnalyzingChange?: (analyzing: boolean) => void;
     }): Promise<DraftElementUpload> => {
-      const presign = await presignElementUploadFn({
+      const presign = await presignDraftElementUploadFn({
         data: { filename: data.file.name },
       });
       await putToR2(

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -81,10 +81,10 @@ export type DraftElementUpload = {
   filename: string;
   token: string;
   /**
-   * Vision-LLM description, populated during draft upload so the Generate
-   * button can gate on vision-readiness. Null when the analyze call failed
-   * or was skipped (e.g. E2E replay) — promoteTempElements falls back to
-   * triggering the persisted vision workflow in that case.
+   * Vision-LLM description, populated during draft upload. `useUploadDraftElement`
+   * rejects if vision fails, so successful uploads always carry both fields —
+   * but `promoteTempElements` still accepts nullable values for backwards-compat
+   * with E2E fixture paths and falls back to the async vision workflow there.
    */
   description: string | null;
   consistencyTag: string | null;
@@ -96,10 +96,11 @@ export type DraftElementUpload = {
  * and pass it to the createSequence mutation for promotion.
  *
  * Runs vision analysis inline after the upload resolves so promoteTempElements
- * can skip the async element-vision workflow on the happy path. If the vision
- * call fails we still resolve with `description: null` — the upload itself
- * succeeded and the persisted-mode fallback in promoteTempElements will kick
- * the workflow on promotion.
+ * can write the row in `completed` state with description + consistencyTag
+ * already populated. The mutation rejects on vision failure — the element
+ * selector surfaces this as an error entry and the user must retry or remove
+ * the upload before Generate can proceed. (This is what stops a `pending`
+ * element from reaching the analyze workflow and poisoning prompt hashes.)
  */
 export function useUploadDraftElement() {
   return useMutation({
@@ -125,23 +126,15 @@ export function useUploadDraftElement() {
       const finalToken = token.length > 0 ? token : 'ELEMENT';
 
       data.onAnalyzingChange?.(true);
-      let description: string | null = null;
-      let consistencyTag: string | null = null;
+      let result: { description: string; consistencyTag: string };
       try {
-        const result = await analyzeDraftElementFn({
+        result = await analyzeDraftElementFn({
           data: {
             publicUrl: presign.publicUrl,
             filename: data.file.name,
             token: finalToken,
           },
         });
-        description = result.description;
-        consistencyTag = result.consistencyTag;
-      } catch (err) {
-        console.warn(
-          '[useUploadDraftElement] Vision analysis failed; falling back to async workflow on promotion',
-          err
-        );
       } finally {
         data.onAnalyzingChange?.(false);
       }
@@ -151,8 +144,8 @@ export function useUploadDraftElement() {
         tempPublicUrl: presign.publicUrl,
         filename: data.file.name,
         token: finalToken,
-        description,
-        consistencyTag,
+        description: result.description,
+        consistencyTag: result.consistencyTag,
       };
     },
   });

--- a/src/lib/ai/__tests__/prompt-context.test.ts
+++ b/src/lib/ai/__tests__/prompt-context.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'bun:test';
+import type { StyleConfig } from '@/lib/db/schema';
+import {
+  computeMotionPromptInputHash,
+  computeVisualPromptInputHash,
+} from '../input-hash';
+import { narrowFramePromptContext } from '../prompt-context';
+import type {
+  CharacterBibleEntry,
+  ElementBibleEntry,
+  LocationBibleEntry,
+  Scene,
+} from '../scene-analysis.schema';
+
+const style: StyleConfig = {
+  mood: 'neutral',
+  artStyle: 'cinematic',
+  lighting: 'natural',
+  colorPalette: ['neutral'],
+  cameraWork: 'static',
+  referenceFilms: [],
+  colorGrading: 'neutral',
+};
+
+const alice: CharacterBibleEntry = {
+  characterId: 'alice',
+  name: 'Alice',
+  age: '30',
+  gender: '',
+  ethnicity: '',
+  physicalDescription: '',
+  standardClothing: '',
+  distinguishingFeatures: '',
+  consistencyTag: '',
+};
+const bob: CharacterBibleEntry = { ...alice, characterId: 'bob', name: 'Bob' };
+
+const beach: LocationBibleEntry = {
+  locationId: 'beach',
+  name: 'Beach',
+  type: 'exterior',
+  timeOfDay: '',
+  description: '',
+  architecturalStyle: '',
+  keyFeatures: '',
+  colorPalette: '',
+  lightingSetup: '',
+  ambiance: '',
+  consistencyTag: '',
+  firstMention: { sceneId: '', text: '', lineNumber: 0 },
+};
+const forest: LocationBibleEntry = {
+  ...beach,
+  locationId: 'forest',
+  name: 'Forest',
+  firstMention: { sceneId: '', text: '', lineNumber: 0 },
+};
+
+const logo: ElementBibleEntry = {
+  token: 'LOGO',
+  description: 'Red hex logo',
+  consistencyTag: 'red-hex-logo',
+  firstMention: { sceneId: 's1', text: 'LOGO', lineNumber: 1 },
+};
+const bottle: ElementBibleEntry = {
+  token: 'BOTTLE',
+  description: 'Silver bottle',
+  consistencyTag: 'silver-bottle',
+  firstMention: { sceneId: 's1', text: 'BOTTLE', lineNumber: 1 },
+};
+
+function sceneReferencing(opts: {
+  characterTags?: string[];
+  environmentTag?: string;
+  elementTags?: string[];
+  script?: string;
+  location?: string;
+}): Scene {
+  return {
+    sceneId: 's1',
+    sceneNumber: 1,
+    originalScript: { extract: opts.script ?? '', dialogue: [] },
+    metadata: {
+      title: 'Test scene',
+      durationSeconds: 5,
+      location: opts.location ?? '',
+      timeOfDay: '',
+      storyBeat: '',
+    },
+    continuity: {
+      characterTags: opts.characterTags ?? [],
+      environmentTag: opts.environmentTag ?? '',
+      elementTags: opts.elementTags ?? [],
+      colorPalette: '',
+      lightingSetup: '',
+      styleTag: '',
+    },
+  };
+}
+
+describe('narrowFramePromptContext', () => {
+  it('keeps only the character entries the scene references', () => {
+    const ctx = {
+      scene: sceneReferencing({ characterTags: ['alice'] }),
+      styleConfig: style,
+      characterBible: [alice, bob],
+      locationBible: [],
+      elementBible: [],
+      aspectRatio: '16:9',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    };
+    const narrowed = narrowFramePromptContext(ctx);
+    expect(narrowed.characterBible.map((c) => c.characterId)).toEqual([
+      'alice',
+    ]);
+  });
+
+  it('keeps only the location entries that match environmentTag or scene location', () => {
+    const ctx = {
+      scene: sceneReferencing({ environmentTag: 'beach' }),
+      styleConfig: style,
+      characterBible: [],
+      locationBible: [beach, forest],
+      elementBible: [],
+      aspectRatio: '16:9',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    };
+    const narrowed = narrowFramePromptContext(ctx);
+    expect(narrowed.locationBible.map((l) => l.locationId)).toEqual(['beach']);
+  });
+
+  it('keeps only the element entries this scene tags or mentions in its script', () => {
+    const ctx = {
+      scene: sceneReferencing({ elementTags: ['LOGO'] }),
+      styleConfig: style,
+      characterBible: [],
+      locationBible: [],
+      elementBible: [logo, bottle],
+      aspectRatio: '16:9',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    };
+    const narrowed = narrowFramePromptContext(ctx);
+    expect(narrowed.elementBible.map((e) => e.token)).toEqual(['LOGO']);
+  });
+
+  it('returns the full context unchanged when continuity is absent', () => {
+    const ctx = {
+      scene: {
+        sceneId: 's1',
+        sceneNumber: 1,
+        originalScript: { extract: '', dialogue: [] },
+      } as Scene,
+      styleConfig: style,
+      characterBible: [alice, bob],
+      locationBible: [beach],
+      elementBible: [logo],
+      aspectRatio: '16:9',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    };
+    const narrowed = narrowFramePromptContext(ctx);
+    expect(narrowed).toEqual(ctx);
+  });
+});
+
+describe('narrowed hash stability (the user-reported bug)', () => {
+  const baseCtx = {
+    scene: sceneReferencing({
+      characterTags: ['alice'],
+      environmentTag: 'beach',
+      elementTags: ['LOGO'],
+    }),
+    styleConfig: style,
+    characterBible: [alice],
+    locationBible: [beach],
+    elementBible: [logo],
+    aspectRatio: '16:9',
+    analysisModel: 'anthropic/claude-haiku-4.5',
+  };
+
+  it('adding an unreferenced element does NOT change the visual hash', async () => {
+    const before = await computeVisualPromptInputHash(
+      narrowFramePromptContext(baseCtx)
+    );
+    // Simulate uploading a new element that no scene references yet.
+    const after = await computeVisualPromptInputHash(
+      narrowFramePromptContext({
+        ...baseCtx,
+        elementBible: [logo, bottle],
+      })
+    );
+    expect(after).toBe(before);
+  });
+
+  it('adding an unreferenced character does NOT change the visual hash', async () => {
+    const before = await computeVisualPromptInputHash(
+      narrowFramePromptContext(baseCtx)
+    );
+    const after = await computeVisualPromptInputHash(
+      narrowFramePromptContext({
+        ...baseCtx,
+        characterBible: [alice, bob],
+      })
+    );
+    expect(after).toBe(before);
+  });
+
+  it('adding an unreferenced location does NOT change the motion hash', async () => {
+    const before = await computeMotionPromptInputHash(
+      narrowFramePromptContext(baseCtx)
+    );
+    const after = await computeMotionPromptInputHash(
+      narrowFramePromptContext({
+        ...baseCtx,
+        locationBible: [beach, forest],
+      })
+    );
+    expect(after).toBe(before);
+  });
+
+  it('referencing a new element via continuity tags DOES change the hash', async () => {
+    const before = await computeVisualPromptInputHash(
+      narrowFramePromptContext({
+        ...baseCtx,
+        elementBible: [logo, bottle],
+      })
+    );
+    // Same bibles, but now the scene's continuity additionally references BOTTLE.
+    const after = await computeVisualPromptInputHash(
+      narrowFramePromptContext({
+        ...baseCtx,
+        scene: sceneReferencing({
+          characterTags: ['alice'],
+          environmentTag: 'beach',
+          elementTags: ['LOGO', 'BOTTLE'],
+        }),
+        elementBible: [logo, bottle],
+      })
+    );
+    expect(after).not.toBe(before);
+  });
+});

--- a/src/lib/ai/prompt-context.ts
+++ b/src/lib/ai/prompt-context.ts
@@ -16,6 +16,11 @@ import type {
 import type { ScopedDb } from '@/lib/db/scoped';
 import type { StyleConfig } from '@/lib/db/schema';
 import { StyleConfigSchema } from '@/lib/db/schema';
+import {
+  matchCharactersToScene,
+  matchElementsToScene,
+  matchLocationsToScene,
+} from '@/lib/workflows/scene-matching';
 
 export type FramePromptContext = {
   scene: Scene;
@@ -77,4 +82,59 @@ export async function loadFramePromptContext(args: {
     aspectRatio: sequence.aspectRatio,
     analysisModel,
   };
+}
+
+/**
+ * Same as `loadFramePromptContext` but narrows the character / location /
+ * element bibles down to the entries this scene actually references — i.e. the
+ * inputs that would actually change the regenerated prompt. Used when stamping
+ * or comparing `visualPromptInputHash` / `motionPromptInputHash` so unrelated
+ * sequence entities don't poison the hash.
+ *
+ * Matching mirrors the same logic that decides reference-image attachment at
+ * generation time (`scene-matching.ts`), so if the hash flips, regeneration
+ * really would see different inputs.
+ */
+export async function loadNarrowFramePromptContext(args: {
+  scopedDb: Pick<
+    ScopedDb,
+    'characters' | 'sequenceLocations' | 'sequenceElements' | 'styles'
+  >;
+  sequence: FramePromptContextSequence;
+  scene: Scene;
+  analysisModelOverride?: string | null;
+}): Promise<FramePromptContext> {
+  const full = await loadFramePromptContext(args);
+  return narrowFramePromptContext(full);
+}
+
+/**
+ * Filter an already-built `FramePromptContext` down to the entities this
+ * scene's `continuity` references. Pure function — exposed so workflows that
+ * already received full bibles as inputs (visual/motion prompt scene workflows)
+ * can narrow without re-fetching from the DB.
+ */
+export function narrowFramePromptContext(
+  ctx: FramePromptContext
+): FramePromptContext {
+  const { scene } = ctx;
+  const continuity = scene.continuity;
+  if (!continuity) return ctx;
+
+  const characterBible = matchCharactersToScene(
+    ctx.characterBible,
+    continuity.characterTags ?? []
+  );
+  const locationBible = matchLocationsToScene(
+    ctx.locationBible,
+    continuity.environmentTag ?? '',
+    scene.metadata?.location ?? ''
+  );
+  const elementBible = matchElementsToScene(
+    ctx.elementBible,
+    continuity.elementTags ?? [],
+    scene.originalScript?.extract
+  );
+
+  return { ...ctx, characterBible, locationBible, elementBible };
 }

--- a/src/lib/scenes/rescan-continuity-from-prompt.ts
+++ b/src/lib/scenes/rescan-continuity-from-prompt.ts
@@ -1,0 +1,68 @@
+/**
+ * Server helper: re-scan a (possibly user-edited) prompt for canonical
+ * character / element / location tags and additively merge them into a
+ * frame's `metadata.continuity`.
+ *
+ * Lives here — not inline in `updateFrameFn` — because the auto-link feature
+ * (#683) needs to fire from both the explicit save path AND the regenerate
+ * paths (`generateFrameImageFn`, `generateFrameMotionFn`). In practice the
+ * regenerate paths are the only ones the UI actually calls today, so without
+ * this helper the auto-link is dead code.
+ *
+ * Pure with respect to the database: callers are responsible for persisting
+ * the returned continuity if `changed === true`.
+ */
+
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import type { ScopedDb } from '@/lib/db/scoped';
+import {
+  extractContinuityFromPrompt,
+  hasContinuityAdditions,
+  mergeContinuityAdditions,
+} from '@/lib/workflows/extract-continuity-from-prompt';
+
+type Continuity = NonNullable<Scene['continuity']>;
+
+export type ContinuityRescanResult = {
+  continuity: Continuity;
+  changed: boolean;
+};
+
+export async function rescanContinuityFromPrompt(args: {
+  scopedDb: Pick<
+    ScopedDb,
+    'characters' | 'sequenceElements' | 'sequenceLocations'
+  >;
+  sequenceId: string;
+  existing: Continuity;
+  promptText: string;
+}): Promise<ContinuityRescanResult> {
+  const { scopedDb, sequenceId, existing, promptText } = args;
+
+  if (!promptText.trim()) {
+    return { continuity: existing, changed: false };
+  }
+
+  const [characters, elements, locations] = await Promise.all([
+    scopedDb.characters.list(sequenceId),
+    scopedDb.sequenceElements.list(sequenceId),
+    scopedDb.sequenceLocations.list(sequenceId),
+  ]);
+
+  const additions = extractContinuityFromPrompt({
+    promptText,
+    characters,
+    elements,
+    locations,
+    existing,
+  });
+
+  if (!hasContinuityAdditions(additions)) {
+    return { continuity: existing, changed: false };
+  }
+
+  return {
+    continuity: mergeContinuityAdditions(existing, additions),
+    changed: true,
+  };
+}

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -85,58 +85,32 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
       });
     });
 
-    // Load sequence elements, polling briefly for vision descriptions to finish.
+    // Load sequence elements. Element vision MUST be terminal (`completed` or
+    // `failed`) before scene-split runs — otherwise the LLM would see a
+    // placeholder description and the prompt-input hashes stamped on each frame
+    // would diverge from the live hash once vision completes, surfacing as
+    // false-positive "out of sync" indicators on every scene's Image/Motion tab.
     //
-    // Why this exists: reference elements (logos, product shots, etc.) are uploaded
-    // via `finalizeElementUploadFn`, which fires `elementVisionWorkflow` async so
-    // the upload response isn't blocked. That vision workflow generates the
-    // `description` + `consistencyTag` used below in `elementsMinimal`, which is
-    // passed to `sceneSplitWorkflow` so the LLM knows what each token (e.g. LOGO,
-    // BOTTLE) depicts and can weave them into scene prompts correctly.
-    //
-    // If the user hits "Analyze" immediately after uploading, vision analysis may
-    // still be pending/analyzing. Proceeding right away would hand the LLM bare
-    // tokens with no visual context, producing weaker scene prompts and missing
-    // reference-image matches downstream.
-    //
-    // The wait is bounded (30s) because vision calls hit external providers (Fal/
-    // OpenRouter) and can stall — we'd rather degrade gracefully than block the
-    // whole generation pipeline. Elements without a description still appear in
-    // the prompt as known tokens; they're just excluded from reference-image lists.
-    const elements = await context.run(
-      'load-and-wait-for-elements',
-      async () => {
-        if (!sequenceId) return [];
-
-        // With the inline draft-mode analyze call, vision usually finishes
-        // before Generate fires and this loop returns immediately. The cap
-        // is a safety. In E2E record runs we widen it so real fal/OpenRouter
-        // latency during fixture capture doesn't trip the placeholder path
-        // and pollute the recorded scene-split prompt with `(vision
-        // description pending)`.
-        const isRecording = process.env.E2E_RECORD === '1';
-        const MAX_WAIT_MS = isRecording ? 600_000 : 30_000;
-        const POLL_INTERVAL_MS = 1500;
-        const startedAt = Date.now();
-
-        // oxlint-disable-next-line no-unnecessary-condition -- loop has a break condition
-        while (true) {
-          const list = await scopedDb.sequenceElements.list(sequenceId);
-          const stillAnalyzing = list.filter(
-            (el) =>
-              el.visionStatus === 'pending' || el.visionStatus === 'analyzing'
-          );
-          if (stillAnalyzing.length === 0) return list;
-          if (Date.now() - startedAt > MAX_WAIT_MS) {
-            console.warn(
-              `[AnalyzeScriptWorkflow] Proceeding with ${stillAnalyzing.length} elements still analyzing`
-            );
-            return list;
-          }
-          await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-        }
+    // The UI gates Generate on `isBusy` (`element-selector.tsx`) which tracks
+    // pending/analyzing vision status, so a draft upload with in-flight vision
+    // can never reach here through the happy path. This check is defence in
+    // depth — if a `pending` row does sneak in (e.g. a stale tab triggering
+    // the mutation, or a developer wiring), we fail loudly rather than
+    // degrading.
+    const elements = await context.run('load-elements', async () => {
+      if (!sequenceId) return [];
+      const list = await scopedDb.sequenceElements.list(sequenceId);
+      const stillRunning = list.filter(
+        (el) => el.visionStatus === 'pending' || el.visionStatus === 'analyzing'
+      );
+      if (stillRunning.length > 0) {
+        throw new WorkflowValidationError(
+          `Element vision is still running for ${stillRunning.length} element(s). ` +
+            `Wait for vision analysis to finish before regenerating.`
+        );
       }
-    );
+      return list;
+    });
 
     const elementsMinimal = elements.map((el) => ({
       id: el.id,

--- a/src/lib/workflows/extract-continuity-from-prompt.test.ts
+++ b/src/lib/workflows/extract-continuity-from-prompt.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  extractContinuityFromPrompt,
+  hasContinuityAdditions,
+  mergeContinuityAdditions,
+} from './extract-continuity-from-prompt';
+import type { Continuity } from '@/lib/ai/scene-analysis.schema';
+import type { SequenceElementMinimal } from '@/lib/db/schema';
+
+const el = (token: string): SequenceElementMinimal => ({
+  id: `el_${token}`,
+  token,
+  description: '',
+  imageUrl: '',
+  consistencyTag: null,
+});
+
+const emptyContinuity: Continuity = {
+  characterTags: [],
+  environmentTag: '',
+  elementTags: [],
+  colorPalette: '',
+  lightingSetup: '',
+  styleTag: '',
+};
+
+const baseArgs = {
+  characters: [],
+  elements: [],
+  locations: [],
+  existing: {
+    characterTags: [] as string[],
+    elementTags: [] as string[],
+    environmentTag: '',
+  },
+};
+
+describe('extractContinuityFromPrompt', () => {
+  it('matches an element token as a whole word', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'A logo close-up of the LOGO on the table.',
+      elements: [el('LOGO')],
+    });
+    expect(result.elementTags).toEqual(['LOGO']);
+  });
+
+  it('does not match an element token inside a larger word', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'A LOGOLOGO repeating pattern.',
+      elements: [el('LOGO')],
+    });
+    expect(result.elementTags).toEqual([]);
+  });
+
+  it('skips elements already in existing tags', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'Featuring LOGO and BOTTLE.',
+      elements: [el('LOGO'), el('BOTTLE')],
+      existing: { ...baseArgs.existing, elementTags: ['LOGO'] },
+    });
+    expect(result.elementTags).toEqual(['BOTTLE']);
+  });
+
+  it('matches a character by characterId', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'char_001 walks into frame.',
+      characters: [{ characterId: 'char_001', consistencyTag: null }],
+    });
+    expect(result.characterTags).toEqual(['char_001']);
+  });
+
+  it('matches a character by consistencyTag slug (after colon prefix)', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'Tight shot of jack-denim-jacket leaning on the bar.',
+      characters: [
+        {
+          characterId: 'char_001',
+          consistencyTag: 'char_001: jack-denim-jacket',
+        },
+      ],
+    });
+    expect(result.characterTags).toEqual(['jack-denim-jacket']);
+  });
+
+  it('character matching is case-insensitive', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'CHAR_001 looks up.',
+      characters: [{ characterId: 'char_001', consistencyTag: null }],
+    });
+    expect(result.characterTags).toEqual(['char_001']);
+  });
+
+  it('skips characters already linked', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'char_001 and char_002 meet.',
+      characters: [
+        { characterId: 'char_001', consistencyTag: null },
+        { characterId: 'char_002', consistencyTag: null },
+      ],
+      existing: { ...baseArgs.existing, characterTags: ['char_001'] },
+    });
+    expect(result.characterTags).toEqual(['char_002']);
+  });
+
+  it('returns a single location term when environmentTag is empty', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'Set at office-modern-steel at sunset.',
+      locations: [
+        {
+          locationId: 'loc_001',
+          consistencyTag: 'loc_001: office-modern-steel',
+        },
+      ],
+    });
+    expect(result.environmentTag).toBe('office-modern-steel');
+  });
+
+  it('skips a location term already contained in environmentTag', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'Back in office-modern-steel for the meeting.',
+      locations: [
+        {
+          locationId: 'loc_001',
+          consistencyTag: 'loc_001: office-modern-steel',
+        },
+      ],
+      existing: {
+        ...baseArgs.existing,
+        environmentTag: 'office-modern-steel-glass',
+      },
+    });
+    // `office-modern-steel` is a substring of the existing tag, so we don't
+    // double-link.
+    expect(result.environmentTag).toBeNull();
+  });
+
+  it('picks the location term that appears earliest in the prompt', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: 'Open in rooftop-bar then cut to office-modern-steel.',
+      locations: [
+        {
+          locationId: 'loc_001',
+          consistencyTag: 'loc_001: office-modern-steel',
+        },
+        { locationId: 'loc_002', consistencyTag: 'loc_002: rooftop-bar' },
+      ],
+    });
+    expect(result.environmentTag).toBe('rooftop-bar');
+  });
+
+  it('returns no additions for an empty prompt', () => {
+    const result = extractContinuityFromPrompt({
+      ...baseArgs,
+      promptText: '   ',
+      elements: [el('LOGO')],
+      characters: [{ characterId: 'char_001', consistencyTag: null }],
+      locations: [{ locationId: 'loc_001', consistencyTag: 'loc_001: office' }],
+    });
+    expect(hasContinuityAdditions(result)).toBe(false);
+  });
+});
+
+describe('mergeContinuityAdditions', () => {
+  it('appends new character and element tags', () => {
+    const merged = mergeContinuityAdditions(
+      {
+        ...emptyContinuity,
+        characterTags: ['girl_one'],
+        elementTags: ['LOGO'],
+      },
+      {
+        characterTags: ['char_001'],
+        elementTags: ['BOTTLE'],
+        environmentTag: null,
+      }
+    );
+    expect(merged.characterTags).toEqual(['girl_one', 'char_001']);
+    expect(merged.elementTags).toEqual(['LOGO', 'BOTTLE']);
+  });
+
+  it('sets environmentTag when current value is empty', () => {
+    const merged = mergeContinuityAdditions(
+      { ...emptyContinuity, environmentTag: '' },
+      { characterTags: [], elementTags: [], environmentTag: 'office-modern' }
+    );
+    expect(merged.environmentTag).toBe('office-modern');
+  });
+
+  it('space-appends a new environmentTag onto the existing one', () => {
+    const merged = mergeContinuityAdditions(
+      { ...emptyContinuity, environmentTag: 'rooftop-bar' },
+      { characterTags: [], elementTags: [], environmentTag: 'office-modern' }
+    );
+    expect(merged.environmentTag).toBe('rooftop-bar office-modern');
+  });
+
+  it('is a no-op when there is nothing to add', () => {
+    const base: Continuity = {
+      ...emptyContinuity,
+      characterTags: ['girl_one'],
+      elementTags: ['LOGO'],
+      environmentTag: 'rooftop-bar',
+    };
+    const merged = mergeContinuityAdditions(base, {
+      characterTags: [],
+      elementTags: [],
+      environmentTag: null,
+    });
+    expect(merged).toEqual(base);
+  });
+});

--- a/src/lib/workflows/extract-continuity-from-prompt.ts
+++ b/src/lib/workflows/extract-continuity-from-prompt.ts
@@ -1,0 +1,176 @@
+/**
+ * Extracts canonical character / element / location tags mentioned in a
+ * user-edited prompt, so the next regeneration picks them up via
+ * `frame.metadata.continuity`.
+ *
+ * Strict matching: each entity is searched by its stable identifier(s)
+ * (whole-word, case-insensitive). No fuzzy name matching — predictable, no
+ * false positives. Returns additions only; the caller merges them with the
+ * existing continuity so removals from the prompt don't drop linked items.
+ */
+
+import type { Continuity } from '@/lib/ai/scene-analysis.schema';
+import type {
+  CharacterMinimal,
+  SequenceElementMinimal,
+  SequenceLocationMinimal,
+} from '@/lib/db/schema';
+import { matchElementsToScene } from '@/lib/workflows/scene-matching';
+
+type CharacterTerm = Pick<CharacterMinimal, 'characterId' | 'consistencyTag'>;
+type LocationTerm = Pick<
+  SequenceLocationMinimal,
+  'locationId' | 'consistencyTag'
+>;
+
+export type ContinuityAdditions = {
+  characterTags: string[];
+  elementTags: string[];
+  /**
+   * The matched location term, or null if none. The caller decides whether
+   * to set or append based on the current `environmentTag` value.
+   */
+  environmentTag: string | null;
+};
+
+/**
+ * Drizzle stores `consistencyTag` as `"char_001: jack-denim-jacket"`. Users
+ * type either side of the colon, so we expose both halves as search terms.
+ */
+function consistencyTagSlug(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const idx = raw.indexOf(':');
+  const slug = (idx >= 0 ? raw.slice(idx + 1) : raw).trim();
+  return slug.length > 0 ? slug : null;
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Whole-word match for a tag that may contain hyphens/underscores. The
+ * boundary class excludes hyphen so `jack-denim-jacket` matches a single
+ * term and isn't broken into pieces.
+ */
+function tagMatchesText(tag: string, text: string): boolean {
+  const escaped = escapeForRegex(tag);
+  const re = new RegExp(
+    `(?:^|[^A-Za-z0-9_-])${escaped}(?:[^A-Za-z0-9_-]|$)`,
+    'i'
+  );
+  return re.test(text);
+}
+
+function termsFromConsistencyTag(
+  id: string,
+  consistencyTag: string | null | undefined
+): string[] {
+  const slug = consistencyTagSlug(consistencyTag);
+  return slug ? [id, slug] : [id];
+}
+
+export function extractContinuityFromPrompt(args: {
+  promptText: string;
+  characters: CharacterTerm[];
+  elements: SequenceElementMinimal[];
+  locations: LocationTerm[];
+  existing: Pick<
+    Continuity,
+    'characterTags' | 'elementTags' | 'environmentTag'
+  >;
+}): ContinuityAdditions {
+  const { promptText, characters, elements, locations, existing } = args;
+
+  if (!promptText.trim()) {
+    return { characterTags: [], elementTags: [], environmentTag: null };
+  }
+
+  const existingCharacterTagsLower = new Set(
+    existing.characterTags.map((t) => t.toLowerCase())
+  );
+  const existingElementTagsUpper = new Set(
+    (existing.elementTags ?? []).map((t) => t.toUpperCase())
+  );
+  const existingEnvLower = existing.environmentTag.toLowerCase();
+
+  const characterAdditions: string[] = [];
+  for (const char of characters) {
+    const terms = termsFromConsistencyTag(
+      char.characterId,
+      char.consistencyTag
+    );
+    const matched = terms.find((term) => tagMatchesText(term, promptText));
+    if (!matched) continue;
+    const canonical = matched.toLowerCase();
+    if (existingCharacterTagsLower.has(canonical)) continue;
+    if (characterAdditions.includes(canonical)) continue;
+    characterAdditions.push(canonical);
+  }
+
+  const elementAdditions = matchElementsToScene(elements, [], promptText)
+    .map((el) => el.token.toUpperCase())
+    .filter((token) => !existingElementTagsUpper.has(token));
+
+  let environmentTag: string | null = null;
+  let earliestIndex = Number.POSITIVE_INFINITY;
+  const promptLower = promptText.toLowerCase();
+  for (const loc of locations) {
+    const terms = termsFromConsistencyTag(loc.locationId, loc.consistencyTag);
+    for (const term of terms) {
+      if (!tagMatchesText(term, promptText)) continue;
+      const termLower = term.toLowerCase();
+      if (existingEnvLower.includes(termLower)) continue;
+      const idx = promptLower.indexOf(termLower);
+      if (idx >= 0 && idx < earliestIndex) {
+        earliestIndex = idx;
+        environmentTag = termLower;
+      }
+    }
+  }
+
+  return {
+    characterTags: characterAdditions,
+    elementTags: elementAdditions,
+    environmentTag,
+  };
+}
+
+/**
+ * Apply the additions returned by `extractContinuityFromPrompt` to a
+ * continuity object, returning the merged result. `environmentTag` is
+ * space-appended (deduped) so the substring-based location matcher resolves
+ * both the original tag and the new one.
+ */
+export function mergeContinuityAdditions(
+  current: Continuity,
+  additions: ContinuityAdditions
+): Continuity {
+  const characterTags =
+    additions.characterTags.length > 0
+      ? [...current.characterTags, ...additions.characterTags]
+      : current.characterTags;
+
+  const elementTags =
+    additions.elementTags.length > 0
+      ? [...(current.elementTags ?? []), ...additions.elementTags]
+      : current.elementTags;
+
+  let environmentTag = current.environmentTag;
+  if (additions.environmentTag) {
+    const existing = environmentTag.trim();
+    environmentTag = existing
+      ? `${existing} ${additions.environmentTag}`
+      : additions.environmentTag;
+  }
+
+  return { ...current, characterTags, elementTags, environmentTag };
+}
+
+export function hasContinuityAdditions(a: ContinuityAdditions): boolean {
+  return (
+    a.characterTags.length > 0 ||
+    a.elementTags.length > 0 ||
+    a.environmentTag !== null
+  );
+}

--- a/src/lib/workflows/motion-prompt-scene-workflow.ts
+++ b/src/lib/workflows/motion-prompt-scene-workflow.ts
@@ -9,6 +9,7 @@ import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type { MotionPromptSceneWorkflowInput } from '@/lib/workflow/types';
 import { computeMotionPromptInputHash } from '../ai/input-hash';
+import { narrowFramePromptContext } from '../ai/prompt-context';
 import { getGenerationChannel } from '../realtime';
 import {
   type MotionPrompt,
@@ -95,7 +96,10 @@ export const motionPromptSceneWorkflow = createScopedWorkflow<
         );
       }
 
-      const inputHash = await computeMotionPromptInputHash({
+      // Hash inputs are narrowed by the scene's continuity (populated upstream
+      // by the visual-prompt workflow) so unreferenced entities don't poison
+      // the stored hash.
+      const narrowed = narrowFramePromptContext({
         scene,
         styleConfig,
         characterBible,
@@ -104,6 +108,7 @@ export const motionPromptSceneWorkflow = createScopedWorkflow<
         aspectRatio,
         analysisModel: analysisModelId,
       });
+      const inputHash = await computeMotionPromptInputHash(narrowed);
 
       const enrichedScene = {
         ...scene,

--- a/src/lib/workflows/scene-matching.ts
+++ b/src/lib/workflows/scene-matching.ts
@@ -93,15 +93,23 @@ export function matchCharactersToScene<T extends CharacterMatchInput>(
   );
 }
 
+type LocationMatchInput = Pick<
+  SequenceLocationMinimal,
+  'locationId' | 'name' | 'consistencyTag'
+>;
+
 /**
  * Match locations to a scene by environment tag or location name.
  * Pure function that works in-memory without DB queries.
+ *
+ * Generic so we can reuse it on `LocationBibleEntry` (same id/name/tag shape)
+ * when narrowing the bible for prompt-input hashing.
  */
-export function matchLocationsToScene(
-  allLocations: SequenceLocationMinimal[],
+export function matchLocationsToScene<T extends LocationMatchInput>(
+  allLocations: T[],
   environmentTag: string,
   sceneLocation: string
-): SequenceLocationMinimal[] {
+): T[] {
   if (!environmentTag && !sceneLocation) return [];
 
   const envTagLower = environmentTag.toLowerCase();
@@ -115,19 +123,24 @@ export function matchLocationsToScene(
       locName,
       locId,
       ...(consistencyTag ? [consistencyTag] : []),
-    ];
+    ].filter((t) => t.length > 0);
 
-    // Check if any location identifier appears in the environment tag or scene location
+    // Forward match: a location identifier appears in the env/scene-location
+    // tag. Reverse match: the env/scene-location tag appears in a location
+    // identifier. Both directions guard against empty haystacks — without the
+    // length check, `'forest'.includes('')` returns true for every location
+    // when only one of envTagLower / sceneLocLower is populated.
     return searchTerms.some(
       (term) =>
-        envTagLower.includes(term) ||
-        sceneLocLower.includes(term) ||
-        // Reverse match: location name contains the search terms
-        term.includes(envTagLower) ||
-        term.includes(sceneLocLower)
+        (envTagLower.length > 0 && envTagLower.includes(term)) ||
+        (sceneLocLower.length > 0 && sceneLocLower.includes(term)) ||
+        (envTagLower.length > 0 && term.includes(envTagLower)) ||
+        (sceneLocLower.length > 0 && term.includes(sceneLocLower))
     );
   });
 }
+
+type ElementMatchInput = Pick<SequenceElementMinimal, 'token'>;
 
 /**
  * Match user-uploaded elements to a scene by UPPERCASE token.
@@ -135,12 +148,15 @@ export function matchLocationsToScene(
  * Primary match: `elementTags[]` (emitted by the LLM during scene-split).
  * Fallback match: token appears in the raw scene script text — catches
  * cases where the model forgets to populate `elementTags`.
+ *
+ * Generic so we can reuse it on `ElementBibleEntry` (same token shape) when
+ * narrowing the bible for prompt-input hashing.
  */
-export function matchElementsToScene(
-  allElements: SequenceElementMinimal[],
+export function matchElementsToScene<T extends ElementMatchInput>(
+  allElements: T[],
   elementTags: string[],
   sceneScript?: string
-): SequenceElementMinimal[] {
+): T[] {
   if (allElements.length === 0) return [];
 
   const tagsUpper = new Set(elementTags.map((t) => t.toUpperCase()));

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -67,9 +67,12 @@ export const sceneSplitWorkflow = createScopedWorkflow<
           elements.length > 0
             ? elements
                 .map((el) => {
+                  // analyzeScriptWorkflow refuses to start while any element is
+                  // pending/analyzing, so a null description here means vision
+                  // genuinely failed for this row.
                   const desc = el.description
                     ? `: ${el.description}`
-                    : ' (vision description pending)';
+                    : ' (no visual reference available)';
                   return `- ${el.token}${desc}`;
                 })
                 .join('\n')

--- a/src/lib/workflows/visual-prompt-scene-workflow.ts
+++ b/src/lib/workflows/visual-prompt-scene-workflow.ts
@@ -9,6 +9,7 @@ import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type { VisualPromptSceneWorkflowInput } from '@/lib/workflow/types';
 import { computeVisualPromptInputHash } from '../ai/input-hash';
+import { narrowFramePromptContext } from '../ai/prompt-context';
 import {
   type VisualPromptWithContinuity,
   visualPromptWithContinuitySchema,
@@ -82,16 +83,6 @@ export const visualPromptSceneWorkflow = createScopedWorkflow<
         );
       }
 
-      const inputHash = await computeVisualPromptInputHash({
-        scene,
-        styleConfig,
-        characterBible,
-        locationBible,
-        elementBible,
-        aspectRatio,
-        analysisModel: analysisModelId,
-      });
-
       const enrichedScene = {
         ...scene,
         prompts: {
@@ -100,6 +91,20 @@ export const visualPromptSceneWorkflow = createScopedWorkflow<
         },
         continuity: result.continuity,
       };
+
+      // Hash inputs are narrowed by the LLM's continuity output so unreferenced
+      // characters / elements / locations elsewhere in the sequence don't flip
+      // this frame's hash later.
+      const narrowed = narrowFramePromptContext({
+        scene: enrichedScene,
+        styleConfig,
+        characterBible,
+        locationBible,
+        elementBible,
+        aspectRatio,
+        analysisModel: analysisModelId,
+      });
+      const inputHash = await computeVisualPromptInputHash(narrowed);
 
       await context.run('save-visual-prompt-to-db', async () => {
         const previous = await scopedDb.framePromptVariants.getLatest(


### PR DESCRIPTION
## Summary

This PR has grown to bundle the original #683 feature with three follow-up bug fixes uncovered while testing it end-to-end.

### Original feature (commit `6111f7e`)

- When a user edits a scene's image or motion prompt and saves, scan the text for canonical tags (element token, characterId/consistencyTag, locationId/consistencyTag) and additively merge any matches into `frame.metadata.continuity` so the next regeneration pulls them in.
- Strict whole-word, case-insensitive matching — element tokens go through the existing `matchElementsToScene` helper; characters/locations match on their stable identifiers, never on free-form name. No fuzzy matching, no false positives.
- Additive only: existing tags are preserved; locations are space-appended onto `environmentTag` (which the location matcher resolves as a substring).

The `@`-mention autocomplete UI deferred by the original ticket is tracked in #695.

### Follow-up fix: element upload after sequence creation (commit `2f68cb8`)

- Uploading an element on an existing sequence's elements page failed with `Invalid storage path`. Root cause: `presignElementUploadFn` used `authWithTeamMiddleware` (resolves the user's default team) while `finalizeElementUploadFn` used `sequenceAccessMiddleware` (which reassigns `teamId` to the sequence's actual team for system admins). Split into a draft variant + a sequence-aware variant so both ends use the sequence's `teamId`.
- Toast styling: enabled Sonner `richColors` so error toasts get a red surface and the configured `OctagonXIcon` reads as an error at a glance.

### Follow-up fix: false-positive prompt staleness on new sequences (commit `d27e333b`)

Three independent gaps were combining to make Image/Motion tabs show red "out of sync" dots on every scene immediately after creating a sequence:

- `useUploadDraftElement` silently swallowed inline-vision failures. The hook now lets the rejection propagate so the element-selector marks the entry `error` and the user must retry or remove before Generate proceeds.
- `analyzeScriptWorkflow` polled for vision completion for up to 30s and then degraded to `(vision description pending)`. The poll is gone; pending elements now throw `WorkflowValidationError`.
- The hash inputs included every character/element/location in the sequence, so adding an unreferenced element flipped every frame's hash. The hash callers now narrow the bibles via `narrowFramePromptContext` using the scene's continuity. LLM regeneration still receives the full bibles for context.
- Also fixes a pre-existing `matchLocationsToScene` overmatch when one of `environmentTag` / `sceneLocation` is empty.

Existing frames will be one-time stale per scene until regenerated — no migration to null legacy hashes. `PROMPT_INPUT_HASH_VERSION` stays at 2 (inputs changed; body shape did not).

### Follow-up fix: continuity rescan only fired from updateFrameFn (this commit)

The auto-link continuity logic added in `6111f7e` lived inside `updateFrameFn`, which the UI never calls — `useUpdateFrame` exists but has zero consumers. The only path that persists `frame.imagePrompt` today is the Regenerate Image button, which writes via the image workflow's `framePromptVariants.write({ source: 'user-edit' })` but did **not** update continuity. So a user editing the prompt to mention a new `LOGO` never got its reference image attached.

- Extracted the auto-link logic to `src/lib/scenes/rescan-continuity-from-prompt.ts` — pure helper, returns merged continuity + `changed` flag.
- `updateFrameFn` delegates to the helper.
- `generateFrameImageFn` rescans before computing reference attachment so a freshly-mentioned token gets its reference image attached to THIS regeneration, and persists the merged continuity.
- `generateFrameMotionFn` rescans on user-edited motion prompts too — motion doesn't compose references itself, but persisting keeps subsequent reads consistent with the prompt.

## Test plan

- [x] Unit tests for `extractContinuityFromPrompt` / `mergeContinuityAdditions` (15 cases)
- [x] Unit tests for `narrowFramePromptContext` + the user-reported staleness scenario
- [x] `bun typecheck` clean
- [x] Full `bun test` — 734 pass / 0 fail / 3 skip
- [ ] Manual e2e: edit a scene prompt to mention an unlinked element token / characterId / location slug, click Regenerate Image, confirm the new reference image is attached on this regeneration
- [ ] Manual e2e: upload an element on an existing sequence's elements page, confirm the upload succeeds (no `Invalid storage path`)
- [ ] Manual e2e: create a sequence with elements referenced by some scenes but not others — no red dots on Image/Motion tabs
- [ ] Manual e2e: upload an element via the elements page that no scene references — existing scenes stay fresh
- [ ] Manual e2e: simulate a failing inline vision call — upload entry shows the error and Generate stays disabled until the element is removed or vision retried

Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)