### PR TITLE
Turn off music and sfx / dialogue #687

### DIFF
--- a/src/components/music/music-view.tsx
+++ b/src/components/music/music-view.tsx
@@ -2,6 +2,7 @@ import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { PromptHistorySheet } from '@/components/prompts/prompt-history-sheet';
 import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -31,12 +32,17 @@ type GenerateMusicArgs = {
   duration?: number;
 };
 
+type MergeVideoAndMusicArgs = {
+  /** When `false`, restitch frame videos but skip the music mux. */
+  includeMusic: boolean;
+};
+
 type MusicViewProps = {
   sequence: Sequence;
   videoDuration?: number;
   onGenerateMusic: (args?: GenerateMusicArgs) => void;
   isGeneratingMusic: boolean;
-  onMergeVideoAndMusic: () => void;
+  onMergeVideoAndMusic: (args: MergeVideoAndMusicArgs) => void;
   isMergingVideoAndMusic: boolean;
   /** Banner rendered above the audio player while `musicStatus === 'completed'`. */
   divergentBanner?: React.ReactNode;
@@ -160,6 +166,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
     () => videoDuration
   );
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [includeMusicInMerge, setIncludeMusicInMerge] = useState(true);
 
   // Resync the textarea when the source-of-truth musicPrompt changes from
   // outside (regenerate, restore, realtime update). Without this, a successful
@@ -254,6 +261,21 @@ export const MusicView: React.FC<MusicViewProps> = ({
         <ReadOnlyField label="Prompt" value={musicPrompt ?? 'Missing prompt'} />
         <ReadOnlyField label="Tags" value={musicTags ?? 'Missing tags'} />
 
+        <label
+          htmlFor="merge-include-music"
+          className="flex items-center gap-2 self-center text-sm text-muted-foreground"
+        >
+          <Checkbox
+            id="merge-include-music"
+            checked={includeMusicInMerge}
+            onCheckedChange={(checked) =>
+              setIncludeMusicInMerge(checked === true)
+            }
+            disabled={isMerging}
+          />
+          <span>Include music in merged video</span>
+        </label>
+
         <div className="flex justify-center gap-3">
           {historyButton}
           <LoadingButton
@@ -265,7 +287,9 @@ export const MusicView: React.FC<MusicViewProps> = ({
             Regenerate Music
           </LoadingButton>
           <LoadingButton
-            onClick={onMergeVideoAndMusic}
+            onClick={() =>
+              onMergeVideoAndMusic({ includeMusic: includeMusicInMerge })
+            }
             isLoading={isMerging}
             loadingText="Merging…"
           >

--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -13,6 +13,7 @@ import {
 import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
+  videoModelSupportsAudio,
   type AudioModel,
   type ImageToVideoModel,
 } from '@/lib/ai/models';
@@ -67,12 +68,15 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(false);
+  const [generateAudio, setGenerateAudio] = useState(true);
   const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
     initialMotionModel ?? DEFAULT_VIDEO_MODEL
   );
   const [musicModel, setMusicModel] = useState<AudioModel>(
     initialMusicModel ?? DEFAULT_MUSIC_MODEL
   );
+
+  const motionSupportsAudio = videoModelSupportsAudio(motionModel);
 
   const prevInitialMotionRef = useRef(initialMotionModel);
   if (
@@ -127,7 +131,12 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
+      await onBatchGenerateMotion({
+        includeMusic,
+        motionModel,
+        musicModel,
+        generateAudio: motionSupportsAudio ? generateAudio : false,
+      });
     } finally {
       setIsGenerating(false);
     }
@@ -287,6 +296,21 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
                   )}
                 </span>
               </label>
+              {motionSupportsAudio && (
+                <label
+                  htmlFor="mobile-batch-generate-audio"
+                  className="flex items-center gap-2 text-sm text-muted-foreground justify-center"
+                >
+                  <Checkbox
+                    id="mobile-batch-generate-audio"
+                    checked={generateAudio}
+                    onCheckedChange={(checked) =>
+                      setGenerateAudio(checked === true)
+                    }
+                  />
+                  <span>Include SFX &amp; dialogue</span>
+                </label>
+              )}
             </SheetFooter>
           )}
         </SheetContent>

--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -152,7 +152,7 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   const hasEligibleFrames = eligibleFrames.length > 0;
   const isMotionInProgress = regeneratingMotion.size > 0;
   const showFooter =
-    !hideBatchButton && (hasEligibleFrames || isMotionInProgress);
+    !hideBatchButton && hasEligibleFrames && !isMotionInProgress;
   const isButtonDisabled =
     isGenerating ||
     isMotionInProgress ||

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
+  videoModelSupportsAudio,
   type AudioModel,
   type ImageToVideoModel,
 } from '@/lib/ai/models';
