### PR TITLE
Schema-driven scene duration select #688

### DIFF
--- a/src/components/music/music-view.tsx
+++ b/src/components/music/music-view.tsx
@@ -2,6 +2,7 @@ import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { PromptHistorySheet } from '@/components/prompts/prompt-history-sheet';
 import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -31,12 +32,17 @@ type GenerateMusicArgs = {
   duration?: number;
 };
 
+type MergeVideoAndMusicArgs = {
+  /** When `false`, restitch frame videos but skip the music mux. */
+  includeMusic: boolean;
+};
+
 type MusicViewProps = {
   sequence: Sequence;
   videoDuration?: number;
   onGenerateMusic: (args?: GenerateMusicArgs) => void;
   isGeneratingMusic: boolean;
-  onMergeVideoAndMusic: () => void;
+  onMergeVideoAndMusic: (args: MergeVideoAndMusicArgs) => void;
   isMergingVideoAndMusic: boolean;
   /** Banner rendered above the audio player while `musicStatus === 'completed'`. */
   divergentBanner?: React.ReactNode;
@@ -160,6 +166,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
     () => videoDuration
   );
   const [historyOpen, setHistoryOpen] = useState(false);
+  const [includeMusicInMerge, setIncludeMusicInMerge] = useState(true);
 
   // Resync the textarea when the source-of-truth musicPrompt changes from
   // outside (regenerate, restore, realtime update). Without this, a successful
@@ -254,6 +261,21 @@ export const MusicView: React.FC<MusicViewProps> = ({
         <ReadOnlyField label="Prompt" value={musicPrompt ?? 'Missing prompt'} />
         <ReadOnlyField label="Tags" value={musicTags ?? 'Missing tags'} />
 
+        <label
+          htmlFor="merge-include-music"
+          className="flex items-center gap-2 self-center text-sm text-muted-foreground"
+        >
+          <Checkbox
+            id="merge-include-music"
+            checked={includeMusicInMerge}
+            onCheckedChange={(checked) =>
+              setIncludeMusicInMerge(checked === true)
+            }
+            disabled={isMerging}
+          />
+          <span>Include music in merged video</span>
+        </label>
+
         <div className="flex justify-center gap-3">
           {historyButton}
           <LoadingButton
@@ -265,7 +287,9 @@ export const MusicView: React.FC<MusicViewProps> = ({
             Regenerate Music
           </LoadingButton>
           <LoadingButton
-            onClick={onMergeVideoAndMusic}
+            onClick={() =>
+              onMergeVideoAndMusic({ includeMusic: includeMusicInMerge })
+            }
             isLoading={isMerging}
             loadingText="Merging…"
           >

--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -13,6 +13,7 @@ import {
 import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
+  videoModelSupportsAudio,
   type AudioModel,
   type ImageToVideoModel,
 } from '@/lib/ai/models';
@@ -67,12 +68,15 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(false);
+  const [generateAudio, setGenerateAudio] = useState(true);
   const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
     initialMotionModel ?? DEFAULT_VIDEO_MODEL
   );
   const [musicModel, setMusicModel] = useState<AudioModel>(
     initialMusicModel ?? DEFAULT_MUSIC_MODEL
   );
+
+  const motionSupportsAudio = videoModelSupportsAudio(motionModel);
 
   const prevInitialMotionRef = useRef(initialMotionModel);
   if (
@@ -127,7 +131,12 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
+      await onBatchGenerateMotion({
+        includeMusic,
+        motionModel,
+        musicModel,
+        generateAudio: motionSupportsAudio ? generateAudio : false,
+      });
     } finally {
       setIsGenerating(false);
     }
@@ -287,6 +296,21 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
                   )}
                 </span>
               </label>
+              {motionSupportsAudio && (
+                <label
+                  htmlFor="mobile-batch-generate-audio"
+                  className="flex items-center gap-2 text-sm text-muted-foreground justify-center"
+                >
+                  <Checkbox
+                    id="mobile-batch-generate-audio"
+                    checked={generateAudio}
+                    onCheckedChange={(checked) =>
+                      setGenerateAudio(checked === true)
+                    }
+                  />
+                  <span>Include SFX &amp; dialogue</span>
+                </label>
+              )}
             </SheetFooter>
           )}
         </SheetContent>

--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -1,3 +1,5 @@
+import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
@@ -8,11 +10,18 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
+import {
+  DEFAULT_MUSIC_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  type AudioModel,
+  type ImageToVideoModel,
+} from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { cn } from '@/lib/utils';
 import type { Frame } from '@/types/database';
 import { ChevronUp, Loader2, Video } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
+import type { BatchGenerateMotionArgs } from './scene-list';
 import { SceneListItem } from './scene-list-item';
 import { SceneThumbnail } from './scene-thumbnail';
 
@@ -23,10 +32,16 @@ type MobileSceneDrawerProps = {
   onSelectFrame: (frameId: string) => void;
   regeneratingImages: Set<string>;
   regeneratingMotion: Set<string>;
-  onBatchGenerateMotion?: (includeMusic: boolean) => Promise<void>;
+  onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
   musicPromptsReady: boolean;
   /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
   hideBatchButton?: boolean;
+  /** Initial motion model for the batch selector (from `sequence.videoModel`). */
+  initialMotionModel?: ImageToVideoModel;
+  /** Initial music model for the batch selector (from `sequence.musicModel`). */
+  initialMusicModel?: AudioModel;
+  /** Current style category — used to filter style-restricted motion models. */
+  styleCategory?: string;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -45,10 +60,33 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   onBatchGenerateMotion,
   musicPromptsReady,
   hideBatchButton = false,
+  initialMotionModel,
+  initialMusicModel,
+  styleCategory,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(false);
+  const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
+    initialMotionModel ?? DEFAULT_VIDEO_MODEL
+  );
+  const [musicModel, setMusicModel] = useState<AudioModel>(
+    initialMusicModel ?? DEFAULT_MUSIC_MODEL
+  );
+
+  const prevInitialMotionRef = useRef(initialMotionModel);
+  if (
+    initialMotionModel &&
+    initialMotionModel !== prevInitialMotionRef.current
+  ) {
+    prevInitialMotionRef.current = initialMotionModel;
+    setMotionModel(initialMotionModel);
+  }
+  const prevInitialMusicRef = useRef(initialMusicModel);
+  if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
+    prevInitialMusicRef.current = initialMusicModel;
+    setMusicModel(initialMusicModel);
+  }
 
   const totalFrames = frames?.length ?? 0;
 
@@ -89,7 +127,7 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion(includeMusic);
+      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
     } finally {
       setIsGenerating(false);
     }
@@ -182,6 +220,30 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
           {showFooter && (
             <SheetFooter className="border-t pt-4 px-4 flex-col items-stretch gap-3">
+              <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">
+                  Motion model
+                </span>
+                <MotionModelSelector
+                  selectedModel={motionModel}
+                  onModelChange={setMotionModel}
+                  disabled={isGenerating || isMotionInProgress}
+                  aspectRatio={aspectRatio}
+                  styleCategory={styleCategory}
+                />
+              </div>
+              {includeMusic && (
+                <div className="flex flex-col gap-1">
+                  <span className="text-xs text-muted-foreground">
+                    Music model
+                  </span>
+                  <MusicModelSelector
+                    selectedModel={musicModel}
+                    onModelChange={setMusicModel}
+                    disabled={isGenerating || isMotionInProgress}
+                  />
+                </div>
+              )}
               <Button
                 variant="default"
                 onClick={() => void handleGenerateMotion()}

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
+  videoModelSupportsAudio,
   type AudioModel,
   type ImageToVideoModel,
 } from '@/lib/ai/models';
@@ -19,6 +20,9 @@ export type BatchGenerateMotionArgs = {
   includeMusic: boolean;
   motionModel: ImageToVideoModel;
   musicModel: AudioModel;
+  /** When the motion model emits audio (sfx/dialogue/ambient), allow the
+   *  user to suppress it. Ignored for models without audio output. */
+  generateAudio: boolean;
 };
 
 type SceneListProps = {
@@ -78,12 +82,15 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
+  const [generateAudio, setGenerateAudio] = useState(true);
   const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
     initialMotionModel ?? DEFAULT_VIDEO_MODEL
   );
   const [musicModel, setMusicModel] = useState<AudioModel>(
     initialMusicModel ?? DEFAULT_MUSIC_MODEL
   );
+
+  const motionSupportsAudio = videoModelSupportsAudio(motionModel);
 
   // Sync local selection when the sequence's saved model changes from outside
   // (e.g. after generation completes and the workflow persists the new model).
@@ -133,7 +140,12 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
+      await onBatchGenerateMotion({
+        includeMusic,
+        motionModel,
+        musicModel,
+        generateAudio: motionSupportsAudio ? generateAudio : false,
+      });
     } finally {
       setIsGenerating(false);
     }
@@ -262,6 +274,21 @@ const SceneListComponent: React.FC<SceneListProps> = ({
               )}
             </span>
           </label>
