### PR TITLE
Replace elements #689

### DIFF
--- a/e2e/fixtures/recorded/openrouter/element-vision/openai-2026-05-15T01-25-41-410Z-0623a6e5.json
+++ b/e2e/fixtures/recorded/openrouter/element-vision/openai-2026-05-15T01-25-41-410Z-0623a6e5.json
@@ -2,13 +2,13 @@
   "fixtures": [
     {
       "match": {
-        "userMessage": "Element token: BROADCAST_MIC\nUploaded filename: broadcast-mic.jpg\n\nDescribe the element in the image below.",
+        "userMessage": "Uploaded filename (hint only — may be meaningless): broadcast-mic.jpg\n\nDescribe the element in the image below and suggest a token.",
         "model": "anthropic/claude-sonnet-4.6",
         "turnIndex": 0,
         "hasToolResult": false
       },
       "response": {
-        "content": "{\"description\": \"A large-diaphragm condenser studio microphone with a cylindrical champagne/satin-nickel metal body. The upper capsule section features a fine mesh grille with a curved top. The body bears engraved text reading 'PHANTOM classic' and a serial number 'Nr. 1307', along with a circular logo emblem. The microphone is mounted in a silver spider-style shock mount with elastic bands. A circular black pop filter with dual-layer mesh is attached via a gooseneck arm to the same stand. The overall finish is matte champagne silver with black hardware accents.\", \"consistencyTag\": \"champagne-condenser-studio-microphone\"}"
+        "content": "{\"description\": \"A large-diaphragm condenser studio microphone with a cylindrical champagne/satin-nickel metal body. The upper capsule section features a fine mesh grille with a curved top. The body bears engraved text reading 'PHANTOM classic' and a serial number 'Nr. 1307', along with a circular logo emblem. The microphone is mounted in a silver spider-style shock mount with elastic bands. A circular black pop filter with dual-layer mesh is attached via a gooseneck arm to the same stand. The overall finish is matte champagne silver with black hardware accents.\", \"consistencyTag\": \"champagne-condenser-studio-microphone\", \"suggestedToken\": \"BROADCAST_MIC\"}"
       },
       "metadata": {
         "systemHash": "7547c536"

--- a/e2e/mocks/aimock-server.ts
+++ b/e2e/mocks/aimock-server.ts
@@ -63,7 +63,7 @@ const STAGE_PREFIXES: ReadonlyArray<readonly [string, string]> = [
   ['Generate the visual prompt for the starting frame', 'visual-prompts'],
   ['Generate the motion prompt for this scene', 'motion-prompts'],
   ['Classify music design for each scene', 'music-design'],
-  ['Element token:', 'element-vision'],
+  ['Uploaded filename (hint only', 'element-vision'],
 ];
 
 // Diagnostic dump for unmatched requests — written on shutdown so we can diff

--- a/src/components/element/element-card.tsx
+++ b/src/components/element/element-card.tsx
@@ -1,77 +1,41 @@
 import { Button } from '@/components/ui/button';
 import {
   useDeleteSequenceElement,
-  useRenameSequenceElementToken,
   useReplaceElementProgress,
-  useReplaceSequenceElement,
 } from '@/hooks/use-sequence-elements';
 import type { SequenceElement } from '@/lib/db/schema';
-import { Loader2, RefreshCw, Trash2 } from 'lucide-react';
-import { useRef, useState } from 'react';
-import { toast } from 'sonner';
-import { ReplaceElementConfirmDialog } from './replace-element-confirm-dialog';
+import { Loader2, Pencil, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { RenameElementDialog } from './rename-element-dialog';
+import { ReplaceElementPopover } from './replace-element-popover';
 
 type ElementCardProps = {
   element: SequenceElement;
   sequenceId: string;
   affectedFrameCount: number;
+  affectedVideoCount: number;
 };
 
 export const ElementCard: React.FC<ElementCardProps> = ({
   element,
   sequenceId,
   affectedFrameCount,
+  affectedVideoCount,
 }) => {
   const deleteMutation = useDeleteSequenceElement();
-  const renameMutation = useRenameSequenceElementToken();
-  const replaceMutation = useReplaceSequenceElement();
   const { editing: editingFrames } = useReplaceElementProgress(
     sequenceId,
     element.id,
     element.token
   );
 
-  const fileInputRef = useRef<HTMLInputElement>(null);
-  const [pendingFile, setPendingFile] = useState<File | null>(null);
-  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [renameOpen, setRenameOpen] = useState(false);
 
-  const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    // Reset the input so re-selecting the same file fires onChange.
-    e.target.value = '';
-    if (!file) return;
-    setPendingFile(file);
-    setConfirmOpen(true);
-  };
-
-  const handleConfirm = () => {
-    if (!pendingFile) return;
-    replaceMutation.mutate(
-      { file: pendingFile, sequenceId, elementId: element.id },
-      {
-        onSuccess: (result) => {
-          setConfirmOpen(false);
-          setPendingFile(null);
-          const count = result.affectedFrameIds.length;
-          toast.info(
-            count > 0
-              ? `Replacing ${element.token} — editing ${count} frame${count === 1 ? '' : 's'}…`
-              : `Replaced ${element.token}`
-          );
-        },
-        onError: (err) => {
-          toast.error('Failed to replace element', {
-            description: err instanceof Error ? err.message : 'Unknown error',
-          });
-        },
-      }
-    );
-  };
-
-  const isReplacing =
-    replaceMutation.isPending ||
-    editingFrames ||
-    element.visionStatus === 'analyzing';
+  const isAnalyzing =
+    element.visionStatus === 'pending' || element.visionStatus === 'analyzing';
+  const isReplacing = editingFrames || isAnalyzing;
+  const visionDone = element.visionStatus === 'completed';
+  const visionFailed = element.visionStatus === 'failed';
 
   return (
     <>
@@ -81,7 +45,7 @@ export const ElementCard: React.FC<ElementCardProps> = ({
             <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/70 backdrop-blur-sm">
               <Loader2 className="size-6 animate-spin text-muted-foreground" />
               <p className="text-xs text-muted-foreground">
-                {replaceMutation.isPending ? 'Uploading…' : 'Editing frames…'}
+                {isAnalyzing ? 'Analyzing…' : 'Editing frames…'}
               </p>
             </div>
           ) : null}
@@ -92,32 +56,48 @@ export const ElementCard: React.FC<ElementCardProps> = ({
           />
         </div>
         <div className="flex items-center justify-between gap-2">
-          <input
-            type="text"
-            defaultValue={element.token}
-            className="flex-1 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
-            onBlur={(e) => {
-              const next = e.currentTarget.value.trim();
-              if (next && next.toUpperCase() !== element.token) {
-                renameMutation.mutate({
-                  elementId: element.id,
-                  sequenceId,
-                  token: next,
-                });
-              }
-            }}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
+          <div className="flex flex-1 items-center gap-2 min-w-0">
+            {visionDone ? (
+              <>
+                <span
+                  className="flex-1 truncate rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
+                  title={element.token}
+                >
+                  {element.token}
+                </span>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  disabled={isReplacing}
+                  aria-label={`Rename ${element.token}`}
+                  title="Rename"
+                  onClick={() => setRenameOpen(true)}
+                >
+                  <Pencil className="size-4" />
+                </Button>
+              </>
+            ) : (
+              <span className="flex-1 inline-flex items-center gap-2 rounded-md border border-input bg-muted px-2 py-1 text-sm text-muted-foreground italic">
+                {isAnalyzing ? (
+                  <>
+                    <Loader2 className="size-3 animate-spin" />
+                    Naming…
+                  </>
+                ) : (
+                  'Unnamed'
+                )}
+              </span>
+            )}
+          </div>
+          <ReplaceElementPopover
+            sequenceId={sequenceId}
+            elementId={element.id}
+            token={element.token}
+            affectedFrameCount={affectedFrameCount}
+            affectedVideoCount={affectedVideoCount}
             disabled={isReplacing}
-            aria-label={`Replace ${element.token} image`}
-            title="Replace image"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            <RefreshCw className="size-4" />
-          </Button>
+          />
           <Button
             type="button"
             variant="ghost"
@@ -135,13 +115,12 @@ export const ElementCard: React.FC<ElementCardProps> = ({
           </Button>
         </div>
         <div className="text-xs text-muted-foreground">
-          {element.visionStatus === 'pending' ||
-          element.visionStatus === 'analyzing' ? (
+          {isAnalyzing ? (
             <span className="inline-flex items-center gap-1">
               <Loader2 className="size-3 animate-spin" />
               Analyzing image…
             </span>
-          ) : element.visionStatus === 'failed' ? (
+          ) : visionFailed ? (
             <span className="text-destructive">
               Vision failed: {element.visionError ?? 'unknown error'}
             </span>
@@ -153,32 +132,23 @@ export const ElementCard: React.FC<ElementCardProps> = ({
           <p className="text-xs text-muted-foreground/70">
             Used in {affectedFrameCount} frame
             {affectedFrameCount === 1 ? '' : 's'}
+            {affectedVideoCount > 0
+              ? ` (${affectedVideoCount} with video)`
+              : ''}
           </p>
         ) : null}
       </div>
 
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={handleFileSelected}
-      />
-
-      {pendingFile ? (
-        <ReplaceElementConfirmDialog
-          open={confirmOpen}
-          onOpenChange={(next) => {
-            setConfirmOpen(next);
-            if (!next) setPendingFile(null);
-          }}
-          onConfirm={handleConfirm}
-          token={element.token}
-          newFilename={pendingFile.name}
+      {visionDone && (
+        <RenameElementDialog
+          open={renameOpen}
+          onOpenChange={setRenameOpen}
+          sequenceId={sequenceId}
+          elementId={element.id}
+          currentToken={element.token}
           affectedFrameCount={affectedFrameCount}
-          isLoading={replaceMutation.isPending}
         />
-      ) : null}
+      )}
     </>
   );
 };

--- a/src/components/element/element-card.tsx
+++ b/src/components/element/element-card.tsx
@@ -2,6 +2,7 @@ import { Button } from '@/components/ui/button';
 import {
   useDeleteSequenceElement,
   useRenameSequenceElementToken,
+  useReplaceElementProgress,
   useReplaceSequenceElement,
 } from '@/hooks/use-sequence-elements';
 import type { SequenceElement } from '@/lib/db/schema';
@@ -24,6 +25,11 @@ export const ElementCard: React.FC<ElementCardProps> = ({
   const deleteMutation = useDeleteSequenceElement();
   const renameMutation = useRenameSequenceElementToken();
   const replaceMutation = useReplaceSequenceElement();
+  const { editing: editingFrames } = useReplaceElementProgress(
+    sequenceId,
+    element.id,
+    element.token
+  );
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -47,9 +53,9 @@ export const ElementCard: React.FC<ElementCardProps> = ({
           setConfirmOpen(false);
           setPendingFile(null);
           const count = result.affectedFrameIds.length;
-          toast.success(
+          toast.info(
             count > 0
-              ? `Replaced ${element.token} — editing ${count} frame${count === 1 ? '' : 's'}…`
+              ? `Replacing ${element.token} — editing ${count} frame${count === 1 ? '' : 's'}…`
               : `Replaced ${element.token}`
           );
         },
@@ -63,7 +69,9 @@ export const ElementCard: React.FC<ElementCardProps> = ({
   };
 
   const isReplacing =
-    replaceMutation.isPending || element.visionStatus === 'analyzing';
+    replaceMutation.isPending ||
+    editingFrames ||
+    element.visionStatus === 'analyzing';
 
   return (
     <>

--- a/src/components/element/element-card.tsx
+++ b/src/components/element/element-card.tsx
@@ -1,0 +1,175 @@
+import { Button } from '@/components/ui/button';
+import {
+  useDeleteSequenceElement,
+  useFrameIdsForElement,
+  useRenameSequenceElementToken,
+  useReplaceSequenceElement,
+} from '@/hooks/use-sequence-elements';
+import type { SequenceElement } from '@/lib/db/schema';
+import { Loader2, RefreshCw, Trash2 } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { ReplaceElementConfirmDialog } from './replace-element-confirm-dialog';
+
+type ElementCardProps = {
+  element: SequenceElement;
+  sequenceId: string;
+};
+
+export const ElementCard: React.FC<ElementCardProps> = ({
+  element,
+  sequenceId,
+}) => {
+  const deleteMutation = useDeleteSequenceElement();
+  const renameMutation = useRenameSequenceElementToken();
+  const replaceMutation = useReplaceSequenceElement();
+  const { data: frameData } = useFrameIdsForElement(sequenceId, element.id);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const handleFileSelected = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset the input so re-selecting the same file fires onChange.
+    e.target.value = '';
+    if (!file) return;
+    setPendingFile(file);
+    setConfirmOpen(true);
+  };
+
+  const handleConfirm = () => {
+    if (!pendingFile) return;
+    replaceMutation.mutate(
+      { file: pendingFile, sequenceId, elementId: element.id },
+      {
+        onSuccess: (result) => {
+          setConfirmOpen(false);
+          setPendingFile(null);
+          const count = result.affectedFrameIds.length;
+          toast.success(
+            count > 0
+              ? `Replaced ${element.token} — editing ${count} frame${count === 1 ? '' : 's'}…`
+              : `Replaced ${element.token}`
+          );
+        },
+        onError: (err) => {
+          toast.error('Failed to replace element', {
+            description: err instanceof Error ? err.message : 'Unknown error',
+          });
+        },
+      }
+    );
+  };
+
+  const isReplacing =
+    replaceMutation.isPending || element.visionStatus === 'analyzing';
+
+  return (
+    <>
+      <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3">
+        <div className="relative aspect-video overflow-hidden rounded-md bg-muted">
+          {isReplacing ? (
+            <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-background/70 backdrop-blur-sm">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+              <p className="text-xs text-muted-foreground">
+                {replaceMutation.isPending ? 'Uploading…' : 'Editing frames…'}
+              </p>
+            </div>
+          ) : null}
+          <img
+            src={element.imageUrl}
+            alt={element.uploadedFilename}
+            className="size-full object-contain"
+          />
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <input
+            type="text"
+            defaultValue={element.token}
+            className="flex-1 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
+            onBlur={(e) => {
+              const next = e.currentTarget.value.trim();
+              if (next && next.toUpperCase() !== element.token) {
+                renameMutation.mutate({
+                  elementId: element.id,
+                  sequenceId,
+                  token: next,
+                });
+              }
+            }}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled={isReplacing}
+            aria-label={`Replace ${element.token} image`}
+            title="Replace image"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <RefreshCw className="size-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            disabled={deleteMutation.isPending || isReplacing}
+            aria-label={`Delete ${element.token}`}
+            onClick={() =>
+              deleteMutation.mutate({
+                elementId: element.id,
+                sequenceId,
+              })
+            }
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {element.visionStatus === 'pending' ||
+          element.visionStatus === 'analyzing' ? (
+            <span className="inline-flex items-center gap-1">
+              <Loader2 className="size-3 animate-spin" />
+              Analyzing image…
+            </span>
+          ) : element.visionStatus === 'failed' ? (
+            <span className="text-destructive">
+              Vision failed: {element.visionError ?? 'unknown error'}
+            </span>
+          ) : (
+            <span>{element.description ?? 'No description'}</span>
+          )}
+        </div>
+        {frameData && frameData.count > 0 ? (
+          <p className="text-xs text-muted-foreground/70">
+            Used in {frameData.count} frame{frameData.count === 1 ? '' : 's'}
+          </p>
+        ) : null}
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileSelected}
+      />
+
+      {pendingFile ? (
+        <ReplaceElementConfirmDialog
+          open={confirmOpen}
+          onOpenChange={(next) => {
+            setConfirmOpen(next);
+            if (!next) setPendingFile(null);
+          }}
+          onConfirm={handleConfirm}
+          token={element.token}
+          newFilename={pendingFile.name}
+          affectedFrameCount={frameData?.count ?? 0}
+          isLoading={replaceMutation.isPending}
+        />
+      ) : null}
+    </>
+  );
+};

--- a/src/components/element/element-card.tsx
+++ b/src/components/element/element-card.tsx
@@ -1,7 +1,6 @@
 import { Button } from '@/components/ui/button';
 import {
   useDeleteSequenceElement,
-  useFrameIdsForElement,
   useRenameSequenceElementToken,
   useReplaceSequenceElement,
 } from '@/hooks/use-sequence-elements';
@@ -14,16 +13,17 @@ import { ReplaceElementConfirmDialog } from './replace-element-confirm-dialog';
 type ElementCardProps = {
   element: SequenceElement;
   sequenceId: string;
+  affectedFrameCount: number;
 };
 
 export const ElementCard: React.FC<ElementCardProps> = ({
   element,
   sequenceId,
+  affectedFrameCount,
 }) => {
   const deleteMutation = useDeleteSequenceElement();
   const renameMutation = useRenameSequenceElementToken();
   const replaceMutation = useReplaceSequenceElement();
-  const { data: frameData } = useFrameIdsForElement(sequenceId, element.id);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -141,9 +141,10 @@ export const ElementCard: React.FC<ElementCardProps> = ({
             <span>{element.description ?? 'No description'}</span>
           )}
         </div>
-        {frameData && frameData.count > 0 ? (
+        {affectedFrameCount > 0 ? (
           <p className="text-xs text-muted-foreground/70">
-            Used in {frameData.count} frame{frameData.count === 1 ? '' : 's'}
+            Used in {affectedFrameCount} frame
+            {affectedFrameCount === 1 ? '' : 's'}
           </p>
         ) : null}
       </div>
@@ -166,7 +167,7 @@ export const ElementCard: React.FC<ElementCardProps> = ({
           onConfirm={handleConfirm}
           token={element.token}
           newFilename={pendingFile.name}
-          affectedFrameCount={frameData?.count ?? 0}
+          affectedFrameCount={affectedFrameCount}
           isLoading={replaceMutation.isPending}
         />
       ) : null}

--- a/src/components/element/element-selector.tsx
+++ b/src/components/element/element-selector.tsx
@@ -542,7 +542,7 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
                           {item.errorMessage ?? 'Failed'}
                         </div>
                       )}
-                      {item.token && (
+                      {item.status === 'done' && item.token && (
                         <div className="absolute bottom-0 left-0 right-0 bg-background/90 px-1.5 py-0.5 text-[10px] font-mono truncate">
                           {item.token}
                         </div>

--- a/src/components/element/elements-view.tsx
+++ b/src/components/element/elements-view.tsx
@@ -113,7 +113,8 @@ export const ElementsView: React.FC<ElementsViewProps> = ({ sequenceId }) => {
               key={el.id}
               element={el}
               sequenceId={sequenceId}
-              affectedFrameCount={frameCounts?.[el.id] ?? 0}
+              affectedFrameCount={frameCounts?.[el.id]?.frameCount ?? 0}
+              affectedVideoCount={frameCounts?.[el.id]?.videoCount ?? 0}
             />
           ))}
         </div>

--- a/src/components/element/elements-view.tsx
+++ b/src/components/element/elements-view.tsx
@@ -11,14 +11,13 @@ import {
   type FileUploadProps,
 } from '@/components/ui/file-upload';
 import {
-  useDeleteSequenceElement,
-  useRenameSequenceElementToken,
   useSequenceElements,
   useUploadElementToSequence,
 } from '@/hooks/use-sequence-elements';
 import { getFileKey } from '@/lib/utils/upload';
-import { Loader2, Trash2, Upload, X } from 'lucide-react';
+import { Upload, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { ElementCard } from './element-card';
 
 type ElementsViewProps = {
   sequenceId: string;
@@ -27,8 +26,6 @@ type ElementsViewProps = {
 export const ElementsView: React.FC<ElementsViewProps> = ({ sequenceId }) => {
   const { data: elements = [] } = useSequenceElements(sequenceId);
   const uploadMutation = useUploadElementToSequence();
-  const deleteMutation = useDeleteSequenceElement();
-  const renameMutation = useRenameSequenceElementToken();
   const [files, setFiles] = useState<File[]>([]);
 
   const onUpload: NonNullable<FileUploadProps['onUpload']> = useCallback(
@@ -110,64 +107,7 @@ export const ElementsView: React.FC<ElementsViewProps> = ({ sequenceId }) => {
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
           {elements.map((el) => (
-            <div
-              key={el.id}
-              className="flex flex-col gap-3 rounded-lg border border-border bg-card p-3"
-            >
-              <div className="relative aspect-video overflow-hidden rounded-md bg-muted">
-                <img
-                  src={el.imageUrl}
-                  alt={el.uploadedFilename}
-                  className="size-full object-contain"
-                />
-              </div>
-              <div className="flex items-center justify-between gap-2">
-                <input
-                  type="text"
-                  defaultValue={el.token}
-                  className="flex-1 rounded-md border border-input bg-background px-2 py-1 font-mono text-sm"
-                  onBlur={(e) => {
-                    const next = e.currentTarget.value.trim();
-                    if (next && next.toUpperCase() !== el.token) {
-                      renameMutation.mutate({
-                        elementId: el.id,
-                        sequenceId,
-                        token: next,
-                      });
-                    }
-                  }}
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  disabled={deleteMutation.isPending}
-                  onClick={() =>
-                    deleteMutation.mutate({
-                      elementId: el.id,
-                      sequenceId,
-                    })
-                  }
-                >
-                  <Trash2 className="size-4" />
-                </Button>
-              </div>
-              <div className="text-xs text-muted-foreground">
-                {el.visionStatus === 'pending' ||
-                el.visionStatus === 'analyzing' ? (
-                  <span className="inline-flex items-center gap-1">
-                    <Loader2 className="size-3 animate-spin" />
-                    Analyzing image…
-                  </span>
-                ) : el.visionStatus === 'failed' ? (
-                  <span className="text-destructive">
-                    Vision failed: {el.visionError ?? 'unknown error'}
-                  </span>
-                ) : (
-                  <span>{el.description ?? 'No description'}</span>
-                )}
-              </div>
-            </div>
+            <ElementCard key={el.id} element={el} sequenceId={sequenceId} />
           ))}
         </div>
       )}

--- a/src/components/element/elements-view.tsx
+++ b/src/components/element/elements-view.tsx
@@ -11,6 +11,7 @@ import {
   type FileUploadProps,
 } from '@/components/ui/file-upload';
 import {
+  useFrameCountsForAllElements,
   useSequenceElements,
   useUploadElementToSequence,
 } from '@/hooks/use-sequence-elements';
@@ -25,6 +26,7 @@ type ElementsViewProps = {
 
 export const ElementsView: React.FC<ElementsViewProps> = ({ sequenceId }) => {
   const { data: elements = [] } = useSequenceElements(sequenceId);
+  const { data: frameCounts } = useFrameCountsForAllElements(sequenceId);
   const uploadMutation = useUploadElementToSequence();
   const [files, setFiles] = useState<File[]>([]);
 
@@ -107,7 +109,12 @@ export const ElementsView: React.FC<ElementsViewProps> = ({ sequenceId }) => {
       ) : (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
           {elements.map((el) => (
-            <ElementCard key={el.id} element={el} sequenceId={sequenceId} />
+            <ElementCard
+              key={el.id}
+              element={el}
+              sequenceId={sequenceId}
+              affectedFrameCount={frameCounts?.[el.id] ?? 0}
+            />
           ))}
         </div>
       )}

--- a/src/components/element/rename-element-dialog.tsx
+++ b/src/components/element/rename-element-dialog.tsx
@@ -1,0 +1,147 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useRenameSequenceElementToken } from '@/hooks/use-sequence-elements';
+import { deriveTokenFromFilename } from '@/lib/sequence-elements/derive-token';
+import { useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+type RenameElementDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sequenceId: string;
+  elementId: string;
+  currentToken: string;
+  affectedFrameCount: number;
+};
+
+export const RenameElementDialog: React.FC<RenameElementDialogProps> = ({
+  open,
+  onOpenChange,
+  sequenceId,
+  elementId,
+  currentToken,
+  affectedFrameCount,
+}) => {
+  const renameMutation = useRenameSequenceElementToken();
+  const [value, setValue] = useState(currentToken);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setValue(currentToken);
+      setError(null);
+      // Focus on open; deferred so the dialog's mount-time focus trap
+      // doesn't immediately steal it back.
+      const t = window.setTimeout(() => {
+        inputRef.current?.select();
+        inputRef.current?.focus();
+      }, 0);
+      return () => window.clearTimeout(t);
+    }
+  }, [open, currentToken]);
+
+  const normalized = deriveTokenFromFilename(value);
+  const isUnchanged = normalized === currentToken;
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (isUnchanged) {
+      onOpenChange(false);
+      return;
+    }
+    setError(null);
+    renameMutation.mutate(
+      { sequenceId, elementId, token: normalized },
+      {
+        onSuccess: (result) => {
+          onOpenChange(false);
+          const updates: string[] = [];
+          if (result.scriptUpdated) updates.push('script');
+          if (result.framesUpdated > 0) {
+            updates.push(
+              `${result.framesUpdated} frame${result.framesUpdated === 1 ? '' : 's'}`
+            );
+          }
+          const suffix =
+            updates.length > 0 ? ` — updated ${updates.join(' + ')}` : '';
+          toast.success(`Renamed to ${normalized}${suffix}`);
+        },
+        onError: (err) => {
+          const message =
+            err instanceof Error ? err.message : 'Failed to rename element';
+          setError(message);
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Rename element</DialogTitle>
+            <DialogDescription>
+              {affectedFrameCount > 0
+                ? `${currentToken} is used in ${affectedFrameCount} frame${
+                    affectedFrameCount === 1 ? '' : 's'
+                  }. Renaming will rewrite every reference in your script and frames.`
+                : 'Renaming will rewrite every reference in your script and frames.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-2 py-4">
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={(e) => {
+                setValue(e.currentTarget.value);
+                if (error) setError(null);
+              }}
+              placeholder="ELEMENT_NAME"
+              className="font-mono"
+              aria-invalid={!!error}
+              aria-describedby={error ? 'rename-error' : 'rename-hint'}
+            />
+            <p id="rename-hint" className="text-xs text-muted-foreground">
+              Saved as <span className="font-mono">{normalized}</span>
+            </p>
+            {error && (
+              <p
+                id="rename-error"
+                className="text-xs text-destructive"
+                role="alert"
+              >
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => onOpenChange(false)}
+              disabled={renameMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={renameMutation.isPending || isUnchanged}
+            >
+              {renameMutation.isPending ? 'Renaming…' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/element/replace-element-confirm-dialog.tsx
+++ b/src/components/element/replace-element-confirm-dialog.tsx
@@ -1,0 +1,78 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Loader2 } from 'lucide-react';
+
+type ReplaceElementConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  token: string;
+  newFilename: string;
+  affectedFrameCount: number;
+  isLoading: boolean;
+};
+
+export const ReplaceElementConfirmDialog: React.FC<
+  ReplaceElementConfirmDialogProps
+> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+  token,
+  newFilename,
+  affectedFrameCount,
+  isLoading,
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Replace {token}?</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="block">
+              The new image{' '}
+              <span className="font-mono text-foreground">{newFilename}</span>{' '}
+              will replace the existing {token} reference.
+            </span>
+            {affectedFrameCount > 0 ? (
+              <span className="mt-2 block">
+                <strong>
+                  {affectedFrameCount} frame
+                  {affectedFrameCount !== 1 ? 's' : ''}
+                </strong>{' '}
+                referencing {token} will be edited to swap the element while
+                keeping the rest of the frame intact.
+              </span>
+            ) : (
+              <span className="mt-2 block">
+                No frames currently reference {token} — only the element image
+                will change.
+              </span>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm} disabled={isLoading}>
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Replacing…
+              </>
+            ) : (
+              'Replace'
+            )}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/element/replace-element-confirm-dialog.tsx
+++ b/src/components/element/replace-element-confirm-dialog.tsx
@@ -37,27 +37,25 @@ export const ReplaceElementConfirmDialog: React.FC<
         <AlertDialogHeader>
           <AlertDialogTitle>Replace {token}?</AlertDialogTitle>
           <AlertDialogDescription>
-            <span className="block">
-              The new image{' '}
-              <span className="font-mono text-foreground">{newFilename}</span>{' '}
-              will replace the existing {token} reference.
-            </span>
-            {affectedFrameCount > 0 ? (
-              <span className="mt-2 block">
-                <strong>
-                  {affectedFrameCount} frame
-                  {affectedFrameCount !== 1 ? 's' : ''}
-                </strong>{' '}
-                referencing {token} will be edited to swap the element while
-                keeping the rest of the frame intact.
-              </span>
-            ) : (
-              <span className="mt-2 block">
-                No frames currently reference {token} — only the element image
-                will change.
-              </span>
-            )}
+            The new image{' '}
+            <span className="font-mono text-foreground">{newFilename}</span>{' '}
+            will replace the existing {token} reference.
           </AlertDialogDescription>
+          {affectedFrameCount > 0 ? (
+            <p className="mt-2 text-sm text-muted-foreground">
+              <strong>
+                {affectedFrameCount} frame
+                {affectedFrameCount !== 1 ? 's' : ''}
+              </strong>{' '}
+              referencing {token} will be edited to swap the element while
+              keeping the rest of the frame intact.
+            </p>
+          ) : (
+            <p className="mt-2 text-sm text-muted-foreground">
+              No frames currently reference {token} — only the element image
+              will change.
+            </p>
+          )}
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>

--- a/src/components/element/replace-element-popover.tsx
+++ b/src/components/element/replace-element-popover.tsx
@@ -1,0 +1,301 @@
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { useReplaceSequenceElement } from '@/hooks/use-sequence-elements';
+import { cn } from '@/lib/utils';
+import {
+  extractImagesFromSnapshot,
+  snapshotDataTransfer,
+  toastDragImportCorsError,
+} from '@/lib/utils/drag-images';
+import { Loader2, RefreshCw, Upload, X } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+type ReplaceElementPopoverProps = {
+  sequenceId: string;
+  elementId: string;
+  token: string;
+  affectedFrameCount: number;
+  affectedVideoCount: number;
+  disabled?: boolean;
+};
+
+/**
+ * Replace one element's image. Two-step flow inside a single popover:
+ *
+ *  1. Dropzone — drag/drop, paste, or browse for a new image. Nothing
+ *     destructive runs yet.
+ *  2. Confirmation — shows the picked file with an explicit "Replace" button
+ *     that spells out the cascade (script, frames, videos) before any upload
+ *     starts. The user can cancel without touching server state.
+ *
+ * The actual upload + replace-element workflow only fires once the user
+ * confirms; the popover stays open and shows an uploading state until the
+ * mutation resolves, then closes.
+ */
+export const ReplaceElementPopover: React.FC<ReplaceElementPopoverProps> = ({
+  sequenceId,
+  elementId,
+  token,
+  affectedFrameCount,
+  affectedVideoCount,
+  disabled = false,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const replaceMutation = useReplaceSequenceElement();
+
+  // Object URL for the picked file. Created on selection, revoked when the
+  // file changes, the popover closes, or the component unmounts — otherwise
+  // each re-pick would leak a blob.
+  useEffect(() => {
+    if (!pendingFile) {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(pendingFile);
+    setPreviewUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [pendingFile]);
+
+  // Reset the staged file whenever the popover closes so a stale pick from a
+  // previous open doesn't reappear when the user comes back.
+  useEffect(() => {
+    if (!open) setPendingFile(null);
+  }, [open]);
+
+  const clearPending = useCallback(() => {
+    setPendingFile(null);
+  }, []);
+
+  const handleFiles = useCallback((files: File[]) => {
+    const image = files.find((f) => f.type.startsWith('image/'));
+    if (!image) return;
+    setPendingFile(image);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    if (!pendingFile) return;
+    replaceMutation.mutate(
+      { file: pendingFile, sequenceId, elementId },
+      {
+        onSuccess: (result) => {
+          setOpen(false);
+          setPendingFile(null);
+          const count = result.affectedFrameIds.length;
+          toast.info(
+            count > 0
+              ? `Replacing ${token} — editing ${count} frame${count === 1 ? '' : 's'}…`
+              : `Replaced ${token}`
+          );
+        },
+        onError: (err) => {
+          toast.error('Failed to replace element', {
+            description: err instanceof Error ? err.message : 'Unknown error',
+          });
+        },
+      }
+    );
+  }, [elementId, pendingFile, replaceMutation, sequenceId, token]);
+
+  const isPending = replaceMutation.isPending;
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        // Block dismiss while the upload + workflow trigger is in-flight so
+        // the user can't navigate away mid-mutation and leave the element
+        // stranded in `analyzing` without UI feedback.
+        if (isPending && !next) return;
+        setOpen(next);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          disabled={disabled}
+          aria-label={`Replace ${token} image`}
+          title="Replace image"
+        >
+          <RefreshCw className="size-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-[360px]">
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <p className="text-sm font-medium">
+              Replace <span className="font-mono">{token}</span>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {pendingFile
+                ? `Confirming will replace ${token} everywhere it's used — your script, ${affectedFrameCount} frame${affectedFrameCount === 1 ? '' : 's'}, and ${affectedVideoCount} video${affectedVideoCount === 1 ? '' : 's'} will be updated.`
+                : `Drop a new image to replace ${token}. You'll get a chance to confirm before anything changes.`}
+            </p>
+          </div>
+
+          {pendingFile && previewUrl ? (
+            <div className="flex flex-col gap-3">
+              <div className="relative aspect-video overflow-hidden rounded-md border bg-muted">
+                <img
+                  src={previewUrl}
+                  alt={pendingFile.name}
+                  className="size-full object-contain"
+                />
+                {!isPending && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="icon"
+                    className="absolute top-1 right-1 size-6"
+                    onClick={clearPending}
+                    aria-label="Choose a different image"
+                  >
+                    <X className="size-3" />
+                  </Button>
+                )}
+              </div>
+              <p
+                className="truncate text-xs text-muted-foreground"
+                title={pendingFile.name}
+              >
+                {pendingFile.name}
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={clearPending}
+                  disabled={isPending}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleConfirm}
+                  disabled={isPending}
+                >
+                  {isPending ? (
+                    <>
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                      Replacing…
+                    </>
+                  ) : (
+                    `Replace ${token}`
+                  )}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div
+              // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- dropzone cannot be a <button> because it contains a nested <Button>
+              role="button"
+              tabIndex={0}
+              onClick={() => inputRef.current?.click()}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  inputRef.current?.click();
+                }
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragEnter={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={(e) => {
+                const related = e.relatedTarget;
+                if (
+                  related instanceof Node &&
+                  e.currentTarget.contains(related)
+                ) {
+                  return;
+                }
+                setDragOver(false);
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                setDragOver(false);
+                const snapshot = snapshotDataTransfer(e.dataTransfer);
+                void extractImagesFromSnapshot(snapshot).then(
+                  ({ files, failedUrls }) => {
+                    if (files.length > 0) {
+                      handleFiles(files);
+                    } else if (failedUrls.length > 0) {
+                      toastDragImportCorsError();
+                    }
+                  }
+                );
+              }}
+              onPaste={(e) => {
+                const items = e.clipboardData.items;
+                const pasted: File[] = [];
+                for (const item of items) {
+                  if (item.kind === 'file') {
+                    const file = item.getAsFile();
+                    if (file) pasted.push(file);
+                  }
+                }
+                if (pasted.length === 0) return;
+                e.preventDefault();
+                handleFiles(pasted);
+              }}
+              className={cn(
+                'relative flex select-none flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-5 min-h-[100px] outline-none transition-colors hover:bg-accent/30 focus-visible:border-ring/50 cursor-pointer',
+                dragOver && 'border-primary/50 bg-accent/30'
+              )}
+            >
+              <Upload className="size-6 text-muted-foreground/50" />
+              <span className="text-sm font-medium">Drag & drop or paste</span>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  inputRef.current?.click();
+                }}
+              >
+                Browse
+              </Button>
+            </div>
+          )}
+
+          {!pendingFile && (
+            <p className="text-[11px] text-muted-foreground">
+              Vision will re-analyze the new image and may rename {token} if a
+              better identifier is visible.
+            </p>
+          )}
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          accept="image/*"
+          className="sr-only"
+          onChange={(e) => {
+            const files = Array.from(e.target.files ?? []);
+            e.target.value = '';
+            handleFiles(files);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/scenes/frame-staleness-banners.tsx
+++ b/src/components/scenes/frame-staleness-banners.tsx
@@ -87,7 +87,11 @@ export const FrameStalenessBanners: React.FC<FrameStalenessBannersProps> = ({
     );
   }
 
-  if (staleness?.thumbnail === 'stale') {
+  // Suppress the thumbnail banner when the visual prompt is also stale: the
+  // visual-prompt banner inside the Image tab is the prerequisite action
+  // (regenerating the image from a stale prompt would just produce another
+  // stale image), and showing both at once is redundant.
+  if (staleness?.thumbnail === 'stale' && staleness.visualPrompt !== 'stale') {
     return (
       <StalenessIndicator
         artifact="thumbnail"

--- a/src/functions/__tests__/sequence-elements.test.ts
+++ b/src/functions/__tests__/sequence-elements.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import { isValidElementStoragePath } from '@/functions/sequence-elements';
+
+describe('isValidElementStoragePath', () => {
+  const teamId = 'teamA';
+
+  it('accepts a well-formed path under the team prefix', () => {
+    expect(isValidElementStoragePath('elements/teamA/file.png', teamId)).toBe(
+      true
+    );
+  });
+
+  it('accepts nested paths under the team prefix', () => {
+    expect(
+      isValidElementStoragePath('elements/teamA/sub/dir/file.png', teamId)
+    ).toBe(true);
+  });
+
+  it('rejects a `..` segment that traverses out of the team namespace', () => {
+    expect(
+      isValidElementStoragePath('elements/teamA/../teamB/file.png', teamId)
+    ).toBe(false);
+  });
+
+  it('rejects empty segments (double slash) that would normalize away', () => {
+    expect(isValidElementStoragePath('elements/teamA//file.png', teamId)).toBe(
+      false
+    );
+  });
+
+  it('rejects an empty rest after the team prefix (path equals the prefix)', () => {
+    expect(isValidElementStoragePath('elements/teamA/', teamId)).toBe(false);
+  });
+
+  it('rejects another team prefix even with a valid-looking suffix', () => {
+    expect(isValidElementStoragePath('elements/teamB/file.png', teamId)).toBe(
+      false
+    );
+  });
+
+  it('rejects a prefix-collision team id (teamAB starts with teamA but is different)', () => {
+    expect(isValidElementStoragePath('elements/teamAB/file.png', teamId)).toBe(
+      false
+    );
+  });
+});

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -27,7 +27,10 @@ import { authWithTeamMiddleware, sequenceAccessMiddleware } from './middleware';
  * practical blast radius is small, but rejecting `..` and `//` segments closes
  * the namespace boundary explicitly.
  */
-function isValidElementStoragePath(path: string, teamId: string): boolean {
+export function isValidElementStoragePath(
+  path: string,
+  teamId: string
+): boolean {
   const prefix = `elements/${teamId}/`;
   if (!path.startsWith(prefix)) return false;
   const rest = path.slice(prefix.length);
@@ -177,15 +180,26 @@ export const finalizeElementUploadFn = createServerFn({ method: 'POST' })
       visionStatus: 'pending',
     });
 
-    // Kick off vision workflow — do not block the upload response.
-    await triggerElementVision(
-      element.id,
-      element.sequenceId,
-      element.imageUrl,
-      element.uploadedFilename,
-      context.teamId,
-      context.user.id
-    );
+    // If the QStash trigger fails, mark the row failed before re-throwing —
+    // otherwise the element would poll forever in `pending`.
+    try {
+      await triggerElementVision(
+        element.id,
+        element.sequenceId,
+        element.imageUrl,
+        element.uploadedFilename,
+        context.teamId,
+        context.user.id
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      await context.scopedDb.sequenceElements.updateVisionStatus(
+        element.id,
+        'failed',
+        message
+      );
+      throw err;
+    }
 
     return element;
   });
@@ -346,10 +360,10 @@ export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
       affectedFrameIds,
     };
 
-    // Workflow emits :start/:complete/:failed exclusively (matches the recast
-    // pattern). If the trigger throws here, the element is stranded in
-    // `analyzing` — recover by marking vision failed and emitting :failed so
-    // any UI subscriber sees a final lifecycle event.
+    // If the trigger throws, the row is stranded in `analyzing` — restore
+    // status and emit :failed so subscribers see a terminal lifecycle event.
+    // Each side effect is isolated so a Turso/Redis blip can't replace the
+    // original `err` with a downstream error the user can't act on.
     let workflowRunId: string;
     try {
       workflowRunId = await triggerWorkflow('/replace-element', workflowInput, {
@@ -357,15 +371,26 @@ export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error';
-      await context.scopedDb.sequenceElements.updateVisionStatus(
-        data.elementId,
-        'failed',
-        message
-      );
-      await getGenerationChannel(context.sequence.id).emit(
-        'generation.replace-element:failed',
-        { elementId: data.elementId, error: message }
-      );
+      try {
+        await context.scopedDb.sequenceElements.updateVisionStatus(
+          data.elementId,
+          'failed',
+          message
+        );
+      } catch (e) {
+        console.error(
+          '[replaceSequenceElementFn] persist failed status threw:',
+          e
+        );
+      }
+      try {
+        await getGenerationChannel(context.sequence.id).emit(
+          'generation.replace-element:failed',
+          { elementId: data.elementId, error: message }
+        );
+      } catch (e) {
+        console.error('[replaceSequenceElementFn] emit :failed threw:', e);
+      }
       throw err;
     }
 

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -1,6 +1,7 @@
 import { getSignedUploadUrl } from '#storage';
 import { describeElementImage } from '@/lib/ai/element-vision';
 import { generateId } from '@/lib/db/id';
+import { getGenerationChannel } from '@/lib/realtime';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { deriveTokenFromFilename } from '@/lib/sequence-elements/derive-token';
 import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
@@ -10,7 +11,10 @@ import {
 } from '@/lib/utils/file';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
-import type { ElementVisionWorkflowInput } from '@/lib/workflow/types';
+import type {
+  ElementVisionWorkflowInput,
+  ReplaceElementWorkflowInput,
+} from '@/lib/workflow/types';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -226,4 +230,108 @@ export const renameSequenceElementTokenFn = createServerFn({ method: 'POST' })
     return await context.scopedDb.sequenceElements.update(data.elementId, {
       token: unique,
     });
+  });
+
+// ============================================================================
+// Frame IDs / Replace
+// ============================================================================
+
+/** Get frame IDs for all frames that reference an element by token */
+export const getFrameIdsForElementFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(z.object({ sequenceId: ulidSchema, elementId: ulidSchema }))
+  )
+  .handler(async ({ context, data }) => {
+    const frameIds =
+      await context.scopedDb.sequenceElements.getFrameIdsForElement(
+        context.sequence.id,
+        data.elementId
+      );
+    return { frameIds, count: frameIds.length };
+  });
+
+/**
+ * Replace an element's image. Persists the new image on the element row,
+ * then triggers the `replace-element` workflow which re-runs vision on the
+ * new image and edits each affected frame to swap the element while keeping
+ * the rest of the frame intact.
+ */
+export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        elementId: ulidSchema,
+        publicUrl: z.string().url(),
+        path: z.string().min(1),
+        filename: z.string().min(1),
+      })
+    )
+  )
+  .handler(async ({ context, data }) => {
+    if (!data.path.startsWith(`elements/${context.teamId}/`)) {
+      throw new Error('Invalid storage path');
+    }
+
+    const element = await context.scopedDb.sequenceElements.getById(
+      data.elementId
+    );
+    if (!element || element.sequenceId !== context.sequence.id) {
+      throw new Error('Element not found');
+    }
+
+    const previousDescription = element.description;
+
+    // Update the element row with the new image. Reset vision so the UI
+    // surfaces "analyzing" while the workflow re-describes the new image.
+    const updated = await context.scopedDb.sequenceElements.update(
+      data.elementId,
+      {
+        imageUrl: data.publicUrl,
+        imagePath: data.path,
+        uploadedFilename: data.filename,
+        description: null,
+        consistencyTag: null,
+        visionStatus: 'analyzing',
+        visionError: null,
+        visionGeneratedAt: null,
+      }
+    );
+
+    const affectedFrameIds =
+      await context.scopedDb.sequenceElements.getFrameIdsForElement(
+        context.sequence.id,
+        data.elementId
+      );
+
+    await getGenerationChannel(context.sequence.id).emit(
+      'generation.replace-element:start',
+      { elementId: data.elementId, frameCount: affectedFrameIds.length }
+    );
+
+    const workflowInput: ReplaceElementWorkflowInput = {
+      userId: context.user.id,
+      teamId: context.teamId,
+      sequenceId: context.sequence.id,
+      elementId: data.elementId,
+      token: updated.token,
+      previousDescription,
+      newImageUrl: data.publicUrl,
+      newFilename: data.filename,
+      affectedFrameIds,
+    };
+
+    const workflowRunId = await triggerWorkflow(
+      '/replace-element',
+      workflowInput,
+      { label: buildWorkflowLabel(context.sequence.id) }
+    );
+
+    return {
+      element: updated,
+      affectedFrameIds,
+      workflowRunId,
+    };
   });

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -124,7 +124,6 @@ export const analyzeDraftElementFn = createServerFn({ method: 'POST' })
       z.object({
         publicUrl: z.string().url(),
         filename: z.string().min(1),
-        token: z.string().min(1).max(100),
       })
     )
   )
@@ -134,12 +133,12 @@ export const analyzeDraftElementFn = createServerFn({ method: 'POST' })
     const result = await describeElementImage({
       imageUrl: data.publicUrl,
       filename: data.filename,
-      token: data.token,
       openRouterApiKey: openRouterApiKeyInfo.key,
     });
     return {
       description: result.description,
       consistencyTag: result.consistencyTag,
+      suggestedToken: result.suggestedToken,
     };
   });
 
@@ -251,13 +250,32 @@ export const renameSequenceElementTokenFn = createServerFn({ method: 'POST' })
     }
 
     const cleaned = deriveTokenFromFilename(data.token);
-    const unique = await context.scopedDb.sequenceElements.ensureUniqueToken(
-      context.sequence.id,
-      cleaned
-    );
+    if (cleaned === element.token) {
+      return {
+        element,
+        framesUpdated: 0,
+        scriptUpdated: false,
+      };
+    }
 
-    return await context.scopedDb.sequenceElements.update(data.elementId, {
-      token: unique,
+    // User-driven rename: hard-reject on collision rather than silently
+    // suffixing — the user explicitly typed this name and expects it.
+    const taken = await context.scopedDb.sequenceElements.isTokenTaken(
+      context.sequence.id,
+      cleaned,
+      element.id
+    );
+    if (taken) {
+      throw new Error(
+        `Another element is already named "${cleaned}". Pick a different name.`
+      );
+    }
+
+    return await context.scopedDb.sequenceElements.cascadeRename({
+      sequenceId: context.sequence.id,
+      elementId: element.id,
+      oldToken: element.token,
+      newToken: cleaned,
     });
   });
 

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -20,6 +20,21 @@ import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 import { authWithTeamMiddleware, sequenceAccessMiddleware } from './middleware';
 
+/**
+ * Sequence-element storage paths must live exactly under
+ * `elements/<teamId>/`. `startsWith` alone accepts traversal artifacts like
+ * `elements/<myTeamId>/../<otherTeamId>/x` — R2 stores keys literally so the
+ * practical blast radius is small, but rejecting `..` and `//` segments closes
+ * the namespace boundary explicitly.
+ */
+function isValidElementStoragePath(path: string, teamId: string): boolean {
+  const prefix = `elements/${teamId}/`;
+  if (!path.startsWith(prefix)) return false;
+  const rest = path.slice(prefix.length);
+  if (rest.length === 0) return false;
+  return !rest.split('/').some((seg) => seg === '' || seg === '..');
+}
+
 async function triggerElementVision(
   elementId: string,
   sequenceId: string,
@@ -142,7 +157,7 @@ export const finalizeElementUploadFn = createServerFn({ method: 'POST' })
     )
   )
   .handler(async ({ context, data }) => {
-    if (!data.path.startsWith(`elements/${context.teamId}/`)) {
+    if (!isValidElementStoragePath(data.path, context.teamId)) {
       throw new Error('Invalid storage path');
     }
 
@@ -252,6 +267,19 @@ export const getFrameIdsForElementFn = createServerFn({ method: 'GET' })
   });
 
 /**
+ * Batched frame counts for every element in the sequence. Use this from the
+ * elements grid to avoid the N+1 where each card fetched its own frame IDs.
+ */
+export const getFrameCountsByElementFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .handler(async ({ context }) => {
+    return await context.scopedDb.sequenceElements.getFrameCountsByElement(
+      context.sequence.id
+    );
+  });
+
+/**
  * Replace an element's image. Persists the new image on the element row,
  * then triggers the `replace-element` workflow which re-runs vision on the
  * new image and edits each affected frame to swap the element while keeping
@@ -271,7 +299,7 @@ export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
     )
   )
   .handler(async ({ context, data }) => {
-    if (!data.path.startsWith(`elements/${context.teamId}/`)) {
+    if (!isValidElementStoragePath(data.path, context.teamId)) {
       throw new Error('Invalid storage path');
     }
 
@@ -306,11 +334,6 @@ export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
         data.elementId
       );
 
-    await getGenerationChannel(context.sequence.id).emit(
-      'generation.replace-element:start',
-      { elementId: data.elementId, frameCount: affectedFrameIds.length }
-    );
-
     const workflowInput: ReplaceElementWorkflowInput = {
       userId: context.user.id,
       teamId: context.teamId,
@@ -323,11 +346,28 @@ export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
       affectedFrameIds,
     };
 
-    const workflowRunId = await triggerWorkflow(
-      '/replace-element',
-      workflowInput,
-      { label: buildWorkflowLabel(context.sequence.id) }
-    );
+    // Workflow emits :start/:complete/:failed exclusively (matches the recast
+    // pattern). If the trigger throws here, the element is stranded in
+    // `analyzing` — recover by marking vision failed and emitting :failed so
+    // any UI subscriber sees a final lifecycle event.
+    let workflowRunId: string;
+    try {
+      workflowRunId = await triggerWorkflow('/replace-element', workflowInput, {
+        label: buildWorkflowLabel(context.sequence.id),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      await context.scopedDb.sequenceElements.updateVisionStatus(
+        data.elementId,
+        'failed',
+        message
+      );
+      await getGenerationChannel(context.sequence.id).emit(
+        'generation.replace-element:failed',
+        { elementId: data.elementId, error: message }
+      );
+      throw err;
+    }
 
     return {
       element: updated,

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -11,8 +11,30 @@ import {
   replaceSequenceElementFn,
 } from '@/functions/sequence-elements';
 import type { SequenceElement } from '@/lib/db/schema';
+import type {
+  ReplaceElementCompletePayload,
+  ReplaceElementFailedPayload,
+  ReplaceElementStartPayload,
+} from '@/lib/realtime';
+import { useRealtime } from '@/lib/realtime/client';
 import { putToR2 } from '@/lib/utils/upload';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+type ReplaceElementEvent =
+  | {
+      event: 'generation.replace-element:start';
+      data: ReplaceElementStartPayload;
+    }
+  | {
+      event: 'generation.replace-element:complete';
+      data: ReplaceElementCompletePayload;
+    }
+  | {
+      event: 'generation.replace-element:failed';
+      data: ReplaceElementFailedPayload;
+    };
 
 export const sequenceElementKeys = {
   all: ['sequence-elements'] as const,
@@ -32,7 +54,6 @@ export function useSequenceElements(sequenceId: string | undefined) {
     queryFn: () =>
       listSequenceElementsFn({ data: { sequenceId: sequenceId ?? '' } }),
     enabled: Boolean(sequenceId),
-    // Poll while vision is still analyzing
     refetchInterval: (query) => {
       const data = query.state.data as SequenceElement[] | undefined;
       if (!data) return false;
@@ -223,6 +244,80 @@ export function useFrameIdsForElement(
 }
 
 /**
+ * Subscribes to `replace-element:start|complete|failed` for one element so
+ * the card can show a spinner across the whole flow (server-fn → :start →
+ * vision → per-frame edits → :complete) and surface a final-state toast.
+ *
+ * Without this hook the card's `isReplacing` clears the moment vision flips
+ * to `completed`, hiding the per-frame edit phase from the user — and any
+ * post-vision failure becomes user-invisible.
+ */
+export function useReplaceElementProgress(
+  sequenceId: string | undefined,
+  elementId: string,
+  token: string
+): { editing: boolean } {
+  const queryClient = useQueryClient();
+  const [editing, setEditing] = useState(false);
+
+  const onData = useCallback(
+    (evt: ReplaceElementEvent) => {
+      if (evt.data.elementId !== elementId) return;
+
+      if (evt.event === 'generation.replace-element:start') {
+        setEditing(true);
+        return;
+      }
+
+      if (evt.event === 'generation.replace-element:complete') {
+        setEditing(false);
+        const { successCount, failedCount } = evt.data;
+        if (failedCount > 0) {
+          toast.warning(
+            `${token}: ${successCount} edited, ${failedCount} failed`
+          );
+        } else if (successCount > 0) {
+          toast.success(
+            `${token}: edited ${successCount} frame${successCount === 1 ? '' : 's'}`
+          );
+        }
+        if (sequenceId) {
+          void queryClient.invalidateQueries({
+            queryKey: sequenceElementKeys.bySequence(sequenceId),
+          });
+        }
+        void queryClient.invalidateQueries({ queryKey: ['frames'] });
+        return;
+      }
+
+      setEditing(false);
+      toast.error(`Replace failed for ${token}`, {
+        description: evt.data.error,
+      });
+      if (sequenceId) {
+        void queryClient.invalidateQueries({
+          queryKey: sequenceElementKeys.bySequence(sequenceId),
+        });
+      }
+    },
+    [elementId, token, sequenceId, queryClient]
+  );
+
+  useRealtime({
+    channels: sequenceId ? [sequenceId] : [],
+    events: [
+      'generation.replace-element:start',
+      'generation.replace-element:complete',
+      'generation.replace-element:failed',
+    ] as const,
+    onData,
+    enabled: Boolean(sequenceId),
+  });
+
+  return { editing };
+}
+
+/**
  * Replace an element image: presign → R2 → finalize.
  * Triggers per-frame image edits via the replace-element workflow.
  */
@@ -269,7 +364,6 @@ export function useReplaceSequenceElement() {
           variables.sequenceId
         ),
       });
-      // Affected frames will be edited; refresh frame views.
       void queryClient.invalidateQueries({ queryKey: ['frames'] });
     },
   });

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -146,21 +146,17 @@ export function useUploadDraftElement() {
         presign.contentType,
         data.onProgress
       );
-      const token = data.file.name
-        .replace(/\.[^.]+$/, '')
-        .toUpperCase()
-        .replace(/[^A-Z0-9]+/g, '_')
-        .replace(/^_+|_+$/g, '');
-      const finalToken = token.length > 0 ? token : 'ELEMENT';
-
       data.onAnalyzingChange?.(true);
-      let result: { description: string; consistencyTag: string };
+      let result: {
+        description: string;
+        consistencyTag: string;
+        suggestedToken: string;
+      };
       try {
         result = await analyzeDraftElementFn({
           data: {
             publicUrl: presign.publicUrl,
             filename: data.file.name,
-            token: finalToken,
           },
         });
       } finally {
@@ -171,7 +167,7 @@ export function useUploadDraftElement() {
         tempPath: presign.path,
         tempPublicUrl: presign.publicUrl,
         filename: data.file.name,
-        token: finalToken,
+        token: result.suggestedToken,
         description: result.description,
         consistencyTag: result.consistencyTag,
       };
@@ -200,10 +196,20 @@ export function useRenameSequenceElementToken() {
       sequenceId: string;
       token: string;
     }) => renameSequenceElementTokenFn({ data }),
-    onSuccess: (_res, variables) => {
+    onSuccess: (result, variables) => {
       void queryClient.invalidateQueries({
         queryKey: sequenceElementKeys.bySequence(variables.sequenceId),
       });
+      // Frames now contain the new token in metadata / prompts. Refresh
+      // anything that renders frame text or counts.
+      if (result.framesUpdated > 0) {
+        void queryClient.invalidateQueries({ queryKey: ['frames'] });
+        void queryClient.invalidateQueries({
+          queryKey: sequenceElementKeys.frameCountsBySequence(
+            variables.sequenceId
+          ),
+        });
+      }
     },
   });
 }
@@ -271,15 +277,38 @@ export function useReplaceElementProgress(
 
       if (evt.event === 'generation.replace-element:complete') {
         setEditing(false);
-        const { successCount, failedCount } = evt.data;
+        const {
+          successCount,
+          failedCount,
+          videoSuccessCount,
+          videoFailedCount,
+          renamedTo,
+        } = evt.data;
+        const displayName = renamedTo ?? token;
+        if (renamedTo && renamedTo !== token) {
+          toast.message(`Renamed ${token} → ${renamedTo}`);
+        }
         if (failedCount > 0) {
           toast.warning(
-            `${token}: ${successCount} edited, ${failedCount} failed`
+            `${displayName}: ${successCount} edited, ${failedCount} failed`
           );
         } else if (successCount > 0) {
           toast.success(
-            `${token}: edited ${successCount} frame${successCount === 1 ? '' : 's'}`
+            `${displayName}: edited ${successCount} frame${successCount === 1 ? '' : 's'}`
           );
+        }
+        const vidSuccess = videoSuccessCount ?? 0;
+        const vidFailed = videoFailedCount ?? 0;
+        if (vidSuccess > 0 || vidFailed > 0) {
+          if (vidFailed > 0) {
+            toast.warning(
+              `${displayName} videos: ${vidSuccess} regenerated, ${vidFailed} failed`
+            );
+          } else {
+            toast.success(
+              `${displayName}: regenerated ${vidSuccess} video${vidSuccess === 1 ? '' : 's'}`
+            );
+          }
         }
         if (sequenceId) {
           void queryClient.invalidateQueries({

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -2,10 +2,12 @@ import {
   analyzeDraftElementFn,
   deleteSequenceElementFn,
   finalizeElementUploadFn,
+  getFrameIdsForElementFn,
   listSequenceElementsFn,
   presignDraftElementUploadFn,
   presignElementUploadFn,
   renameSequenceElementTokenFn,
+  replaceSequenceElementFn,
 } from '@/functions/sequence-elements';
 import type { SequenceElement } from '@/lib/db/schema';
 import { putToR2 } from '@/lib/utils/upload';
@@ -15,6 +17,8 @@ export const sequenceElementKeys = {
   all: ['sequence-elements'] as const,
   bySequence: (sequenceId: string) =>
     ['sequence-elements', sequenceId] as const,
+  framesForElement: (sequenceId: string, elementId: string) =>
+    ['sequence-elements', sequenceId, 'frames', elementId] as const,
 };
 
 export function useSequenceElements(sequenceId: string | undefined) {
@@ -176,6 +180,73 @@ export function useRenameSequenceElementToken() {
       void queryClient.invalidateQueries({
         queryKey: sequenceElementKeys.bySequence(variables.sequenceId),
       });
+    },
+  });
+}
+
+/** Frame count + IDs for frames that reference this element by token */
+export function useFrameIdsForElement(
+  sequenceId: string | undefined,
+  elementId: string | undefined
+) {
+  return useQuery({
+    queryKey:
+      sequenceId && elementId
+        ? sequenceElementKeys.framesForElement(sequenceId, elementId)
+        : ['sequence-elements', 'frames', 'none'],
+    queryFn: () =>
+      getFrameIdsForElementFn({
+        data: { sequenceId: sequenceId ?? '', elementId: elementId ?? '' },
+      }),
+    enabled: Boolean(sequenceId) && Boolean(elementId),
+    staleTime: 60 * 1000,
+  });
+}
+
+/**
+ * Replace an element image: presign → R2 → finalize.
+ * Triggers per-frame image edits via the replace-element workflow.
+ */
+export function useReplaceSequenceElement() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (data: {
+      file: File;
+      sequenceId: string;
+      elementId: string;
+      onProgress?: (percent: number) => void;
+    }) => {
+      const presign = await presignElementUploadFn({
+        data: { filename: data.file.name, sequenceId: data.sequenceId },
+      });
+      await putToR2(
+        presign.uploadUrl,
+        data.file,
+        presign.contentType,
+        data.onProgress
+      );
+      return await replaceSequenceElementFn({
+        data: {
+          sequenceId: data.sequenceId,
+          elementId: data.elementId,
+          publicUrl: presign.publicUrl,
+          path: presign.path,
+          filename: data.file.name,
+        },
+      });
+    },
+    onSuccess: (_result, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: sequenceElementKeys.bySequence(variables.sequenceId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: sequenceElementKeys.framesForElement(
+          variables.sequenceId,
+          variables.elementId
+        ),
+      });
+      // Affected frames will be edited; refresh frame views.
+      void queryClient.invalidateQueries({ queryKey: ['frames'] });
     },
   });
 }

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -2,6 +2,7 @@ import {
   analyzeDraftElementFn,
   deleteSequenceElementFn,
   finalizeElementUploadFn,
+  getFrameCountsByElementFn,
   getFrameIdsForElementFn,
   listSequenceElementsFn,
   presignDraftElementUploadFn,
@@ -19,6 +20,8 @@ export const sequenceElementKeys = {
     ['sequence-elements', sequenceId] as const,
   framesForElement: (sequenceId: string, elementId: string) =>
     ['sequence-elements', sequenceId, 'frames', elementId] as const,
+  frameCountsBySequence: (sequenceId: string) =>
+    ['sequence-elements', sequenceId, 'frame-counts'] as const,
 };
 
 export function useSequenceElements(sequenceId: string | undefined) {
@@ -184,6 +187,22 @@ export function useRenameSequenceElementToken() {
   });
 }
 
+/**
+ * Frame counts for *all* elements in a sequence, fetched in one query.
+ * Use this from the elements grid to avoid the per-card N+1.
+ */
+export function useFrameCountsForAllElements(sequenceId: string | undefined) {
+  return useQuery({
+    queryKey: sequenceId
+      ? sequenceElementKeys.frameCountsBySequence(sequenceId)
+      : ['sequence-elements', 'frame-counts', 'none'],
+    queryFn: () =>
+      getFrameCountsByElementFn({ data: { sequenceId: sequenceId ?? '' } }),
+    enabled: Boolean(sequenceId),
+    staleTime: 60 * 1000,
+  });
+}
+
 /** Frame count + IDs for frames that reference this element by token */
 export function useFrameIdsForElement(
   sequenceId: string | undefined,
@@ -243,6 +262,11 @@ export function useReplaceSequenceElement() {
         queryKey: sequenceElementKeys.framesForElement(
           variables.sequenceId,
           variables.elementId
+        ),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: sequenceElementKeys.frameCountsBySequence(
+          variables.sequenceId
         ),
       });
       // Affected frames will be edited; refresh frame views.

--- a/src/lib/ai/element-vision.ts
+++ b/src/lib/ai/element-vision.ts
@@ -15,6 +15,7 @@ const VISION_MODEL = 'anthropic/claude-sonnet-4.6';
 const responseSchema = z.object({
   description: z.string().min(1),
   consistencyTag: z.string().min(1),
+  suggestedToken: z.string().min(1),
 });
 
 export type ElementDescription = z.infer<typeof responseSchema>;
@@ -22,32 +23,43 @@ export type ElementDescription = z.infer<typeof responseSchema>;
 export type DescribeElementInput = {
   imageUrl: string;
   filename: string;
-  token: string;
   /** Override OpenRouter API key (team-provided) */
   openRouterApiKey?: string;
 };
+
+/**
+ * Normalize a vision-suggested token to canonical UPPERCASE_SNAKE_CASE.
+ * Drops everything outside `[A-Z0-9]`, collapses runs to `_`, caps length.
+ */
+export function normalizeSuggestedToken(raw: string): string {
+  const cleaned = raw
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 30);
+  return cleaned.length > 0 ? cleaned : 'ELEMENT';
+}
 
 /**
  * Build the multimodal chat messages for the vision LLM.
  * Exported for testing.
  */
 export function buildVisionMessages(
-  token: string,
   filename: string,
   imageUrl: string
 ): ChatMessage[] {
-  const system = `You are a visual reference describer. You will be shown a single image that will serve as a canonical reference for an element (logo, product, screenshot, or similar object) in a film/video production. Your job is to describe what the image visually contains so that AI image generators can later reproduce the element faithfully across scenes.
+  const system = `You are a visual reference describer. You will be shown a single image that will serve as a canonical reference for an element (logo, product, screenshot, or similar object) in a film/video production. Your job is to describe what the image visually contains so that AI image generators can later reproduce the element faithfully across scenes, AND to suggest a concise UPPERCASE token that a screenwriter would type to reference this element in a script.
 
-Your output MUST be strict JSON with two fields:
+Your output MUST be strict JSON with three fields:
 - "description": 60-120 words. Describe shape, proportions, colors, text rendered on the element (verbatim), finish/material, any distinguishing marks, and how it is oriented. Do NOT describe background, lighting, camera angle, or the overall photograph — only the element itself.
 - "consistencyTag": A lowercase slug (3-6 words joined by hyphens) capturing the element's visual identity for reuse in prompts (e.g. "red-hex-brand-logo", "silver-metal-water-bottle").
+- "suggestedToken": A short UPPERCASE_SNAKE_CASE identifier (1-3 words, joined by underscores, max 30 characters) naming the element so a screenwriter can reference it. Prefer brand/product names visible in the image (e.g. "PEPSI_LOGO", "IPHONE", "STARBUCKS_CUP"); if no brand text is visible, name the object descriptively (e.g. "RED_BOTTLE", "OFFICE_CHAIR"). Letters and digits only; no spaces, dashes, or punctuation.
 
 Return ONLY the JSON object. No prose, no markdown fences.`;
 
-  const userText = `Element token: ${token}
-Uploaded filename: ${filename}
+  const userText = `Uploaded filename (hint only — may be meaningless): ${filename}
 
-Describe the element in the image below.`;
+Describe the element in the image below and suggest a token.`;
 
   return [
     { role: 'system', content: system },
@@ -64,11 +76,7 @@ Describe the element in the image below.`;
 export async function describeElementImage(
   input: DescribeElementInput
 ): Promise<ElementDescription> {
-  const messages = buildVisionMessages(
-    input.token,
-    input.filename,
-    input.imageUrl
-  );
+  const messages = buildVisionMessages(input.filename, input.imageUrl);
 
   const systemPrompts: string[] = [];
   const chatMessages: Array<{
@@ -96,5 +104,9 @@ export async function describeElementImage(
     debug: false,
   });
 
-  return responseSchema.parse(result);
+  const parsed = responseSchema.parse(result);
+  return {
+    ...parsed,
+    suggestedToken: normalizeSuggestedToken(parsed.suggestedToken),
+  };
 }

--- a/src/lib/db/scoped/sequence-elements.test.ts
+++ b/src/lib/db/scoped/sequence-elements.test.ts
@@ -129,7 +129,8 @@ describe('getFrameCountsByElement', () => {
     if (!unused) throw new Error('test setup: element insert returned nothing');
 
     const result = await methods.getFrameCountsByElement(sequenceId);
-    expect(result[unused.id]).toBe(0);
+    expect(result[unused.id]?.frameCount).toBe(0);
+    expect(result[unused.id]?.videoCount).toBe(0);
   });
 
   it('counts a frame against every matched element (multi-tag frame increments each)', async () => {
@@ -192,8 +193,8 @@ describe('getFrameCountsByElement', () => {
     });
 
     const result = await methods.getFrameCountsByElement(sequenceId);
-    expect(result[logo.id]).toBe(2);
-    expect(result[bottle.id]).toBe(1);
-    expect(result[orphan.id]).toBe(0);
+    expect(result[logo.id]?.frameCount).toBe(2);
+    expect(result[bottle.id]?.frameCount).toBe(1);
+    expect(result[orphan.id]?.frameCount).toBe(0);
   });
 });

--- a/src/lib/db/scoped/sequence-elements.test.ts
+++ b/src/lib/db/scoped/sequence-elements.test.ts
@@ -1,0 +1,199 @@
+/**
+ * In-memory DB tests for getFrameCountsByElement.
+ *
+ * Pins the two invariants the elements grid relies on:
+ *   - Elements with zero matching frames appear in the result map with `0`
+ *     (otherwise the badge reads `undefined`).
+ *   - A frame that references N elements increments every matched element's
+ *     count (no first-match short-circuit).
+ */
+
+import { type Client, createClient } from '@libsql/client';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'bun:test';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import type { Frame } from '@/lib/db/schema';
+import {
+  frames,
+  sequenceElements,
+  sequences,
+  styles,
+  teams,
+} from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { createSequenceElementsMethods } from './sequence-elements';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let sequenceId = '';
+
+async function seed() {
+  await db.delete(frames);
+  await db.delete(sequenceElements);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+
+  teamId = generateId();
+  sequenceId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db.insert(sequences).values({
+    id: sequenceId,
+    teamId,
+    title: 'S',
+    styleId: style.id,
+  });
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+function frameMetadata(args: {
+  sceneId: string;
+  elementTags: string[];
+  extract: string;
+}): NonNullable<Frame['metadata']> {
+  return {
+    sceneId: args.sceneId,
+    sceneNumber: 1,
+    originalScript: { extract: args.extract, dialogue: [] },
+    continuity: {
+      environmentTag: '',
+      characterTags: [],
+      elementTags: args.elementTags,
+      colorPalette: '',
+      lightingSetup: '',
+      styleTag: '',
+    },
+  };
+}
+
+describe('getFrameCountsByElement', () => {
+  it('returns an empty object when no elements exist', async () => {
+    const methods = createSequenceElementsMethods(db);
+    const result = await methods.getFrameCountsByElement(sequenceId);
+    expect(result).toEqual({});
+  });
+
+  it('seeds a zero entry for every element, even those with no matching frames', async () => {
+    const methods = createSequenceElementsMethods(db);
+
+    const [unused] = await db
+      .insert(sequenceElements)
+      .values({
+        sequenceId,
+        uploadedFilename: 'unused.png',
+        token: 'UNUSED',
+        imageUrl: 'https://r2/unused.png',
+        imagePath: 'elements/x/unused.png',
+      })
+      .returning();
+    if (!unused) throw new Error('test setup: element insert returned nothing');
+
+    const result = await methods.getFrameCountsByElement(sequenceId);
+    expect(result[unused.id]).toBe(0);
+  });
+
+  it('counts a frame against every matched element (multi-tag frame increments each)', async () => {
+    const methods = createSequenceElementsMethods(db);
+
+    const [logo] = await db
+      .insert(sequenceElements)
+      .values({
+        sequenceId,
+        uploadedFilename: 'logo.png',
+        token: 'LOGO',
+        imageUrl: 'https://r2/logo.png',
+        imagePath: 'elements/x/logo.png',
+      })
+      .returning();
+    const [bottle] = await db
+      .insert(sequenceElements)
+      .values({
+        sequenceId,
+        uploadedFilename: 'bottle.png',
+        token: 'BOTTLE',
+        imageUrl: 'https://r2/bottle.png',
+        imagePath: 'elements/x/bottle.png',
+      })
+      .returning();
+    const [orphan] = await db
+      .insert(sequenceElements)
+      .values({
+        sequenceId,
+        uploadedFilename: 'orphan.png',
+        token: 'ORPHAN',
+        imageUrl: 'https://r2/orphan.png',
+        imagePath: 'elements/x/orphan.png',
+      })
+      .returning();
+    if (!logo || !bottle || !orphan) {
+      throw new Error('test setup: element insert returned nothing');
+    }
+
+    // Frame referencing both LOGO and BOTTLE via continuity.elementTags.
+    await db.insert(frames).values({
+      sequenceId,
+      orderIndex: 0,
+      metadata: frameMetadata({
+        sceneId: 's1',
+        elementTags: ['LOGO', 'BOTTLE'],
+        extract: 'scene script',
+      }),
+    });
+
+    // Frame referencing only LOGO via script-text fallback (no elementTags).
+    await db.insert(frames).values({
+      sequenceId,
+      orderIndex: 1,
+      metadata: frameMetadata({
+        sceneId: 's2',
+        elementTags: [],
+        extract: 'The LOGO appears on screen.',
+      }),
+    });
+
+    const result = await methods.getFrameCountsByElement(sequenceId);
+    expect(result[logo.id]).toBe(2);
+    expect(result[bottle.id]).toBe(1);
+    expect(result[orphan.id]).toBe(0);
+  });
+});

--- a/src/lib/db/scoped/sequence-elements.ts
+++ b/src/lib/db/scoped/sequence-elements.ts
@@ -3,7 +3,6 @@
  * Element CRUD for per-sequence uploaded reference images.
  */
 
-import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
 import type { Database } from '@/lib/db/client';
 import type {
   ElementVisionStatus,
@@ -13,6 +12,7 @@ import type {
 } from '@/lib/db/schema';
 import { frames, sequenceElements } from '@/lib/db/schema';
 import { matchElementsToScene } from '@/lib/workflows/scene-matching';
+import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
 
 export function createSequenceElementsMethods(db: Database) {
   const update = async (
@@ -82,6 +82,8 @@ export function createSequenceElementsMethods(db: Database) {
       const taken = new Set(rows.map((r) => r.token));
       if (!taken.has(token)) return token;
 
+      // Hard cap — 100 is well above any realistic upload-of-same-name count
+      // and bounds the worst-case query path.
       for (let suffix = 2; suffix <= 100; suffix += 1) {
         const candidate = `${token}_${suffix}`;
         if (!taken.has(candidate)) return candidate;
@@ -190,7 +192,7 @@ export function createSequenceElementsMethods(db: Database) {
       return (allFrames as Frame[])
         .filter((frame) => {
           const elementTags = frame.metadata?.continuity?.elementTags ?? [];
-          const sceneScript = frame.metadata?.originalScript.extract ?? '';
+          const sceneScript = frame.metadata?.originalScript?.extract ?? '';
           return (
             matchElementsToScene([element], elementTags, sceneScript).length > 0
           );
@@ -200,10 +202,11 @@ export function createSequenceElementsMethods(db: Database) {
 
     /**
      * Frame counts for *all* elements in a sequence, computed in a single
-     * scan over frames + elements. The elements grid renders N cards, each of
-     * which previously called `getFrameIdsForElement` — an N+1 over the full
-     * frame set. Returns a token→count map (elementId would re-issue per
-     * element on the client; the grid only needs counts).
+     * scan over frames + elements. The elements grid renders N cards, each
+     * of which previously called `getFrameIdsForElement` — an N+1 over the
+     * full frame set. Returns an `elementId → count` map; elements with zero
+     * matches are pre-seeded so the grid can render `Used in 0 frames`
+     * instead of `undefined`.
      */
     getFrameCountsByElement: async (
       sequenceId: string

--- a/src/lib/db/scoped/sequence-elements.ts
+++ b/src/lib/db/scoped/sequence-elements.ts
@@ -197,5 +197,45 @@ export function createSequenceElementsMethods(db: Database) {
         })
         .map((f) => f.id);
     },
+
+    /**
+     * Frame counts for *all* elements in a sequence, computed in a single
+     * scan over frames + elements. The elements grid renders N cards, each of
+     * which previously called `getFrameIdsForElement` — an N+1 over the full
+     * frame set. Returns a token→count map (elementId would re-issue per
+     * element on the client; the grid only needs counts).
+     */
+    getFrameCountsByElement: async (
+      sequenceId: string
+    ): Promise<Record<string, number>> => {
+      const allElements = await db
+        .select()
+        .from(sequenceElements)
+        .where(eq(sequenceElements.sequenceId, sequenceId));
+      const counts: Record<string, number> = {};
+      for (const el of allElements) {
+        counts[el.id] = 0;
+      }
+      if (allElements.length === 0) return counts;
+
+      const allFrames = await db
+        .select()
+        .from(frames)
+        .where(eq(frames.sequenceId, sequenceId));
+
+      for (const frame of allFrames as Frame[]) {
+        const elementTags = frame.metadata?.continuity?.elementTags ?? [];
+        const sceneScript = frame.metadata?.originalScript.extract ?? '';
+        const matched = matchElementsToScene(
+          allElements,
+          elementTags,
+          sceneScript
+        );
+        for (const el of matched) {
+          counts[el.id] = (counts[el.id] ?? 0) + 1;
+        }
+      }
+      return counts;
+    },
   };
 }

--- a/src/lib/db/scoped/sequence-elements.ts
+++ b/src/lib/db/scoped/sequence-elements.ts
@@ -10,9 +10,13 @@ import type {
   NewSequenceElement,
   SequenceElement,
 } from '@/lib/db/schema';
-import { frames, sequenceElements } from '@/lib/db/schema';
+import { frames, sequenceElements, sequences } from '@/lib/db/schema';
+import {
+  buildFrameRenameDeltas,
+  replaceTokenInText,
+} from '@/lib/sequence-elements/cascade-rename';
 import { matchElementsToScene } from '@/lib/workflows/scene-matching';
-import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
+import { and, eq, inArray, like, ne, or, sql } from 'drizzle-orm';
 
 export function createSequenceElementsMethods(db: Database) {
   const update = async (
@@ -59,6 +63,31 @@ export function createSequenceElementsMethods(db: Database) {
     },
 
     getByToken,
+
+    /**
+     * Throws if `token` is already taken by another element in this sequence.
+     * Use for user-driven renames where collisions must be surfaced; for
+     * system-driven renames (vision auto-suggest), use ensureUniqueToken
+     * which suffixes a `_N` instead.
+     */
+    isTokenTaken: async (
+      sequenceId: string,
+      token: string,
+      excludeElementId?: string
+    ): Promise<boolean> => {
+      const whereClauses = [
+        eq(sequenceElements.sequenceId, sequenceId),
+        eq(sequenceElements.token, token),
+      ];
+      if (excludeElementId) {
+        whereClauses.push(ne(sequenceElements.id, excludeElementId));
+      }
+      const rows = await db
+        .select({ id: sequenceElements.id })
+        .from(sequenceElements)
+        .where(and(...whereClauses));
+      return rows.length > 0;
+    },
 
     ensureUniqueToken: async (
       sequenceId: string,
@@ -162,6 +191,72 @@ export function createSequenceElementsMethods(db: Database) {
       });
     },
 
+    /**
+     * Rename an element's token and rewrite every reference to the old token
+     * across the sequence: `sequences.script`, per-frame `metadata` (continuity
+     * tags, originalScript extract, prompt strings) and the user-edit
+     * `imagePrompt`/`motionPrompt` overrides on `frames`.
+     *
+     * Returns the affected counts so callers can surface a meaningful toast
+     * ("Renamed LOGO → BRAND across 5 frames + script"). The caller is
+     * expected to have already validated uniqueness of `newToken` within the
+     * sequence — this method does not check collisions.
+     */
+    cascadeRename: async (args: {
+      sequenceId: string;
+      elementId: string;
+      oldToken: string;
+      newToken: string;
+    }): Promise<{
+      element: SequenceElement;
+      framesUpdated: number;
+      scriptUpdated: boolean;
+    }> => {
+      const { sequenceId, elementId, oldToken, newToken } = args;
+      const element = await update(elementId, { token: newToken });
+
+      if (oldToken === newToken) {
+        return { element, framesUpdated: 0, scriptUpdated: false };
+      }
+
+      let scriptUpdated = false;
+      const [sequenceRow] = await db
+        .select({ script: sequences.script })
+        .from(sequences)
+        .where(eq(sequences.id, sequenceId));
+      if (sequenceRow?.script) {
+        const rewritten = replaceTokenInText(
+          sequenceRow.script,
+          oldToken,
+          newToken
+        );
+        if (rewritten !== sequenceRow.script) {
+          await db
+            .update(sequences)
+            .set({ script: rewritten, updatedAt: new Date() })
+            .where(eq(sequences.id, sequenceId));
+          scriptUpdated = true;
+        }
+      }
+
+      const allFrames = (await db
+        .select()
+        .from(frames)
+        .where(eq(frames.sequenceId, sequenceId))) as Frame[];
+      const deltas = buildFrameRenameDeltas(allFrames, oldToken, newToken);
+      for (const delta of deltas) {
+        const set: Record<string, unknown> = { updatedAt: new Date() };
+        if (delta.metadata !== undefined) set.metadata = delta.metadata;
+        if (delta.imagePrompt !== undefined)
+          set.imagePrompt = delta.imagePrompt;
+        if (delta.motionPrompt !== undefined)
+          set.motionPrompt = delta.motionPrompt;
+        await db.update(frames).set(set).where(eq(frames.id, delta.frameId));
+      }
+
+      return { element, framesUpdated: deltas.length, scriptUpdated };
+    },
+
     delete: async (id: string): Promise<boolean> => {
       const result = await db
         .delete(sequenceElements)
@@ -210,14 +305,15 @@ export function createSequenceElementsMethods(db: Database) {
      */
     getFrameCountsByElement: async (
       sequenceId: string
-    ): Promise<Record<string, number>> => {
+    ): Promise<Record<string, { frameCount: number; videoCount: number }>> => {
       const allElements = await db
         .select()
         .from(sequenceElements)
         .where(eq(sequenceElements.sequenceId, sequenceId));
-      const counts: Record<string, number> = {};
+      const counts: Record<string, { frameCount: number; videoCount: number }> =
+        {};
       for (const el of allElements) {
-        counts[el.id] = 0;
+        counts[el.id] = { frameCount: 0, videoCount: 0 };
       }
       if (allElements.length === 0) return counts;
 
@@ -234,8 +330,12 @@ export function createSequenceElementsMethods(db: Database) {
           elementTags,
           sceneScript
         );
+        const hasVideo = !!frame.videoUrl;
         for (const el of matched) {
-          counts[el.id] = (counts[el.id] ?? 0) + 1;
+          const entry = counts[el.id];
+          if (!entry) continue;
+          entry.frameCount += 1;
+          if (hasVideo) entry.videoCount += 1;
         }
       }
       return counts;

--- a/src/lib/db/scoped/sequence-elements.ts
+++ b/src/lib/db/scoped/sequence-elements.ts
@@ -7,10 +7,12 @@ import { and, eq, inArray, like, or, sql } from 'drizzle-orm';
 import type { Database } from '@/lib/db/client';
 import type {
   ElementVisionStatus,
+  Frame,
   NewSequenceElement,
   SequenceElement,
 } from '@/lib/db/schema';
-import { sequenceElements } from '@/lib/db/schema';
+import { frames, sequenceElements } from '@/lib/db/schema';
+import { matchElementsToScene } from '@/lib/workflows/scene-matching';
 
 export function createSequenceElementsMethods(db: Database) {
   const update = async (
@@ -164,6 +166,36 @@ export function createSequenceElementsMethods(db: Database) {
         .where(eq(sequenceElements.id, id));
       // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined
       return (result.rowsAffected ?? 0) > 0;
+    },
+
+    getFrameIdsForElement: async (
+      sequenceId: string,
+      elementId: string
+    ): Promise<string[]> => {
+      const elementResult = await db
+        .select()
+        .from(sequenceElements)
+        .where(eq(sequenceElements.id, elementId));
+      const element = elementResult[0] ?? null;
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard: DB query may return undefined
+      if (!element || element.sequenceId !== sequenceId) {
+        return [];
+      }
+
+      const allFrames = await db
+        .select()
+        .from(frames)
+        .where(eq(frames.sequenceId, sequenceId));
+
+      return (allFrames as Frame[])
+        .filter((frame) => {
+          const elementTags = frame.metadata?.continuity?.elementTags ?? [];
+          const sceneScript = frame.metadata?.originalScript.extract ?? '';
+          return (
+            matchElementsToScene([element], elementTags, sceneScript).length > 0
+          );
+        })
+        .map((f) => f.id);
     },
   };
 }

--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -172,12 +172,42 @@ async function generateImageInternal(
   }
 
   const adapter = createFalAdapter(endpoint, falApiKeyInfo.key);
+
+  console.log(
+    '[Image Generation] generateImage request',
+    JSON.stringify(
+      {
+        model: params.model,
+        endpoint,
+        keySource: falApiKeyInfo.source,
+        prompt,
+        modelOptions,
+        referenceImageUrls: params.referenceImageUrls ?? [],
+      },
+      null,
+      2
+    )
+  );
+
   const result = await generateImage({
     adapter,
     prompt,
     modelOptions,
-    debug: false,
+    debug: true,
   });
+
+  console.log(
+    '[Image Generation] generateImage response',
+    JSON.stringify(
+      {
+        model: params.model,
+        endpoint,
+        imageUrls: result.images.map((img) => img.url),
+      },
+      null,
+      2
+    )
+  );
 
   const imageUrls = result.images
     .map((img) => img.url)

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -193,17 +193,17 @@ export const realtimeSchema = {
 
     // Replace-element events: edit affected frames to swap an element
     'replace-element:start': z.object({
-      elementId: z.string(),
-      frameCount: z.number(),
+      elementId: z.string().min(1),
+      frameCount: z.number().int().nonnegative(),
     }),
     'replace-element:complete': z.object({
-      elementId: z.string(),
-      successCount: z.number(),
-      failedCount: z.number(),
+      elementId: z.string().min(1),
+      successCount: z.number().int().nonnegative(),
+      failedCount: z.number().int().nonnegative(),
     }),
     'replace-element:failed': z.object({
-      elementId: z.string(),
-      error: z.string(),
+      elementId: z.string().min(1),
+      error: z.string().min(1),
     }),
 
     // Location matching events
@@ -328,6 +328,16 @@ export const realtimeSchema = {
  */
 export type StaleDetectedPayload = z.infer<
   (typeof realtimeSchema.generation)['stale:detected']
+>;
+
+export type ReplaceElementStartPayload = z.infer<
+  (typeof realtimeSchema.generation)['replace-element:start']
+>;
+export type ReplaceElementCompletePayload = z.infer<
+  (typeof realtimeSchema.generation)['replace-element:complete']
+>;
+export type ReplaceElementFailedPayload = z.infer<
+  (typeof realtimeSchema.generation)['replace-element:failed']
 >;
 
 let realtimeInstance: ReturnType<typeof createRealtime> | null = null;

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -191,6 +191,21 @@ export const realtimeSchema = {
       error: z.string(),
     }),
 
+    // Replace-element events: edit affected frames to swap an element
+    'replace-element:start': z.object({
+      elementId: z.string(),
+      frameCount: z.number(),
+    }),
+    'replace-element:complete': z.object({
+      elementId: z.string(),
+      successCount: z.number(),
+      failedCount: z.number(),
+    }),
+    'replace-element:failed': z.object({
+      elementId: z.string(),
+      error: z.string(),
+    }),
+
     // Location matching events
     'location:matched': z.object({
       matches: z.array(

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -195,11 +195,16 @@ export const realtimeSchema = {
     'replace-element:start': z.object({
       elementId: z.string().min(1),
       frameCount: z.number().int().nonnegative(),
+      videoCount: z.number().int().nonnegative().optional(),
     }),
     'replace-element:complete': z.object({
       elementId: z.string().min(1),
       successCount: z.number().int().nonnegative(),
       failedCount: z.number().int().nonnegative(),
+      videoSuccessCount: z.number().int().nonnegative().optional(),
+      videoFailedCount: z.number().int().nonnegative().optional(),
+      /** Token after any vision-driven auto-rename. */
+      renamedTo: z.string().min(1).optional(),
     }),
     'replace-element:failed': z.object({
       elementId: z.string().min(1),

--- a/src/lib/sequence-elements/cascade-rename.ts
+++ b/src/lib/sequence-elements/cascade-rename.ts
@@ -1,0 +1,165 @@
+/**
+ * Cascade an element token rename through every place the old token can be
+ * referenced: sequence script text, per-frame metadata (continuity tags,
+ * original script extract, prompt strings), and the user-edited
+ * imagePrompt/motionPrompt overrides on the frame row.
+ *
+ * The rewrite is whole-word and case-insensitive on the haystack side (so a
+ * lowercase mention inside script prose is still rewritten), but always emits
+ * the new token in its canonical UPPERCASE form. We never touch sub-strings of
+ * a longer identifier — renaming `BAR` must not affect `BARBER`.
+ */
+
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import type { Frame } from '@/lib/db/schema';
+
+/** Whole-token regex. Boundaries are anything that isn't `[A-Za-z0-9_]`. */
+function tokenRegex(token: string): RegExp {
+  const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|[^A-Za-z0-9_])(${escaped})(?=[^A-Za-z0-9_]|$)`, 'gi');
+}
+
+export function replaceTokenInText(
+  text: string,
+  oldToken: string,
+  newToken: string
+): string {
+  if (!text) return text;
+  return text.replace(tokenRegex(oldToken), (_match, prefix: string) => {
+    return `${prefix}${newToken}`;
+  });
+}
+
+export function textContainsToken(text: string, token: string): boolean {
+  if (!text) return false;
+  return tokenRegex(token).test(text);
+}
+
+/** Pure rewrite of one frame's Scene metadata. Returns null if nothing changed. */
+export function renameTokenInScene(
+  scene: Scene,
+  oldToken: string,
+  newToken: string
+): Scene | null {
+  if (oldToken === newToken) return null;
+
+  let changed = false;
+  const next: Scene = { ...scene };
+
+  // continuity.elementTags — uppercase tokens, exact match
+  if (scene.continuity) {
+    const oldTags = scene.continuity.elementTags ?? [];
+    const newTags = oldTags.map((tag) =>
+      tag.toUpperCase() === oldToken.toUpperCase() ? newToken : tag
+    );
+    const tagsDiffer = newTags.some((t, i) => t !== oldTags[i]);
+    if (tagsDiffer) {
+      next.continuity = { ...scene.continuity, elementTags: newTags };
+      changed = true;
+    }
+  }
+
+  // originalScript.extract — case-insensitive whole-word replace
+  if (scene.originalScript.extract) {
+    const rewritten = replaceTokenInText(
+      scene.originalScript.extract,
+      oldToken,
+      newToken
+    );
+    if (rewritten !== scene.originalScript.extract) {
+      next.originalScript = { ...scene.originalScript, extract: rewritten };
+      changed = true;
+    }
+  }
+
+  // prompts.visual.fullPrompt / prompts.motion.fullPrompt
+  if (scene.prompts) {
+    let promptsChanged = false;
+    const nextPrompts = { ...scene.prompts };
+    if (scene.prompts.visual?.fullPrompt) {
+      const rewritten = replaceTokenInText(
+        scene.prompts.visual.fullPrompt,
+        oldToken,
+        newToken
+      );
+      if (rewritten !== scene.prompts.visual.fullPrompt) {
+        nextPrompts.visual = {
+          ...scene.prompts.visual,
+          fullPrompt: rewritten,
+        };
+        promptsChanged = true;
+      }
+    }
+    if (scene.prompts.motion?.fullPrompt) {
+      const rewritten = replaceTokenInText(
+        scene.prompts.motion.fullPrompt,
+        oldToken,
+        newToken
+      );
+      if (rewritten !== scene.prompts.motion.fullPrompt) {
+        nextPrompts.motion = {
+          ...scene.prompts.motion,
+          fullPrompt: rewritten,
+        };
+        promptsChanged = true;
+      }
+    }
+    if (promptsChanged) {
+      next.prompts = nextPrompts;
+      changed = true;
+    }
+  }
+
+  return changed ? next : null;
+}
+
+export type FrameRenameDelta = {
+  frameId: string;
+  metadata?: Scene;
+  imagePrompt?: string;
+  motionPrompt?: string;
+};
+
+/** Compute per-frame deltas for a token rename. Frames with no references return null. */
+export function buildFrameRenameDeltas(
+  frames: Frame[],
+  oldToken: string,
+  newToken: string
+): FrameRenameDelta[] {
+  if (oldToken === newToken) return [];
+
+  const deltas: FrameRenameDelta[] = [];
+  for (const frame of frames) {
+    const delta: FrameRenameDelta = { frameId: frame.id };
+    let touched = false;
+
+    if (frame.metadata) {
+      const rewritten = renameTokenInScene(frame.metadata, oldToken, newToken);
+      if (rewritten) {
+        delta.metadata = rewritten;
+        touched = true;
+      }
+    }
+
+    if (frame.imagePrompt && textContainsToken(frame.imagePrompt, oldToken)) {
+      delta.imagePrompt = replaceTokenInText(
+        frame.imagePrompt,
+        oldToken,
+        newToken
+      );
+      touched = true;
+    }
+
+    if (frame.motionPrompt && textContainsToken(frame.motionPrompt, oldToken)) {
+      delta.motionPrompt = replaceTokenInText(
+        frame.motionPrompt,
+        oldToken,
+        newToken
+      );
+      touched = true;
+    }
+
+    if (touched) deltas.push(delta);
+  }
+  return deltas;
+}

--- a/src/lib/sequence-elements/promote-temp-elements.ts
+++ b/src/lib/sequence-elements/promote-temp-elements.ts
@@ -14,6 +14,9 @@ const tempUploadSchema = z.object({
   tempPath: z.string().min(1),
   tempPublicUrl: z.string().url(),
   filename: z.string().min(1),
+  // Optional: vision-suggested token returned by analyzeDraftElementFn during
+  // draft upload. Falls back to filename-derived when missing (legacy clients).
+  token: z.string().min(1).max(100).nullable().optional(),
   // Optional: pre-computed by analyzeDraftElementFn during draft upload so we
   // can write the row in `completed` state without re-running vision here.
   description: z.string().nullable().optional(),
@@ -90,7 +93,10 @@ export async function promoteTempElements(params: {
         ? upload.tempPublicUrl
         : getPublicUrl(STORAGE_BUCKETS.ELEMENTS, permanentRelative);
 
-    const rawToken = deriveTokenFromFilename(upload.filename);
+    const rawToken =
+      upload.token && upload.token.length > 0
+        ? upload.token
+        : deriveTokenFromFilename(upload.filename);
     const token = await scopedDb.sequenceElements.ensureUniqueToken(
       sequenceId,
       rawToken

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -881,3 +881,35 @@ export interface ElementVisionWorkflowResult {
   description: string;
   consistencyTag: string;
 }
+
+/**
+ * Replace element workflow input
+ * Orchestrates element image swap + per-frame image edits for affected frames.
+ *
+ * Per-frame behaviour: invokes `image-workflow` with the existing frame
+ * thumbnail as the PRIMARY SOURCE and the new element image as an ELEMENT REF.
+ * The image edit endpoint swaps the element while preserving the rest of the
+ * frame — this is by design for elements (vs cast/location which fully
+ * regenerate the frame).
+ */
+export interface ReplaceElementWorkflowInput extends SequenceWorkflowContext {
+  elementId: string;
+  /** Token of the element being replaced (for logging + edit prompt) */
+  token: string;
+  /** Description of the prior element (for the edit prompt; null if vision never ran) */
+  previousDescription: string | null;
+  /** New image URL (already uploaded to R2 and persisted on the element row) */
+  newImageUrl: string;
+  /** Original filename of the new image (for vision analysis context) */
+  newFilename: string;
+  /** Frame IDs to edit using the new element */
+  affectedFrameIds: string[];
+  /** Image model to use for the edit (defaults to nano_banana_2 for edit support) */
+  imageModel?: TextToImageModel;
+}
+
+export interface ReplaceElementWorkflowResult {
+  elementId: string;
+  framesEdited: number;
+  framesFailed: number;
+}

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -880,6 +880,8 @@ export interface ElementVisionWorkflowResult {
   elementId: string;
   description: string;
   consistencyTag: string;
+  /** Final token after any vision-driven auto-rename. */
+  token: string;
 }
 
 /**

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -893,6 +893,8 @@ export interface ElementVisionWorkflowResult {
  * regenerate the frame).
  */
 export interface ReplaceElementWorkflowInput extends SequenceWorkflowContext {
+  /** Always present for this workflow — narrowed from the optional base type. */
+  sequenceId: string;
   elementId: string;
   /** Token of the element being replaced (for logging + edit prompt) */
   token: string;
@@ -910,6 +912,6 @@ export interface ReplaceElementWorkflowInput extends SequenceWorkflowContext {
 
 export interface ReplaceElementWorkflowResult {
   elementId: string;
-  framesEdited: number;
-  framesFailed: number;
+  successCount: number;
+  failedCount: number;
 }

--- a/src/lib/workflows/element-vision-workflow.ts
+++ b/src/lib/workflows/element-vision-workflow.ts
@@ -29,15 +29,15 @@ export const elementVisionWorkflow = createScopedWorkflow<
       );
     });
 
-    // Step 2: load element for token (needed in the prompt)
+    // Step 2: load element so we know the current token (for auto-rename).
     const element = await context.run('load-element', async () => {
       const el = await scopedDb.sequenceElements.getById(elementId);
       if (!el) throw new Error(`Element ${elementId} not found`);
       return el;
     });
 
-    // Step 3: vision call
-    const { description, consistencyTag } = await context.run(
+    // Step 3: vision call (also returns a vision-suggested token).
+    const { description, consistencyTag, suggestedToken } = await context.run(
       'describe-element',
       async () => {
         const openRouterApiKeyInfo =
@@ -45,13 +45,12 @@ export const elementVisionWorkflow = createScopedWorkflow<
         return await describeElementImage({
           imageUrl,
           filename,
-          token: element.token,
           openRouterApiKey: openRouterApiKeyInfo.key,
         });
       }
     );
 
-    // Step 4: persist result
+    // Step 4: persist description + consistencyTag.
     await context.run('persist-vision', async () => {
       await scopedDb.sequenceElements.updateVisionResult(
         elementId,
@@ -60,7 +59,32 @@ export const elementVisionWorkflow = createScopedWorkflow<
       );
     });
 
-    return { elementId, description, consistencyTag };
+    // Step 5: auto-rename to vision-suggested token if different. Uses
+    // ensureUniqueToken (suffixes `_2` on collision) because the system is
+    // choosing the name — failing the workflow on collision would strand the
+    // element with no usable name.
+    const finalToken = await context.run('auto-rename', async () => {
+      if (suggestedToken === element.token) return element.token;
+      const unique = await scopedDb.sequenceElements.ensureUniqueToken(
+        element.sequenceId,
+        suggestedToken
+      );
+      if (unique === element.token) return element.token;
+      const result = await scopedDb.sequenceElements.cascadeRename({
+        sequenceId: element.sequenceId,
+        elementId,
+        oldToken: element.token,
+        newToken: unique,
+      });
+      return result.element.token;
+    });
+
+    return {
+      elementId,
+      description,
+      consistencyTag,
+      token: finalToken,
+    };
   },
   {
     failureFunction: async ({ context, scopedDb, failResponse }) => {

--- a/src/lib/workflows/replace-element-workflow.test.ts
+++ b/src/lib/workflows/replace-element-workflow.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'bun:test';
-import { buildEditPrompt } from './replace-element-workflow';
+import {
+  buildEditPrompt,
+  decideBatchOutcome,
+  type FrameResult,
+  rejectionReasonMessage,
+  settledToResult,
+  shouldDowngradeVisionOnFailure,
+} from './replace-element-workflow';
 
 describe('buildEditPrompt', () => {
   it('includes the previous description in parens when present', () => {
@@ -33,5 +40,129 @@ describe('buildEditPrompt', () => {
     expect(prompt).toContain('WIDGET');
     expect(prompt).toContain('(previously: old widget)');
     expect(prompt).not.toContain('New element description:');
+  });
+});
+
+describe('decideBatchOutcome', () => {
+  it('returns complete with zero counts when no frames ran (e.g. all skipped-deleted)', () => {
+    const outcome = decideBatchOutcome([]);
+    expect(outcome).toEqual({
+      kind: 'complete',
+      successCount: 0,
+      failedCount: 0,
+    });
+  });
+
+  it('throws-via-fail-kind when every attempted frame failed', () => {
+    const results: FrameResult[] = [
+      { frameId: 'f1', success: false, error: 'edit timeout' },
+      { frameId: 'f2', success: false, error: 'no imageUrl' },
+    ];
+    const outcome = decideBatchOutcome(results);
+    expect(outcome.kind).toBe('fail');
+    if (outcome.kind !== 'fail') throw new Error('narrowing');
+    expect(outcome.total).toBe(2);
+    // Uses the first failure's reason as the sample for the thrown error.
+    expect(outcome.sampleReason).toBe('edit timeout');
+  });
+
+  it('returns complete with mixed counts when some succeeded and some failed', () => {
+    const results: FrameResult[] = [
+      { frameId: 'f1', success: true, imageUrl: 'https://r2/a.png' },
+      { frameId: 'f2', success: false, error: 'edit failed' },
+      { frameId: 'f3', success: true, imageUrl: 'https://r2/c.png' },
+    ];
+    const outcome = decideBatchOutcome(results);
+    expect(outcome).toEqual({
+      kind: 'complete',
+      successCount: 2,
+      failedCount: 1,
+    });
+  });
+});
+
+describe('shouldDowngradeVisionOnFailure', () => {
+  it('downgrades when vision was still in flight (analyzing)', () => {
+    expect(shouldDowngradeVisionOnFailure('analyzing')).toBe(true);
+  });
+
+  it('downgrades when vision had not started (pending)', () => {
+    expect(shouldDowngradeVisionOnFailure('pending')).toBe(true);
+  });
+
+  it('does NOT downgrade when vision already succeeded (failure was in per-frame edit)', () => {
+    expect(shouldDowngradeVisionOnFailure('completed')).toBe(false);
+  });
+
+  it('downgrades when status is already failed (idempotent rewrite)', () => {
+    expect(shouldDowngradeVisionOnFailure('failed')).toBe(true);
+  });
+});
+
+describe('rejectionReasonMessage', () => {
+  it('extracts message from Error instances', () => {
+    expect(rejectionReasonMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('returns string rejections verbatim', () => {
+    expect(rejectionReasonMessage('plain string reason')).toBe(
+      'plain string reason'
+    );
+  });
+
+  it('serializes plain object rejections so the original payload survives', () => {
+    expect(rejectionReasonMessage({ code: 503, msg: 'svc down' })).toContain(
+      '503'
+    );
+  });
+
+  it('falls back to a typeof tag for non-serializable values (e.g. circular refs)', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(rejectionReasonMessage(circular)).toBe(
+      'non-error rejection (object)'
+    );
+  });
+
+  it('falls back for empty-object rejections rather than producing `{}`', () => {
+    expect(rejectionReasonMessage({})).toBe('non-error rejection (object)');
+  });
+});
+
+describe('settledToResult', () => {
+  it('passes fulfilled results through unchanged', () => {
+    const fulfilled: PromiseSettledResult<FrameResult> = {
+      status: 'fulfilled',
+      value: { frameId: 'f1', success: true, imageUrl: 'https://r2/a.png' },
+    };
+    expect(settledToResult(fulfilled, 'ignored')).toEqual({
+      frameId: 'f1',
+      success: true,
+      imageUrl: 'https://r2/a.png',
+    });
+  });
+
+  it('converts Error rejection to a failure result with the message', () => {
+    const rejected: PromiseSettledResult<FrameResult> = {
+      status: 'rejected',
+      reason: new Error('invoke failed'),
+    };
+    expect(settledToResult(rejected, 'f1')).toEqual({
+      frameId: 'f1',
+      success: false,
+      error: 'invoke failed',
+    });
+  });
+
+  it('uses `unknown` frameId when the index lookup returns undefined', () => {
+    const rejected: PromiseSettledResult<FrameResult> = {
+      status: 'rejected',
+      reason: new Error('boom'),
+    };
+    expect(settledToResult(rejected, undefined)).toEqual({
+      frameId: 'unknown',
+      success: false,
+      error: 'boom',
+    });
   });
 });

--- a/src/lib/workflows/replace-element-workflow.test.ts
+++ b/src/lib/workflows/replace-element-workflow.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { buildEditPrompt } from './replace-element-workflow';
+
+describe('buildEditPrompt', () => {
+  it('includes the previous description in parens when present', () => {
+    const prompt = buildEditPrompt({
+      token: 'LOGO',
+      newDescription: 'A blue square logo',
+      previousDescription: 'A red hex logo',
+    });
+    expect(prompt).toContain('LOGO');
+    expect(prompt).toContain('(previously: A red hex logo)');
+    expect(prompt).toContain('New element description: A blue square logo');
+  });
+
+  it('omits the previous description clause when null', () => {
+    const prompt = buildEditPrompt({
+      token: 'BOTTLE',
+      newDescription: 'Silver water bottle',
+      previousDescription: null,
+    });
+    expect(prompt).toContain('BOTTLE');
+    expect(prompt).not.toContain('previously:');
+    expect(prompt).toContain('New element description: Silver water bottle');
+  });
+
+  it('omits the "New element description" line when description is empty', () => {
+    const prompt = buildEditPrompt({
+      token: 'WIDGET',
+      newDescription: '',
+      previousDescription: 'old widget',
+    });
+    expect(prompt).toContain('WIDGET');
+    expect(prompt).toContain('(previously: old widget)');
+    expect(prompt).not.toContain('New element description:');
+  });
+});

--- a/src/lib/workflows/replace-element-workflow.ts
+++ b/src/lib/workflows/replace-element-workflow.ts
@@ -1,0 +1,289 @@
+/**
+ * Replace Element Workflow
+ *
+ * Per-frame edits a sequence element across all affected frames using an
+ * image edit endpoint. Unlike character/location recast (which fully
+ * regenerates the frame), this swaps just the element while keeping the
+ * rest of the frame intact.
+ *
+ * Steps:
+ * 1. Re-run vision analysis on the new element image so token gets fresh
+ *    description + consistencyTag (used by future scene generations).
+ * 2. For each affected frame, invoke `image-workflow` with the existing
+ *    frame thumbnail as PRIMARY SOURCE and the new element image as
+ *    ELEMENT REF — the model edits the frame to swap the element.
+ */
+
+import { describeElementImage } from '@/lib/ai/element-vision';
+import {
+  DEFAULT_IMAGE_MODEL,
+  safeTextToImageModel,
+  supportsReferenceImages,
+} from '@/lib/ai/models';
+import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
+import { getGenerationChannel } from '@/lib/realtime';
+import { buildWorkflowLabel } from '@/lib/workflow/labels';
+import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
+import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
+import type {
+  ImageWorkflowInput,
+  ReplaceElementWorkflowInput,
+  ReplaceElementWorkflowResult,
+} from '@/lib/workflow/types';
+import { getFalFlowControl } from './constants';
+import { generateImageWorkflow } from './image-workflow';
+
+type FrameResult =
+  | { frameId: string; success: true; imageUrl: string }
+  | { frameId: string; success: false; error: string };
+
+function buildEditPrompt(args: {
+  token: string;
+  newDescription: string;
+  previousDescription: string | null;
+}): string {
+  const previous = args.previousDescription
+    ? ` (previously: ${args.previousDescription})`
+    : '';
+  return [
+    `Edit the PRIMARY SOURCE image to replace the existing ${args.token} element${previous} with the new version shown in the ELEMENT REF image.`,
+    `Render the new ${args.token} naturally where the old one appeared, matching scale, perspective, lighting, and occlusion of the original placement.`,
+    `Keep all other content — characters, environment, framing, camera angle, color grading, and composition — exactly as they appear in the PRIMARY SOURCE. Only the ${args.token} element should change.`,
+    args.newDescription
+      ? `New element description: ${args.newDescription}`
+      : '',
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+}
+
+export const replaceElementWorkflow = createScopedWorkflow<
+  ReplaceElementWorkflowInput,
+  ReplaceElementWorkflowResult
+>(
+  async (context, scopedDb) => {
+    const input = context.requestPayload;
+    const { sequenceId, elementId, token, affectedFrameIds, newImageUrl } =
+      input;
+    if (!sequenceId) {
+      throw new Error('[ReplaceElementWorkflow] sequenceId is required');
+    }
+    const label = buildWorkflowLabel(sequenceId);
+
+    console.log(
+      '[ReplaceElementWorkflow]',
+      `Starting replace for element ${token} (${elementId}) — ${affectedFrameIds.length} affected frames`
+    );
+
+    // Step 1: re-run vision on the new element image so future scene
+    // generations and prompts have the correct description + consistencyTag.
+    const visionResult = await context.run('describe-new-element', async () => {
+      await scopedDb.sequenceElements.updateVisionStatus(
+        elementId,
+        'analyzing'
+      );
+      const openRouterApiKeyInfo =
+        await scopedDb.apiKeys.resolveKey('openrouter');
+      const result = await describeElementImage({
+        imageUrl: newImageUrl,
+        filename: input.newFilename,
+        token,
+        openRouterApiKey: openRouterApiKeyInfo.key,
+      });
+      await scopedDb.sequenceElements.updateVisionResult(
+        elementId,
+        result.description,
+        result.consistencyTag
+      );
+      return result;
+    });
+
+    if (affectedFrameIds.length === 0) {
+      return {
+        elementId,
+        framesEdited: 0,
+        framesFailed: 0,
+      };
+    }
+
+    await context.run('emit-start', async () => {
+      await getGenerationChannel(sequenceId).emit(
+        'generation.replace-element:start',
+        { elementId, frameCount: affectedFrameIds.length }
+      );
+    });
+
+    const sequence = await context.run('load-sequence', () =>
+      scopedDb.sequences.getById(sequenceId)
+    );
+    if (!sequence) {
+      throw new Error(
+        `[ReplaceElementWorkflow] Sequence ${sequenceId} not found`
+      );
+    }
+
+    const aspectRatio = sequence.aspectRatio;
+    const imageModel = input.imageModel ?? DEFAULT_IMAGE_MODEL;
+
+    const frames = await context.run('load-frames', () =>
+      scopedDb.frames.getByIds(affectedFrameIds)
+    );
+    if (frames.length !== affectedFrameIds.length) {
+      const found = new Set(frames.map((f) => f.id));
+      const missing = affectedFrameIds.filter((id) => !found.has(id));
+      throw new Error(
+        `[ReplaceElementWorkflow] Missing frames for element ${token}: ${missing.join(', ')}`
+      );
+    }
+
+    const editPrompt = buildEditPrompt({
+      token,
+      newDescription: visionResult.description,
+      previousDescription: input.previousDescription,
+    });
+
+    const results: FrameResult[] = await Promise.all(
+      frames.map(async (frame): Promise<FrameResult> => {
+        const sourceImageUrl = frame.thumbnailUrl;
+        if (!sourceImageUrl) {
+          // Frame has no image to edit — replacement only meaningful when a
+          // primary thumbnail exists. Skip rather than fall back to text-to-
+          // image, which would silently regenerate from prose.
+          return {
+            frameId: frame.id,
+            success: false,
+            error: 'no source thumbnail to edit',
+          };
+        }
+
+        // Prefer the frame's existing model when it supports edits, so the
+        // edit reads as a natural continuation of the original render. Fall
+        // back to the workflow's chosen edit-capable model otherwise.
+        const frameModel = safeTextToImageModel(
+          frame.imageModel,
+          DEFAULT_IMAGE_MODEL
+        );
+        const model = supportsReferenceImages(frameModel)
+          ? frameModel
+          : imageModel;
+
+        const body: ImageWorkflowInput = {
+          userId: input.userId,
+          teamId: input.teamId,
+          sequenceId,
+          frameId: frame.id,
+          prompt: editPrompt,
+          model,
+          imageSize: aspectRatioToImageSize(aspectRatio),
+          numImages: 1,
+          referenceImages: [
+            {
+              referenceImageUrl: sourceImageUrl,
+              description: 'Existing frame to edit',
+              role: 'primary',
+            },
+            {
+              referenceImageUrl: newImageUrl,
+              description: `${token} - ${visionResult.description}`,
+              role: 'element',
+            },
+          ],
+        };
+
+        const {
+          body: invokeResult,
+          isFailed,
+          isCanceled,
+        } = await context.invoke('image', {
+          workflow: generateImageWorkflow,
+          label,
+          body,
+          retries: 3,
+          retryDelay: 'pow(2, retried) * 1000',
+          flowControl: getFalFlowControl(),
+        });
+
+        // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
+        if (isFailed || isCanceled || !invokeResult?.imageUrl) {
+          const reason = isCanceled
+            ? 'canceled'
+            : isFailed
+              ? 'failed'
+              : 'no imageUrl';
+          console.error(
+            '[ReplaceElementWorkflow]',
+            `Image edit failed frame=${frame.id} reason=${reason}`
+          );
+          return {
+            frameId: frame.id,
+            success: false,
+            error: `Image edit ${reason}`,
+          };
+        }
+
+        return {
+          frameId: frame.id,
+          success: true,
+          imageUrl: invokeResult.imageUrl,
+        };
+      })
+    );
+
+    const successCount = results.filter((r) => r.success).length;
+    const failedCount = results.length - successCount;
+
+    await context.run('emit-complete', async () => {
+      await getGenerationChannel(sequenceId).emit(
+        'generation.replace-element:complete',
+        { elementId, successCount, failedCount }
+      );
+    });
+
+    console.log(
+      '[ReplaceElementWorkflow]',
+      `Completed: ${successCount} edited, ${failedCount} failed for element ${token}`
+    );
+
+    return {
+      elementId,
+      framesEdited: successCount,
+      framesFailed: failedCount,
+    };
+  },
+  {
+    failureFunction: async ({ context, scopedDb, failResponse }) => {
+      const input = context.requestPayload;
+      const error = sanitizeFailResponse(failResponse);
+
+      // Mark vision failed so the UI surfaces the problem on the element row;
+      // the new image is already persisted so the user can retry by uploading
+      // again or by triggering vision separately.
+      try {
+        await scopedDb.sequenceElements.updateVisionStatus(
+          input.elementId,
+          'failed',
+          error
+        );
+      } catch (e) {
+        console.error(
+          '[ReplaceElementWorkflow] Failed to persist vision error:',
+          e
+        );
+      }
+
+      if (input.sequenceId) {
+        await getGenerationChannel(input.sequenceId).emit(
+          'generation.replace-element:failed',
+          { elementId: input.elementId, error }
+        );
+      }
+
+      console.error(
+        '[ReplaceElementWorkflow]',
+        `Replace failed for element ${input.token}: ${error}`
+      );
+
+      return `Replace element failed for ${input.token}`;
+    },
+  }
+);

--- a/src/lib/workflows/replace-element-workflow.ts
+++ b/src/lib/workflows/replace-element-workflow.ts
@@ -37,7 +37,7 @@ type FrameResult =
   | { frameId: string; success: true; imageUrl: string }
   | { frameId: string; success: false; error: string };
 
-function buildEditPrompt(args: {
+export function buildEditPrompt(args: {
   token: string;
   newDescription: string;
   previousDescription: string | null;
@@ -75,6 +75,16 @@ export const replaceElementWorkflow = createScopedWorkflow<
       `Starting replace for element ${token} (${elementId}) — ${affectedFrameIds.length} affected frames`
     );
 
+    // Emit :start exactly once from the workflow side (the server fn no
+    // longer emits). Fires before vision so subscribers see the full
+    // lifecycle even if vision throws.
+    await context.run('emit-start', async () => {
+      await getGenerationChannel(sequenceId).emit(
+        'generation.replace-element:start',
+        { elementId, frameCount: affectedFrameIds.length }
+      );
+    });
+
     // Step 1: re-run vision on the new element image so future scene
     // generations and prompts have the correct description + consistencyTag.
     const visionResult = await context.run('describe-new-element', async () => {
@@ -99,19 +109,18 @@ export const replaceElementWorkflow = createScopedWorkflow<
     });
 
     if (affectedFrameIds.length === 0) {
+      await context.run('emit-complete-empty', async () => {
+        await getGenerationChannel(sequenceId).emit(
+          'generation.replace-element:complete',
+          { elementId, successCount: 0, failedCount: 0 }
+        );
+      });
       return {
         elementId,
         framesEdited: 0,
         framesFailed: 0,
       };
     }
-
-    await context.run('emit-start', async () => {
-      await getGenerationChannel(sequenceId).emit(
-        'generation.replace-element:start',
-        { elementId, frameCount: affectedFrameIds.length }
-      );
-    });
 
     const sequence = await context.run('load-sequence', () =>
       scopedDb.sequences.getById(sequenceId)
@@ -125,14 +134,20 @@ export const replaceElementWorkflow = createScopedWorkflow<
     const aspectRatio = sequence.aspectRatio;
     const imageModel = input.imageModel ?? DEFAULT_IMAGE_MODEL;
 
-    const frames = await context.run('load-frames', () =>
+    // Frames captured at trigger time may have been deleted mid-flight. Treat
+    // missing frames as skipped rather than aborting the whole batch (matches
+    // the per-frame `skipped-deleted` pattern in regenerate-frames-workflow).
+    const liveFrames = await context.run('load-frames', () =>
       scopedDb.frames.getByIds(affectedFrameIds)
     );
-    if (frames.length !== affectedFrameIds.length) {
-      const found = new Set(frames.map((f) => f.id));
-      const missing = affectedFrameIds.filter((id) => !found.has(id));
-      throw new Error(
-        `[ReplaceElementWorkflow] Missing frames for element ${token}: ${missing.join(', ')}`
+    const liveFrameIds = new Set(liveFrames.map((f) => f.id));
+    const skippedDeletedFrameIds = affectedFrameIds.filter(
+      (id) => !liveFrameIds.has(id)
+    );
+    if (skippedDeletedFrameIds.length > 0) {
+      console.warn(
+        '[ReplaceElementWorkflow]',
+        `Skipping ${skippedDeletedFrameIds.length} deleted frame(s): ${skippedDeletedFrameIds.join(', ')}`
       );
     }
 
@@ -143,7 +158,7 @@ export const replaceElementWorkflow = createScopedWorkflow<
     });
 
     const results: FrameResult[] = await Promise.all(
-      frames.map(async (frame): Promise<FrameResult> => {
+      liveFrames.map(async (frame): Promise<FrameResult> => {
         const sourceImageUrl = frame.thumbnailUrl;
         if (!sourceImageUrl) {
           // Frame has no image to edit — replacement only meaningful when a
@@ -232,6 +247,21 @@ export const replaceElementWorkflow = createScopedWorkflow<
     const successCount = results.filter((r) => r.success).length;
     const failedCount = results.length - successCount;
 
+    // If every frame failed at image-edit (and there *was* at least one to
+    // edit), surface as a real failure instead of a green :complete. Skipped-
+    // deleted frames are not counted against the success-floor because they
+    // never had a chance to run.
+    if (results.length > 0 && successCount === 0) {
+      const firstFailure = results.find((r) => !r.success);
+      const sampleReason =
+        firstFailure && !firstFailure.success
+          ? firstFailure.error
+          : 'image edit failed';
+      throw new Error(
+        `[ReplaceElementWorkflow] All ${results.length} frame edit(s) failed for ${token}: ${sampleReason}`
+      );
+    }
+
     await context.run('emit-complete', async () => {
       await getGenerationChannel(sequenceId).emit(
         'generation.replace-element:complete',
@@ -241,7 +271,7 @@ export const replaceElementWorkflow = createScopedWorkflow<
 
     console.log(
       '[ReplaceElementWorkflow]',
-      `Completed: ${successCount} edited, ${failedCount} failed for element ${token}`
+      `Completed: ${successCount} edited, ${failedCount} failed, ${skippedDeletedFrameIds.length} skipped-deleted for element ${token}`
     );
 
     return {
@@ -255,18 +285,25 @@ export const replaceElementWorkflow = createScopedWorkflow<
       const input = context.requestPayload;
       const error = sanitizeFailResponse(failResponse);
 
-      // Mark vision failed so the UI surfaces the problem on the element row;
-      // the new image is already persisted so the user can retry by uploading
-      // again or by triggering vision separately.
+      // The failure could be in the vision step (visionStatus still
+      // `analyzing`) or in the image-edit step (vision succeeded → status is
+      // `completed`). Only downgrade vision in the first case; otherwise the
+      // element card would mislead the user into thinking the description
+      // analysis failed when it was actually the per-frame edit.
       try {
-        await scopedDb.sequenceElements.updateVisionStatus(
-          input.elementId,
-          'failed',
-          error
+        const current = await scopedDb.sequenceElements.getById(
+          input.elementId
         );
+        if (current && current.visionStatus !== 'completed') {
+          await scopedDb.sequenceElements.updateVisionStatus(
+            input.elementId,
+            'failed',
+            error
+          );
+        }
       } catch (e) {
         console.error(
-          '[ReplaceElementWorkflow] Failed to persist vision error:',
+          '[ReplaceElementWorkflow] Failed to read/persist vision error:',
           e
         );
       }

--- a/src/lib/workflows/replace-element-workflow.ts
+++ b/src/lib/workflows/replace-element-workflow.ts
@@ -21,6 +21,7 @@ import {
   supportsReferenceImages,
 } from '@/lib/ai/models';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
+import type { ElementVisionStatus } from '@/lib/db/schema';
 import { getGenerationChannel } from '@/lib/realtime';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
@@ -33,9 +34,81 @@ import type {
 import { getFalFlowControl } from './constants';
 import { generateImageWorkflow } from './image-workflow';
 
-type FrameResult =
+export type FrameResult =
   | { frameId: string; success: true; imageUrl: string }
   | { frameId: string; success: false; error: string };
+
+export type BatchOutcome =
+  | { kind: 'complete'; successCount: number; failedCount: number }
+  | { kind: 'fail'; sampleReason: string; total: number };
+
+/**
+ * Pure decision: given per-frame results, should the workflow emit `:complete`
+ * or throw to trigger `failureFunction`? Skipped-deleted frames never enter
+ * `results` so they don't count against the success floor.
+ */
+export function decideBatchOutcome(results: FrameResult[]): BatchOutcome {
+  const successCount = results.filter((r) => r.success).length;
+  const failedCount = results.length - successCount;
+  if (results.length === 0) {
+    return { kind: 'complete', successCount: 0, failedCount: 0 };
+  }
+  if (successCount === 0) {
+    const firstFailure = results.find((r) => !r.success);
+    const sampleReason =
+      firstFailure && !firstFailure.success
+        ? firstFailure.error
+        : 'image edit failed';
+    return { kind: 'fail', sampleReason, total: results.length };
+  }
+  return { kind: 'complete', successCount, failedCount };
+}
+
+/**
+ * Pure decision: when the workflow's `failureFunction` fires, should the
+ * element's `visionStatus` be downgraded to `'failed'`? Only when vision was
+ * still in flight — if vision already succeeded, the failure was in a per-
+ * frame edit and downgrading would mislead the element card into showing
+ * "vision failed".
+ */
+export function shouldDowngradeVisionOnFailure(
+  current: ElementVisionStatus
+): boolean {
+  return current !== 'completed';
+}
+
+/**
+ * Best-effort string extraction from a `Promise.allSettled` rejection reason.
+ * Errors thrown by application code are usually `Error`, but third-party
+ * SDKs and async helpers can reject with strings, plain objects, or
+ * DOMException-like values; serializing those preserves the production
+ * trail instead of collapsing to a literal `'unknown'`.
+ */
+export function rejectionReasonMessage(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  if (typeof reason === 'string') return reason;
+  try {
+    const json = JSON.stringify(reason);
+    if (json && json !== '{}') return json;
+  } catch {
+    // Circular references etc. fall through to the typeof tag.
+  }
+  return `non-error rejection (${typeof reason})`;
+}
+
+export function settledToResult(
+  settled: PromiseSettledResult<FrameResult>,
+  frameId: string | undefined
+): FrameResult {
+  if (settled.status === 'fulfilled') return settled.value;
+  const message = rejectionReasonMessage(settled.reason);
+  const id = frameId ?? 'unknown';
+  console.error('[ReplaceElementWorkflow] Per-frame promise rejected', {
+    frameId: id,
+    reason: settled.reason,
+  });
+  return { frameId: id, success: false, error: message };
+}
 
 export function buildEditPrompt(args: {
   token: string;
@@ -57,6 +130,26 @@ export function buildEditPrompt(args: {
     .join('\n\n');
 }
 
+/**
+ * Emit a realtime event without letting transient Redis failures take down a
+ * successful generation. The element card polls for the row's vision status,
+ * so a dropped event degrades UX (no toast) but never blocks completion.
+ */
+async function safeEmit(
+  sequenceId: string,
+  label: string,
+  fn: () => Promise<unknown> | null
+): Promise<void> {
+  try {
+    await fn();
+  } catch (e) {
+    console.error(
+      `[ReplaceElementWorkflow] emit ${label} for ${sequenceId} failed:`,
+      e
+    );
+  }
+}
+
 export const replaceElementWorkflow = createScopedWorkflow<
   ReplaceElementWorkflowInput,
   ReplaceElementWorkflowResult
@@ -65,9 +158,6 @@ export const replaceElementWorkflow = createScopedWorkflow<
     const input = context.requestPayload;
     const { sequenceId, elementId, token, affectedFrameIds, newImageUrl } =
       input;
-    if (!sequenceId) {
-      throw new Error('[ReplaceElementWorkflow] sequenceId is required');
-    }
     const label = buildWorkflowLabel(sequenceId);
 
     console.log(
@@ -75,18 +165,17 @@ export const replaceElementWorkflow = createScopedWorkflow<
       `Starting replace for element ${token} (${elementId}) — ${affectedFrameIds.length} affected frames`
     );
 
-    // Emit :start exactly once from the workflow side (the server fn no
-    // longer emits). Fires before vision so subscribers see the full
-    // lifecycle even if vision throws.
-    await context.run('emit-start', async () => {
-      await getGenerationChannel(sequenceId).emit(
-        'generation.replace-element:start',
-        { elementId, frameCount: affectedFrameIds.length }
-      );
-    });
+    // Fires before vision so subscribers see the full lifecycle even if
+    // vision throws.
+    await context.run('emit-start', () =>
+      safeEmit(sequenceId, 'start', () =>
+        getGenerationChannel(sequenceId).emit(
+          'generation.replace-element:start',
+          { elementId, frameCount: affectedFrameIds.length }
+        )
+      )
+    );
 
-    // Step 1: re-run vision on the new element image so future scene
-    // generations and prompts have the correct description + consistencyTag.
     const visionResult = await context.run('describe-new-element', async () => {
       await scopedDb.sequenceElements.updateVisionStatus(
         elementId,
@@ -109,16 +198,18 @@ export const replaceElementWorkflow = createScopedWorkflow<
     });
 
     if (affectedFrameIds.length === 0) {
-      await context.run('emit-complete-empty', async () => {
-        await getGenerationChannel(sequenceId).emit(
-          'generation.replace-element:complete',
-          { elementId, successCount: 0, failedCount: 0 }
-        );
-      });
+      await context.run('emit-complete-empty', () =>
+        safeEmit(sequenceId, 'complete-empty', () =>
+          getGenerationChannel(sequenceId).emit(
+            'generation.replace-element:complete',
+            { elementId, successCount: 0, failedCount: 0 }
+          )
+        )
+      );
       return {
         elementId,
-        framesEdited: 0,
-        framesFailed: 0,
+        successCount: 0,
+        failedCount: 0,
       };
     }
 
@@ -135,8 +226,7 @@ export const replaceElementWorkflow = createScopedWorkflow<
     const imageModel = input.imageModel ?? DEFAULT_IMAGE_MODEL;
 
     // Frames captured at trigger time may have been deleted mid-flight. Treat
-    // missing frames as skipped rather than aborting the whole batch (matches
-    // the per-frame `skipped-deleted` pattern in regenerate-frames-workflow).
+    // missing frames as skipped rather than aborting the whole batch.
     const liveFrames = await context.run('load-frames', () =>
       scopedDb.frames.getByIds(affectedFrameIds)
     );
@@ -157,13 +247,16 @@ export const replaceElementWorkflow = createScopedWorkflow<
       previousDescription: input.previousDescription,
     });
 
-    const results: FrameResult[] = await Promise.all(
+    // Parallel fan-out — flowControl + per-invoke retries handle backpressure.
+    // `allSettled` so a per-frame throw (e.g. invoke rejection that bypasses
+    // the isFailed/isCanceled return path) doesn't abort sibling frames.
+    const settled = await Promise.allSettled(
       liveFrames.map(async (frame): Promise<FrameResult> => {
         const sourceImageUrl = frame.thumbnailUrl;
         if (!sourceImageUrl) {
-          // Frame has no image to edit — replacement only meaningful when a
-          // primary thumbnail exists. Skip rather than fall back to text-to-
-          // image, which would silently regenerate from prose.
+          // Replacement is only meaningful when a primary thumbnail exists;
+          // text-to-image regeneration would silently invent a frame from
+          // prose alone.
           return {
             frameId: frame.id,
             success: false,
@@ -171,9 +264,9 @@ export const replaceElementWorkflow = createScopedWorkflow<
           };
         }
 
-        // Prefer the frame's existing model when it supports edits, so the
-        // edit reads as a natural continuation of the original render. Fall
-        // back to the workflow's chosen edit-capable model otherwise.
+        // Prefer the frame's own model when it supports edits, so the swap
+        // reads as a continuation of the original render. Fall back to the
+        // workflow's edit-capable default otherwise.
         const frameModel = safeTextToImageModel(
           frame.imageModel,
           DEFAULT_IMAGE_MODEL
@@ -244,40 +337,39 @@ export const replaceElementWorkflow = createScopedWorkflow<
       })
     );
 
-    const successCount = results.filter((r) => r.success).length;
-    const failedCount = results.length - successCount;
+    const results: FrameResult[] = settled.map((s, i) =>
+      settledToResult(s, liveFrames[i]?.id)
+    );
 
-    // If every frame failed at image-edit (and there *was* at least one to
-    // edit), surface as a real failure instead of a green :complete. Skipped-
-    // deleted frames are not counted against the success-floor because they
-    // never had a chance to run.
-    if (results.length > 0 && successCount === 0) {
-      const firstFailure = results.find((r) => !r.success);
-      const sampleReason =
-        firstFailure && !firstFailure.success
-          ? firstFailure.error
-          : 'image edit failed';
+    const outcome = decideBatchOutcome(results);
+    if (outcome.kind === 'fail') {
       throw new Error(
-        `[ReplaceElementWorkflow] All ${results.length} frame edit(s) failed for ${token}: ${sampleReason}`
+        `[ReplaceElementWorkflow] All ${outcome.total} frame edit(s) failed for ${token}: ${outcome.sampleReason}`
       );
     }
 
-    await context.run('emit-complete', async () => {
-      await getGenerationChannel(sequenceId).emit(
-        'generation.replace-element:complete',
-        { elementId, successCount, failedCount }
-      );
-    });
+    await context.run('emit-complete', () =>
+      safeEmit(sequenceId, 'complete', () =>
+        getGenerationChannel(sequenceId).emit(
+          'generation.replace-element:complete',
+          {
+            elementId,
+            successCount: outcome.successCount,
+            failedCount: outcome.failedCount,
+          }
+        )
+      )
+    );
 
     console.log(
       '[ReplaceElementWorkflow]',
-      `Completed: ${successCount} edited, ${failedCount} failed, ${skippedDeletedFrameIds.length} skipped-deleted for element ${token}`
+      `Completed: ${outcome.successCount} edited, ${outcome.failedCount} failed, ${skippedDeletedFrameIds.length} skipped-deleted for element ${token}`
     );
 
     return {
       elementId,
-      framesEdited: successCount,
-      framesFailed: failedCount,
+      successCount: outcome.successCount,
+      failedCount: outcome.failedCount,
     };
   },
   {
@@ -285,35 +377,52 @@ export const replaceElementWorkflow = createScopedWorkflow<
       const input = context.requestPayload;
       const error = sanitizeFailResponse(failResponse);
 
-      // The failure could be in the vision step (visionStatus still
-      // `analyzing`) or in the image-edit step (vision succeeded → status is
-      // `completed`). Only downgrade vision in the first case; otherwise the
-      // element card would mislead the user into thinking the description
-      // analysis failed when it was actually the per-frame edit.
+      // The failure could be in vision (status still `analyzing`) or in a
+      // per-frame edit (vision succeeded → status is `completed`). Only
+      // downgrade in the first case; otherwise the element card would
+      // mislead the user about which step failed.
+      //
+      // If reading the row throws (Turso blip), default to writing `failed`
+      // anyway — better to mislabel as vision-failed than leave the row
+      // stuck in `analyzing` forever (the whole point of this recovery).
+      let shouldDowngrade = true;
       try {
         const current = await scopedDb.sequenceElements.getById(
           input.elementId
         );
-        if (current && current.visionStatus !== 'completed') {
+        if (current) {
+          shouldDowngrade = shouldDowngradeVisionOnFailure(
+            current.visionStatus
+          );
+        }
+      } catch (e) {
+        console.error(
+          '[ReplaceElementWorkflow] Failed to read current element status; assuming vision in-flight:',
+          e
+        );
+      }
+
+      if (shouldDowngrade) {
+        try {
           await scopedDb.sequenceElements.updateVisionStatus(
             input.elementId,
             'failed',
             error
           );
+        } catch (e) {
+          console.error(
+            '[ReplaceElementWorkflow] Failed to persist vision-failed status:',
+            e
+          );
         }
-      } catch (e) {
-        console.error(
-          '[ReplaceElementWorkflow] Failed to read/persist vision error:',
-          e
-        );
       }
 
-      if (input.sequenceId) {
-        await getGenerationChannel(input.sequenceId).emit(
+      await safeEmit(input.sequenceId, 'failed', () =>
+        getGenerationChannel(input.sequenceId).emit(
           'generation.replace-element:failed',
           { elementId: input.elementId, error }
-        );
-      }
+        )
+      );
 
       console.error(
         '[ReplaceElementWorkflow]',

--- a/src/lib/workflows/replace-element-workflow.ts
+++ b/src/lib/workflows/replace-element-workflow.ts
@@ -17,22 +17,27 @@
 import { describeElementImage } from '@/lib/ai/element-vision';
 import {
   DEFAULT_IMAGE_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  safeImageToVideoModel,
   safeTextToImageModel,
   supportsReferenceImages,
 } from '@/lib/ai/models';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
-import type { ElementVisionStatus } from '@/lib/db/schema';
+import type { ElementVisionStatus, Frame } from '@/lib/db/schema';
+import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type {
   ImageWorkflowInput,
+  MotionWorkflowInput,
   ReplaceElementWorkflowInput,
   ReplaceElementWorkflowResult,
 } from '@/lib/workflow/types';
 import { getFalFlowControl } from './constants';
 import { generateImageWorkflow } from './image-workflow';
+import { generateMotionWorkflow } from './motion-workflow';
 
 export type FrameResult =
   | { frameId: string; success: true; imageUrl: string }
@@ -156,8 +161,8 @@ export const replaceElementWorkflow = createScopedWorkflow<
 >(
   async (context, scopedDb) => {
     const input = context.requestPayload;
-    const { sequenceId, elementId, token, affectedFrameIds, newImageUrl } =
-      input;
+    const { sequenceId, elementId, affectedFrameIds, newImageUrl } = input;
+    let token = input.token;
     const label = buildWorkflowLabel(sequenceId);
 
     console.log(
@@ -186,7 +191,6 @@ export const replaceElementWorkflow = createScopedWorkflow<
       const result = await describeElementImage({
         imageUrl: newImageUrl,
         filename: input.newFilename,
-        token,
         openRouterApiKey: openRouterApiKeyInfo.key,
       });
       await scopedDb.sequenceElements.updateVisionResult(
@@ -197,12 +201,39 @@ export const replaceElementWorkflow = createScopedWorkflow<
       return result;
     });
 
+    // Vision-driven auto-rename: if the new image suggests a meaningfully
+    // different identifier AND that identifier isn't taken, cascade the
+    // rename through script + frames before the edits so the rewritten
+    // prompts/extracts land on the new token rather than the stale one.
+    let renamedTo: string | undefined;
+    if (visionResult.suggestedToken !== token) {
+      const newToken = await context.run('auto-rename-token', async () => {
+        const taken = await scopedDb.sequenceElements.isTokenTaken(
+          sequenceId,
+          visionResult.suggestedToken,
+          elementId
+        );
+        if (taken) return null;
+        const result = await scopedDb.sequenceElements.cascadeRename({
+          sequenceId,
+          elementId,
+          oldToken: token,
+          newToken: visionResult.suggestedToken,
+        });
+        return result.element.token;
+      });
+      if (newToken && newToken !== token) {
+        renamedTo = newToken;
+        token = newToken;
+      }
+    }
+
     if (affectedFrameIds.length === 0) {
       await context.run('emit-complete-empty', () =>
         safeEmit(sequenceId, 'complete-empty', () =>
           getGenerationChannel(sequenceId).emit(
             'generation.replace-element:complete',
-            { elementId, successCount: 0, failedCount: 0 }
+            { elementId, successCount: 0, failedCount: 0, renamedTo }
           )
         )
       );
@@ -234,6 +265,45 @@ export const replaceElementWorkflow = createScopedWorkflow<
     const skippedDeletedFrameIds = affectedFrameIds.filter(
       (id) => !liveFrameIds.has(id)
     );
+
+    // Flip every affected frame to `generating` and emit progress events
+    // BEFORE fanning out per-frame edits. Otherwise the user can navigate to
+    // a scene during the vision phase and see stale "completed" thumbnails —
+    // the image-workflow's own set-generating-status step runs too late to
+    // cover that window. Same upfront flip for videos: any frame with a
+    // prior video will be regenerated, so its video tile should already read
+    // as in-flight.
+    await context.run('mark-frames-generating', async () => {
+      for (const frame of liveFrames) {
+        const updates: Record<string, unknown> = {};
+        if (frame.thumbnailUrl) {
+          updates.thumbnailStatus = 'generating';
+          updates.thumbnailError = null;
+        }
+        if (frame.videoUrl) {
+          updates.videoStatus = 'generating';
+          updates.videoError = null;
+        }
+        if (Object.keys(updates).length === 0) continue;
+        await scopedDb.frames.update(frame.id, updates, {
+          throwOnMissing: false,
+        });
+        await safeEmit(sequenceId, `image-progress:${frame.id}`, () =>
+          getGenerationChannel(sequenceId).emit('generation.image:progress', {
+            frameId: frame.id,
+            status: 'generating',
+          })
+        );
+        if (frame.videoUrl) {
+          await safeEmit(sequenceId, `video-progress:${frame.id}`, () =>
+            getGenerationChannel(sequenceId).emit('generation.video:progress', {
+              frameId: frame.id,
+              status: 'generating',
+            })
+          );
+        }
+      }
+    });
     if (skippedDeletedFrameIds.length > 0) {
       console.warn(
         '[ReplaceElementWorkflow]',
@@ -348,6 +418,86 @@ export const replaceElementWorkflow = createScopedWorkflow<
       );
     }
 
+    // Cascade to videos: for each successfully-edited frame that previously
+    // had a video, regenerate the video off the new thumbnail. The frame's
+    // `videoStatus` flips to `generating` so the existing UI surfaces the
+    // in-flight state on both the image and video pages.
+    const successByFrameId = new Map<string, string>();
+    for (const r of results) {
+      if (r.success) successByFrameId.set(r.frameId, r.imageUrl);
+    }
+    const videoModel = safeImageToVideoModel(
+      sequence.videoModel,
+      DEFAULT_VIDEO_MODEL
+    );
+    const framesNeedingVideoRegen: Frame[] = liveFrames.filter(
+      (f) => !!f.videoUrl && successByFrameId.has(f.id)
+    );
+
+    let videoSuccessCount = 0;
+    let videoFailedCount = 0;
+    if (framesNeedingVideoRegen.length > 0) {
+      console.log(
+        '[ReplaceElementWorkflow]',
+        `Regenerating video for ${framesNeedingVideoRegen.length} frame(s) tied to element ${token}`
+      );
+      const videoSettled = await Promise.allSettled(
+        framesNeedingVideoRegen.map(async (frame) => {
+          const newThumbnailUrl = successByFrameId.get(frame.id);
+          if (!newThumbnailUrl) {
+            return { frameId: frame.id, success: false };
+          }
+
+          await scopedDb.frames.update(frame.id, {
+            videoStatus: 'generating',
+            videoError: null,
+          });
+
+          const body: MotionWorkflowInput = {
+            userId: input.userId,
+            teamId: input.teamId,
+            sequenceId,
+            frameId: frame.id,
+            imageUrl: newThumbnailUrl,
+            prompt: resolveMotionPrompt(frame, videoModel),
+            model: videoModel,
+            aspectRatio,
+            duration: frame.durationMs ? frame.durationMs / 1000 : undefined,
+          };
+
+          const { isFailed, isCanceled } = await context.invoke(
+            `motion-${frame.id}`,
+            {
+              workflow: generateMotionWorkflow,
+              label,
+              body,
+              retries: 3,
+              retryDelay: 'pow(2, retried) * 1000',
+              flowControl: getFalFlowControl(),
+            }
+          );
+
+          return {
+            frameId: frame.id,
+            success: !isFailed && !isCanceled,
+          };
+        })
+      );
+      for (const settled of videoSettled) {
+        if (settled.status === 'fulfilled' && settled.value.success) {
+          videoSuccessCount += 1;
+        } else {
+          videoFailedCount += 1;
+          if (settled.status === 'rejected') {
+            console.error(
+              '[ReplaceElementWorkflow] motion regen rejected:',
+              rejectionReasonMessage(settled.reason)
+            );
+          }
+        }
+      }
+    }
+
     await context.run('emit-complete', () =>
       safeEmit(sequenceId, 'complete', () =>
         getGenerationChannel(sequenceId).emit(
@@ -356,6 +506,9 @@ export const replaceElementWorkflow = createScopedWorkflow<
             elementId,
             successCount: outcome.successCount,
             failedCount: outcome.failedCount,
+            videoSuccessCount,
+            videoFailedCount,
+            renamedTo,
           }
         )
       )
@@ -363,7 +516,7 @@ export const replaceElementWorkflow = createScopedWorkflow<
 
     console.log(
       '[ReplaceElementWorkflow]',
-      `Completed: ${outcome.successCount} edited, ${outcome.failedCount} failed, ${skippedDeletedFrameIds.length} skipped-deleted for element ${token}`
+      `Completed: ${outcome.successCount} edited, ${outcome.failedCount} failed, ${skippedDeletedFrameIds.length} skipped-deleted, videos ${videoSuccessCount}/${videoFailedCount} for element ${token}`
     );
 
     return {

--- a/src/routes/api/workflows/$.ts
+++ b/src/routes/api/workflows/$.ts
@@ -34,6 +34,7 @@ import { generateMusicWorkflow } from '@/lib/workflows/music-workflow';
 import { recastCharacterWorkflow } from '@/lib/workflows/recast-character-workflow';
 import { recastLocationWorkflow } from '@/lib/workflows/recast-location-workflow';
 import { regenerateFramesWorkflow } from '@/lib/workflows/regenerate-frames-workflow';
+import { replaceElementWorkflow } from '@/lib/workflows/replace-element-workflow';
 import { sceneSplitWorkflow } from '@/lib/workflows/scene-split-workflow';
 import { generateStoryboardWorkflow } from '@/lib/workflows/storyboard-workflow';
 import { talentMatchingWorkflow } from '@/lib/workflows/talent-matching-workflow';
@@ -76,6 +77,7 @@ function getHandler() {
         'recast-character': recastCharacterWorkflow,
         'recast-location': recastLocationWorkflow,
         'regenerate-frames': regenerateFramesWorkflow,
+        'replace-element': replaceElementWorkflow,
         storyboard: generateStoryboardWorkflow,
         'talent-matching': talentMatchingWorkflow,
         'upscale-variant': upscaleShotVariantWorkflow,


### PR DESCRIPTION
## Related Issue
Closes #689

> Stacked on `688-edit-scene-duration`. Merge the parent PR first; GitHub will auto-retarget this one.

## Summary
Implemented replace-element flow: per-element file picker + confirm dialog, server fn + workflow that edits affected frames in place via image-workflow's edit endpoint.

## Notes
Opened by the agent-harness overnight runner. See the `harness-active` label.
