### PR TITLE
fix(script): clarify Generate button creates a copy on edit

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -789,16 +789,22 @@ export const ScriptView: FC<{
                       ? 'Generating…'
                       : isElementBusy
                         ? 'Analyzing elements…'
-                        : 'Generate'}
+                        : isEditing
+                          ? 'Generate Copy'
+                          : 'Generate'}
                   </span>
                   {/* Shine effect */}
                   <div className="absolute inset-0 bg-linear-to-r from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700 pointer-events-none" />
                 </Button>
               </div>
               <span className="hidden sm:block text-xs text-muted-foreground text-right">
-                {analysisModels.length === 1
-                  ? '1 sequence will be created'
-                  : `${analysisModels.length} sequences will be created`}
+                {isEditing
+                  ? analysisModels.length === 1
+                    ? '1 copy will be created'
+                    : `${analysisModels.length} copies will be created`
+                  : analysisModels.length === 1
+                    ? '1 sequence will be created'
+                    : `${analysisModels.length} sequences will be created`}
               </span>
             </div>
           </div>
@@ -816,9 +822,12 @@ export const ScriptView: FC<{
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Generate new sequence?</AlertDialogTitle>
+            <AlertDialogTitle>
+              Generate a copy of this sequence?
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              A new sequence will be created from this script.
+              A copy will be created from this script. Your original sequence
+              won't change.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -829,7 +838,7 @@ export const ScriptView: FC<{
                 executeRegeneration();
               }}
             >
-              Generate
+              Generate Copy
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## Summary
- On the script edit screen, the primary Generate button now reads **Generate Copy** and the meta line reads "N copies will be created", since clicking it actually creates a new sequence with `sourceSequenceId` pointing at the original rather than editing in place.
- The confirmation dialog title is now **Generate a copy of this sequence?** with a description that reassures the user the original sequence won't change. Its action button reads **Generate Copy**.
- The new-sequence creation flow (blank script) and the enhance-script nudge dialog are intentionally unchanged.

Closes #698

## Test plan
- [ ] On an existing sequence's script edit page, primary button reads **Generate Copy** and meta reads `1 copy will be created` (or `N copies will be created`).
- [ ] Clicking it opens a dialog titled **Generate a copy of this sequence?** with the "won't change" description and a **Generate Copy** action button.
- [ ] Confirming creates a new sequence (verify `sourceSequenceId` is set).
- [ ] In the new-sequence creation flow, button still reads **Generate** and meta still reads `1 sequence will be created`.
- [ ] With a short script in the create-new flow, the enhance-script nudge dialog still appears unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)