### PR TITLE
refactor: stop motion-batch + smart-retry invoking merge (2/4 of #751)

### DIFF
--- a/e2e/fixtures/sequence.fixture.ts
+++ b/e2e/fixtures/sequence.fixture.ts
@@ -256,24 +256,21 @@ export async function getTestCharacter(characterId: string): Promise<{
 }
 
 /**
- * Get sequence-level music + merged-video status. Music is generated once
- * per sequence (not per frame — see src/lib/workflows/music-workflow.ts:133
- * TODO), and merging composes the muxed video, so the full pipeline is
- * "done" when `mergedVideoStatus === 'completed'`.
+ * Get sequence-level music status. Music is generated once per sequence
+ * (not per frame — see src/lib/workflows/music-workflow.ts:133 TODO).
+ * Per-frame video completion is checked via getTestSequenceFrames; final
+ * composition is now client-side via Mediabunny, so no merged-video row
+ * is written.
  */
 export async function getTestSequenceStatus(sequenceId: string): Promise<{
   musicStatus: string | null;
   musicUrl: string | null;
-  mergedVideoStatus: string | null;
-  mergedVideoUrl: string | null;
 } | null> {
   const row = await testDb.query.sequences.findFirst({
     where: { id: sequenceId },
     columns: {
       musicStatus: true,
       musicUrl: true,
-      mergedVideoStatus: true,
-      mergedVideoUrl: true,
     },
   });
   return row ?? null;

--- a/e2e/tests/full-sequence.spec.ts
+++ b/e2e/tests/full-sequence.spec.ts
@@ -342,13 +342,10 @@ SUPER:  CORAL.  OUT NOW.
       // 14. Thin DB sanity tail: a UI bug that silently hides a player
       //     mustn't make the test pass green. We've already proved every
       //     resource decodes above, so the URL-presence asserts are
-      //     belt-and-braces only.
+      //     belt-and-braces only. The "merged video" concept is gone —
+      //     final composition happens client-side via Mediabunny.
       const finalStatus = await getTestSequenceStatus(sequenceId);
       expect(finalStatus?.musicUrl, 'sequence missing music url').toBeTruthy();
-      expect(
-        finalStatus?.mergedVideoUrl,
-        'sequence missing merged video url'
-      ).toBeTruthy();
       const finalFrames = await getTestSequenceFrames(sequenceId);
       for (const frame of finalFrames) {
         expect(frame.videoUrl, `frame ${frame.id} missing video`).toBeTruthy();

--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -240,7 +240,7 @@ export const smartRetryFn = createServerFn({ method: 'POST' })
           model: videoModel,
           aspectRatio: sequence.aspectRatio,
           duration: frame.durationMs ? frame.durationMs / 1000 : undefined,
-          triggerMergeOnComplete: true,
+          triggerMergeOnComplete: false,
         };
 
         await triggerWorkflow('/motion', workflowInput, {

--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -240,7 +240,6 @@ export const smartRetryFn = createServerFn({ method: 'POST' })
           model: videoModel,
           aspectRatio: sequence.aspectRatio,
           duration: frame.durationMs ? frame.durationMs / 1000 : undefined,
-          triggerMergeOnComplete: false,
         };
 
         await triggerWorkflow('/motion', workflowInput, {

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -202,15 +202,6 @@ export interface MotionWorkflowInput extends SequenceWorkflowContext {
    * the workflow appends a `user-edit` variant row.
    */
   userEditedPrompt?: boolean;
-  /**
-   * When `true`, the workflow's final step checks whether *all* sequence
-   * frames now have completed videos and, if so, triggers `/merge-video`.
-   * Only callers that fan out motion without their own subsequent merge
-   * invocation (e.g. `smart-retry`'s motion-retry path) should set this.
-   * The batch orchestrator (`motionBatchWorkflow`) invokes merge itself and
-   * leaves this unset to avoid redundant triggers.
-   */
-  triggerMergeOnComplete?: boolean;
 }
 
 /**

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -422,7 +422,7 @@ export const analyzeScriptWorkflow = createScopedWorkflow<
         });
       });
 
-      // Phase 5: single orchestrator for motion + optional music + merge
+      // Phase 5: single orchestrator for motion + optional music
       const motionBatchResult = await context.invoke('motion-batch', {
         workflow: motionBatchWorkflow,
         label,

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -60,7 +60,6 @@ export const motionBatchWorkflow =
             aspectRatio: frame.aspectRatio,
             generateAudio: frame.generateAudio,
             userEditedPrompt: frame.userEditedPrompt,
-            triggerMergeOnComplete: false,
           } satisfies MotionWorkflowInput,
           retries: 3,
           retryDelay: 'pow(2, retried) * 1000',

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -1,7 +1,8 @@
 /**
  * Batch Motion + Music Workflow
- * Orchestrates parallel motion generation for all frames + optional music,
- * then merges videos and optionally muxes audio onto the final output.
+ * Orchestrates parallel motion generation for all frames + optional music.
+ * Playback and download are handled client-side by `<SequencePlayer>` /
+ * the Mediabunny browser export — no server-side video merge step.
  */
 
 import { getGenerationChannel } from '@/lib/realtime';
@@ -11,25 +12,16 @@ import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
 import type {
   BatchMotionMusicWorkflowInput,
-  MergeAudioVideoWorkflowInput,
-  MergeVideoWorkflowInput,
   MotionWorkflowInput,
   MusicWorkflowInput,
 } from '@/lib/workflow/types';
 
-import { mergeAudioVideoWorkflow } from './merge-audio-video-workflow';
-import {
-  MERGE_VIDEO_WORKFLOW_NAME,
-  mergeVideoWorkflow,
-} from './merge-video-workflow';
 import { generateMotionWorkflow } from './motion-workflow';
 import { generateMusicWorkflow } from './music-workflow';
-import { resolveMotionBatchMergeMusicVariants } from './merge-variant-resolution';
-import { buildMergeVideoSourcesFromFrames } from './sequence-snapshots';
 
 export const motionBatchWorkflow =
   createScopedWorkflow<BatchMotionMusicWorkflowInput>(
-    async (context, scopedDb) => {
+    async (context) => {
       const input = context.requestPayload;
       const { sequenceId, includeMusic } = input;
       const label = buildWorkflowLabel(sequenceId);
@@ -46,7 +38,10 @@ export const motionBatchWorkflow =
         );
       }
 
-      // Step 1: Invoke all motion workflows + optional music workflow in parallel
+      // Invoke all motion workflows + optional music workflow in parallel.
+      // The live `<SequencePlayer>` plays per-frame videos directly and the
+      // browser export pipeline composes the final MP4 on the client — no
+      // server-side merge step.
       const motionInvocations = input.frames.map((frame, index) =>
         context.invoke(`motion-${index}`, {
           workflow: generateMotionWorkflow,
@@ -65,7 +60,6 @@ export const motionBatchWorkflow =
             aspectRatio: frame.aspectRatio,
             generateAudio: frame.generateAudio,
             userEditedPrompt: frame.userEditedPrompt,
-            // motion-batch invokes merge itself at step 3
             triggerMergeOnComplete: false,
           } satisfies MotionWorkflowInput,
           retries: 3,
@@ -93,67 +87,9 @@ export const motionBatchWorkflow =
           : null;
 
       await Promise.all([
-        Promise.all(motionInvocations),
+        ...motionInvocations,
         ...(musicInvocation ? [musicInvocation] : []),
       ]);
-
-      // Step 2: Collect video URLs and inline each frame's videoInputHash for
-      // the merge-video snapshot pattern. Frames without a videoUrl are skipped.
-      const { videoUrls, sourceFrameVideoHashes } = await context.run(
-        'collect-video-urls',
-        async () => {
-          const frames = await scopedDb.frames.listBySequence(sequenceId);
-          const sorted = [...frames].sort(
-            (a, b) => a.orderIndex - b.orderIndex
-          );
-          return buildMergeVideoSourcesFromFrames(sorted);
-        }
-      );
-
-      if (videoUrls.length === 0) {
-        throw new WorkflowValidationError(
-          'No completed frame videos found after motion generation'
-        );
-      }
-
-      // Step 3: Merge all frame videos into one
-      await context.invoke(MERGE_VIDEO_WORKFLOW_NAME, {
-        workflow: mergeVideoWorkflow,
-        label,
-        body: {
-          userId: input.userId,
-          teamId: input.teamId,
-          sequenceId,
-          videoUrls,
-          sourceFrameVideoHashes,
-        } satisfies MergeVideoWorkflowInput,
-      });
-
-      // Step 4: If music was generated, mux audio onto merged video.
-      // Resolve both source variants — final mux is a function of (video, music).
-      if (includeMusic) {
-        const mergeAndMusicSources = await context.run(
-          'get-merge-music-variants',
-          async () =>
-            resolveMotionBatchMergeMusicVariants(
-              scopedDb,
-              sequenceId,
-              MERGE_VIDEO_WORKFLOW_NAME
-            )
-        );
-
-        await context.invoke('merge-audio-video', {
-          workflow: mergeAudioVideoWorkflow,
-          label,
-          body: {
-            userId: input.userId,
-            teamId: input.teamId,
-            sequenceId,
-            mergedVideoVariantId: mergeAndMusicSources.mergedVideoVariantId,
-            musicVariantId: mergeAndMusicSources.musicVariantId,
-          } satisfies MergeAudioVideoWorkflowInput,
-        });
-      }
 
       return { sequenceId };
     },

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -20,21 +20,12 @@ import {
 } from '@/lib/motion/motion-generation';
 import { uploadVideoToStorage } from '@/lib/motion/video-storage';
 import { getGenerationChannel } from '@/lib/realtime';
-import { triggerWorkflow } from '@/lib/workflow/client';
-import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import { sanitizeFailResponse } from '@/lib/workflow/sanitize-fail-response';
 import { createScopedWorkflow } from '@/lib/workflow/scoped-workflow';
-import type {
-  MergeVideoWorkflowInput,
-  MotionWorkflowInput,
-} from '@/lib/workflow/types';
+import type { MotionWorkflowInput } from '@/lib/workflow/types';
 import { endSpanSuccess, startGenAISpan } from '@/lib/observability/tracer';
 import { WorkflowNonRetryableError } from '@upstash/workflow';
-import {
-  buildMergeVideoSourcesFromFrames,
-  computeSequenceVideoHashFromDto,
-} from './sequence-snapshots';
 import { shouldRecordUserEdit } from './user-edit-predicate';
 
 /** Each batch polls in a tight loop for ~30s, then checkpoints for durability */
@@ -433,51 +424,6 @@ export const generateMotionWorkflow = createScopedWorkflow<MotionWorkflowInput>(
             emitError
           );
         }
-      });
-
-      // Step 6: Opt-in merge auto-trigger for callers that fan out motion
-      // without their own subsequent merge invocation (e.g. smart-retry's
-      // motion-retry path). N parallel motion workflows can each reach this
-      // step near-simultaneously after the last frame lands; the content-
-      // derived dedup ID makes QStash collapse the duplicates into a single
-      // workflowRunId. Regenerating any frame's video changes the hash and
-      // re-arms a fresh merge. See issue #690.
-      await context.run('check-merge-trigger', async () => {
-        if (!input.triggerMergeOnComplete) return;
-        if (!input.sequenceId || !input.teamId || !input.userId) return;
-
-        const allFrames = await scopedDb.frames.listBySequence(
-          input.sequenceId
-        );
-        if (allFrames.length === 0) return;
-        if (!allFrames.every((f) => f.videoStatus === 'completed')) return;
-
-        const sorted = [...allFrames].sort(
-          (a, b) => a.orderIndex - b.orderIndex
-        );
-        const { videoUrls, sourceFrameVideoHashes } =
-          buildMergeVideoSourcesFromFrames(sorted);
-
-        if (videoUrls.length !== allFrames.length) return;
-
-        console.log(
-          `[MotionWorkflow] All ${allFrames.length} frames complete, triggering merge workflow`
-        );
-
-        const mergeInput: MergeVideoWorkflowInput = {
-          userId: input.userId,
-          teamId: input.teamId,
-          sequenceId: input.sequenceId,
-          videoUrls,
-          sourceFrameVideoHashes,
-        };
-
-        const inputHash = await computeSequenceVideoHashFromDto(mergeInput);
-
-        await triggerWorkflow('/merge-video', mergeInput, {
-          deduplicationId: `merge-${input.sequenceId}-${inputHash.slice(0, 16)}`,
-          label: buildWorkflowLabel(input.sequenceId),
-        });
       });
     }
 


### PR DESCRIPTION
## Summary

Stops every production code path that writes to `mergedVideo*` columns or `sequence_video_variants`. After this PR ships, the merge-video workflow is reachable only via the QStash route registration (which stays until #758) — nothing in our code paths invokes it.

- **`motion-batch-workflow.ts`** no longer invokes `merge-video` or `merge-audio-video`. The workflow ends at "all motion + optional music done". Drops the `collect-video-urls` step, the now-unused `scopedDb` param, four stale imports, and flattens the redundant nested `Promise.all`.
- **`smart-retry.ts`** motion-retry path stops passing `triggerMergeOnComplete`, so retrying a failed frame no longer chains into `merge-video-workflow`.
- **`motion-workflow.ts`** drops the now-unreachable `check-merge-trigger` step (every caller had stopped opting in) and its five dead imports. The `triggerMergeOnComplete` field is removed from `MotionWorkflowInput` along with it.
- **`full-sequence.spec.ts`** (e2e) drops the `mergedVideoUrl` "belt-and-braces" assertion. The real signal is already covered by the live SequencePlayer "Play" button check + per-frame `videoUrl` asserts.
- Drive-by: stale "+ merge" comment in `analyze-script-workflow.ts` phase-5.

This severs motion-workflow's last reference to `merge-video`, so PR 3 (#758) just deletes the workflow files without touching motion.

Part 2/4 of #751.

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun test src/lib/workflows` — 145 pass / 0 fail
- [ ] Reviewer: `bun test:e2e` — full-sequence spec passes
- [ ] Reviewer: trigger a sequence generation in `bun dev`; confirm no new `sequence_video_variants` rows and `sequences.mergedVideoStatus` stays at its prior value
- [ ] Reviewer: trigger a smart-retry on a failed motion frame; confirm same (no merge invocation in QStash logs)
- [ ] Reviewer: verify live `<SequencePlayer>` playback + Mediabunny export still work end-to-end

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)