+          {motionSupportsAudio && (
+            <label
+              htmlFor="batch-generate-audio"
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              <Checkbox
+                id="batch-generate-audio"
+                checked={generateAudio}
+                onCheckedChange={(checked) =>
+                  setGenerateAudio(checked === true)
+                }
+              />
+              <span>Include SFX &amp; dialogue</span>
+            </label>
+          )}
         </div>
       )}
     </div>

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -1,11 +1,25 @@
+import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  DEFAULT_MUSIC_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  type AudioModel,
+  type ImageToVideoModel,
+} from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import type { Frame, FrameVariant } from '@/lib/db/schema';
 import { Loader2, Video } from 'lucide-react';
-import { memo, useMemo, useState } from 'react';
+import { memo, useMemo, useRef, useState } from 'react';
 import { SceneListItem } from './scene-list-item';
+
+export type BatchGenerateMotionArgs = {
+  includeMusic: boolean;
+  motionModel: ImageToVideoModel;
+  musicModel: AudioModel;
+};
 
 type SceneListProps = {
   frames?: Frame[] | undefined;
@@ -14,13 +28,19 @@ type SceneListProps = {
   onSelectFrame: (frameId: string) => void;
   regeneratingImages: Set<string>;
   regeneratingMotion: Set<string>;
-  onBatchGenerateMotion?: (includeMusic: boolean) => Promise<void>;
+  onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
   musicPromptsReady: boolean;
   /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
   hideBatchButton?: boolean;
   /** Live divergent alternates for the current sequence (filtered per-frame). */
   divergentVariants?: FrameVariant[];
   onCompareDivergent?: (variant: FrameVariant) => void;
+  /** Initial motion model for the batch selector (from `sequence.videoModel`). */
+  initialMotionModel?: ImageToVideoModel;
+  /** Initial music model for the batch selector (from `sequence.musicModel`). */
+  initialMusicModel?: AudioModel;
+  /** Current style category — used to filter style-restricted motion models. */
+  styleCategory?: string;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -41,6 +61,9 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   hideBatchButton = false,
   divergentVariants,
   onCompareDivergent,
+  initialMotionModel,
+  initialMusicModel,
+  styleCategory,
 }) => {
   const divergentByFrameId = useMemo(() => {
     const map = new Map<string, FrameVariant>();
@@ -55,6 +78,28 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
+  const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
+    initialMotionModel ?? DEFAULT_VIDEO_MODEL
+  );
+  const [musicModel, setMusicModel] = useState<AudioModel>(
+    initialMusicModel ?? DEFAULT_MUSIC_MODEL
+  );
+
+  // Sync local selection when the sequence's saved model changes from outside
+  // (e.g. after generation completes and the workflow persists the new model).
+  const prevInitialMotionRef = useRef(initialMotionModel);
+  if (
+    initialMotionModel &&
+    initialMotionModel !== prevInitialMotionRef.current
+  ) {
+    prevInitialMotionRef.current = initialMotionModel;
+    setMotionModel(initialMotionModel);
+  }
+  const prevInitialMusicRef = useRef(initialMusicModel);
+  if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
+    prevInitialMusicRef.current = initialMusicModel;
+    setMusicModel(initialMusicModel);
+  }
 
   const totalFrames = frames?.length ?? 0;
 
@@ -88,7 +133,7 @@ const SceneListComponent: React.FC<SceneListProps> = ({
 
     setIsGenerating(true);
     try {
-      await onBatchGenerateMotion(includeMusic);
+      await onBatchGenerateMotion({ includeMusic, motionModel, musicModel });
     } finally {
       setIsGenerating(false);
     }
@@ -154,6 +199,26 @@ const SceneListComponent: React.FC<SceneListProps> = ({
       {/* Sticky footer with Generate Motion button */}
       {showButton && (
         <div className="sticky bottom-0 border-t bg-background p-4 flex flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <span className="text-xs text-muted-foreground">Motion model</span>
+            <MotionModelSelector
+              selectedModel={motionModel}
+              onModelChange={setMotionModel}
+              disabled={isGenerating || isMotionInProgress}
+              aspectRatio={aspectRatio}
+              styleCategory={styleCategory}
+            />
+          </div>
+          {includeMusic && (
+            <div className="flex flex-col gap-1">
+              <span className="text-xs text-muted-foreground">Music model</span>
+              <MusicModelSelector
+                selectedModel={musicModel}
+                onModelChange={setMusicModel}
+                disabled={isGenerating || isMotionInProgress}
+              />
+            </div>
+          )}
           <Button
             variant="default"
             className="w-full"
@@ -213,7 +278,10 @@ const areEqual = (
   if (
     prevProps.selectedFrameId !== nextProps.selectedFrameId ||
     prevProps.aspectRatio !== nextProps.aspectRatio ||
-    prevProps.musicPromptsReady !== nextProps.musicPromptsReady
+    prevProps.musicPromptsReady !== nextProps.musicPromptsReady ||
+    prevProps.initialMotionModel !== nextProps.initialMotionModel ||
+    prevProps.initialMusicModel !== nextProps.initialMusicModel ||
+    prevProps.styleCategory !== nextProps.styleCategory
   ) {
     return false;
   }

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -6,6 +6,7 @@ import { DivergentAlternateBanner } from '@/components/staleness/divergent-alter
 import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Select,
   SelectContent,
@@ -41,6 +42,7 @@ import {
   getCompatibleModel,
   safeImageToVideoModel,
   safeTextToImageModel,
+  videoModelSupportsAudio,
   type ImageToVideoModel,
   type TextToImageModel,
 } from '@/lib/ai/models';
@@ -165,6 +167,8 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     setEditPrompts((s) => ({ ...s, motionPrompt: v }));
   const setSelectedMotionModel = (v: ImageToVideoModel | undefined) =>
     setEditPrompts((s) => ({ ...s, motionModel: v }));
+  // SFX/dialogue toggle for audio-capable models (kling v3, veo3, etc.)
+  const [generateAudio, setGenerateAudio] = useState(true);
 
   const handleImageModelChange = useCallback(
     (model: TextToImageModel) => {
@@ -493,6 +497,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       };
     });
 
+    const motionModelForCall = selectedMotionModel || DEFAULT_VIDEO_MODEL;
+    const supportsAudio = videoModelSupportsAudio(motionModelForCall);
+
     try {
       await generateFrameMotionFn({
         data: {
@@ -500,6 +507,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           frameId: frame.id,
           model: selectedMotionModel,
           prompt: editedMotionPrompt || undefined,
+          generateAudio: supportsAudio ? generateAudio : undefined,
         },
       });
 
@@ -528,6 +536,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     frame,
     selectedMotionModel,
     editedMotionPrompt,
+    generateAudio,
     queryClient,
     onRegenerateStart,
     showFalGate,
@@ -1131,6 +1140,26 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               entityType="frame"
               onCompare={() => onCompareDivergent?.(divergentVideoVariant)}
             />
+          )}
+
+          {/* SFX/dialogue toggle — only for audio-capable models */}
+          {videoModelSupportsAudio(
+            selectedMotionModel || DEFAULT_VIDEO_MODEL
+          ) && (
+            <label
+              htmlFor="scene-generate-audio"
+              className="flex items-center gap-2 text-sm text-muted-foreground"
+            >
+              <Checkbox
+                id="scene-generate-audio"
+                checked={generateAudio}
+                onCheckedChange={(checked) =>
+                  setGenerateAudio(checked === true)
+                }
+                disabled={isGenerating || isGeneratingMotion}
+              />
+              <span>Include SFX &amp; dialogue</span>
+            </label>
           )}
 
           {/* Regenerate button */}

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -48,7 +48,7 @@ import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
 import type { Frame } from '@/types/database';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { CopyIcon, History, Loader2, Minimize2 } from 'lucide-react';
+import { CopyIcon, History, Loader2, Minimize2, RefreshCw } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { FrameStalenessBanners } from './frame-staleness-banners';
@@ -204,15 +204,29 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     frameId: frame?.id,
   });
   const regeneratePromptMutation = useMutation({
-    mutationFn: (promptType: 'visual' | 'motion') => {
+    mutationFn: (vars: {
+      promptType: 'visual' | 'motion';
+      force?: boolean;
+    }) => {
       if (!frame?.id) throw new Error('frame required');
       return regenerateFramePromptFn({
-        data: { sequenceId, frameId: frame.id, promptType },
+        data: {
+          sequenceId,
+          frameId: frame.id,
+          promptType: vars.promptType,
+          force: vars.force,
+        },
       });
     },
-    onSuccess: async (result) => {
+    onSuccess: async (result, vars) => {
       if (result.alreadyUpToDate) {
         toast.info('Prompt is already up to date');
+      } else {
+        toast.success(
+          vars.promptType === 'visual'
+            ? 'Regenerating visual prompt…'
+            : 'Regenerating motion prompt…'
+        );
       }
       if (frame?.id) {
         await queryClient.invalidateQueries({
@@ -282,7 +296,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // triggered it. Without this, both tabs' indicators would show busy whenever
   // either was clicked.
   const inFlightPromptType = regeneratePromptMutation.isPending
-    ? regeneratePromptMutation.variables
+    ? regeneratePromptMutation.variables?.promptType
     : null;
   const isRegeneratingVisualPrompt = inFlightPromptType === 'visual';
   const isRegeneratingMotionPrompt = inFlightPromptType === 'motion';
@@ -895,10 +909,37 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               artifact="visual-prompt"
               entityType="frame"
               density="inline"
-              onRegenerate={() => regeneratePromptMutation.mutate('visual')}
+              onRegenerate={() =>
+                regeneratePromptMutation.mutate({ promptType: 'visual' })
+              }
               isRegenerating={isRegeneratingVisualPrompt}
             />
           )}
+
+          {/* Explicit regenerate-prompt button — always available so the user
+              can roll the dice on a fresh LLM completion regardless of
+              staleness. Passes `force: true` so the server skips the
+              up-to-date short-circuit even when no upstream input changed. */}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              regeneratePromptMutation.mutate({
+                promptType: 'visual',
+                force: true,
+              })
+            }
+            disabled={!frame || isRegeneratingVisualPrompt}
+            className="w-full"
+            aria-label="Regenerate visual prompt"
+          >
+            {isRegeneratingVisualPrompt ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            {isRegeneratingVisualPrompt ? 'Regenerating…' : 'Regenerate Prompt'}
+          </Button>
 
           {divergentImageVariant && (
             <DivergentAlternateBanner
@@ -1052,10 +1093,36 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               artifact="motion-prompt"
               entityType="frame"
               density="inline"
-              onRegenerate={() => regeneratePromptMutation.mutate('motion')}
+              onRegenerate={() =>
+                regeneratePromptMutation.mutate({ promptType: 'motion' })
+              }
               isRegenerating={isRegeneratingMotionPrompt}
             />
           )}
+
+          {/* Explicit regenerate-prompt button — see image-prompt tab for the
+              full rationale; `force: true` lets the user request a fresh LLM
+              completion even when upstream inputs are unchanged. */}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() =>
+              regeneratePromptMutation.mutate({
+                promptType: 'motion',
+                force: true,
+              })
+            }
+            disabled={!frame || isRegeneratingMotionPrompt}
+            className="w-full"
+            aria-label="Regenerate motion prompt"
+          >
+            {isRegeneratingMotionPrompt ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            {isRegeneratingMotionPrompt ? 'Regenerating…' : 'Regenerate Prompt'}
+          </Button>
 
           {divergentVideoVariant && (
             <DivergentAlternateBanner

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -7,6 +7,7 @@ import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -184,6 +185,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   const [editedScript, setEditedScript] = useState<string | undefined>(
     undefined
   );
+  const [editedDurationSeconds, setEditedDurationSeconds] = useState<
+    string | undefined
+  >(undefined);
   const prevScriptFrameIdRef = useRef<string | undefined>(undefined);
 
   // Previous value tracking for prop-to-state sync (refs avoid extra re-renders)
@@ -245,25 +249,46 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     },
   });
 
-  // Persist a scene-script edit. Sends the patched scene via `metadata`;
-  // `updateFrameFn` (server) clears stale dialogue and mirrors the change into
-  // `sequences.script`. Existing prompt-input-hash staleness lights up the
-  // Image/Motion banners automatically once the new extract lands.
+  // Persist a scene-script and/or duration edit. Sends the patched scene via
+  // `metadata`; `updateFrameFn` (server) clears stale dialogue (when extract
+  // changes) and mirrors the new extract into `sequences.script`. Existing
+  // prompt-input-hash staleness lights up the Image/Motion banners
+  // automatically once the new scene metadata lands.
   const saveScriptMutation = useMutation({
-    mutationFn: async (nextExtract: string) => {
+    mutationFn: async (input: {
+      nextExtract: string;
+      nextDurationSeconds: number | undefined;
+    }) => {
       if (!frame?.id || !frame.metadata) {
         throw new Error('frame metadata required');
       }
+      const { nextExtract, nextDurationSeconds } = input;
       const updated = await updateFrameFn({
         data: {
           sequenceId,
           frameId: frame.id,
+          ...(nextDurationSeconds !== undefined
+            ? { durationMs: Math.round(nextDurationSeconds * 1000) }
+            : {}),
           metadata: {
             ...frame.metadata,
             originalScript: {
               ...frame.metadata.originalScript,
               extract: nextExtract,
             },
+            ...(nextDurationSeconds !== undefined
+              ? {
+                  metadata: {
+                    ...(frame.metadata.metadata ?? {
+                      title: '',
+                      location: '',
+                      timeOfDay: '',
+                      storyBeat: '',
+                    }),
+                    durationSeconds: nextDurationSeconds,
+                  },
+                }
+              : {}),
           },
         },
       });
@@ -274,6 +299,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     },
     onSuccess: async (updated) => {
       setEditedScript(undefined);
+      setEditedDurationSeconds(undefined);
       queryClient.setQueryData(frameKeys.detail(updated.id), updated);
       await Promise.all([
         queryClient.invalidateQueries({
@@ -286,10 +312,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           queryKey: sequenceKeys.detail(sequenceId),
         }),
       ]);
-      toast.success('Scene script saved');
+      toast.success('Scene saved');
     },
     onError: (error) => {
-      toast.error('Failed to save scene script', {
+      toast.error('Failed to save scene', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     },
@@ -611,6 +637,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   if (frame?.id !== prevScriptFrameIdRef.current) {
     prevScriptFrameIdRef.current = frame?.id;
     setEditedScript(undefined);
+    setEditedDurationSeconds(undefined);
   }
 
   if (imagePrompt !== prevImagePromptRef.current) {
@@ -746,10 +773,41 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
         {(() => {
           const savedScript = scriptText ?? '';
           const currentScript = editedScript ?? savedScript;
-          const isDirty =
+          const isScriptDirty =
             editedScript !== undefined && editedScript !== savedScript;
+
+          const savedDurationSeconds =
+            frame?.durationMs !== undefined &&
+            frame.durationMs !== null &&
+            frame.durationMs > 0
+              ? frame.durationMs / 1000
+              : (frame?.metadata?.metadata?.durationSeconds ?? undefined);
+          const savedDurationDisplay =
+            savedDurationSeconds !== undefined
+              ? String(savedDurationSeconds)
+              : '';
+          const currentDurationDisplay =
+            editedDurationSeconds ?? savedDurationDisplay;
+          const parsedDuration =
+            editedDurationSeconds === undefined
+              ? undefined
+              : Number(editedDurationSeconds);
+          const isDurationDirty =
+            editedDurationSeconds !== undefined &&
+            editedDurationSeconds !== savedDurationDisplay;
+          const isDurationValid =
+            editedDurationSeconds === undefined ||
+            (parsedDuration !== undefined &&
+              Number.isFinite(parsedDuration) &&
+              parsedDuration >= 1 &&
+              parsedDuration <= 60);
+
+          const isDirty = isScriptDirty || isDurationDirty;
           const canSave =
-            isDirty && !!frame?.metadata && !saveScriptMutation.isPending;
+            isDirty &&
+            isDurationValid &&
+            !!frame?.metadata &&
+            !saveScriptMutation.isPending;
           return (
             <div className="space-y-3">
               <div className="space-y-2">
@@ -790,18 +848,56 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 </div>
               </div>
 
+              <div className="space-y-2">
+                <label
+                  htmlFor="scene-duration-input"
+                  className="text-sm font-medium"
+                >
+                  Duration (seconds)
+                </label>
+                <Input
+                  id="scene-duration-input"
+                  type="number"
+                  inputMode="decimal"
+                  min={1}
+                  max={60}
+                  step={0.5}
+                  value={currentDurationDisplay}
+                  onChange={(e) => setEditedDurationSeconds(e.target.value)}
+                  placeholder="3"
+                  className="w-32"
+                  disabled={!frame || saveScriptMutation.isPending}
+                  aria-invalid={!isDurationValid}
+                />
+                {!isDurationValid && (
+                  <p className="text-xs text-destructive">
+                    Duration must be between 1 and 60 seconds.
+                  </p>
+                )}
+              </div>
+
               <div className="flex items-center justify-end gap-2">
                 <Button
                   size="sm"
                   variant="outline"
-                  onClick={() => setEditedScript(undefined)}
+                  onClick={() => {
+                    setEditedScript(undefined);
+                    setEditedDurationSeconds(undefined);
+                  }}
                   disabled={!isDirty || saveScriptMutation.isPending}
                 >
                   Cancel
                 </Button>
                 <Button
                   size="sm"
-                  onClick={() => saveScriptMutation.mutate(currentScript)}
+                  onClick={() =>
+                    saveScriptMutation.mutate({
+                      nextExtract: currentScript,
+                      nextDurationSeconds: isDurationDirty
+                        ? parsedDuration
+                        : undefined,
+                    })
+                  }
                   disabled={!canSave}
                 >
                   {saveScriptMutation.isPending && (
@@ -811,19 +907,11 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 </Button>
               </div>
 
-              {isDirty && (
+              {isDirty && isDurationValid && (
                 <p className="text-xs text-muted-foreground">
                   Saving will mark the image and motion prompts as stale.
                 </p>
               )}
-
-              {frame?.durationMs !== undefined &&
-                frame.durationMs !== null &&
-                frame.durationMs > 0 && (
-                  <div className="text-xs text-muted-foreground">
-                    Duration: {(frame.durationMs / 1000).toFixed(1)}s
-                  </div>
-                )}
             </div>
           );
         })()}

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -7,7 +7,6 @@ import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
-import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -58,6 +57,7 @@ import { FrameStalenessBanners } from './frame-staleness-banners';
 import { SceneCastTab } from './scene-cast-tab';
 import { SceneElementsTab } from './scene-elements-tab';
 import { SceneLocationTab } from './scene-location-tab';
+import { SceneScriptTab } from './scene-script-tab';
 import { VariantSelector } from './variant-selector';
 
 export type TabValue =
@@ -186,7 +186,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     undefined
   );
   const [editedDurationSeconds, setEditedDurationSeconds] = useState<
-    string | undefined
+    number | undefined
   >(undefined);
   const prevScriptFrameIdRef = useRef<string | undefined>(undefined);
 
@@ -770,151 +770,19 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       </TabsList>
 
       <TabsContent value="script">
-        {(() => {
-          const savedScript = scriptText ?? '';
-          const currentScript = editedScript ?? savedScript;
-          const isScriptDirty =
-            editedScript !== undefined && editedScript !== savedScript;
-
-          const savedDurationSeconds =
-            frame?.durationMs !== undefined &&
-            frame.durationMs !== null &&
-            frame.durationMs > 0
-              ? frame.durationMs / 1000
-              : (frame?.metadata?.metadata?.durationSeconds ?? undefined);
-          const savedDurationDisplay =
-            savedDurationSeconds !== undefined
-              ? String(savedDurationSeconds)
-              : '';
-          const currentDurationDisplay =
-            editedDurationSeconds ?? savedDurationDisplay;
-          const parsedDuration =
-            editedDurationSeconds === undefined
-              ? undefined
-              : Number(editedDurationSeconds);
-          const isDurationDirty =
-            editedDurationSeconds !== undefined &&
-            editedDurationSeconds !== savedDurationDisplay;
-          const isDurationValid =
-            editedDurationSeconds === undefined ||
-            (parsedDuration !== undefined &&
-              Number.isFinite(parsedDuration) &&
-              parsedDuration >= 1 &&
-              parsedDuration <= 60);
-
-          const isDirty = isScriptDirty || isDurationDirty;
-          const canSave =
-            isDirty &&
-            isDurationValid &&
-            !!frame?.metadata &&
-            !saveScriptMutation.isPending;
-          return (
-            <div className="space-y-3">
-              <div className="space-y-2">
-                <div className="flex items-center justify-between">
-                  <label
-                    htmlFor="script-extract-input"
-                    className="text-sm font-medium"
-                  >
-                    Scene script
-                  </label>
-                  <span className="text-xs text-muted-foreground">
-                    {currentScript.length} characters
-                  </span>
-                </div>
-                <div className="relative">
-                  <Textarea
-                    id="script-extract-input"
-                    value={currentScript}
-                    onChange={(e) => setEditedScript(e.target.value)}
-                    placeholder="Enter the script text for this scene…"
-                    className="min-h-[180px] resize-y pr-10"
-                    disabled={!frame || saveScriptMutation.isPending}
-                  />
-                  <Button
-                    size="icon"
-                    variant="ghost"
-                    onClick={() => void handleCopy(currentScript, 'script')}
-                    disabled={!currentScript}
-                    aria-label="Copy scene script"
-                    className="absolute right-1 top-1 h-8 w-8"
-                  >
-                    {copiedTab === 'script' ? (
-                      <span className="text-xs">✓</span>
-                    ) : (
-                      <CopyIcon className="h-4 w-4" />
-                    )}
-                  </Button>
-                </div>
-              </div>
-
-              <div className="space-y-2">
-                <label
-                  htmlFor="scene-duration-input"
-                  className="text-sm font-medium"
-                >
-                  Duration (seconds)
-                </label>
-                <Input
-                  id="scene-duration-input"
-                  type="number"
-                  inputMode="decimal"
-                  min={1}
-                  max={60}
-                  step={0.5}
-                  value={currentDurationDisplay}
-                  onChange={(e) => setEditedDurationSeconds(e.target.value)}
-                  placeholder="3"
-                  className="w-32"
-                  disabled={!frame || saveScriptMutation.isPending}
-                  aria-invalid={!isDurationValid}
-                />
-                {!isDurationValid && (
-                  <p className="text-xs text-destructive">
-                    Duration must be between 1 and 60 seconds.
-                  </p>
-                )}
-              </div>
-
-              <div className="flex items-center justify-end gap-2">
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => {
-                    setEditedScript(undefined);
-                    setEditedDurationSeconds(undefined);
-                  }}
-                  disabled={!isDirty || saveScriptMutation.isPending}
-                >
-                  Cancel
-                </Button>
-                <Button
-                  size="sm"
-                  onClick={() =>
-                    saveScriptMutation.mutate({
-                      nextExtract: currentScript,
-                      nextDurationSeconds: isDurationDirty
-                        ? parsedDuration
-                        : undefined,
-                    })
-                  }
-                  disabled={!canSave}
-                >
-                  {saveScriptMutation.isPending && (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  )}
-                  {saveScriptMutation.isPending ? 'Saving…' : 'Save'}
-                </Button>
-              </div>
-
-              {isDirty && isDurationValid && (
-                <p className="text-xs text-muted-foreground">
-                  Saving will mark the image and motion prompts as stale.
-                </p>
-              )}
-            </div>
-          );
-        })()}
+        <SceneScriptTab
+          frame={frame}
+          scriptText={scriptText}
+          motionModel={selectedMotionModel || DEFAULT_VIDEO_MODEL}
+          editedScript={editedScript}
+          onEditedScriptChange={setEditedScript}
+          editedDurationSeconds={editedDurationSeconds}
+          onEditedDurationChange={setEditedDurationSeconds}
+          isSaving={saveScriptMutation.isPending}
+          onSave={(payload) => saveScriptMutation.mutate(payload)}
+          isCopied={copiedTab === 'script'}
+          onCopy={(text) => void handleCopy(text, 'script')}
+        />
       </TabsContent>
 
       <TabsContent value="image-prompt">

--- a/src/components/scenes/scene-script-tab.tsx
+++ b/src/components/scenes/scene-script-tab.tsx
@@ -1,0 +1,179 @@
+/**
+ * Scene Script Tab
+ * Edits the scene script extract and duration. Duration options are sourced
+ * from the selected motion model's JSON Schema so the user can only pick
+ * values the model accepts.
+ */
+
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { IMAGE_TO_VIDEO_MODELS, type ImageToVideoModel } from '@/lib/ai/models';
+import { MOTION_JSON_SCHEMAS } from '@/lib/motion/endpoint-map';
+import { snapDuration } from '@/lib/motion/motion-generation';
+import { getDurationValues, numericOf } from '@/lib/motion/motion-transform';
+import type { Frame } from '@/types/database';
+import { CopyIcon, Loader2 } from 'lucide-react';
+
+export type SceneScriptTabSavePayload = {
+  nextExtract: string;
+  nextDurationSeconds: number | undefined;
+};
+
+type SceneScriptTabProps = {
+  frame: Frame | undefined;
+  scriptText: string | undefined;
+  motionModel: ImageToVideoModel;
+  editedScript: string | undefined;
+  onEditedScriptChange: (value: string | undefined) => void;
+  editedDurationSeconds: number | undefined;
+  onEditedDurationChange: (value: number | undefined) => void;
+  isSaving: boolean;
+  onSave: (payload: SceneScriptTabSavePayload) => void;
+  isCopied: boolean;
+  onCopy: (text: string) => void;
+};
+
+export const SceneScriptTab: React.FC<SceneScriptTabProps> = ({
+  frame,
+  scriptText,
+  motionModel,
+  editedScript,
+  onEditedScriptChange,
+  editedDurationSeconds,
+  onEditedDurationChange,
+  isSaving,
+  onSave,
+  isCopied,
+  onCopy,
+}) => {
+  const savedScript = scriptText ?? '';
+  const currentScript = editedScript ?? savedScript;
+  const isScriptDirty =
+    editedScript !== undefined && editedScript !== savedScript;
+
+  const savedDurationSeconds =
+    frame?.durationMs && frame.durationMs > 0
+      ? frame.durationMs / 1000
+      : frame?.metadata?.metadata?.durationSeconds;
+
+  // Drive the options off the selected motion model's JSON Schema so the user
+  // can only pick a value the model actually accepts. If the saved value isn't
+  // in the set (model changed since last save, or legacy data), snapping
+  // surfaces a pending edit so Save re-anchors the frame onto a valid duration.
+  const durationOptions = getDurationValues(
+    MOTION_JSON_SCHEMAS[IMAGE_TO_VIDEO_MODELS[motionModel].id]
+  ).map(numericOf);
+  const snappedSavedSeconds = snapDuration(savedDurationSeconds, motionModel);
+  const isSavedOutOfRange =
+    savedDurationSeconds !== undefined &&
+    snappedSavedSeconds !== savedDurationSeconds;
+  const currentDurationSeconds = editedDurationSeconds ?? snappedSavedSeconds;
+  const isDurationDirty =
+    editedDurationSeconds !== undefined
+      ? editedDurationSeconds !== savedDurationSeconds
+      : isSavedOutOfRange;
+
+  const isDirty = isScriptDirty || isDurationDirty;
+  const canSave = isDirty && !!frame?.metadata && !isSaving;
+
+  const handleCancel = () => {
+    onEditedScriptChange(undefined);
+    onEditedDurationChange(undefined);
+  };
+
+  const handleSave = () => {
+    onSave({
+      nextExtract: currentScript,
+      nextDurationSeconds: isDurationDirty ? currentDurationSeconds : undefined,
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <label htmlFor="script-extract-input" className="text-sm font-medium">
+            Scene script
+          </label>
+          <span className="text-xs text-muted-foreground">
+            {currentScript.length} characters
+          </span>
+        </div>
+        <div className="relative">
+          <Textarea
+            id="script-extract-input"
+            value={currentScript}
+            onChange={(e) => onEditedScriptChange(e.target.value)}
+            placeholder="Enter the script text for this scene…"
+            className="min-h-[180px] resize-y pr-10"
+            disabled={!frame || isSaving}
+          />
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={() => onCopy(currentScript)}
+            disabled={!currentScript}
+            aria-label="Copy scene script"
+            className="absolute right-1 top-1 h-8 w-8"
+          >
+            {isCopied ? (
+              <span className="text-xs">✓</span>
+            ) : (
+              <CopyIcon className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <label htmlFor="scene-duration-input" className="text-sm font-medium">
+          Duration (seconds)
+        </label>
+        <Select
+          value={String(currentDurationSeconds)}
+          onValueChange={(value) => onEditedDurationChange(Number(value))}
+          disabled={!frame || isSaving}
+        >
+          <SelectTrigger id="scene-duration-input" className="w-32">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {durationOptions.map((seconds) => (
+              <SelectItem key={seconds} value={String(seconds)}>
+                {seconds}s
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex items-center justify-end gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleCancel}
+          disabled={!isDirty || isSaving}
+        >
+          Cancel
+        </Button>
+        <Button size="sm" onClick={handleSave} disabled={!canSave}>
+          {isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          {isSaving ? 'Saving…' : 'Save'}
+        </Button>
+      </div>
+
+      {isDirty && (
+        <p className="text-xs text-muted-foreground">
+          Saving will mark the image and motion prompts as stale.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -512,6 +512,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
       includeMusic,
       motionModel,
       musicModel,
+      generateAudio,
     }: BatchGenerateMotionArgs) => {
       // Optimistic: compute eligible frames locally (same filter as backend)
       const eligibleFrameIds = (frames ?? [])
@@ -548,6 +549,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         eligible_frame_count: eligibleFrameIds.length,
         motion_model: motionModel,
         music_model: includeMusic ? musicModel : undefined,
+        generate_audio: generateAudio,
       });
 
       try {
@@ -557,6 +559,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             includeMusic,
             model: motionModel,
             musicModel: includeMusic ? musicModel : undefined,
+            generateAudio,
           },
         });
       } catch (error) {

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -3,6 +3,7 @@ import { MotionProgressBanner } from '@/components/generation/motion-progress-ba
 import { ScenePlayer } from '@/components/motion/scene-player';
 import { MobileSceneDrawer } from '@/components/scenes/mobile-scene-drawer';
 import { SceneList } from '@/components/scenes/scene-list';
+import type { BatchGenerateMotionArgs } from '@/components/scenes/scene-list';
 import {
   SceneScriptPrompts,
   type TabValue,
@@ -25,7 +26,14 @@ import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-
 import { getDivergentVariantPromptDiffFn } from '@/functions/prompt-variants';
 import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
 import { useStyle } from '@/hooks/use-styles';
-import { safeTextToImageModel, DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
+import {
+  DEFAULT_IMAGE_MODEL,
+  DEFAULT_MUSIC_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  safeAudioModel,
+  safeImageToVideoModel,
+  safeTextToImageModel,
+} from '@/lib/ai/models';
 import {
   DEFAULT_ASPECT_RATIO,
   type AspectRatio,
@@ -177,6 +185,14 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   const isProcessing = sequence?.status === 'processing';
   const { data: style } = useStyle(sequence?.styleId ?? '');
   const styleCategory = style?.category ?? undefined;
+  const sequenceMotionModel = safeImageToVideoModel(
+    sequence?.videoModel,
+    DEFAULT_VIDEO_MODEL
+  );
+  const sequenceMusicModel = safeAudioModel(
+    sequence?.musicModel,
+    DEFAULT_MUSIC_MODEL
+  );
 
   // Phase config from DB — set in stone when the workflow was triggered
   const phaseConfig = useMemo<GenerationPhaseConfig>(
@@ -492,7 +508,11 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
 
   // Handler for batch motion generation (server determines eligible frames)
   const handleBatchMotionGeneration = useCallback(
-    async (includeMusic: boolean) => {
+    async ({
+      includeMusic,
+      motionModel,
+      musicModel,
+    }: BatchGenerateMotionArgs) => {
       // Optimistic: compute eligible frames locally (same filter as backend)
       const eligibleFrameIds = (frames ?? [])
         .filter(
@@ -526,11 +546,18 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         sequence_id: sequenceId,
         include_music: includeMusic,
         eligible_frame_count: eligibleFrameIds.length,
+        motion_model: motionModel,
+        music_model: includeMusic ? musicModel : undefined,
       });
 
       try {
         await batchGenerateMotionFn({
-          data: { sequenceId, includeMusic },
+          data: {
+            sequenceId,
+            includeMusic,
+            model: motionModel,
+            musicModel: includeMusic ? musicModel : undefined,
+          },
         });
       } catch (error) {
         setRegeneratingMotion((prev) =>
@@ -636,6 +663,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             }
             divergentVariants={divergentVariants}
             onCompareDivergent={(variant) => setCompareVariant(variant)}
+            initialMotionModel={sequenceMotionModel}
+            initialMusicModel={sequenceMusicModel}
+            styleCategory={styleCategory}
           />
         </div>
 
@@ -653,6 +683,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             hideBatchButton={
               phaseConfig.autoGenerateMotion && isGenerationActive
             }
+            initialMotionModel={sequenceMotionModel}
+            initialMusicModel={sequenceMusicModel}
+            styleCategory={styleCategory}
           />
         </div>
 

--- a/src/functions/__tests__/prompt-variants.test.ts
+++ b/src/functions/__tests__/prompt-variants.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
   framePromptDedupId,
+  framePromptForceDedupId,
   isPromptUpToDate,
   musicPromptDedupId,
 } from '@/functions/prompt-variants';
@@ -53,6 +54,23 @@ describe('framePromptDedupId', () => {
     const first = framePromptDedupId('visual', 'frame-1', 'hash');
     const second = framePromptDedupId('visual', 'frame-1', 'hash');
     expect(first).toBe(second);
+  });
+});
+
+describe('framePromptForceDedupId', () => {
+  it('builds an id distinct from the stable hash-based dedup id', () => {
+    // The force-regen path must use a different ID prefix so QStash treats it
+    // as a fresh run instead of collapsing it into the stable hash bucket.
+    const stable = framePromptDedupId('visual', 'frame-1', 'hash');
+    const forced = framePromptForceDedupId('visual', 'frame-1', 'nonce');
+    expect(forced).not.toBe(stable);
+    expect(forced.startsWith('prompt-visual-frame-1-force-')).toBe(true);
+  });
+
+  it('changes with each unique nonce so repeated clicks do not dedupe', () => {
+    const a = framePromptForceDedupId('visual', 'frame-1', 'nonce-a');
+    const b = framePromptForceDedupId('visual', 'frame-1', 'nonce-b');
+    expect(a).not.toBe(b);
   });
 });
 

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -96,6 +96,7 @@ export const generateFrameMotionFn = createServerFn({ method: 'POST' })
           fps: data.fps,
           motionBucket: data.motionBucket,
           aspectRatio: sequence.aspectRatio,
+          generateAudio: data.generateAudio,
           userEditedPrompt,
         },
       ],
@@ -128,6 +129,7 @@ const batchGenerateMotionInputSchema = z.object({
   duration: generateMotionSchema.shape.duration,
   fps: generateMotionSchema.shape.fps,
   motionBucket: generateMotionSchema.shape.motionBucket,
+  generateAudio: generateMotionSchema.shape.generateAudio,
 });
 
 export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
@@ -212,6 +214,7 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
           fps: data.fps,
           motionBucket: data.motionBucket,
           aspectRatio: sequence.aspectRatio,
+          generateAudio: data.generateAudio,
         };
       }),
       music: musicConfig,

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -7,7 +7,11 @@ import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 
-import { DEFAULT_VIDEO_MODEL, safeImageToVideoModel } from '@/lib/ai/models';
+import {
+  AUDIO_MODELS,
+  DEFAULT_VIDEO_MODEL,
+  safeImageToVideoModel,
+} from '@/lib/ai/models';
 import { estimateVideoCost } from '@/lib/billing/cost-estimation';
 import { multiplyMicros, usdToMicros } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
@@ -115,6 +119,12 @@ const batchGenerateMotionInputSchema = z.object({
   sequenceId: ulidSchema,
   includeMusic: z.boolean().optional(),
   model: generateMotionSchema.shape.model,
+  musicModel: z
+    .enum(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Required for z.enum with dynamic keys
+      Object.keys(AUDIO_MODELS) as [keyof typeof AUDIO_MODELS]
+    )
+    .optional(),
   duration: generateMotionSchema.shape.duration,
   fps: generateMotionSchema.shape.fps,
   motionBucket: generateMotionSchema.shape.motionBucket,
@@ -174,6 +184,7 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
         prompt: sequence.musicPrompt,
         tags: sequence.musicTags,
         duration: totalDuration || 30,
+        model: data.musicModel,
       };
     }
 

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -15,6 +15,7 @@ import {
 import { estimateVideoCost } from '@/lib/billing/cost-estimation';
 import { multiplyMicros, usdToMicros } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
+import { resolveFrameDuration } from '@/lib/motion/resolve-frame-duration';
 import { snapDuration } from '@/lib/motion/motion-generation';
 import { generateMotionSchema } from '@/lib/schemas/frame.schemas';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
@@ -75,17 +76,17 @@ export const generateFrameMotionFn = createServerFn({ method: 'POST' })
       }
     }
 
-    // Honor the frame's stored duration (set on scene-split + editable via the
-    // script tab) so user edits to scene duration actually take effect on the
-    // next motion regenerate. `durationMs` is the canonical source — populated
-    // both on scene-split and after motion completes — falling back to
-    // `metadata.durationSeconds` for legacy frames and finally the model
-    // default if nothing is stored.
-    const frameDurationSeconds = frame.durationMs
-      ? frame.durationMs / 1000
-      : (frame.metadata?.metadata?.durationSeconds ?? null);
-    const duration =
-      data.duration ?? frameDurationSeconds ?? snapDuration(undefined, model);
+    // Snap the resolved duration onto the selected model's valid set before
+    // both the credit pre-flight and the workflow input — otherwise an
+    // unsnapped value (e.g. legacy `durationMs` from a different model) gets
+    // priced at the raw seconds while the workflow bills against the snapped
+    // value, leaving the two paths inconsistent.
+    const duration = resolveFrameDuration({
+      explicit: data.duration,
+      durationMs: frame.durationMs,
+      metadataSeconds: frame.metadata?.metadata?.durationSeconds,
+      model,
+    });
 
     await requireCredits(context.scopedDb, estimateVideoCost(model, duration), {
       errorMessage: 'Insufficient credits for motion generation',

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -75,7 +75,17 @@ export const generateFrameMotionFn = createServerFn({ method: 'POST' })
       }
     }
 
-    const duration = data.duration ?? snapDuration(undefined, model);
+    // Honor the frame's stored duration (set on scene-split + editable via the
+    // script tab) so user edits to scene duration actually take effect on the
+    // next motion regenerate. `durationMs` is the canonical source — populated
+    // both on scene-split and after motion completes — falling back to
+    // `metadata.durationSeconds` for legacy frames and finally the model
+    // default if nothing is stored.
+    const frameDurationSeconds = frame.durationMs
+      ? frame.durationMs / 1000
+      : (frame.metadata?.metadata?.durationSeconds ?? null);
+    const duration =
+      data.duration ?? frameDurationSeconds ?? snapDuration(undefined, model);
 
     await requireCredits(context.scopedDb, estimateVideoCost(model, duration), {
       errorMessage: 'Insufficient credits for motion generation',

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -46,6 +46,20 @@ export function framePromptDedupId(
   return `prompt-${promptType}-${frameId}-${liveHash}`;
 }
 
+/**
+ * Unique deduplication ID for an explicit user-driven force-regeneration.
+ * Distinct from `framePromptDedupId` because the user is asking for a fresh
+ * LLM completion regardless of whether upstream inputs changed — collapsing
+ * repeat clicks to one run would silently swallow the regeneration.
+ */
+export function framePromptForceDedupId(
+  promptType: 'visual' | 'motion',
+  frameId: string,
+  nonce: string
+): string {
+  return `prompt-${promptType}-${frameId}-force-${nonce}`;
+}
+
 /** Stable deduplication ID for music-prompt regeneration — see above. */
 export function musicPromptDedupId(
   sequenceId: string,
@@ -176,6 +190,10 @@ const frameRegenerateInput = z.object({
   sequenceId: ulidSchema,
   frameId: ulidSchema,
   promptType: promptTypeSchema,
+  // `force: true` bypasses the up-to-date short-circuit so the user can roll
+  // the dice on a fresh non-deterministic LLM completion even when no upstream
+  // inputs have changed. The staleness-banner path leaves this unset.
+  force: z.boolean().optional(),
 });
 
 export const regenerateFramePromptFn = createServerFn({ method: 'POST' })
@@ -199,6 +217,10 @@ export const regenerateFramePromptFn = createServerFn({ method: 'POST' })
     // appends a no-op `'regenerated'` history row. Hash inputs are narrowed
     // to what this frame's continuity actually references; the workflow
     // downstream still gets the full bibles for LLM context.
+    //
+    // `force` skips this bail so an explicit user click always reaches the
+    // LLM — there's no other way to get a fresh non-deterministic completion
+    // when upstream inputs are unchanged.
     const narrowed = narrowFramePromptContext(ctx);
     const liveHash =
       data.promptType === 'visual'
@@ -208,7 +230,7 @@ export const regenerateFramePromptFn = createServerFn({ method: 'POST' })
       data.promptType === 'visual'
         ? frame.visualPromptInputHash
         : frame.motionPromptInputHash;
-    if (isPromptUpToDate(storedHash, liveHash)) {
+    if (!data.force && isPromptUpToDate(storedHash, liveHash)) {
       return { workflowRunId: null, alreadyUpToDate: true } as const;
     }
 
@@ -234,11 +256,20 @@ export const regenerateFramePromptFn = createServerFn({ method: 'POST' })
         ? '/visual-prompt-scene'
         : '/motion-prompt-scene';
 
-    // Dedup by the live input hash so a QStash retry of the same upstream
-    // context collapses to one workflow run instead of N — `Date.now()` would
-    // defeat the deduplication entirely.
+    // Force-regen needs a unique dedup ID per click so QStash doesn't collapse
+    // repeat clicks into a single run — the user is explicitly asking for
+    // another LLM completion. The auto-staleness path keeps the stable
+    // hash-based ID so genuine retries collapse to one run.
+    const deduplicationId = data.force
+      ? framePromptForceDedupId(
+          data.promptType,
+          frame.id,
+          `${Date.now()}-${crypto.randomUUID()}`
+        )
+      : framePromptDedupId(data.promptType, frame.id, liveHash);
+
     const workflowRunId = await triggerWorkflow(urlPath, baseInput, {
-      deduplicationId: framePromptDedupId(data.promptType, frame.id, liveHash),
+      deduplicationId,
       label: buildWorkflowLabel(sequence.id),
     });
 

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -464,11 +464,21 @@ export const generateMusicFn = createServerFn({ method: 'POST' })
  */
 export const mergeVideoAndMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
-  .handler(async ({ context }) => {
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        /** When `false`, restitch frame videos without muxing the generated
+         *  music track. Default `true` preserves the legacy behavior. */
+        includeMusic: z.boolean().optional(),
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
     const { sequence, user, teamId } = context;
+    const includeMusic = data.includeMusic !== false;
 
-    if (!sequence.musicUrl) {
+    if (includeMusic && !sequence.musicUrl) {
       throw new Error('Music must be generated before merging');
     }
 
@@ -509,6 +519,7 @@ export const mergeVideoAndMusicFn = createServerFn({ method: 'POST' })
         teamId,
         sequenceId: sequence.id,
         videoUrls,
+        skipAudioMux: !includeMusic,
       } satisfies MergeVideoWorkflowInput,
       { label: buildWorkflowLabel(sequence.id) }
     );

--- a/src/lib/db/scoped/frame-prompt-variants.test.ts
+++ b/src/lib/db/scoped/frame-prompt-variants.test.ts
@@ -310,6 +310,85 @@ describe('frame_prompt_variants helper', () => {
     expect(history).toHaveLength(1);
   });
 
+  it('force-regen at the same input_hash appends a null-hash history row with the new text and keeps the cached hash tracking the live context', async () => {
+    // Mirrors the user-driven "Regenerate Prompt" path: the LLM is invoked
+    // again against unchanged upstream inputs, so the new completion's hash
+    // collides with the existing row. The helper must still record the new
+    // text in history (otherwise the user's regenerated prompt would be
+    // silently lost) while keeping the cached `*_prompt_input_hash` column
+    // tracking the real upstream hash so staleness detection stays correct.
+    const methods = createFramePromptVariantsMethods(asDatabase(db));
+
+    const first = await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'context-hash-1',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    const forced = await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'Fresh LLM completion against same inputs',
+      source: 'regenerated',
+      inputHash: 'context-hash-1',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    // A distinct row was inserted (not the existing one returned verbatim).
+    expect(forced.id).not.toBe(first.id);
+    // Bypasses the partial unique index via null `input_hash`.
+    expect(forced.inputHash).toBeNull();
+    expect(forced.source).toBe('regenerated');
+    expect(forced.text).toBe('Fresh LLM completion against same inputs');
+
+    const history = await methods.listByFrame(frameId, 'visual');
+    expect(history).toHaveLength(2);
+    expect(history[0].text).toBe('Fresh LLM completion against same inputs');
+    expect(history[1].text).toBe('AI prompt v1');
+
+    const [refreshed] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    expect(refreshed.imagePrompt).toBe(
+      'Fresh LLM completion against same inputs'
+    );
+    // Cached hash still reflects the live upstream so staleness detection
+    // doesn't fire spuriously after a force regeneration.
+    expect(refreshed.visualPromptInputHash).toBe('context-hash-1');
+  });
+
+  it('idempotent retry of the same text at the same hash still de-dupes (does not fall through to the null-hash branch)', async () => {
+    // Regression guard for the force-regen branch: it must only fire when
+    // `existing.text !== input.text`. A genuine workflow step retry submits
+    // the same text + same hash and should still collapse to one row.
+    const methods = createFramePromptVariantsMethods(asDatabase(db));
+
+    await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'context-hash-1',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    await methods.write({
+      frameId,
+      promptType: 'visual',
+      text: 'AI prompt v1',
+      source: 'regenerated',
+      inputHash: 'context-hash-1',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    const history = await methods.listByFrame(frameId, 'visual');
+    expect(history).toHaveLength(1);
+  });
+
   it('a different input_hash produces a new row for the same frame+type', async () => {
     const methods = createFramePromptVariantsMethods(asDatabase(db));
 

--- a/src/lib/db/scoped/frame-prompt-variants.ts
+++ b/src/lib/db/scoped/frame-prompt-variants.ts
@@ -38,9 +38,11 @@ type WriteFramePromptVariantBase = {
  * `inputHash` represents the upstream context (scene + style + narrowed
  * bibles + aspectRatio + analysisModel) that this prompt is aligned with,
  * regardless of who authored the text. AI-generated and regenerated rows
- * always carry a real hash — they can't be written without one. User-edits
- * also carry the live hash captured at edit time so staleness detection
- * keeps working after a hand-typed prompt; null is permitted only when the
+ * carry a real hash at the call site so the partial unique index can dedupe
+ * QStash retries; the helper may downgrade the persisted hash to null on
+ * the force-regen fallback path (see `write` for details). User-edits also
+ * carry the live hash captured at edit time so staleness detection keeps
+ * working after a hand-typed prompt; null is permitted only when the
  * upstream context was uncomputable at write time (e.g. style deleted), in
  * which case the staleness function falls back to an earlier non-null row.
  *
@@ -98,6 +100,14 @@ export function createFramePromptVariantsMethods(db: Database) {
      * `(frame_id, prompt_type, input_hash) WHERE input_hash IS NOT NULL`:
      * an insert that conflicts with an existing row no-ops, the existing row
      * is fetched, and the cached pointer is updated as normal.
+     *
+     * Force-regeneration corner case: an explicit user-triggered regen runs
+     * the LLM against unchanged upstream inputs. The new completion's hash
+     * matches an existing row, so the unique-index insert no-ops — but the
+     * text genuinely differs. We append a fallback row with `input_hash =
+     * NULL` (excluded by the partial index) so history records the new text;
+     * the cached `*_prompt_input_hash` column still tracks the real
+     * `liveHash` so staleness detection stays correct.
      */
     write: async (
       input: WriteFramePromptVariantInput
@@ -138,7 +148,34 @@ export function createFramePromptVariantsMethods(db: Database) {
             )
           )
           .limit(1);
-        variant = existing;
+
+        if (
+          existing &&
+          existing.text !== input.text &&
+          (input.source === 'ai-generated' || input.source === 'regenerated')
+        ) {
+          // Force-regen path: same upstream hash but a fresh LLM completion.
+          // Bypass the partial unique index with a null `input_hash` so the
+          // new text lands in history. Restore/user-edit paths never reach
+          // this branch — they don't carry a non-null `inputHash` here.
+          const [forced] = await db
+            .insert(framePromptVariants)
+            .values({
+              frameId: input.frameId,
+              promptType: input.promptType,
+              text: input.text,
+              components: input.components,
+              parameters: input.parameters,
+              source: input.source,
+              inputHash: null,
+              analysisModel,
+              createdBy: input.createdBy ?? null,
+            })
+            .returning();
+          variant = forced;
+        } else {
+          variant = existing;
+        }
       }
 
       if (!variant) {

--- a/src/lib/motion/build-model-input.test.ts
+++ b/src/lib/motion/build-model-input.test.ts
@@ -44,6 +44,11 @@ describe('buildModelInput', () => {
       const result = build('kling_v3_pro');
       expect(result.generate_audio).toBe(true);
     });
+
+    it('forwards generate_audio=false when caller suppresses audio', () => {
+      const result = build('kling_v3_pro', { generateAudio: false });
+      expect(result.generate_audio).toBe(false);
+    });
   });
 
   describe('Grok Imagine Video', () => {
@@ -62,6 +67,11 @@ describe('buildModelInput', () => {
     it('sets generate_audio to true from schema default', () => {
       const result = build('veo3_1');
       expect(result.generate_audio).toBe(true);
+    });
+
+    it('forwards generate_audio=false when caller suppresses audio', () => {
+      const result = build('veo3_1', { generateAudio: false });
+      expect(result.generate_audio).toBe(false);
     });
 
     it('uses image_url', () => {

--- a/src/lib/motion/build-model-input.ts
+++ b/src/lib/motion/build-model-input.ts
@@ -46,6 +46,12 @@ export function buildModelInput<T extends ImageToVideoModel>(
     imageUrl: options.imageUrl,
     aspectRatio: options.aspectRatio,
     ...QUALITY_OVERRIDES[modelKey],
+    // Pass-through `generate_audio` for audio-capable models. The schema-driven
+    // transform forwards unknown keys; models without `generate_audio` strip
+    // it during apiSchema.parse.
+    ...(options.generateAudio !== undefined && {
+      generate_audio: options.generateAudio,
+    }),
   }) as ModelOutputMap[T];
 
   const outputPrompt =

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -34,6 +34,7 @@ export const generationMotionOptionsSchema = z.object({
   fps: z.number().optional(),
   motionBucket: z.number().optional(),
   aspectRatio: aspectRatioSchema.optional(),
+  generateAudio: z.boolean().optional(),
 });
 
 export type GenerateMotionOptions = {
@@ -45,6 +46,10 @@ export type GenerateMotionOptions = {
   fps?: number;
   motionBucket?: number;
   aspectRatio?: AspectRatio;
+  /** For audio-capable models (kling v3, veo3), pass `false` to suppress
+   *  the model's native audio output (sfx/ambient/lip-sync). Omitting the
+   *  flag lets the API schema default apply (true for audio-capable models). */
+  generateAudio?: boolean;
 };
 
 import { buildModelInput } from './build-model-input';
@@ -173,10 +178,12 @@ export function calculateMotionMetadata(options: GenerateMotionOptions): {
   const validatedDuration = snapDuration(options.duration, modelKey);
 
   const providerInput = buildModelInput(options, modelConfig, modelKey);
+  const audioEnabled =
+    videoModelSupportsAudio(modelKey) && options.generateAudio !== false;
   const cost = calculateVideoCost({
     endpointId: modelConfig.id,
     durationSeconds: validatedDuration,
-    audioEnabled: videoModelSupportsAudio(modelKey),
+    audioEnabled,
     resolution:
       'resolution' in providerInput &&
       typeof providerInput.resolution === 'string'

--- a/src/lib/motion/resolve-frame-duration.test.ts
+++ b/src/lib/motion/resolve-frame-duration.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'bun:test';
+
+import { resolveFrameDuration } from './resolve-frame-duration';
+
+// kling_v3_pro accepts integer seconds 1..15 (one entry per integer).
+// veo3_1 accepts only {4, 6, 8} — useful for asserting snap behavior.
+
+describe('resolveFrameDuration', () => {
+  it('uses explicit duration when present, snapped to the model', () => {
+    const result = resolveFrameDuration({
+      explicit: 7,
+      durationMs: 3000,
+      metadataSeconds: 4,
+      model: 'veo3_1',
+    });
+    // 7 is equidistant from 6 and 8; current snap tie-break keeps the earlier value.
+    expect([6, 8]).toContain(result);
+  });
+
+  it('falls back to durationMs/1000 when explicit is undefined', () => {
+    const result = resolveFrameDuration({
+      durationMs: 5000,
+      metadataSeconds: 9,
+      model: 'kling_v3_pro',
+    });
+    expect(result).toBe(5);
+  });
+
+  it('treats durationMs of 0 as unset and falls through to metadataSeconds', () => {
+    const result = resolveFrameDuration({
+      durationMs: 0,
+      metadataSeconds: 7,
+      model: 'kling_v3_pro',
+    });
+    expect(result).toBe(7);
+  });
+
+  it('falls back to metadataSeconds when durationMs is null', () => {
+    const result = resolveFrameDuration({
+      durationMs: null,
+      metadataSeconds: 9,
+      model: 'kling_v3_pro',
+    });
+    expect(result).toBe(9);
+  });
+
+  it('falls back to a valid model duration when nothing is stored', () => {
+    const result = resolveFrameDuration({ model: 'veo3_1' });
+    expect([4, 6, 8]).toContain(result);
+  });
+
+  it('snaps onto the model duration set even when the source was valid for a different model', () => {
+    // 12s is valid for kling_v3_pro but not for veo3_1
+    const result = resolveFrameDuration({
+      durationMs: 12000,
+      model: 'veo3_1',
+    });
+    expect(result).toBe(8);
+  });
+});

--- a/src/lib/motion/resolve-frame-duration.ts
+++ b/src/lib/motion/resolve-frame-duration.ts
@@ -1,0 +1,27 @@
+import type { ImageToVideoModel } from '../ai/models';
+import { snapDuration } from './motion-generation';
+
+export type ResolveFrameDurationInput = {
+  /** Caller-supplied override (e.g. `data.duration` from the API). Wins if defined. */
+  explicit?: number;
+  /** Frame's stored duration in milliseconds. `0` / `null` / `undefined` are treated as unset. */
+  durationMs?: number | null;
+  /** Fallback from scene metadata for legacy frames where `durationMs` was never populated. */
+  metadataSeconds?: number | null;
+  /** Motion model whose JSON Schema defines the valid duration set to snap to. */
+  model: ImageToVideoModel;
+};
+
+/** Resolve the duration (seconds) for a motion generation call and snap it
+ *  onto the selected model's valid duration set. Used by both the credit
+ *  pre-flight and the workflow input so they always agree. */
+export function resolveFrameDuration({
+  explicit,
+  durationMs,
+  metadataSeconds,
+  model,
+}: ResolveFrameDurationInput): number {
+  const fromMs = durationMs && durationMs > 0 ? durationMs / 1000 : undefined;
+  const requested = explicit ?? fromMs ?? metadataSeconds ?? undefined;
+  return snapDuration(requested, model);
+}

--- a/src/lib/schemas/frame.schemas.ts
+++ b/src/lib/schemas/frame.schemas.ts
@@ -85,6 +85,8 @@ export const generateMotionSchema = z.object({
   duration: z.number().min(1).max(10).optional(),
   fps: z.number().min(7).max(30).optional(),
   motionBucket: z.number().min(1).max(255).optional(),
+  /** Toggle sfx/dialogue/ambient audio for audio-capable models. */
+  generateAudio: z.boolean().optional(),
 });
 
 export const generateVariantSchema = z.object({

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -189,6 +189,12 @@ export interface MotionWorkflowInput extends SequenceWorkflowContext {
   motionBucket?: number;
   aspectRatio?: AspectRatio; // "16:9", "9:16", "1:1"
   /**
+   * For audio-capable models (kling v3, veo3), pass `false` to suppress the
+   * model's native audio output (sfx/ambient/lip-sync). Omit to use the API
+   * schema default (true for audio-capable models).
+   */
+  generateAudio?: boolean;
+  /**
    * `true` when `prompt` came from a user edit (typed in the UI). `false` for
    * auto paths (batch generation, smart-retry) where `prompt` was produced by
    * `resolveMotionPrompt` and may include model-specific dialogue/audio
@@ -524,6 +530,12 @@ export interface MergeVideoWorkflowInput extends SequenceWorkflowContext {
   targetFps?: number;
   /** Target resolution (512-2048 per dimension) */
   resolution?: { width: number; height: number };
+  /**
+   * When `true`, skip the chained merge-audio-video workflow even if a music
+   * variant exists. Used by the music tab's "Merge with Video" CTA when the
+   * user has unchecked "Include music".
+   */
+  skipAudioMux?: boolean;
 }
 
 export interface MergeVideoWorkflowResult {
@@ -763,6 +775,8 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
     fps?: number;
     motionBucket?: number;
     aspectRatio?: AspectRatio;
+    /** See `MotionWorkflowInput.generateAudio`. */
+    generateAudio?: boolean;
     /** See `MotionWorkflowInput.userEditedPrompt`. */
     userEditedPrompt?: boolean;
   }>;

--- a/src/lib/workflows/merge-video-workflow.ts
+++ b/src/lib/workflows/merge-video-workflow.ts
@@ -47,6 +47,13 @@ async function chainAudioMux(
   input: MergeVideoWorkflowInput & { sequenceId: string },
   mergedVideoVariantId: string
 ): Promise<void> {
+  if (input.skipAudioMux) {
+    console.log(
+      `[MergeVideoWorkflow] skipAudioMux=true; bypassing audio mux for sequence ${input.sequenceId}`
+    );
+    return;
+  }
+
   const musicVariantId = await context.run(
     'fetch-music-variant-for-mux',
     async () => resolveMusicVariantForMux(scopedDb, input.sequenceId)

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -64,6 +64,7 @@ export const motionBatchWorkflow =
             fps: frame.fps,
             motionBucket: frame.motionBucket,
             aspectRatio: frame.aspectRatio,
+            generateAudio: frame.generateAudio,
             userEditedPrompt: frame.userEditedPrompt,
             // motion-batch invokes merge itself at step 3
             triggerMergeOnComplete: false,

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -91,6 +91,7 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
         fps: input.fps,
         motionBucket: input.motionBucket,
         aspectRatio: input.aspectRatio,
+        generateAudio: input.generateAudio,
       });
 
       // Check if team has enough credits (resolve BYOK status before job submission)
@@ -236,6 +237,7 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
         fps: input.fps,
         motionBucket: input.motionBucket,
         aspectRatio: input.aspectRatio,
+        generateAudio: input.generateAudio,
         scopedDb,
       }).catch((error) => {
         if (

--- a/src/routes/_protected/sequences/$id/music.tsx
+++ b/src/routes/_protected/sequences/$id/music.tsx
@@ -168,14 +168,18 @@ function MusicPage() {
   });
 
   const mergeVideoAndMusic = useMutation({
-    mutationFn: () => mergeVideoAndMusicFn({ data: { sequenceId } }),
-    onMutate: () => {
+    mutationFn: (args: { includeMusic: boolean }) =>
+      mergeVideoAndMusicFn({
+        data: { sequenceId, includeMusic: args.includeMusic },
+      }),
+    onMutate: (args) => {
       queryClient.setQueryData<Sequence>(
         sequenceKeys.detail(sequenceId),
         (old) => (old ? { ...old, mergedVideoStatus: 'merging' as const } : old)
       );
       posthog.capture('merged_video_generation_started', {
         sequence_id: sequenceId,
+        include_music: args.includeMusic,
       });
     },
   });
@@ -241,7 +245,7 @@ function MusicPage() {
           videoDuration={videoDuration}
           onGenerateMusic={(args) => generateMusic.mutate(args)}
           isGeneratingMusic={generateMusic.isPending}
-          onMergeVideoAndMusic={() => mergeVideoAndMusic.mutate()}
+          onMergeVideoAndMusic={(args) => mergeVideoAndMusic.mutate(args)}
           isMergingVideoAndMusic={mergeVideoAndMusic.isPending}
           divergentBanner={divergentBanner}
           isMusicPromptStale={musicPromptStaleness?.musicPrompt === 'stale'}


### PR DESCRIPTION
## Related Issue
Closes #688

## Summary
Addresses review feedback on the prior commit:
- Duration input is now a model-aware `<Select>` driven by each motion model's JSON Schema (`getDurationValues(MOTION_JSON_SCHEMAS[...])`) — users can only pick a value the selected model accepts.
- Extracts `resolveFrameDuration` helper + tests; snaps before `requireCredits` so the credit pre-flight prices the same duration the workflow bills.
- Extracts the script tab into a `SceneScriptTab` component (matches existing `scene-*-tab.tsx` pattern), removes the IIFE.

## Test plan
- [ ] Open Script tab — duration `<Select>` shows model-specific options
- [ ] Pick a different duration → Save → motion banner flips stale
- [ ] Switch motion model — saved value snaps to nearest valid option; Save activates if it changed
- [ ] Regenerate single-frame motion — billed amount matches the snapped duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)