### PR TITLE
fix(storage): wrap R2 uploads in FixedLengthStream so workerd accepts them

### DIFF
--- a/src/lib/storage/upload-response.ts
+++ b/src/lib/storage/upload-response.ts
@@ -19,5 +19,43 @@ export async function uploadResponse(
   if (!body) {
     throw new Error('Response body is null — cannot upload empty response');
   }
+
+  // workerd's r2.put() rejects ReadableStreams without a known length.
+  // fetch responses keep that link when Content-Length is set upstream,
+  // but some sources (chunked transfer encoding, intermediate proxies)
+  // strip it — and once it's gone, R2 throws "Provided readable stream
+  // must have a known length...". Re-establish the length via
+  // FixedLengthStream when the header is present, fall back to buffering
+  // when it's not. See issue #738.
+  //
+  // `FixedLengthStream` only exists on workerd; on Bun the native S3
+  // client streams responses without this restriction, so we leave the
+  // body untouched there.
+  if (typeof FixedLengthStream !== 'undefined') {
+    const contentLengthHeader = response.headers.get('content-length');
+    const contentLength = contentLengthHeader
+      ? Number.parseInt(contentLengthHeader, 10)
+      : Number.NaN;
+
+    if (Number.isFinite(contentLength) && contentLength > 0) {
+      const fixed = new FixedLengthStream(contentLength);
+      body.pipeTo(fixed.writable).catch(() => {
+        // Pipe errors propagate through the readable side and reject
+        // r2.put() below, which the outer caller surfaces.
+      });
+      return uploadFile(bucket, path, fixed.readable, {
+        ...options,
+        upsert: true,
+      });
+    }
+
+    // No Content-Length: buffer to a bounded payload so r2.put() can
+    // size it. All current callers upload bounded media (merged videos,
+    // generated images, motion clips, music tracks), so this stays
+    // within Worker memory limits.
+    const buffer = await response.arrayBuffer();
+    return uploadFile(bucket, path, buffer, { ...options, upsert: true });
+  }
+
   return uploadFile(bucket, path, body, { ...options, upsert: true });
 }

--- a/src/routes/api/storage/upload.ts
+++ b/src/routes/api/storage/upload.ts
@@ -62,7 +62,34 @@ export const Route = createFileRoute('/api/storage/upload')({
             );
           }
 
-          await uploadFile(validBucket, path, body, {
+          // workerd's R2 binding rejects ReadableStreams without a known
+          // length. The browser sends Content-Length (the body is a Blob),
+          // but once `request.body` has been routed through TanStack Start
+          // the length link is lost — so we re-establish it explicitly via
+          // FixedLengthStream. See issue #738.
+          const contentLengthHeader = request.headers.get('content-length');
+          const contentLength = contentLengthHeader
+            ? Number.parseInt(contentLengthHeader, 10)
+            : Number.NaN;
+
+          if (!Number.isFinite(contentLength) || contentLength <= 0) {
+            return Response.json(
+              {
+                success: false,
+                error: 'Content-Length header required for upload',
+              },
+              { status: 411 }
+            );
+          }
+
+          const fixedLength = new FixedLengthStream(contentLength);
+          body.pipeTo(fixedLength.writable).catch(() => {
+            // Pipe errors (client disconnect, length mismatch) surface
+            // through the readable side and reject the r2.put() below,
+            // which the outer catch turns into a 5xx via handleApiError.
+          });
+
+          await uploadFile(validBucket, path, fixedLength.readable, {
             contentType,
           });
 


### PR DESCRIPTION
## Summary

- Every server-side merge has been failing with `Provided readable stream must have a known length (request/response body or readable half of FixedLengthStream)` thrown by `r2.put()` inside the `merge-audio-video` (and `merge-video`) workflow.
- workerd's R2 binding only accepts `ReadableStream` bodies that either carry a verifiable `Content-Length` or are the readable half of a `FixedLengthStream`. `fetch(...).body` from fal.media loses that link, so every `uploadResponse()` caller (14+ workflow upload paths) is hit.
- Fix lives centrally in `src/lib/storage/upload-response.ts`: on workerd, wrap the body in `FixedLengthStream(contentLength)` when the header is present, or buffer via `response.arrayBuffer()` when it isn't (current callers upload bounded media well under the 128 MB Worker memory limit). Bun keeps streaming natively.
- Apply the same defensive wrap to the `/api/storage/upload` proxy route in `src/routes/api/storage/upload.ts` so the browser-merge path is fixed for whenever its feature flag flips on.

Closes #738

## Test plan

- [ ] Preview deploy: trigger a multi-frame sequence merge with music; both `merge-video` and `merge-audio-video` workflow `upload-to-storage` steps complete successfully and `sequences.mergedVideoUrl` populates.
- [ ] Confirm no new rows in `sequences.mergedVideoError` after the fix is live.
- [ ] Regression: talent / location / sequence-element image uploads on the preview deploy still succeed (they hit `/api/storage/upload` with Content-Length set by the Blob body).
- [ ] Negative case: `PUT /api/storage/upload?...` from `curl` without a body / `Content-Length` returns 411 instead of 5xx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)