@@ -19,6 +20,9 @@ export type BatchGenerateMotionArgs = {
   includeMusic: boolean;
   motionModel: ImageToVideoModel;
   musicModel: AudioModel;
+  /** When the motion model emits audio (sfx/dialogue/ambient), allow the
+   *  user to suppress it. Ignored for models without audio output. */
+  generateAudio: boolean;
 };
 
 type SceneListProps = {
@@ -78,12 +82,15 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
+  const [generateAudio, setGenerateAudio] = useState(true);
   const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
     initialMotionModel ?? DEFAULT_VIDEO_MODEL
   );
   const [musicModel, setMusicModel] = useState<AudioModel>(
     initialMusicModel ?? DEFAULT_MUSIC_MODEL
   );
+
+  const motionSupportsAudio = videoModelSupportsAudio(motionModel);
 
   // Sync local selection when the sequence's saved model changes from outside
   // (e.g. after generation completes and the workflow persists the new model).
@@ -133,7 +140,12 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
+      await onBatchGenerateMotion({
+        includeMusic,
+        motionModel,
+        musicModel,
+        generateAudio: motionSupportsAudio ? generateAudio : false,
+      });
     } finally {
       setIsGenerating(false);
     }
@@ -262,6 +274,21 @@ const SceneListComponent: React.FC<SceneListProps> = ({
               )}
             </span>
           </label>
+          {motionSupportsAudio && (
+            <label
+              htmlFor="batch-generate-audio"
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              <Checkbox
+                id="batch-generate-audio"
+                checked={generateAudio}
+                onCheckedChange={(checked) =>
+                  setGenerateAudio(checked === true)
+                }
+              />
+              <span>Include SFX &amp; dialogue</span>
+            </label>
+          )}
         </div>
       )}
     </div>

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -153,7 +153,7 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
   const isMotionInProgress = regeneratingMotion.size > 0 || hasGeneratingFrames;
   const showButton =
-    !hideBatchButton && (notStartedFrames.length > 0 || isMotionInProgress);
+    !hideBatchButton && notStartedFrames.length > 0 && !isMotionInProgress;
   const isButtonDisabled =
     isGenerating ||
     notStartedFrames.length === 0 ||

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -6,6 +6,7 @@ import { DivergentAlternateBanner } from '@/components/staleness/divergent-alter
 import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Select,
   SelectContent,
@@ -42,6 +43,7 @@ import {
   getCompatibleModel,
   safeImageToVideoModel,
   safeTextToImageModel,
+  videoModelSupportsAudio,
   type ImageToVideoModel,
   type TextToImageModel,
 } from '@/lib/ai/models';
@@ -173,6 +175,8 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     setEditPrompts((s) => ({ ...s, motionPrompt: v }));
   const setSelectedMotionModel = (v: ImageToVideoModel | undefined) =>
     setEditPrompts((s) => ({ ...s, motionModel: v }));
+  // SFX/dialogue toggle for audio-capable models (kling v3, veo3, etc.)
+  const [generateAudio, setGenerateAudio] = useState(true);
 
   const handleImageModelChange = useCallback(
     (model: TextToImageModel) => {
@@ -597,6 +601,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       };
     });
 
+    const motionModelForCall = selectedMotionModel || DEFAULT_VIDEO_MODEL;
+    const supportsAudio = videoModelSupportsAudio(motionModelForCall);
+
     try {
       await generateFrameMotionFn({
         data: {
@@ -604,6 +611,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           frameId: frame.id,
           model: selectedMotionModel,
           prompt: editedMotionPrompt || undefined,
+          generateAudio: supportsAudio ? generateAudio : undefined,
         },
       });
 
@@ -632,6 +640,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     frame,
     selectedMotionModel,
     editedMotionPrompt,
+    generateAudio,
     queryClient,
     onRegenerateStart,
     showFalGate,
@@ -1266,6 +1275,26 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               entityType="frame"
               onCompare={() => onCompareDivergent?.(divergentVideoVariant)}
             />
+          )}
+
+          {/* SFX/dialogue toggle — only for audio-capable models */}
+          {videoModelSupportsAudio(
+            selectedMotionModel || DEFAULT_VIDEO_MODEL
+          ) && (
+            <label
+              htmlFor="scene-generate-audio"
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              <Checkbox
+                id="scene-generate-audio"
+                checked={generateAudio}
+                onCheckedChange={(checked) =>
+                  setGenerateAudio(checked === true)
+                }
+                disabled={isGenerating || isGeneratingMotion}
+              />
+              <span>Include SFX &amp; dialogue</span>
+            </label>
           )}
 
           {/* Regenerate button */}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -512,6 +512,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
       includeMusic,
       motionModel,
       musicModel,
