### PR TITLE
Select video and / or music model when generating #686

### DIFF
--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -1,3 +1,5 @@
+import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -8,11 +10,18 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import {
+  DEFAULT_MUSIC_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  type AudioModel,
+  type ImageToVideoModel,
+} from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { cn } from '@/lib/utils';
 import type { Frame } from '@/types/database';
 import { ChevronUp, Loader2, Video } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import type { BatchGenerateMotionArgs } from './scene-list';
 import { SceneListItem } from './scene-list-item';
 import { SceneThumbnail } from './scene-thumbnail';
 
@@ -23,10 +32,16 @@ type MobileSceneDrawerProps = {
   onSelectFrame: (frameId: string) => void;
   regeneratingImages: Set<string>;
   regeneratingMotion: Set<string>;
-  onBatchGenerateMotion?: (includeMusic: boolean) => Promise<void>;
+  onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
   musicPromptsReady: boolean;
   /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
   hideBatchButton?: boolean;
+  /** Initial motion model for the batch selector (from `sequence.videoModel`). */
+  initialMotionModel?: ImageToVideoModel;
+  /** Initial music model for the batch selector (from `sequence.musicModel`). */
+  initialMusicModel?: AudioModel;
+  /** Current style category — used to filter style-restricted motion models. */
+  styleCategory?: string;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -45,10 +60,33 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   onBatchGenerateMotion,
   musicPromptsReady,
   hideBatchButton = false,
+  initialMotionModel,
+  initialMusicModel,
+  styleCategory,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(false);
+  const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
+    initialMotionModel ?? DEFAULT_VIDEO_MODEL
+  );
+  const [musicModel, setMusicModel] = useState<AudioModel>(
+    initialMusicModel ?? DEFAULT_MUSIC_MODEL
+  );
+
+  const prevInitialMotionRef = useRef(initialMotionModel);
+  if (
+    initialMotionModel &&
+    initialMotionModel !== prevInitialMotionRef.current
+  ) {
+    prevInitialMotionRef.current = initialMotionModel;
+    setMotionModel(initialMotionModel);
+  }
+  const prevInitialMusicRef = useRef(initialMusicModel);
+  if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
+    prevInitialMusicRef.current = initialMusicModel;
+    setMusicModel(initialMusicModel);
+  }
 
   const totalFrames = frames?.length ?? 0;
 
@@ -89,7 +127,7 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion(includeMusic);
+      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
     } finally {
       setIsGenerating(false);
     }
@@ -182,6 +220,30 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
           {showFooter && (
             <SheetFooter className="border-t pt-4 px-4 flex-col items-stretch gap-3">
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">
+                  Motion model
+                </span>
+                <MotionModelSelector
+                  selectedModel={motionModel}
+                  onModelChange={setMotionModel}
+                  disabled={isGenerating || isMotionInProgress}
+                  aspectRatio={aspectRatio}
+                  styleCategory={styleCategory}
+                />
+              </div>
+              {includeMusic && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-muted-foreground">
+                    Music model
+                  </span>
+                  <MusicModelSelector
+                    selectedModel={musicModel}
+                    onModelChange={setMusicModel}
+                    disabled={isGenerating || isMotionInProgress}
+                  />
+                </div>
+              )}
               <Button
                 variant="default"
                 onClick={() => void handleGenerateMotion()}

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -1,11 +1,25 @@
+import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  DEFAULT_MUSIC_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  type AudioModel,
+  type ImageToVideoModel,
+} from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import type { Frame, FrameVariant } from '@/lib/db/schema';
 import { Loader2, Video } from 'lucide-react';
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo, useRef, useState } from 'react';
 import { SceneListItem } from './scene-list-item';
