### PR TITLE
fix(deploy): correct prod D1 database_name to velro-prd

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -236,7 +236,11 @@
       "d1_databases": [
         {
           "binding": "DB",
-          "database_name": "openstory-prd",
+          // The real prod D1 with this id is named `velro-prd` (legacy name
+          // from before the openstory rename) — NOT `openstory-prd`, which
+          // does not exist in the account. wrangler validates name against
+          // id, so a mismatch fails the deploy. `wrangler d1 list` confirms.
+          "database_name": "velro-prd",
           "database_id": "d6a35f64-abb0-4a34-a092-dc20b29f5812",
           "migrations_dir": "drizzle/migrations",
         },


### PR DESCRIPTION
## Problem

`bun cf:deploy:prd` (`wrangler deploy --env=production`) fails because the `[env.production]` D1 binding declares `database_name: "openstory-prd"`, which does not exist in the Cloudflare account.

`wrangler d1 list` confirms the DB with id `d6a35f64-abb0-4a34-a092-dc20b29f5812` (37 MB, the real production data) is actually named **`velro-prd`** — a legacy name from before the openstory rename. wrangler validates `database_name` against `database_id`, so the mismatch fails the deploy.

## Fix

Set `database_name` to `velro-prd`. The `database_id` was already correct, so this is a name-validation fix only — the targeted database is unchanged.

## Testing

- [x] `wrangler d1 list` confirms id `d6a35f64-…` → `velro-prd`
- [ ] `bun cf:deploy:prd` deploys cleanly (verify on merge / before deploy)

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)