+      generateAudio,
     }: BatchGenerateMotionArgs) => {
       // Optimistic: compute eligible frames locally (same filter as backend)
       const eligibleFrameIds = (frames ?? [])
@@ -548,6 +549,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         eligible_frame_count: eligibleFrameIds.length,
         motion_model: motionModel,
         music_model: includeMusic ? musicModel : undefined,
+        generate_audio: generateAudio,
       });
 
       try {
@@ -557,6 +559,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             includeMusic,
             model: motionModel,
             musicModel: includeMusic ? musicModel : undefined,
+            generateAudio,
           },
         });
         // Server may have updated sequence.videoModel / sequence.musicModel to

--- a/src/components/staleness/divergent-alternate-banner.tsx
+++ b/src/components/staleness/divergent-alternate-banner.tsx
@@ -1,10 +1,5 @@
 import { Info } from 'lucide-react';
-import {
-  Alert,
-  AlertAction,
-  AlertDescription,
-  AlertTitle,
-} from '@/components/ui/alert';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import type {
@@ -93,7 +88,7 @@ export const DivergentAlternateBanner: React.FC<
         An alternate {ARTIFACT_LABEL[artifact]} was generated with the inputs
         you had at the time.
       </AlertDescription>
-      <AlertAction className="flex items-center gap-1">
+      <div className="col-start-2 mt-2 flex flex-wrap items-center gap-2">
         <Button type="button" size="sm" variant="outline" onClick={onCompare}>
           Compare
         </Button>
@@ -107,7 +102,7 @@ export const DivergentAlternateBanner: React.FC<
             Discard
           </Button>
         )}
-      </AlertAction>
+      </div>
     </Alert>
   );
 };

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -96,6 +96,7 @@ export const generateFrameMotionFn = createServerFn({ method: 'POST' })
           fps: data.fps,
           motionBucket: data.motionBucket,
           aspectRatio: sequence.aspectRatio,
+          generateAudio: data.generateAudio,
           userEditedPrompt,
         },
       ],
@@ -128,6 +129,7 @@ const batchGenerateMotionInputSchema = z.object({
   duration: generateMotionSchema.shape.duration,
   fps: generateMotionSchema.shape.fps,
   motionBucket: generateMotionSchema.shape.motionBucket,
+  generateAudio: generateMotionSchema.shape.generateAudio,
 });
 
 export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
@@ -227,6 +229,7 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
           fps: data.fps,
           motionBucket: data.motionBucket,
           aspectRatio: sequence.aspectRatio,
+          generateAudio: data.generateAudio,
         };
       }),
       music: musicConfig,

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -477,11 +477,21 @@ export const generateMusicFn = createServerFn({ method: 'POST' })
  */
 export const mergeVideoAndMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