+
+export type BatchGenerateMotionArgs = {
+  includeMusic: boolean;
+  motionModel: ImageToVideoModel;
+  musicModel: AudioModel;
+};
 
 type SceneListProps = {
   frames?: Frame[] | undefined;
@@ -14,13 +28,19 @@ type SceneListProps = {
   onSelectFrame: (frameId: string) => void;
   regeneratingImages: Set<string>;
   regeneratingMotion: Set<string>;
-  onBatchGenerateMotion?: (includeMusic: boolean) => Promise<void>;
+  onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
   musicPromptsReady: boolean;
   /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
   hideBatchButton?: boolean;
   /** Live divergent alternates for the current sequence (filtered per-frame). */
   divergentVariants?: FrameVariant[];
   onCompareDivergent?: (variant: FrameVariant) => void;
+  /** Initial motion model for the batch selector (from `sequence.videoModel`). */
+  initialMotionModel?: ImageToVideoModel;
+  /** Initial music model for the batch selector (from `sequence.musicModel`). */
+  initialMusicModel?: AudioModel;
+  /** Current style category — used to filter style-restricted motion models. */
+  styleCategory?: string;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -41,6 +61,9 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   hideBatchButton = false,
   divergentVariants,
   onCompareDivergent,
+  initialMotionModel,
+  initialMusicModel,
+  styleCategory,
 }) => {
   const divergentByFrameId = useMemo(() => {
     const map = new Map<string, FrameVariant>();
@@ -55,6 +78,28 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
+  const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
+    initialMotionModel ?? DEFAULT_VIDEO_MODEL
+  );
+  const [musicModel, setMusicModel] = useState<AudioModel>(
+    initialMusicModel ?? DEFAULT_MUSIC_MODEL
+  );
+
+  // Sync local selection when the sequence's saved model changes from outside
+  // (e.g. after generation completes and the workflow persists the new model).
+  const prevInitialMotionRef = useRef(initialMotionModel);
+  if (
+    initialMotionModel &&
+    initialMotionModel !== prevInitialMotionRef.current
+  ) {
+    prevInitialMotionRef.current = initialMotionModel;
+    setMotionModel(initialMotionModel);
+  }
+  const prevInitialMusicRef = useRef(initialMusicModel);
+  if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
+    prevInitialMusicRef.current = initialMusicModel;
+    setMusicModel(initialMusicModel);
+  }
 
   const totalFrames = frames?.length ?? 0;
 
@@ -88,7 +133,7 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion(includeMusic);
+      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
     } finally {
       setIsGenerating(false);
     }
@@ -154,6 +199,26 @@ const SceneListComponent: React.FC<SceneListProps> = ({
       {/* Sticky footer with Generate Motion button */}
       {showButton && (
         <div className="sticky bottom-0 border-t bg-background p-4 flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">Motion model</span>
+            <MotionModelSelector
+              selectedModel={motionModel}
+              onModelChange={setMotionModel}
+              disabled={isGenerating || isMotionInProgress}
+              aspectRatio={aspectRatio}
+              styleCategory={styleCategory}
+            />
+          </div>
+          {includeMusic && (
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-muted-foreground">Music model</span>
+              <MusicModelSelector
+                selectedModel={musicModel}
+                onModelChange={setMusicModel}
+                disabled={isGenerating || isMotionInProgress}
+              />
+            </div>
+          )}
           <Button
             variant="default"
             className="w-full"
@@ -213,7 +278,10 @@ const areEqual = (
   if (
     prevProps.selectedFrameId !== nextProps.selectedFrameId ||
     prevProps.aspectRatio !== nextProps.aspectRatio ||
-    prevProps.musicPromptsReady !== nextProps.musicPromptsReady
+    prevProps.musicPromptsReady !== nextProps.musicPromptsReady ||
+    prevProps.initialMotionModel !== nextProps.initialMotionModel ||
+    prevProps.initialMusicModel !== nextProps.initialMusicModel ||
+    prevProps.styleCategory !== nextProps.styleCategory
   ) {
     return false;
   }

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -110,6 +110,11 @@ type SceneScriptPromptsProps = {
   /** Live divergent alternates for the current frame across variant types. */
   frameDivergentVariants?: FrameVariant[];
   onCompareDivergent?: (variant: FrameVariant) => void;
+  /**
+   * Sequence-level motion model. Used as the display fallback when the user
+   * hasn't picked one in the dropdown and the frame has no completed motion.
+   */
+  sequenceMotionModel?: ImageToVideoModel;
 };
 
 export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
@@ -127,6 +132,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   styleCategory,
   frameDivergentVariants,
   onCompareDivergent,
+  sequenceMotionModel,
 }) => {
   const divergentImageVariant = useMemo(
     () => frameDivergentVariants?.find((v) => v.variantType === 'image'),
@@ -673,6 +679,21 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   const rawMotionPrompt =
     frame?.motionPrompt || motionPromptData?.fullPrompt || '';
 
+  // Resolved motion model for this scene. Precedence:
+  //   1. user picked one in the dropdown right now
+  //   2. frame already has completed motion → show what it was generated with
+  //   3. sequence-level model (reflects most recent batch pick or creation)
+  //   4. global default
+  // Without (2) and (3) the per-frame label would just show DEFAULT_VIDEO_MODEL
+  // regardless of what was actually used or what batch-generate just selected.
+  const effectiveMotionModel: ImageToVideoModel =
+    selectedMotionModel ||
+    (frame?.videoStatus === 'completed' && frame.motionModel
+      ? safeImageToVideoModel(frame.motionModel, DEFAULT_VIDEO_MODEL)
+      : undefined) ||
+    sequenceMotionModel ||
+    DEFAULT_VIDEO_MODEL;
+
   // Assembled preview: exactly what resolveMotionPrompt produces on the server
   const assembledPrompt = useMemo(() => {
     const promptOverride = editedMotionPrompt || rawMotionPrompt;
@@ -682,17 +703,17 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
         metadata: frame?.metadata ?? null,
         description: frame?.description ?? null,
       },
-      selectedMotionModel || DEFAULT_VIDEO_MODEL
+      effectiveMotionModel
     );
   }, [
     editedMotionPrompt,
     rawMotionPrompt,
     frame?.metadata,
     frame?.description,
-    selectedMotionModel,
+    effectiveMotionModel,
   ]);
 
-  const motionModel = selectedMotionModel || DEFAULT_VIDEO_MODEL;
+  const motionModel = effectiveMotionModel;
   const maxPromptLength = IMAGE_TO_VIDEO_MODELS[motionModel].maxPromptLength;
   const isOverLimit = assembledPrompt.length > maxPromptLength;
 
@@ -1154,7 +1175,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           <div className="space-y-2">
             <span className="text-sm font-medium">Model</span>
             <MotionModelSelector
-              selectedModel={selectedMotionModel || DEFAULT_VIDEO_MODEL}
+              selectedModel={effectiveMotionModel}
               onModelChange={setSelectedMotionModel}
               disabled={isGenerating || isGeneratingMotion}
               aspectRatio={aspectRatio}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -559,6 +559,12 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             musicModel: includeMusic ? musicModel : undefined,
           },
         });
