### PR TITLE
fix(eval): prefer first frame thumbnail over sequence poster

### DIFF
--- a/src/components/eval/eval-sequence-row.tsx
+++ b/src/components/eval/eval-sequence-row.tsx
@@ -46,6 +46,8 @@ export const EvalSequenceRow: React.FC<EvalSequenceRowProps> = ({
   const aspectRatio: AspectRatio =
     (sequence.aspectRatio as AspectRatio | null) ?? DEFAULT_ASPECT_RATIO;
 
+  const previewUrl = sequence.frames[0]?.thumbnailUrl ?? sequence.posterUrl;
+
   return (
     <>
       <div
@@ -58,7 +60,7 @@ export const EvalSequenceRow: React.FC<EvalSequenceRowProps> = ({
         className="sticky z-10 bg-background shrink-0 h-full border-r border-b p-2 flex items-center justify-center"
         style={{ left: METADATA_WIDTH, width: VIDEO_WIDTH }}
       >
-        {sequence.posterUrl ? (
+        {previewUrl ? (
           <button
             type="button"
             onClick={() => onOpenTheatre(sequenceIndex)}
@@ -66,7 +68,7 @@ export const EvalSequenceRow: React.FC<EvalSequenceRowProps> = ({
             className="w-full h-full flex items-center justify-center cursor-pointer appearance-none bg-transparent border-0 p-0"
           >
             <Image
-              src={sequence.posterUrl}
+              src={previewUrl}
               alt={`${sequence.title || 'Sequence'} preview`}
               className="max-w-full max-h-full object-contain rounded-md"
               loading="lazy"

--- a/src/components/eval/eval-sequences-mobile.tsx
+++ b/src/components/eval/eval-sequences-mobile.tsx
@@ -289,11 +289,13 @@ const MergedVideoCell: React.FC<MergedVideoCellProps> = ({
     'aria-label': `Open ${sequence.title || 'sequence'}`,
   } as const;
 
-  if (sequence.posterUrl) {
+  const previewUrl = sequence.frames[0]?.thumbnailUrl ?? sequence.posterUrl;
+
+  if (previewUrl) {
     return (
       <Link {...linkProps} className={baseClass} style={style}>
         <Image
-          src={sequence.posterUrl}
+          src={previewUrl}
           alt={`${sequence.title || 'Sequence'} poster`}
           className="w-full h-full object-cover"
           loading="lazy"


### PR DESCRIPTION
## Summary
- Eval view (`/sequences`) now prefers `sequence.frames[0].thumbnailUrl` over `sequence.posterUrl` for the row preview tile, so the script-based poster is replaced by the real starting-frame image as soon as it's generated.
- Same precedence applied to the mobile `MergedVideoCell`.
- Realtime updates via `useSequencesWithFrames` already trigger a re-render when the first frame's thumbnail lands, so the swap happens live.

Closes #762

## Test plan
- [ ] `bun typecheck` clean
- [ ] `bun lint` clean (no new warnings)
- [ ] On `/sequences`, a sequence whose first frame has not yet generated shows `posterUrl` (unchanged)
- [ ] Once the first frame's `thumbnailUrl` is populated, the eval row swaps to that image
- [ ] Mobile breakpoint shows the same precedence
- [ ] Watch a mid-generation sequence flip from poster → first-frame thumbnail in real time

🤖 Generated with [Claude Code](https://claude.com/claude-code)