-  .handler(async ({ context }) => {
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        /** When `false`, restitch frame videos without muxing the generated
+         *  music track. Default `true` preserves the legacy behavior. */
+        includeMusic: z.boolean().optional(),
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
     const { sequence, user, teamId } = context;
+    const includeMusic = data.includeMusic !== false;
 
-    if (!sequence.musicUrl) {
+    if (includeMusic && !sequence.musicUrl) {
       throw new Error('Music must be generated before merging');
     }
 
@@ -522,6 +532,7 @@ export const mergeVideoAndMusicFn = createServerFn({ method: 'POST' })
         teamId,
         sequenceId: sequence.id,
         videoUrls,
+        skipAudioMux: !includeMusic,
       } satisfies MergeVideoWorkflowInput,
       { label: buildWorkflowLabel(sequence.id) }
     );

--- a/src/lib/motion/build-model-input.test.ts
+++ b/src/lib/motion/build-model-input.test.ts
@@ -44,6 +44,11 @@ describe('buildModelInput', () => {
       const result = build('kling_v3_pro');
       expect(result.generate_audio).toBe(true);
     });
+
+    it('forwards generate_audio=false when caller suppresses audio', () => {
+      const result = build('kling_v3_pro', { generateAudio: false });
+      expect(result.generate_audio).toBe(false);
+    });
   });
 
   describe('Grok Imagine Video', () => {
@@ -62,6 +67,11 @@ describe('buildModelInput', () => {
     it('sets generate_audio to true from schema default', () => {
       const result = build('veo3_1');
       expect(result.generate_audio).toBe(true);
+    });
+
+    it('forwards generate_audio=false when caller suppresses audio', () => {
+      const result = build('veo3_1', { generateAudio: false });
+      expect(result.generate_audio).toBe(false);
     });
 
     it('uses image_url', () => {

--- a/src/lib/motion/build-model-input.ts
+++ b/src/lib/motion/build-model-input.ts
@@ -46,6 +46,12 @@ export function buildModelInput<T extends ImageToVideoModel>(
     imageUrl: options.imageUrl,
     aspectRatio: options.aspectRatio,
     ...QUALITY_OVERRIDES[modelKey],
+    // Pass-through `generate_audio` for audio-capable models. The schema-driven
+    // transform forwards unknown keys; models without `generate_audio` strip
+    // it during apiSchema.parse.
+    ...(options.generateAudio !== undefined && {
+      generate_audio: options.generateAudio,
+    }),
   }) as ModelOutputMap[T];
 
   const outputPrompt =

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -34,6 +34,7 @@ export const generationMotionOptionsSchema = z.object({
   fps: z.number().optional(),
   motionBucket: z.number().optional(),
   aspectRatio: aspectRatioSchema.optional(),
+  generateAudio: z.boolean().optional(),
 });
 
 export type GenerateMotionOptions = {
@@ -45,6 +46,10 @@ export type GenerateMotionOptions = {
   fps?: number;
   motionBucket?: number;
   aspectRatio?: AspectRatio;
+  /** For audio-capable models (kling v3, veo3), pass `false` to suppress
+   *  the model's native audio output (sfx/ambient/lip-sync). Omitting the
+   *  flag lets the API schema default apply (true for audio-capable models). */
+  generateAudio?: boolean;
 };
 
 import { buildModelInput } from './build-model-input';
@@ -174,10 +179,12 @@ export function calculateMotionMetadata(options: GenerateMotionOptions): {
   const validatedDuration = snapDuration(options.duration, modelKey);
 
   const providerInput = buildModelInput(options, modelConfig, modelKey);
+  const audioEnabled =
+    videoModelSupportsAudio(modelKey) && options.generateAudio !== false;
   const cost = calculateVideoCost({
     endpointId: modelConfig.id,
     durationSeconds: validatedDuration,
-    audioEnabled: videoModelSupportsAudio(modelKey),
+    audioEnabled,
     resolution:
       'resolution' in providerInput &&
       typeof providerInput.resolution === 'string'

--- a/src/lib/schemas/frame.schemas.ts
+++ b/src/lib/schemas/frame.schemas.ts
@@ -85,6 +85,8 @@ export const generateMotionSchema = z.object({
   duration: z.number().min(1).max(10).optional(),
   fps: z.number().min(7).max(30).optional(),
   motionBucket: z.number().min(1).max(255).optional(),
+  /** Toggle sfx/dialogue/ambient audio for audio-capable models. */
+  generateAudio: z.boolean().optional(),
 });
 
 export const generateVariantSchema = z.object({

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -189,6 +189,12 @@ export interface MotionWorkflowInput extends SequenceWorkflowContext {
   motionBucket?: number;
   aspectRatio?: AspectRatio; // "16:9", "9:16", "1:1"
   /**
+   * For audio-capable models (kling v3, veo3), pass `false` to suppress the
+   * model's native audio output (sfx/ambient/lip-sync). Omit to use the API
+   * schema default (true for audio-capable models).
+   */
+  generateAudio?: boolean;
+  /**
    * `true` when `prompt` came from a user edit (typed in the UI). `false` for
    * auto paths (batch generation, smart-retry) where `prompt` was produced by
    * `resolveMotionPrompt` and may include model-specific dialogue/audio
@@ -534,6 +540,12 @@ export interface MergeVideoWorkflowInput extends SequenceWorkflowContext {
   targetFps?: number;
   /** Target resolution (512-2048 per dimension) */
   resolution?: { width: number; height: number };
+  /**
+   * When `true`, skip the chained merge-audio-video workflow even if a music
+   * variant exists. Used by the music tab's "Merge with Video" CTA when the
+   * user has unchecked "Include music".
+   */
+  skipAudioMux?: boolean;
 }
 
 export interface MergeVideoWorkflowResult {
@@ -773,6 +785,8 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
     fps?: number;
     motionBucket?: number;
     aspectRatio?: AspectRatio;
+    /** See `MotionWorkflowInput.generateAudio`. */
+    generateAudio?: boolean;
     /** See `MotionWorkflowInput.userEditedPrompt`. */
     userEditedPrompt?: boolean;
   }>;

--- a/src/lib/workflows/merge-video-workflow.ts
+++ b/src/lib/workflows/merge-video-workflow.ts
@@ -47,6 +47,13 @@ async function chainAudioMux(
   input: MergeVideoWorkflowInput & { sequenceId: string },
   mergedVideoVariantId: string
 ): Promise<void> {
+  if (input.skipAudioMux) {
+    console.log(
+      `[MergeVideoWorkflow] skipAudioMux=true; bypassing audio mux for sequence ${input.sequenceId}`
+    );
+    return;
+  }
+
   const musicVariantId = await context.run(
     'fetch-music-variant-for-mux',
     async () => resolveMusicVariantForMux(scopedDb, input.sequenceId)

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -64,6 +64,7 @@ export const motionBatchWorkflow =
             fps: frame.fps,
             motionBucket: frame.motionBucket,
             aspectRatio: frame.aspectRatio,
+            generateAudio: frame.generateAudio,
             userEditedPrompt: frame.userEditedPrompt,
             // motion-batch invokes merge itself at step 3
             triggerMergeOnComplete: false,

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -91,6 +91,7 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
         fps: input.fps,
         motionBucket: input.motionBucket,
         aspectRatio: input.aspectRatio,
+        generateAudio: input.generateAudio,
       });
 
       // Check if team has enough credits (resolve BYOK status before job submission)
@@ -236,6 +237,7 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
         fps: input.fps,
         motionBucket: input.motionBucket,
         aspectRatio: input.aspectRatio,
+        generateAudio: input.generateAudio,
         scopedDb,
       }).catch((error) => {
         if (

--- a/src/routes/_protected/sequences/$id/music.tsx
+++ b/src/routes/_protected/sequences/$id/music.tsx
@@ -168,14 +168,18 @@ function MusicPage() {
   });
 
   const mergeVideoAndMusic = useMutation({
-    mutationFn: () => mergeVideoAndMusicFn({ data: { sequenceId } }),
-    onMutate: () => {
+    mutationFn: (args: { includeMusic: boolean }) =>
+      mergeVideoAndMusicFn({
+        data: { sequenceId, includeMusic: args.includeMusic },
+      }),
+    onMutate: (args) => {
       queryClient.setQueryData<Sequence>(
         sequenceKeys.detail(sequenceId),
         (old) => (old ? { ...old, mergedVideoStatus: 'merging' as const } : old)
       );
       posthog.capture('merged_video_generation_started', {
         sequence_id: sequenceId,
+        include_music: args.includeMusic,
       });
     },
   });
@@ -241,7 +245,7 @@ function MusicPage() {
           videoDuration={videoDuration}
           onGenerateMusic={(args) => generateMusic.mutate(args)}
           isGeneratingMusic={generateMusic.isPending}
-          onMergeVideoAndMusic={() => mergeVideoAndMusic.mutate()}
+          onMergeVideoAndMusic={(args) => mergeVideoAndMusic.mutate(args)}
           isMergingVideoAndMusic={mergeVideoAndMusic.isPending}
           divergentBanner={divergentBanner}
           isMusicPromptStale={musicPromptStaleness?.musicPrompt === 'stale'}


### PR DESCRIPTION
## Related Issue
Closes #687

## Summary
- **Include SFX & dialogue** checkbox at scene, batch, and mobile-drawer levels for audio-capable models (kling v3, veo3). Default on. Wires through to the model's `generate_audio` field and adjusts cost estimation.
- **Include music in merged video** checkbox in the music tab. Routes the Merge with Video CTA through a new `skipAudioMux` flag so the merge-video workflow bypasses the audio mux when unchecked.
- UX fix: hide the batch-generate sticky footer while a motion job is in progress (was misleading — checkboxes implied they still influenced the run).
- UX fix: render the Compare/Promote/Discard row inline below the divergent-alternate banner text (was tucked into the corner via absolute positioning, hidden in the narrow scenes motion column).

## Test plan
- [ ] Open a sequence with a kling v3 or veo3 frame → "Include SFX & dialogue" appears on scene panel, batch footer, and mobile drawer, default checked
- [ ] Generate a single frame with the box **unchecked** → resulting motion has no audio track, cost estimate reflects the cheaper run
- [ ] Batch generate with mixed audio-capable + non-audio-capable models → checkbox only affects the audio-capable ones
- [ ] With music already generated, uncheck "Include music in merged video" on the Music tab and trigger Merge with Video → resulting mp4 has motion audio only, no music track
- [ ] While a batch motion job is running, the sticky footer is hidden; MotionProgressBanner still visible
- [ ] On a frame with a divergent alternate, Compare/Promote/Discard sits inline below the banner text