### PR TITLE
feat(scenes): editable scene script with prompt-staleness fix

### DIFF
--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -13,10 +13,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { shortenPromptFn } from '@/functions/ai';
+import { updateFrameFn } from '@/functions/frames';
 import { generateFrameImageFn } from '@/functions/frame-image';
 import { generateFrameMotionFn } from '@/functions/motion-functions';
 import { regenerateFramePromptFn } from '@/functions/prompt-variants';
@@ -32,6 +32,7 @@ import {
   frameStalenessKey,
   useFrameStaleness,
 } from '@/hooks/use-frame-staleness';
+import { sequenceKeys } from '@/hooks/use-sequences';
 import type { FrameVariant } from '@/lib/db/schema';
 import {
   DEFAULT_IMAGE_MODEL,
@@ -109,66 +110,6 @@ type SceneScriptPromptsProps = {
   onCompareDivergent?: (variant: FrameVariant) => void;
 };
 
-type PromptTabContentProps = {
-  text: string | undefined;
-  isCopied: boolean;
-  onCopy: () => void;
-  showDuration?: boolean;
-  durationMs?: number | null;
-};
-
-const PromptTabContent: React.FC<PromptTabContentProps> = ({
-  text,
-  isCopied,
-  onCopy,
-  showDuration,
-  durationMs,
-}) => {
-  return (
-    <div className="space-y-3">
-      <div className="relative">
-        <div className="absolute right-0 top-0">
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={onCopy}
-            disabled={!text}
-            className="h-8 w-8 p-0"
-          >
-            {isCopied ? (
-              <span className="text-xs">✓</span>
-            ) : (
-              <CopyIcon className="h-4 w-4" />
-            )}
-          </Button>
-        </div>
-        <div className="prose prose-sm max-w-none pr-10">
-          {text ? (
-            <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
-              {text}
-            </p>
-          ) : (
-            <div className="space-y-2">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-11/12" />
-              <Skeleton className="h-4 w-10/12" />
-              <Skeleton className="h-4 w-9/12" />
-            </div>
-          )}
-        </div>
-      </div>
-      {showDuration &&
-        durationMs !== undefined &&
-        durationMs !== null &&
-        durationMs > 0 && (
-          <div className="text-xs text-muted-foreground">
-            Duration: {(durationMs / 1000).toFixed(1)}s
-          </div>
-        )}
-    </div>
-  );
-};
-
 export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   frame,
   sequenceId,
@@ -233,6 +174,14 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     [onImageModelChange]
   );
 
+  // Script tab edit state — `undefined` means "no draft" (textarea mirrors the
+  // saved value); a string means "user has typed". We reset to `undefined` when
+  // the frame changes so switching scenes never shows the previous scene's draft.
+  const [editedScript, setEditedScript] = useState<string | undefined>(
+    undefined
+  );
+  const prevScriptFrameIdRef = useRef<string | undefined>(undefined);
+
   // Previous value tracking for prop-to-state sync (refs avoid extra re-renders)
   const prevImagePromptRef = useRef<string | undefined>(undefined);
   const prevImageModelRef = useRef<string | undefined>(undefined);