+        // Server may have updated sequence.videoModel / sequence.musicModel to
+        // the batch picks; invalidate so the header badge, footer pre-fill,
+        // and per-frame fallback all reflect the new values.
+        void queryClient.invalidateQueries({
+          queryKey: sequenceKeys.detail(sequenceId),
+        });
       } catch (error) {
         setRegeneratingMotion((prev) =>
           removeAllFromSet(prev, eligibleFrameIds)
@@ -722,6 +728,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             variantForSelectedModel={variantForSelectedModel}
             onImageModelChange={setImageModelOverride}
             styleCategory={styleCategory}
+            sequenceMotionModel={sequenceMotionModel}
             frameDivergentVariants={divergentVariants?.filter(
               (v) => v.frameId === curSelectedFrameId
             )}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -3,6 +3,7 @@ import { MotionProgressBanner } from '@/components/generation/motion-progress-ba
 import { ScenePlayer } from '@/components/motion/scene-player';
 import { MobileSceneDrawer } from '@/components/scenes/mobile-scene-drawer';
 import { SceneList } from '@/components/scenes/scene-list';
+import type { BatchGenerateMotionArgs } from '@/components/scenes/scene-list';
 import {
   SceneScriptPrompts,
   type TabValue,
@@ -25,7 +26,14 @@ import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-
 import { getDivergentVariantPromptDiffFn } from '@/functions/prompt-variants';
 import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
 import { useStyle } from '@/hooks/use-styles';
-import { safeTextToImageModel, DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
+import {
+  DEFAULT_IMAGE_MODEL,
+  DEFAULT_MUSIC_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  safeAudioModel,
+  safeImageToVideoModel,
+  safeTextToImageModel,
+} from '@/lib/ai/models';
 import {
   DEFAULT_ASPECT_RATIO,
   type AspectRatio,
@@ -177,6 +185,14 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   const isProcessing = sequence?.status === 'processing';
   const { data: style } = useStyle(sequence?.styleId ?? '');
   const styleCategory = style?.category ?? undefined;
+  const sequenceMotionModel = safeImageToVideoModel(
+    sequence?.videoModel,
+    DEFAULT_VIDEO_MODEL
+  );
+  const sequenceMusicModel = safeAudioModel(
+    sequence?.musicModel,
+    DEFAULT_MUSIC_MODEL
+  );
 
   // Phase config from DB — set in stone when the workflow was triggered
   const phaseConfig = useMemo<GenerationPhaseConfig>(
@@ -492,7 +508,11 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
 
   // Handler for batch motion generation (server determines eligible frames)
   const handleBatchMotionGeneration = useCallback(
-    async (includeMusic: boolean) => {
+    async ({
+      includeMusic,
+      motionModel,
+      musicModel,
+    }: BatchGenerateMotionArgs) => {
       // Optimistic: compute eligible frames locally (same filter as backend)
       const eligibleFrameIds = (frames ?? [])
         .filter(
@@ -526,11 +546,18 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         sequence_id: sequenceId,
         include_music: includeMusic,
         eligible_frame_count: eligibleFrameIds.length,
+        motion_model: motionModel,
+        music_model: includeMusic ? musicModel : undefined,
       });
 
       try {
         await batchGenerateMotionFn({
-          data: { sequenceId, includeMusic },
+          data: {
+            sequenceId,
+            includeMusic,
+            model: motionModel,
+            musicModel: includeMusic ? musicModel : undefined,
+          },
         });
       } catch (error) {
         setRegeneratingMotion((prev) =>
@@ -636,6 +663,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             }
             divergentVariants={divergentVariants}
             onCompareDivergent={(variant) => setCompareVariant(variant)}
+            initialMotionModel={sequenceMotionModel}
+            initialMusicModel={sequenceMusicModel}
+            styleCategory={styleCategory}
           />
         </div>
 
@@ -653,6 +683,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             hideBatchButton={
               phaseConfig.autoGenerateMotion && isGenerationActive
             }
+            initialMotionModel={sequenceMotionModel}
+            initialMusicModel={sequenceMusicModel}
+            styleCategory={styleCategory}
           />
         </div>
 

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -7,7 +7,11 @@ import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 
-import { DEFAULT_VIDEO_MODEL, safeImageToVideoModel } from '@/lib/ai/models';
+import {
+  AUDIO_MODELS,
+  DEFAULT_VIDEO_MODEL,
+  safeImageToVideoModel,
+} from '@/lib/ai/models';
 import { estimateVideoCost } from '@/lib/billing/cost-estimation';
 import { multiplyMicros, usdToMicros } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
@@ -115,6 +119,12 @@ const batchGenerateMotionInputSchema = z.object({
   sequenceId: ulidSchema,
   includeMusic: z.boolean().optional(),
   model: generateMotionSchema.shape.model,
+  musicModel: z
+    .enum(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Required for z.enum with dynamic keys
+      Object.keys(AUDIO_MODELS) as [keyof typeof AUDIO_MODELS]
+    )
+    .optional(),
   duration: generateMotionSchema.shape.duration,
   fps: generateMotionSchema.shape.fps,
   motionBucket: generateMotionSchema.shape.motionBucket,
@@ -174,6 +184,7 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
         prompt: sequence.musicPrompt,
         tags: sequence.musicTags,
         duration: totalDuration || 30,
+        model: data.musicModel,
       };
     }
 

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -166,6 +166,21 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
     const includeMusic =
       (data.includeMusic ?? false) && sequence.musicStatus !== 'generating';
 
+    // Persist the batch model picks so the sequence header chip, future batch
+    // sessions, and storyboard regen reflect what the user just chose.
+    const videoModelChanged = data.model && data.model !== sequence.videoModel;
+    const musicModelChanged =
+      includeMusic &&
+      data.musicModel &&
+      data.musicModel !== sequence.musicModel;
+    if (videoModelChanged || musicModelChanged) {
+      await context.scopedDb.sequences.update({
+        id: sequence.id,
+        ...(videoModelChanged ? { videoModel: data.model } : {}),
+        ...(musicModelChanged ? { musicModel: data.musicModel } : {}),
+      });
+    }
+
     // Build music config if requested
     let musicConfig: BatchMotionMusicWorkflowInput['music'];
     if (includeMusic) {

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -124,6 +124,17 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
 
     return Promise.all(
       analysisModels.map(async (modelId) => {
+        // Only persist video/music model choices when the user actually opts
+        // into auto-generation. Otherwise the sequence ends up with a "ghost"
+        // model preference the user never picked, which surfaces stale values
+        // in the header chip and batch footer. Tracked in #714.
+        const persistedMusicModel =
+          autoGenerateMusic && musicModel && isValidAudioModel(musicModel)
+            ? musicModel
+            : autoGenerateMusic
+              ? DEFAULT_MUSIC_MODEL
+              : undefined;
+
         const sequence = await context.scopedDb.sequences.create({
           title: data.title || 'Untitled Sequence',
           script: data.script,
@@ -132,11 +143,8 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
           analysisModel:
             getAnalysisModelById(modelId)?.id || DEFAULT_ANALYSIS_MODEL,
           imageModel: primaryImageModel,
-          videoModel,
-          musicModel:
-            musicModel && isValidAudioModel(musicModel)
-              ? musicModel
-              : DEFAULT_MUSIC_MODEL,
+          videoModel: autoGenerateMotion ? videoModel : undefined,
+          musicModel: persistedMusicModel,
           autoGenerateMotion,
           autoGenerateMusic,
           suggestedTalentIds: suggestedTalentIds?.length

--- a/src/lib/db/scoped/sequences.ts
+++ b/src/lib/db/scoped/sequences.ts
@@ -158,6 +158,7 @@ export function createSequencesMethods(
       aspectRatio?: AspectRatio;
       imageModel?: string;
       videoModel?: string;
+      musicModel?: string;
       musicStatus?: MusicStatus;
       musicError?: string | null;
       musicUrl?: string;


### PR DESCRIPTION
## Related Issue
Closes #686

> Stacked on `685-regenerate-prompts`. Merge the parent PR first; GitHub will auto-retarget this one.

## Summary
Added motion + music model selectors to the batch-generate footer (desktop and mobile) and plumbed both models through to batchGenerateMotionFn.

## Notes
Opened by the agent-harness overnight runner. See the `harness-active` label.
