### PR TITLE
fix(theatre): mix per-scene dialogue audio into live player + export

### DIFF
--- a/src/components/theatre/theatre-view.tsx
+++ b/src/components/theatre/theatre-view.tsx
@@ -150,6 +150,7 @@ function formatExportProgress(progress: ExportProgress | null): string {
     prepare: 'Preparing',
     video: 'Stitching video',
     music: 'Downloading music',
+    dialogue: 'Decoding dialogue',
     mix: 'Mixing audio',
     encode: 'Encoding audio',
     finalize: 'Finalizing',

--- a/src/lib/browser-merge/index.ts
+++ b/src/lib/browser-merge/index.ts
@@ -10,6 +10,7 @@ export {
   gainToTarget,
   integratedLoudnessLUFS,
 } from './loudness-normalize';
+export { assembleChannelData } from './mix-audio-tracks';
 export type {
   MergeProgress,
   MergeProgressCallback,

--- a/src/lib/sequence-player/concatenated-video-source.ts
+++ b/src/lib/sequence-player/concatenated-video-source.ts
@@ -22,6 +22,7 @@ import {
   EncodedPacket,
   EncodedPacketSink,
   Input,
+  type InputAudioTrack,
   type InputVideoTrack,
   UrlSource,
   type WrappedCanvas,
@@ -54,10 +55,19 @@ export type ConcatenatedVideoMeta = {
   displayHeight: number;
 };
 
+export type SceneAudioTrack = {
+  /** Index into the (sorted) scenes array. */
+  sceneIndex: number;
+  /** Cumulative scene start offset (seconds) — where this audio is anchored on the global timeline. */
+  sceneOffsetSeconds: number;
+  track: InputAudioTrack;
+};
+
 export class ConcatenatedVideoSource {
   private readonly scenes: SceneInput[];
   private inputs: Input[] = [];
   private videoTracks: InputVideoTrack[] = [];
+  private audioTracks: Array<InputAudioTrack | null> = [];
   private meta: ConcatenatedVideoMeta | null = null;
 
   constructor(scenes: SceneInput[]) {
@@ -78,6 +88,7 @@ export class ConcatenatedVideoSource {
 
     const inputs: Input[] = [];
     const videoTracks: InputVideoTrack[] = [];
+    const audioTracks: Array<InputAudioTrack | null> = [];
     const sceneDurationsSeconds: number[] = [];
     let displayWidth = 0;
     let displayHeight = 0;
@@ -112,8 +123,16 @@ export class ConcatenatedVideoSource {
         displayHeight = await videoTrack.getDisplayHeight();
       }
 
+      // Embedded scene audio (dialogue / VO). Best-effort: scenes without an
+      // audio track or with an undecodable codec are silent; the rest are
+      // mixed by the player + export.
+      const audioTrack = await input.getPrimaryAudioTrack();
+      const usableAudio =
+        audioTrack && (await audioTrack.canDecode()) ? audioTrack : null;
+
       inputs.push(input);
       videoTracks.push(videoTrack);
+      audioTracks.push(usableAudio);
       sceneDurationsSeconds.push(duration);
     }
 
@@ -126,6 +145,7 @@ export class ConcatenatedVideoSource {
 
     this.inputs = inputs;
     this.videoTracks = videoTracks;
+    this.audioTracks = audioTracks;
     this.meta = {
       totalDurationSeconds: acc,
       sceneDurationsSeconds,
@@ -288,11 +308,29 @@ export class ConcatenatedVideoSource {
     }
   }
 
+  /**
+   * Audio tracks discovered during `prepare()`, paired with their global
+   * scene offset. Scenes without a usable audio track are omitted, so the
+   * length may be smaller than `scenes.length`.
+   */
+  getSceneAudioTracks(): SceneAudioTrack[] {
+    const meta = this.getMeta();
+    const result: SceneAudioTrack[] = [];
+    for (let i = 0; i < this.audioTracks.length; i++) {
+      const track = this.audioTracks[i];
+      const offset = meta.sceneOffsetsSeconds[i];
+      if (!track || offset === undefined) continue;
+      result.push({ sceneIndex: i, sceneOffsetSeconds: offset, track });
+    }
+    return result;
+  }
+
   /** Release every underlying `Input` — call when the source is no longer needed. */
   dispose(): void {
     for (const input of this.inputs) input.dispose();
     this.inputs = [];
     this.videoTracks = [];
+    this.audioTracks = [];
     this.meta = null;
   }
 }

--- a/src/lib/sequence-player/decode-audio-track.ts
+++ b/src/lib/sequence-player/decode-audio-track.ts
@@ -1,0 +1,77 @@
+/**
+ * Decode a mediabunny `InputAudioTrack` to a single `AudioBuffer`, used by
+ * both the live player (scheduling scene dialogue via `AudioBufferSourceNode`)
+ * and the export pipeline (mixing scene dialogue into the master in an
+ * `OfflineAudioContext`).
+ *
+ * Mirrors the WebCodecs decode path in `browser-merge/mix-audio-tracks.ts`
+ * but operates on an already-opened track instead of taking a `Blob`, so we
+ * don't re-fetch each scene's MP4 when `ConcatenatedVideoSource` already has
+ * every `Input` open.
+ */
+
+import { assembleChannelData } from '@/lib/browser-merge';
+import { EncodedPacketSink, type InputAudioTrack } from 'mediabunny';
+
+export async function decodeAudioTrack(
+  audioTrack: InputAudioTrack
+): Promise<AudioBuffer | null> {
+  const decoderConfig = await audioTrack.getDecoderConfig();
+  if (!decoderConfig) return null;
+
+  const sampleRate = await audioTrack.getSampleRate();
+  const numberOfChannels = Math.max(1, await audioTrack.getNumberOfChannels());
+
+  const decoded: AudioData[] = [];
+  // WebCodecs invokes `error` async on its own task; throwing from the callback
+  // does NOT reject the surrounding `await flush()`. Capture and rethrow.
+  let decoderError: Error | null = null;
+  const decoder = new AudioDecoder({
+    output: (data) => decoded.push(data),
+    error: (e) => {
+      decoderError = e instanceof Error ? e : new Error(String(e));
+    },
+  });
+  decoder.configure(decoderConfig);
+
+  const sink = new EncodedPacketSink(audioTrack);
+  for await (const packet of sink.packets()) {
+    // oxlint-disable-next-line typescript/no-unnecessary-condition -- mutated by WebCodecs error callback
+    if (decoderError) throw decoderError;
+    decoder.decode(packet.toEncodedAudioChunk());
+  }
+  await decoder.flush();
+  decoder.close();
+  // oxlint-disable-next-line typescript/no-unnecessary-condition -- mutated by WebCodecs error callback
+  if (decoderError) throw decoderError;
+
+  const { channelData, totalFrames } = assembleChannelData(
+    decoded,
+    numberOfChannels
+  );
+  if (totalFrames === 0) return null;
+
+  const buffer = new AudioBuffer({
+    length: totalFrames,
+    numberOfChannels,
+    sampleRate,
+  });
+  for (let c = 0; c < numberOfChannels; c++) {
+    const channel = channelData[c];
+    if (!channel) throw new Error(`expected channel data ${c}`);
+    buffer.copyToChannel(toArrayBufferBacked(channel), c);
+  }
+  return buffer;
+}
+
+/**
+ * AudioBuffer.copyToChannel requires `Float32Array<ArrayBuffer>` specifically;
+ * Float32Arrays whose buffer type has been widened to `ArrayBufferLike` aren't
+ * assignable. Copy into a fresh, plain-ArrayBuffer-backed Float32Array to
+ * satisfy the signature without a type assertion.
+ */
+function toArrayBufferBacked(input: Float32Array): Float32Array<ArrayBuffer> {
+  const out = new Float32Array(input.length);
+  out.set(input);
+  return out;
+}

--- a/src/lib/sequence-player/export.ts
+++ b/src/lib/sequence-player/export.ts
@@ -3,24 +3,22 @@
  * so the two stay in lock-step — same iterator, same scene timing, same
  * loudness gain. The only difference from playback is the sink:
  *
- * - Live player: video → `CanvasSink`, music → `AudioBufferSink` → `GainNode`.
- * - Export:      video → `EncodedVideoPacketSource`, music → mixed in an
- *                `OfflineAudioContext` → AAC → `EncodedAudioPacketSource`.
+ * - Live player: video → `CanvasSink`, music + per-scene dialogue → `AudioBufferSink`
+ *                / `AudioBufferSourceNode` → `GainNode`.
+ * - Export:      video → `EncodedVideoPacketSource`, music + per-scene dialogue
+ *                mixed in an `OfflineAudioContext` → AAC → `EncodedAudioPacketSource`.
  *
  * The result is an in-memory MP4 `Blob` ready to upload to R2 via the
  * `sequence_exports` server functions.
  */
 
 import {
-  ALL_FORMATS,
   BufferTarget,
   EncodedAudioPacketSource,
   EncodedPacket,
   EncodedVideoPacketSource,
-  Input,
   Mp4OutputFormat,
   Output,
-  UrlSource,
 } from 'mediabunny';
 import { addCorsCacheBuster } from '@/lib/utils/cors-cache-buster';
 
@@ -35,6 +33,7 @@ import {
   ConcatenatedVideoSource,
   type SceneInput,
 } from './concatenated-video-source';
+import { decodeAudioTrack } from './decode-audio-track';
 
 const MAX_TOTAL_DURATION_SECONDS = 5 * 60;
 const TARGET_SAMPLE_RATE = 48_000;
@@ -45,6 +44,7 @@ export type ExportProgressPhase =
   | 'prepare'
   | 'video'
   | 'music'
+  | 'dialogue'
   | 'mix'
   | 'encode'
   | 'finalize';
@@ -81,7 +81,6 @@ export async function exportSequence(
   const { scenes, musicUrl, musicLoudnessGainDb, onProgress, signal } = input;
 
   const videoSource = new ConcatenatedVideoSource(scenes);
-  let musicInput: Input | null = null;
 
   try {
     const meta = await videoSource.prepare();
@@ -93,6 +92,9 @@ export async function exportSequence(
       );
     }
 
+    const sceneAudioTracks = videoSource.getSceneAudioTracks();
+    const hasAudio = Boolean(musicUrl) || sceneAudioTracks.length > 0;
+
     const output = new Output({
       format: new Mp4OutputFormat({ fastStart: 'in-memory' }),
       target: new BufferTarget(),
@@ -100,7 +102,7 @@ export async function exportSequence(
     const videoSrc = new EncodedVideoPacketSource('avc');
     output.addVideoTrack(videoSrc);
 
-    const audioSrc = musicUrl ? new EncodedAudioPacketSource('aac') : null;
+    const audioSrc = hasAudio ? new EncodedAudioPacketSource('aac') : null;
     if (audioSrc) output.addAudioTrack(audioSrc);
 
     await output.start();
@@ -131,22 +133,48 @@ export async function exportSequence(
         total: packetCount,
       });
 
-      // MUSIC: fetch + mix at loudness gain + encode AAC.
-      if (musicUrl && audioSrc) {
-        if (signal?.aborted) throw new Error('Export aborted');
-        const bustedMusicUrl = addCorsCacheBuster(musicUrl);
-        const musicBlob = await fetchBlob(bustedMusicUrl, signal);
+      // AUDIO: fetch music + decode each scene's embedded audio (dialogue/VO),
+      // mix at scene offsets, encode AAC.
+      if (audioSrc) {
+        const musicBlob = musicUrl
+          ? await fetchBlob(addCorsCacheBuster(musicUrl), signal)
+          : null;
         onProgress?.({ phase: 'music', completed: 1, total: 1 });
 
-        musicInput = new Input({
-          formats: ALL_FORMATS,
-          source: new UrlSource(bustedMusicUrl),
-        });
+        const dialogueBuffers: Array<{
+          buffer: AudioBuffer;
+          sceneOffsetSeconds: number;
+        }> = [];
+        for (let i = 0; i < sceneAudioTracks.length; i++) {
+          if (signal?.aborted) throw new Error('Export aborted');
+          const entry = sceneAudioTracks[i];
+          if (!entry) continue;
+          try {
+            const buffer = await decodeAudioTrack(entry.track);
+            if (buffer) {
+              dialogueBuffers.push({
+                buffer,
+                sceneOffsetSeconds: entry.sceneOffsetSeconds,
+              });
+            }
+          } catch (err) {
+            console.warn(
+              `exportSequence: failed to decode embedded audio for scene ${entry.sceneIndex}`,
+              err
+            );
+          }
+          onProgress?.({
+            phase: 'dialogue',
+            completed: i + 1,
+            total: sceneAudioTracks.length,
+          });
+        }
 
-        const mixed = await mixMusic({
+        const mixed = await mixSequenceAudio({
           musicBlob,
-          totalDurationSeconds: meta.totalDurationSeconds,
           musicLoudnessGainDb,
+          dialogueBuffers,
+          totalDurationSeconds: meta.totalDurationSeconds,
           signal,
         });
         onProgress?.({ phase: 'mix', completed: 1, total: 1 });
@@ -178,7 +206,6 @@ export async function exportSequence(
     }
   } finally {
     videoSource.dispose();
-    if (musicInput) musicInput.dispose();
   }
 }
 
@@ -192,49 +219,58 @@ async function fetchBlob(url: string, signal?: AbortSignal): Promise<Blob> {
   return await response.blob();
 }
 
-async function mixMusic(args: {
-  musicBlob: Blob;
-  totalDurationSeconds: number;
+async function mixSequenceAudio(args: {
+  musicBlob: Blob | null;
   musicLoudnessGainDb: number | null;
+  dialogueBuffers: Array<{ buffer: AudioBuffer; sceneOffsetSeconds: number }>;
+  totalDurationSeconds: number;
   signal?: AbortSignal;
 }): Promise<AudioBuffer> {
-  const { musicBlob, totalDurationSeconds, musicLoudnessGainDb, signal } = args;
+  const {
+    musicBlob,
+    musicLoudnessGainDb,
+    dialogueBuffers,
+    totalDurationSeconds,
+    signal,
+  } = args;
 
-  const decodeCtx = new AudioContext();
-  let normalized: AudioBuffer;
-  try {
-    const arrayBuffer = await musicBlob.arrayBuffer();
-    const decoded = await decodeCtx.decodeAudioData(arrayBuffer);
-    if (signal?.aborted) throw new Error('Export aborted');
+  let normalizedMusic: AudioBuffer | null = null;
+  if (musicBlob) {
+    const decodeCtx = new AudioContext();
+    try {
+      const arrayBuffer = await musicBlob.arrayBuffer();
+      const decoded = await decodeCtx.decodeAudioData(arrayBuffer);
+      if (signal?.aborted) throw new Error('Export aborted');
 
-    const channels: Float32Array[] = [];
-    for (let c = 0; c < decoded.numberOfChannels; c++) {
-      channels.push(decoded.getChannelData(c).slice());
+      const channels: Float32Array[] = [];
+      for (let c = 0; c < decoded.numberOfChannels; c++) {
+        channels.push(decoded.getChannelData(c).slice());
+      }
+
+      // Prefer the precomputed gain so playback and export are bit-identical
+      // in loudness. Fall back to measuring if the column hasn't been backfilled.
+      const gainLinear =
+        musicLoudnessGainDb !== null && Number.isFinite(musicLoudnessGainDb)
+          ? Math.pow(10, musicLoudnessGainDb / 20)
+          : gainToTarget(
+              integratedLoudnessLUFS(channels, decoded.sampleRate),
+              DEFAULT_MUSIC_LOUDNESS_LUFS
+            );
+      applyGain(channels, gainLinear);
+
+      normalizedMusic = new AudioBuffer({
+        length: decoded.length,
+        numberOfChannels: decoded.numberOfChannels,
+        sampleRate: decoded.sampleRate,
+      });
+      for (let c = 0; c < channels.length; c++) {
+        const channel = channels[c];
+        if (!channel) throw new Error(`expected channel ${c}`);
+        normalizedMusic.copyToChannel(toArrayBufferBacked(channel), c);
+      }
+    } finally {
+      await decodeCtx.close();
     }
-
-    // Prefer the precomputed gain so playback and export are bit-identical
-    // in loudness. Fall back to measuring if the column hasn't been backfilled.
-    const gainLinear =
-      musicLoudnessGainDb !== null && Number.isFinite(musicLoudnessGainDb)
-        ? Math.pow(10, musicLoudnessGainDb / 20)
-        : gainToTarget(
-            integratedLoudnessLUFS(channels, decoded.sampleRate),
-            DEFAULT_MUSIC_LOUDNESS_LUFS
-          );
-    applyGain(channels, gainLinear);
-
-    normalized = new AudioBuffer({
-      length: decoded.length,
-      numberOfChannels: decoded.numberOfChannels,
-      sampleRate: decoded.sampleRate,
-    });
-    for (let c = 0; c < channels.length; c++) {
-      const channel = channels[c];
-      if (!channel) throw new Error(`expected channel ${c}`);
-      normalized.copyToChannel(toArrayBufferBacked(channel), c);
-    }
-  } finally {
-    await decodeCtx.close();
   }
 
   const length = Math.max(
@@ -246,10 +282,21 @@ async function mixMusic(args: {
     length,
     sampleRate: TARGET_SAMPLE_RATE,
   });
-  const src = offline.createBufferSource();
-  src.buffer = normalized;
-  src.connect(offline.destination);
-  src.start(0);
+
+  if (normalizedMusic) {
+    const src = offline.createBufferSource();
+    src.buffer = normalizedMusic;
+    src.connect(offline.destination);
+    src.start(0);
+  }
+
+  for (const { buffer, sceneOffsetSeconds } of dialogueBuffers) {
+    const src = offline.createBufferSource();
+    src.buffer = buffer;
+    src.connect(offline.destination);
+    src.start(Math.max(0, sceneOffsetSeconds));
+  }
+
   return await offline.startRendering();
 }
 

--- a/src/lib/sequence-player/playback.ts
+++ b/src/lib/sequence-player/playback.ts
@@ -1,11 +1,15 @@
 /**
  * Live playback engine for a stitched sequence (N scene videos + one music
- * track). Modeled on the Mediabunny media-player example, extended with:
+ * track + optional per-scene dialogue). Modeled on the Mediabunny media-player
+ * example, extended with:
  *
  * - `ConcatenatedVideoSource` for the video iterator (handles cross-scene
  *   continuity + global timestamps).
- * - A separate music `Input` + `AudioBufferSink` mixed through a `GainNode`
- *   whose value is derived from the music variant's measured loudness gain.
+ * - A music `Input` + `AudioBufferSink` mixed through a music-only `GainNode`
+ *   that applies the variant's measured loudness gain.
+ * - Per-scene dialogue audio decoded once in `prepare()` and scheduled as
+ *   `AudioBufferSourceNode`s on `play()` / `seek()`, routed through a master
+ *   gain node so dialogue is not attenuated by the music loudness gain.
  * - Codec gating up front via `prepare()`; throws so the React component can
  *   render a fallback CTA.
  *
@@ -29,6 +33,7 @@ import {
   ConcatenatedVideoSource,
   type SceneInput,
 } from './concatenated-video-source';
+import { decodeAudioTrack } from './decode-audio-track';
 
 export type SequencePlayerOptions = {
   canvas: HTMLCanvasElement;
@@ -52,16 +57,25 @@ export type SequencePlayerMeta = {
   hasAudio: boolean;
 };
 
+type DialogueClip = {
+  buffer: AudioBuffer;
+  sceneOffsetSeconds: number;
+};
+
 export class SequencePlayerEngine {
   private readonly opts: SequencePlayerOptions;
   private readonly canvasContext: CanvasRenderingContext2D;
   private readonly videoSource: ConcatenatedVideoSource;
 
   private audioContext: AudioContext | null = null;
-  private gainNode: GainNode | null = null;
+  /** Master gain — volume + mute. Dialogue routes here directly. */
+  private masterGain: GainNode | null = null;
+  /** Music-only gain — applies the music variant's loudness normalization on top of master gain. */
+  private musicGain: GainNode | null = null;
   private musicInput: Input | null = null;
   private musicTrack: InputAudioTrack | null = null;
   private audioSink: AudioBufferSink | null = null;
+  private dialogueClips: DialogueClip[] = [];
 
   private meta: SequencePlayerMeta | null = null;
 
@@ -130,13 +144,39 @@ export class SequencePlayerEngine {
     // browsers that ship the standard, unprefixed AudioContext, so we can use
     // it directly without a webkit fallback.
     this.audioContext = new AudioContext({ sampleRate: musicSampleRate });
-    this.gainNode = this.audioContext.createGain();
-    this.gainNode.connect(this.audioContext.destination);
+    this.masterGain = this.audioContext.createGain();
+    this.masterGain.connect(this.audioContext.destination);
+    this.musicGain = this.audioContext.createGain();
+    this.musicGain.connect(this.masterGain);
     this.applyGain();
 
     if (this.musicTrack) {
       this.audioSink = new AudioBufferSink(this.musicTrack);
     }
+
+    // Per-scene dialogue/VO lives in each scene video's embedded audio track.
+    // Decode upfront so play()/seek() can schedule against the AudioContext
+    // clock without async IO in the hot path. A single failing track shouldn't
+    // kill the whole player — log and stay silent for that scene.
+    const dialogueClips: DialogueClip[] = [];
+    for (const {
+      sceneIndex,
+      sceneOffsetSeconds,
+      track,
+    } of this.videoSource.getSceneAudioTracks()) {
+      try {
+        const buffer = await decodeAudioTrack(track);
+        if (!buffer) continue;
+        dialogueClips.push({ buffer, sceneOffsetSeconds });
+      } catch (err) {
+        console.warn(
+          `SequencePlayerEngine: failed to decode embedded audio for scene ${sceneIndex}`,
+          err
+        );
+      }
+    }
+    this.dialogueClips = dialogueClips;
+    if (dialogueClips.length > 0) hasAudio = true;
 
     this.opts.canvas.width = videoMeta.displayWidth;
     this.opts.canvas.height = videoMeta.displayHeight;
@@ -201,6 +241,8 @@ export class SequencePlayerEngine {
       this.audioBufferIterator = this.audioSink.buffers(this.getPlaybackTime());
       void this.runAudioIterator();
     }
+
+    this.scheduleDialogueClips();
   }
 
   pause(): void {
@@ -262,14 +304,60 @@ export class SequencePlayerEngine {
     void this.audioContext?.close();
     this.audioContext = null;
     this.audioSink = null;
-    this.gainNode = null;
+    this.masterGain = null;
+    this.musicGain = null;
+    this.dialogueClips = [];
   }
 
   private applyGain(): void {
-    if (!this.gainNode) return;
-    const linear = this.muted ? 0 : this.volume ** 2;
-    const loudnessLinear = loudnessDbToLinear(this.opts.musicLoudnessGainDb);
-    this.gainNode.gain.value = linear * loudnessLinear;
+    if (!this.masterGain || !this.musicGain) return;
+    const masterLinear = this.muted ? 0 : this.volume ** 2;
+    this.masterGain.gain.value = masterLinear;
+    this.musicGain.gain.value = loudnessDbToLinear(
+      this.opts.musicLoudnessGainDb
+    );
+  }
+
+  /**
+   * Schedule every dialogue clip whose end timestamp is still ahead of the
+   * current playback head. Each clip is anchored to its scene's global offset:
+   * if the user seeks into the middle of a scene, the clip starts mid-buffer.
+   */
+  private scheduleDialogueClips(): void {
+    if (
+      !this.audioContext ||
+      !this.masterGain ||
+      this.audioContextStartTime === null
+    ) {
+      return;
+    }
+    const playStart = this.playbackTimeAtStart;
+    for (const { buffer, sceneOffsetSeconds } of this.dialogueClips) {
+      const clipEnd = sceneOffsetSeconds + buffer.duration;
+      if (clipEnd <= playStart) continue;
+
+      const node = this.audioContext.createBufferSource();
+      node.buffer = buffer;
+      node.connect(this.masterGain);
+
+      const scheduleTime =
+        this.audioContextStartTime + sceneOffsetSeconds - playStart;
+      const bufferOffset = Math.max(0, playStart - sceneOffsetSeconds);
+
+      if (scheduleTime >= this.audioContext.currentTime) {
+        node.start(scheduleTime, bufferOffset);
+      } else {
+        node.start(
+          this.audioContext.currentTime,
+          bufferOffset + (this.audioContext.currentTime - scheduleTime)
+        );
+      }
+
+      this.queuedAudioNodes.add(node);
+      node.onended = () => {
+        this.queuedAudioNodes.delete(node);
+      };
+    }
   }
 
   private async primeFirstFrame(): Promise<void> {
@@ -358,7 +446,7 @@ export class SequencePlayerEngine {
    * loudness normalization.
    */
   private async runAudioIterator(): Promise<void> {
-    if (!this.audioBufferIterator || !this.audioContext || !this.gainNode) {
+    if (!this.audioBufferIterator || !this.audioContext || !this.musicGain) {
       return;
     }
     for await (const { buffer, timestamp } of this.audioBufferIterator) {
@@ -367,7 +455,7 @@ export class SequencePlayerEngine {
       if (startBaseline === null) return;
       const node = this.audioContext.createBufferSource();
       node.buffer = buffer;
-      node.connect(this.gainNode);
+      node.connect(this.musicGain);
 
       let startTimestamp = startBaseline + timestamp - this.playbackTimeAtStart;
       startTimestamp =


### PR DESCRIPTION
## Summary

- Scene MP4s have an embedded audio track (dialogue/VO) that the new mediabunny browser pipeline silently dropped. `ConcatenatedVideoSource` only extracted video; the live player and MP4 export only mixed music.
- Capture each scene's primary audio track during `prepare()` (free — the `Input`s are already open), decode via WebCodecs, schedule at the scene's global offset alongside music in both the live player and export.
- Split the live player's master gain into `masterGain` (volume + mute) and `musicGain` (music loudness normalization) so the music loudness gain no longer attenuates scene audio.

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint` clean on touched files
- [x] `bun test src/lib/browser-merge src/components/theatre` 21/21 pass
- [x] Live TheatreView playback: dialogue audible alongside music
- [x] Exported MP4 contains mixed dialogue + music
- [ ] Scenes without an embedded audio track stay silent without breaking playback / export

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)