@@ -273,6 +222,56 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     },
     onError: (error) => {
       toast.error('Prompt regenerate failed', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    },
+  });
+
+  // Persist a scene-script edit. Sends the patched scene via `metadata`;
+  // `updateFrameFn` (server) clears stale dialogue and mirrors the change into
+  // `sequences.script`. Existing prompt-input-hash staleness lights up the
+  // Image/Motion banners automatically once the new extract lands.
+  const saveScriptMutation = useMutation({
+    mutationFn: async (nextExtract: string) => {
+      if (!frame?.id || !frame.metadata) {
+        throw new Error('frame metadata required');
+      }
+      const updated = await updateFrameFn({
+        data: {
+          sequenceId,
+          frameId: frame.id,
+          metadata: {
+            ...frame.metadata,
+            originalScript: {
+              ...frame.metadata.originalScript,
+              extract: nextExtract,
+            },
+          },
+        },
+      });
+      if (!updated) {
+        throw new Error('Frame update returned no data');
+      }
+      return updated;
+    },
+    onSuccess: async (updated) => {
+      setEditedScript(undefined);
+      queryClient.setQueryData(frameKeys.detail(updated.id), updated);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: frameKeys.list(sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: frameStalenessKey(updated.id),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: sequenceKeys.detail(sequenceId),
+        }),
+      ]);
+      toast.success('Scene script saved');
+    },
+    onError: (error) => {
+      toast.error('Failed to save scene script', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     },
@@ -586,6 +585,11 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   const isOverLimit = assembledPrompt.length > maxPromptLength;
 
   // Sync local state when props change (prev-value refs avoid extra re-renders)
+  if (frame?.id !== prevScriptFrameIdRef.current) {
+    prevScriptFrameIdRef.current = frame?.id;
+    setEditedScript(undefined);
+  }
+
   if (imagePrompt !== prevImagePromptRef.current) {
     prevImagePromptRef.current = imagePrompt;
     setEditedImagePrompt(imagePrompt || '');
@@ -716,13 +720,90 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       </TabsList>
 
       <TabsContent value="script">
-        <PromptTabContent
-          text={scriptText}
-          isCopied={copiedTab === 'script'}
-          onCopy={() => void handleCopy(scriptText, 'script')}
-          showDuration={true}
-          durationMs={frame?.durationMs}
-        />
+        {(() => {
+          const savedScript = scriptText ?? '';
+          const currentScript = editedScript ?? savedScript;
+          const isDirty =
+            editedScript !== undefined && editedScript !== savedScript;
+          const canSave =
+            isDirty && !!frame?.metadata && !saveScriptMutation.isPending;
+          return (
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <div className="flex items-center justify-between">
+                  <label
+                    htmlFor="script-extract-input"
+                    className="text-sm font-medium"
+                  >
+                    Scene script
+                  </label>
+                  <span className="text-xs text-muted-foreground">
+                    {currentScript.length} characters
+                  </span>
+                </div>
+                <div className="relative">
+                  <Textarea
+                    id="script-extract-input"
+                    value={currentScript}
+                    onChange={(e) => setEditedScript(e.target.value)}
+                    placeholder="Enter the script text for this scene…"
+                    className="min-h-[180px] resize-y pr-10"
+                    disabled={!frame || saveScriptMutation.isPending}
+                  />
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={() => void handleCopy(currentScript, 'script')}
+                    disabled={!currentScript}
+                    aria-label="Copy scene script"
+                    className="absolute right-1 top-1 h-8 w-8"
+                  >
+                    {copiedTab === 'script' ? (
+                      <span className="text-xs">✓</span>
+                    ) : (
+                      <CopyIcon className="h-4 w-4" />
+                    )}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setEditedScript(undefined)}
+                  disabled={!isDirty || saveScriptMutation.isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={() => saveScriptMutation.mutate(currentScript)}
+                  disabled={!canSave}
+                >
+                  {saveScriptMutation.isPending && (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  )}
+                  {saveScriptMutation.isPending ? 'Saving…' : 'Save'}
+                </Button>
+              </div>
+
+              {isDirty && (
+                <p className="text-xs text-muted-foreground">
+                  Saving will mark the image and motion prompts as stale.
+                </p>
+              )}
+
+              {frame?.durationMs !== undefined &&
+                frame.durationMs !== null &&
+                frame.durationMs > 0 && (
+                  <div className="text-xs text-muted-foreground">
+                    Duration: {(frame.durationMs / 1000).toFixed(1)}s
+                  </div>
+                )}
+            </div>
+          );
+        })()}
       </TabsContent>
 
       <TabsContent value="image-prompt">

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -394,25 +394,57 @@ export const updateFrameFn = createServerFn({ method: 'POST' })
         }
       }
 
-      // Splice the new extract into the parent script. Best-effort: if the
-      // old extract isn't a verbatim substring (e.g. the parent was edited
-      // separately), leave the parent untouched — the frame still saves.
-      // Read-then-write on `sequences.script` is racy under concurrent
-      // scene edits; accept that as the worst-case loss of one parent-script
-      // update — both frames still persist correctly.
-      // Reuse `preEditSequence` if the bootstrap above already fetched it.
+      // Splice the new extract into the parent script. The naive
+      // `script.replace(oldExtract, …)` would corrupt the wrong scene
+      // whenever an extract appears more than once (recurring slug lines,
+      // "CUT TO BLACK.", duplicated cues). Instead, walk every frame in
+      // orderIndex order and locate each one's extract sequentially in
+      // `seq.script`; the target frame's match is the one we splice.
+      // Best-effort: if the walk falls out of sync (e.g. the parent was
+      // edited separately), leave the parent untouched — the frame still
+      // saves, the scene tab still reflects the new extract, and we avoid
+      // injecting into the wrong position. Read-then-write on
+      // `sequences.script` is racy under concurrent scene edits; accept
+      // that as the worst-case loss of one parent-script update.
+      // Reuse the sequence fetched above if the bootstrap path already
+      // loaded it.
       const seq =
         preEditSequenceForSplice ??
         (await context.scopedDb.sequences.getById(sequenceId));
