### PR TITLE
fix(elements): persist vision-suggested token on draft promotion

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -516,6 +516,7 @@ export const ScriptView: FC<{
                 tempPath: el.tempPath,
                 tempPublicUrl: el.tempPublicUrl,
                 filename: el.filename,
+                token: el.token,
                 description: el.description,
                 consistencyTag: el.consistencyTag,
               }))

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -124,6 +124,7 @@ export const createSequenceSchema = createInsertSchema(sequences, {
           tempPath: z.string().min(1),
           tempPublicUrl: z.string().url(),
           filename: z.string().min(1),
+          token: z.string().min(1).max(100),
           description: z.string().nullable().optional(),
           consistencyTag: z.string().nullable().optional(),
         })


### PR DESCRIPTION
## Summary

- Add `token` to `createSequenceSchema.elementUploads` so the vision-suggested token survives Zod parsing on the server.
- Forward `el.token` from `draftElements` in `script-view.tsx` so the client actually sends it.

Without these, `promoteTempElements` fell back to `deriveTokenFromFilename`, persisting tokens like `IMAGE` for files named `image.png` — even though vision had already produced (and the script had been enhanced with) the correct token, e.g. `TWININGS_IMMUNITY_CAN`. The mismatch then caused `matchElementsToScene` to skip the element during frame generation.

Closes #752

## Test plan

- [ ] Save a brand image locally as `image.png` (so filename-derived token would be `IMAGE`).
- [ ] On a new script, upload it as a draft element; wait for analysis spinner to clear.
- [ ] Click Generate; accept the enhance prompt; confirm the enhanced script references the AI-suggested token (e.g. `TWININGS_IMMUNITY_CAN`).
- [ ] Click Generate again to create the sequence.
- [ ] Open Manage Elements — the element token matches the suggested token, not `IMAGE`.
- [ ] Open a frame that should reference the element — it appears in the frame's reference panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)