-      if (seq?.script && oldExtract && seq.script.includes(oldExtract)) {
-        await context.scopedDb.sequences.update({
-          id: sequenceId,
-          script: seq.script.replace(oldExtract, incomingExtract),
-        });
-      } else if (oldExtract) {
-        console.warn(
-          `[updateFrameFn] Old script extract not found verbatim in sequence ${sequenceId}; skipping parent script sync for frame ${frameId}`
-        );
+      if (seq?.script && oldExtract) {
+        const siblings =
+          await context.scopedDb.frames.listBySequence(sequenceId);
+        let cursor = 0;
+        let targetStart = -1;
+        let targetLength = 0;
+        let walkDiverged = false;
+        for (const sibling of siblings) {
+          const siblingExtract = sibling.metadata?.originalScript.extract;
+          if (!siblingExtract) continue;
+          const pos = seq.script.indexOf(siblingExtract, cursor);
+          if (pos === -1) {
+            walkDiverged = true;
+            break;
+          }
+          if (sibling.id === frameId) {
+            targetStart = pos;
+            targetLength = siblingExtract.length;
+          }
+          cursor = pos + siblingExtract.length;
+        }
+        if (!walkDiverged && targetStart !== -1) {
+          await context.scopedDb.sequences.update({
+            id: sequenceId,
+            script:
+              seq.script.slice(0, targetStart) +
+              incomingExtract +
+              seq.script.slice(targetStart + targetLength),
+          });
+        } else {
+          console.warn(
+            `[updateFrameFn] Parent script walk could not locate frame ${frameId} for sequence ${sequenceId}; skipping parent script sync`
+          );
+        }
       }
     }
 

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -306,6 +306,116 @@ export const updateFrameFn = createServerFn({ method: 'POST' })
   .handler(async ({ data, context }) => {
     const { sequenceId, frameId, ...updateData } = data;
 
+    // Scene-script edits (#684): when `originalScript.extract` changes,
+    // clear the parsed dialogue (now stale wrt the new text) and mirror the
+    // change into the parent `sequences.script` so script view stays in sync.
+    // Prompt-input-hash staleness handles the Image/Motion banners on its
+    // own — `originalScript.extract` is part of the hashed scene context, so
+    // the next `getFrameStalenessFn` call will report `'stale'` without us
+    // touching the stored prompt hashes here.
+    const oldExtract = context.frame.metadata?.originalScript.extract ?? '';
+    const incomingExtract = updateData.metadata?.originalScript.extract;
+    const scriptChanged =
+      typeof incomingExtract === 'string' && incomingExtract !== oldExtract;
+    if (scriptChanged && updateData.metadata) {
+      updateData.metadata = {
+        ...updateData.metadata,
+        originalScript: {
+          extract: incomingExtract,
+          dialogue: [],
+        },
+      };
+
+      // Bootstrap missing prompt-input hashes. Frames that were generated
+      // before hash tracking landed have `imagePrompt` / `motionPrompt` set
+      // but null hashes and no `frame_prompt_variants` rows — so the
+      // `getLatestWithInputHash` fallback in `getFrameStalenessFn` can't
+      // find a reference either, and staleness stays `'untracked'` forever.
+      // Compute the hash from the PRE-edit scene and stamp it on the frame
+      // now: the post-edit live hash will then differ → banner flips
+      // `'stale'`. One-shot per frame; subsequent edits hit the normal hash
+      // chain.
+      let preEditSequenceForSplice: Awaited<
+        ReturnType<typeof context.scopedDb.sequences.getById>
+      > | null = null;
+      if (context.frame.metadata) {
+        if (context.frame.imagePrompt && !context.frame.visualPromptInputHash) {
+          try {
+            preEditSequenceForSplice ??=
+              await context.scopedDb.sequences.getById(sequenceId);
+            if (preEditSequenceForSplice) {
+              const ctx = await loadNarrowFramePromptContext({
+                scopedDb: context.scopedDb,
+                sequence: {
+                  id: preEditSequenceForSplice.id,
+                  styleId: preEditSequenceForSplice.styleId,
+                  aspectRatio: preEditSequenceForSplice.aspectRatio,
+                  analysisModel: preEditSequenceForSplice.analysisModel,
+                },
+                scene: context.frame.metadata,
+              });
+              updateData.visualPromptInputHash =
+                await computeVisualPromptInputHash(ctx);
+            }
+          } catch (err) {
+            console.warn(
+              `[updateFrameFn] Could not bootstrap visual hash for frame ${frameId}; staleness will remain untracked for this prompt`,
+              err
+            );
+          }
+        }
+        if (
+          context.frame.motionPrompt &&
+          !context.frame.motionPromptInputHash
+        ) {
+          try {
+            preEditSequenceForSplice ??=
+              await context.scopedDb.sequences.getById(sequenceId);
+            if (preEditSequenceForSplice) {
+              const ctx = await loadNarrowFramePromptContext({
+                scopedDb: context.scopedDb,
+                sequence: {
+                  id: preEditSequenceForSplice.id,
+                  styleId: preEditSequenceForSplice.styleId,
+                  aspectRatio: preEditSequenceForSplice.aspectRatio,
+                  analysisModel: preEditSequenceForSplice.analysisModel,
+                },
+                scene: context.frame.metadata,
+              });
+              updateData.motionPromptInputHash =
+                await computeMotionPromptInputHash(ctx);
+            }
+          } catch (err) {
+            console.warn(
+              `[updateFrameFn] Could not bootstrap motion hash for frame ${frameId}; staleness will remain untracked for this prompt`,
+              err
+            );
+          }
+        }
+      }
+
+      // Splice the new extract into the parent script. Best-effort: if the
+      // old extract isn't a verbatim substring (e.g. the parent was edited
+      // separately), leave the parent untouched — the frame still saves.
+      // Read-then-write on `sequences.script` is racy under concurrent
+      // scene edits; accept that as the worst-case loss of one parent-script
+      // update — both frames still persist correctly.
+      // Reuse `preEditSequence` if the bootstrap above already fetched it.
+      const seq =
+        preEditSequenceForSplice ??
+        (await context.scopedDb.sequences.getById(sequenceId));
+      if (seq?.script && oldExtract && seq.script.includes(oldExtract)) {
+        await context.scopedDb.sequences.update({
+          id: sequenceId,
+          script: seq.script.replace(oldExtract, incomingExtract),
+        });
+      } else if (oldExtract) {
+        console.warn(
+          `[updateFrameFn] Old script extract not found verbatim in sequence ${sequenceId}; skipping parent script sync for frame ${frameId}`
+        );
+      }
+    }
+
     // When a user edits a prompt, auto-link any element/cast/location tags
     // they mentioned by additively merging them into frame.metadata.continuity
     // so the next generation pulls those references in (#683). Skip when the
@@ -433,51 +543,75 @@ export const getFrameStalenessFn = createServerFn({ method: 'GET' })
     let visualPrompt: 'stale' | 'fresh' | 'untracked' = 'untracked';
     let motionPrompt: 'stale' | 'fresh' | 'untracked' = 'untracked';
 
-    if (frame.metadata && frame.visualPromptInputHash) {
-      try {
-        const latest = await scopedDb.framePromptVariants.getLatest(
-          frame.id,
-          'visual'
-        );
-        const ctx = await loadNarrowFramePromptContext({
-          scopedDb,
-          sequence,
-          scene: frame.metadata,
-          analysisModelOverride: latest?.analysisModel ?? null,
-        });
-        const liveHash = await computeVisualPromptInputHash(ctx);
-        visualPrompt =
-          liveHash !== frame.visualPromptInputHash ? 'stale' : 'fresh';
-      } catch (error) {
-        // Context unavailable (e.g., style deleted mid-flight). Stay
-        // 'untracked' — fail-open as 'fresh' would silently lie to the user.
-        console.warn(
-          `[getFrameStalenessFn] visual staleness uncomputable for frame ${frame.id}:`,
-          error
-        );
+    // Reference hash resolution: prefer the cached column on `frames`, but
+    // fall back to the most recent variant with a non-null `inputHash` for
+    // frames whose cached column was nulled by a pre-fix user-edit. Without
+    // the fallback, those frames are stuck at `'untracked'` permanently.
+    if (frame.metadata) {
+      let referenceHash = frame.visualPromptInputHash;
+      if (!referenceHash) {
+        const fallback =
+          await scopedDb.framePromptVariants.getLatestWithInputHash(
+            frame.id,
+            'visual'
+          );
+        referenceHash = fallback?.inputHash ?? null;
+      }
+      if (referenceHash) {
+        try {
+          const latest = await scopedDb.framePromptVariants.getLatest(
+            frame.id,
+            'visual'
+          );
+          const ctx = await loadNarrowFramePromptContext({
+            scopedDb,
+            sequence,
+            scene: frame.metadata,
+            analysisModelOverride: latest?.analysisModel ?? null,
+          });
+          const liveHash = await computeVisualPromptInputHash(ctx);
+          visualPrompt = liveHash !== referenceHash ? 'stale' : 'fresh';
+        } catch (error) {
+          // Context unavailable (e.g., style deleted mid-flight). Stay
+          // 'untracked' — fail-open as 'fresh' would silently lie to the user.
+          console.warn(
+            `[getFrameStalenessFn] visual staleness uncomputable for frame ${frame.id}:`,
+            error
+          );
+        }
       }
     }
 
-    if (frame.metadata && frame.motionPromptInputHash) {
-      try {
-        const latest = await scopedDb.framePromptVariants.getLatest(
-          frame.id,
-          'motion'
-        );
-        const ctx = await loadNarrowFramePromptContext({
-          scopedDb,
-          sequence,
-          scene: frame.metadata,
-          analysisModelOverride: latest?.analysisModel ?? null,
-        });
-        const liveHash = await computeMotionPromptInputHash(ctx);
-        motionPrompt =
-          liveHash !== frame.motionPromptInputHash ? 'stale' : 'fresh';
-      } catch (error) {
-        console.warn(
-          `[getFrameStalenessFn] motion staleness uncomputable for frame ${frame.id}:`,
-          error
-        );
+    if (frame.metadata) {
+      let referenceHash = frame.motionPromptInputHash;
+      if (!referenceHash) {
+        const fallback =
+          await scopedDb.framePromptVariants.getLatestWithInputHash(
+            frame.id,
+            'motion'
+          );
+        referenceHash = fallback?.inputHash ?? null;
+      }
+      if (referenceHash) {
+        try {
+          const latest = await scopedDb.framePromptVariants.getLatest(
+            frame.id,
+            'motion'
+          );
+          const ctx = await loadNarrowFramePromptContext({
+            scopedDb,
+            sequence,
+            scene: frame.metadata,
+            analysisModelOverride: latest?.analysisModel ?? null,
+          });
+          const liveHash = await computeMotionPromptInputHash(ctx);
+          motionPrompt = liveHash !== referenceHash ? 'stale' : 'fresh';
+        } catch (error) {
+          console.warn(
+            `[getFrameStalenessFn] motion staleness uncomputable for frame ${frame.id}:`,
+            error
+          );
+        }
       }
     }
 

--- a/src/lib/db/scoped/frame-prompt-variants.test.ts
+++ b/src/lib/db/scoped/frame-prompt-variants.test.ts
@@ -106,10 +106,44 @@ beforeEach(async () => {
 });
 
 describe('frame_prompt_variants helper', () => {
-  it('user-edit appends a row, updates cached column, and clears the input hash', async () => {
+  it('user-edit with null inputHash appends a row and clears the cached hash', async () => {
     const methods = createFramePromptVariantsMethods(asDatabase(db));
 
     // Seed the cached column to mimic an existing AI-generated prompt.
+    await db
+      .update(frames)
+      .set({
+        imagePrompt: 'AI-generated prompt v1',
+        visualPromptInputHash: 'hash-v1',
+      })
+      .where(eq(frames.id, frameId));
+
+    // A user-edit recorded without an upstream hash (e.g., context was
+    // uncomputable at write time) writes null to both the row and the cache.
+    const variant = await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'User edited prompt',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+
+    expect(variant.source).toBe('user-edit');
+    expect(variant.text).toBe('User edited prompt');
+    expect(variant.inputHash).toBeNull();
+
+    const [refreshed] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    expect(refreshed.imagePrompt).toBe('User edited prompt');
+    expect(refreshed.visualPromptInputHash).toBeNull();
+  });
+
+  it('user-edit with a real inputHash stamps both the row and the cached column', async () => {
+    const methods = createFramePromptVariantsMethods(asDatabase(db));
+
     await db
       .update(frames)
       .set({
@@ -123,20 +157,19 @@ describe('frame_prompt_variants helper', () => {
       promptType: 'visual',
       text: 'User edited prompt',
       source: 'user-edit',
+      inputHash: 'hash-at-edit-time',
+      analysisModel: 'anthropic/claude-haiku-4.5',
     });
 
     expect(variant.source).toBe('user-edit');
-    expect(variant.text).toBe('User edited prompt');
-    expect(variant.inputHash).toBeNull();
+    expect(variant.inputHash).toBe('hash-at-edit-time');
 
     const [refreshed] = await db
       .select()
       .from(frames)
       .where(eq(frames.id, frameId));
     expect(refreshed.imagePrompt).toBe('User edited prompt');
-    // user-edit clears the input hash since the cached value is no longer
-    // derived from upstream context.
-    expect(refreshed.visualPromptInputHash).toBeNull();
+    expect(refreshed.visualPromptInputHash).toBe('hash-at-edit-time');
   });
 
   it('regenerated prompt populates input_hash on both the row and the cached column', async () => {
@@ -178,6 +211,8 @@ describe('frame_prompt_variants helper', () => {
       promptType: 'visual',
       text: 'User edited prompt',
       source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
     });
 
     const history = await methods.listByFrame(frameId, 'visual');
@@ -227,6 +262,8 @@ describe('frame_prompt_variants helper', () => {
       promptType: 'visual',
       text: 'User polished it',
       source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
     });
 
     const history = await methods.listByFrame(frameId, 'visual');
@@ -373,13 +410,17 @@ describe('frame_prompt_variants helper', () => {
       analysisModel: 'anthropic/claude-haiku-4.5',
     });
 
-    // User then edits the prompt — clears the cached hash (existing
-    // semantics: a freeform edit no longer derives from upstream).
+    // User then edits the prompt, but the upstream context wasn't
+    // computable at edit time — both the row and the cached column go
+    // null. The restore-from-AI flow below must still re-populate the
+    // cached hash from the source row.
     await methods.write({
       frameId,
       promptType: 'visual',
       text: 'User edited prompt',
       source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
     });
 
     // Restoring the original AI prompt must re-populate the cached hash so
@@ -460,6 +501,8 @@ describe('frame_prompt_variants helper', () => {
       promptType: 'visual',
       text: 'Hand-written prompt',
       source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
     });
 
     // Restoring a user-edit must not synthesize a hash out of nothing —
@@ -476,6 +519,57 @@ describe('frame_prompt_variants helper', () => {
     });
     expect(restored.inputHash).toBeNull();
     expect(restored.analysisModel).toBeNull();
+  });
+
+  it('getLatestWithInputHash skips null-hash user-edits and returns the most recent hashed row', async () => {
+    const methods = createFramePromptVariantsMethods(asDatabase(db));
+
+    // 1) An AI prompt with a real hash.
+    const ai = await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'AI prompt',
+      source: 'ai-generated',
+      inputHash: 'ai-hash-1',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+    // 2) A later user-edit with no upstream context (null hash).
+    await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'Hand-typed prompt',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+
+    // getLatest returns the most recent row regardless of hash.
+    const latest = await methods.getLatest(frameId, 'visual');
+    expect(latest?.inputHash).toBeNull();
+
+    // getLatestWithInputHash skips the user-edit and returns the AI row.
+    const latestHashed = await methods.getLatestWithInputHash(
+      frameId,
+      'visual'
+    );
+    expect(latestHashed?.id).toBe(ai.id);
+    expect(latestHashed?.inputHash).toBe('ai-hash-1');
+  });
+
+  it('getLatestWithInputHash isolates by promptType (visual vs motion)', async () => {
+    const methods = createFramePromptVariantsMethods(asDatabase(db));
+
+    await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'Visual prompt',
+      source: 'ai-generated',
+      inputHash: 'visual-hash',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    const motionMatch = await methods.getLatestWithInputHash(frameId, 'motion');
+    expect(motionMatch).toBeNull();
   });
 });
 

--- a/src/lib/db/scoped/frame-prompt-variants.ts
+++ b/src/lib/db/scoped/frame-prompt-variants.ts
@@ -23,7 +23,7 @@ import type {
   FramePromptVariant,
   FramePromptVariantComponents,
 } from '@/lib/db/schema';
-import { and, desc, eq, lte } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, lte } from 'drizzle-orm';
 
 type WriteFramePromptVariantBase = {
   frameId: string;
@@ -35,17 +35,21 @@ type WriteFramePromptVariantBase = {
 };
 
 /**
- * AI-generated and regenerated rows must carry the upstream-context hash and
- * the analysis model that produced the prompt — without these, the cached
- * `*_prompt_input_hash` column on `frames` is meaningless and staleness
- * detection silently breaks. User-edits have no upstream input surface and
- * forbid both fields so they cannot be set by mistake.
+ * `inputHash` represents the upstream context (scene + style + narrowed
+ * bibles + aspectRatio + analysisModel) that this prompt is aligned with,
+ * regardless of who authored the text. AI-generated and regenerated rows
+ * always carry a real hash — they can't be written without one. User-edits
+ * also carry the live hash captured at edit time so staleness detection
+ * keeps working after a hand-typed prompt; null is permitted only when the
+ * upstream context was uncomputable at write time (e.g. style deleted), in
+ * which case the staleness function falls back to an earlier non-null row.
  *
  * Restored rows carry the source variant's hash + analysisModel verbatim so
  * the cached `*_prompt_input_hash` column keeps tracking the upstream context
  * that originally produced the prompt — restoring an old AI prompt must NOT
- * silently disable staleness detection. Both fields can be null when the
- * source is itself a user-edit (which never had a hash to begin with).
+ * silently disable staleness detection. Both fields stay nullable for restored
+ * rows to accommodate legacy user-edit variants written before this contract
+ * landed (they have null hashes that we can't retroactively recompute).
  */
 export type WriteFramePromptVariantInput = WriteFramePromptVariantBase &
   (
@@ -56,8 +60,8 @@ export type WriteFramePromptVariantInput = WriteFramePromptVariantBase &
       }
     | {
         source: 'user-edit';
-        inputHash?: never;
-        analysisModel?: never;
+        inputHash: string | null;
+        analysisModel: string | null;
       }
     | {
         source: 'restored';
@@ -100,9 +104,8 @@ export function createFramePromptVariantsMethods(db: Database) {
     ): Promise<FramePromptVariant> => {
       const cached = cachedColumnsForType(input.promptType);
 
-      const nextHash = input.source === 'user-edit' ? null : input.inputHash;
-      const analysisModel =
-        input.source === 'user-edit' ? null : input.analysisModel;
+      const nextHash = input.inputHash;
+      const analysisModel = input.analysisModel;
 
       // Append first so a crash can't leave a stale pointer with no row
       // behind it. The reverse order would be unrecoverable.
@@ -252,6 +255,32 @@ export function createFramePromptVariantsMethods(db: Database) {
           and(
             eq(framePromptVariants.frameId, frameId),
             eq(framePromptVariants.promptType, promptType)
+          )
+        )
+        .orderBy(desc(framePromptVariants.createdAt))
+        .limit(1);
+      return row ?? null;
+    },
+
+    /**
+     * Most recent variant of a given type whose `inputHash` is non-null.
+     * Used by the staleness path to find a reference hash for legacy frames
+     * whose cached `*_prompt_input_hash` column was nulled out by a
+     * pre-fix user-edit. Skips user-edit rows that fell back to null when
+     * context was uncomputable.
+     */
+    getLatestWithInputHash: async (
+      frameId: string,
+      promptType: FramePromptType
+    ): Promise<FramePromptVariant | null> => {
+      const [row] = await db
+        .select()
+        .from(framePromptVariants)
+        .where(
+          and(
+            eq(framePromptVariants.frameId, frameId),
+            eq(framePromptVariants.promptType, promptType),
+            isNotNull(framePromptVariants.inputHash)
           )
         )
         .orderBy(desc(framePromptVariants.createdAt))

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -1,4 +1,6 @@
+import { computeVisualPromptInputHash } from '@/lib/ai/input-hash';
 import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from '@/lib/ai/models';
+import { loadNarrowFramePromptContext } from '@/lib/ai/prompt-context';
 import { ZERO_MICROS, microsToUsd } from '@/lib/billing/money';
 import { DEFAULT_IMAGE_SIZE } from '@/lib/constants/aspect-ratios';
 import {
@@ -93,11 +95,47 @@ export const generateImageWorkflow = createScopedWorkflow<
               currentPrompt: frame.imagePrompt,
             })
           ) {
+            // Stamp the user-edit with the upstream-context hash captured at
+            // edit time so staleness detection survives a hand-typed prompt.
+            // If anything blocks the compute (no sequenceId, style deleted,
+            // missing scene metadata), fall back to null — the staleness
+            // function reaches back to an earlier non-null row.
+            let userEditInputHash: string | null = null;
+            let userEditAnalysisModel: string | null = null;
+            try {
+              if (frame.metadata && input.sequenceId) {
+                const sequence = await scopedDb.sequences.getById(
+                  input.sequenceId
+                );
+                if (sequence) {
+                  const ctx = await loadNarrowFramePromptContext({
+                    scopedDb,
+                    sequence: {
+                      id: sequence.id,
+                      styleId: sequence.styleId,
+                      aspectRatio: sequence.aspectRatio,
+                      analysisModel: sequence.analysisModel,
+                    },
+                    scene: frame.metadata,
+                  });
+                  userEditInputHash = await computeVisualPromptInputHash(ctx);
+                  userEditAnalysisModel = ctx.analysisModel;
+                }
+              }
+            } catch (err) {
+              console.warn(
+                `[ImageWorkflow] Could not compute upstream hash for user-edit on frame ${input.frameId}; recording with null hash`,
+                err
+              );
+            }
+
             await scopedDb.framePromptVariants.write({
               frameId: input.frameId,
               promptType: 'visual',
               text: input.prompt,
               source: 'user-edit',
+              inputHash: userEditInputHash,
+              analysisModel: userEditAnalysisModel,
               createdBy: input.userId,
             });
           }

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -8,7 +8,9 @@
  */
 
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
+import { computeMotionPromptInputHash } from '@/lib/ai/input-hash';
 import { DEFAULT_VIDEO_MODEL, IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
+import { loadNarrowFramePromptContext } from '@/lib/ai/prompt-context';
 import { microsToUsd, type Microdollars } from '@/lib/billing/money';
 import { ensureImageUnderLimit } from '@/lib/image/image-compress';
 import {
@@ -140,11 +142,45 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
             currentPrompt: frame.motionPrompt,
           })
         ) {
+          // Stamp the user-edit with the upstream-context hash captured at
+          // edit time so staleness detection survives a hand-typed prompt.
+          // If anything blocks the compute, fall back to null.
+          let userEditInputHash: string | null = null;
+          let userEditAnalysisModel: string | null = null;
+          try {
+            if (frame.metadata && input.sequenceId) {
+              const sequence = await scopedDb.sequences.getById(
+                input.sequenceId
+              );
+              if (sequence) {
+                const ctx = await loadNarrowFramePromptContext({
+                  scopedDb,
+                  sequence: {
+                    id: sequence.id,
+                    styleId: sequence.styleId,
+                    aspectRatio: sequence.aspectRatio,
+                    analysisModel: sequence.analysisModel,
+                  },
+                  scene: frame.metadata,
+                });
+                userEditInputHash = await computeMotionPromptInputHash(ctx);
+                userEditAnalysisModel = ctx.analysisModel;
+              }
+            }
+          } catch (err) {
+            console.warn(
+              `[MotionWorkflow] Could not compute upstream hash for user-edit on frame ${input.frameId}; recording with null hash`,
+              err
+            );
+          }
+
           await scopedDb.framePromptVariants.write({
             frameId: input.frameId,
             promptType: 'motion',
             text: input.prompt,
             source: 'user-edit',
+            inputHash: userEditInputHash,
+            analysisModel: userEditAnalysisModel,
             createdBy: input.userId,
           });
         }


### PR DESCRIPTION
## Summary

- Adds an editable Script tab on the scene detail panel: textarea + Save/Cancel, Copy icon overlaid on the field, dirty-state hint.
- Server: `updateFrameFn` mirrors a scene's new `originalScript.extract` back into the parent `sequences.script` via verbatim string-replace (skips with a warning if the old extract isn't a substring). No storyboard re-analysis.
- Fixes the underlying prompt-staleness chain so banners flip after a script save:
  - User-edit prompt variants now stamp the live upstream-context hash (was: `null`), so editing a prompt once no longer permanently disables staleness detection.
  - `getFrameStalenessFn` falls back to the most recent non-null variant `inputHash` when the cached column is `null` (legacy frames pre-fix).
  - `updateFrameFn` bootstraps a missing `*_prompt_input_hash` on the first script edit by computing it from the **pre-edit** scene — covers frames whose `image_prompt` was written before hash tracking landed (no variant rows at all).
- Cleared `metadata.originalScript.dialogue` on script save (will be re-derived on next regenerate).
- Type widened: `WriteFramePromptVariantInput['user-edit']` now requires `inputHash: string | null` + `analysisModel: string | null`.

Closes #684

## Test plan

- [ ] `bun typecheck` clean
- [ ] `bun test src/lib/db/scoped/frame-prompt-variants.test.ts src/functions/__tests__/frames.test.ts` pass (added `getLatestWithInputHash` coverage + split user-edit test into null-hash and real-hash branches)
- [ ] In dev: open a scene, edit its script, hit Save. Confirm the corner-dot + inline staleness banners appear on Image and Motion tabs.
- [ ] Verify the sequence-level script page reflects the spliced change.
- [ ] Hand-edit an image prompt and click Generate Image. After the workflow, confirm `frames.visual_prompt_input_hash` is non-null (live hash at edit time), not null as it was previously.
- [ ] Regression: regenerate an AI prompt via the existing Regenerate flow — banner clears, staleness stays `'fresh'` until something else upstream changes.

## Out of scope (follow-ups)

- Script-history sheet (mirror of `PromptHistorySheet` over a new `frame_script_variants` table). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)