### PR TITLE
feat(motion): multi-select video models with frame variants (#545)

### DIFF
--- a/e2e/tests/full-sequence.spec.ts
+++ b/e2e/tests/full-sequence.spec.ts
@@ -306,12 +306,21 @@ SUPER:  CORAL.  OUT NOW.
       // 11. Per-scene playback: click through every scene-list-item and
       //     assert the active <video> in the ScenePlayer is decodable.
       //     The list item carries `data-testid="scene-list-item"` so we can
-      //     enumerate without relying on title text. The player only renders
-      //     one <video> at a time (the selected frame), so each iteration
-      //     forces a fresh load.
+      //     enumerate without relying on title text.
+      //
+      //     The player only shows the scene's <video> on a video tab; the
+      //     default "Variants" tab (the multi-model scene-review UX, #545)
+      //     shows the still image instead — leaving the only <video> in the
+      //     DOM the hidden next-scene prefetch (`<video preload="auto">`).
+      //     Select the Motion tab once (it persists across scene selection) so
+      //     each scene's player renders its <video>; that player video is
+      //     ordered before the prefetch in the DOM, so `.first()` resolves to
+      //     it.
       const sceneItems = page.locator('[data-testid="scene-list-item"]');
       const sceneCount = await sceneItems.count();
       expect(sceneCount, 'sequence has at least one scene').toBeGreaterThan(0);
+      await sceneItems.first().click();
+      await page.getByRole('tab', { name: 'Motion' }).click();
       const playerVideo = page.locator('video').first();
       for (let i = 0; i < sceneCount; i++) {
         await sceneItems.nth(i).click();

--- a/src/components/model/base-model-selector.tsx
+++ b/src/components/model/base-model-selector.tsx
@@ -15,8 +15,28 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { ChevronDown } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  CircleAlert,
+  CircleCheck,
+  Loader2,
+} from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
+
+/**
+ * Per-scene marker for a model in the dropdown (#545).
+ * - `set`: this model's output is the scene's live primary (what plays).
+ * - `completed`: a finished variant exists but isn't set — selectable, then
+ *   "Set Video/Image" promotes it.
+ * - `generating`/`failed`/`pending`: variant state, no promotion yet.
+ */
+export type ModelGenerationStatus =
+  | 'pending'
+  | 'generating'
+  | 'completed'
+  | 'failed'
+  | 'set';
 
 type ModelItem = {
   id: string;
@@ -25,7 +45,56 @@ type ModelItem = {
   badge?: 'open-source' | 'proprietary';
   /** Show a "Recommended" badge with the given tooltip text */
   recommendedFor?: string;
+  /**
+   * Renders a per-scene status marker for this model's variant (#545):
+   * ⊙ set (live primary) / ✓ completed / ⟳ generating / ! failed.
+   * `pending`/undefined render nothing.
+   */
+  generationStatus?: ModelGenerationStatus;
 };
+
+const STATUS_ICON: Record<
+  'generating' | 'completed' | 'failed' | 'set',
+  { Icon: typeof Check; className: string; label: string }
+> = {
+  set: {
+    Icon: CircleCheck,
+    className: 'text-emerald-500',
+    label: 'Currently set for this scene',
+  },
+  completed: {
+    Icon: Check,
+    className: 'text-muted-foreground',
+    label: 'Generated — select then click Set to use',
+  },
+  generating: {
+    Icon: Loader2,
+    className: 'text-muted-foreground animate-spin',
+    label: 'Generating…',
+  },
+  failed: {
+    Icon: CircleAlert,
+    className: 'text-destructive',
+    label: 'Generation failed',
+  },
+};
+
+function ModelStatusIcon({ status }: { status?: ModelGenerationStatus }) {
+  if (!status || status === 'pending') return null;
+  const { Icon, className, label } = STATUS_ICON[status];
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0" aria-label={label}>
+            <Icon className={`size-3.5 ${className}`} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
 
 type BaseModelSelectorProps = {
   label: string;
@@ -191,6 +260,7 @@ export const BaseModelSelector: React.FC<BaseModelSelectorProps> = ({
                   >
                     <span className="flex items-center gap-2 text-sm">
                       <span className="truncate">{model.name}</span>
+                      <ModelStatusIcon status={model.generationStatus} />
                       {model.recommendedFor && (
                         <TooltipProvider>
                           <Tooltip>

--- a/src/components/model/image-model-selector.tsx
+++ b/src/components/model/image-model-selector.tsx
@@ -1,4 +1,7 @@
-import { BaseModelSelector } from './base-model-selector';
+import {
+  BaseModelSelector,
+  type ModelGenerationStatus,
+} from './base-model-selector';
 import {
   IMAGE_MODELS,
   isValidTextToImageModel,
@@ -90,6 +93,8 @@ type ImageModelSelectorProps = {
   disabled?: boolean;
   /** When set, only show these models instead of all available models */
   filterModels?: TextToImageModel[];
+  /** Per-scene generation status by model (#545); renders ✓/⟳/! in the list. */
+  generatedStatuses?: Map<string, ModelGenerationStatus>;
 } & RecommendationProps;
 
 export const ImageModelSelector: React.FC<ImageModelSelectorProps> = ({
@@ -99,13 +104,20 @@ export const ImageModelSelector: React.FC<ImageModelSelectorProps> = ({
   filterModels,
   recommendedImageModel,
   styleName,
+  generatedStatuses,
 }) => {
   const allModels = useImageModels({ recommendedImageModel, styleName });
-  const models = filterModels
-    ? allModels.filter(
-        (m) => isValidTextToImageModel(m.id) && filterModels.includes(m.id)
-      )
-    : allModels;
+  const models = useMemo(() => {
+    const filtered = filterModels
+      ? allModels.filter(
+          (m) => isValidTextToImageModel(m.id) && filterModels.includes(m.id)
+        )
+      : allModels;
+    return filtered.map((m) => ({
+      ...m,
+      generationStatus: generatedStatuses?.get(m.id),
+    }));
+  }, [allModels, filterModels, generatedStatuses]);
   const status = useMemo(
     () => resolveRecommendation(recommendedImageModel, filterModels),
     [recommendedImageModel, filterModels]

--- a/src/components/model/model-badge.tsx
+++ b/src/components/model/model-badge.tsx
@@ -3,9 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import {
   AUDIO_MODELS,
   IMAGE_MODELS,
-  IMAGE_TO_VIDEO_MODELS,
   isValidAudioModel,
-  isValidImageToVideoModel,
   isValidTextToImageModel,
 } from '@/lib/ai/models';
 import { getAnalysisModelById } from '@/lib/ai/models.config';
@@ -67,21 +65,6 @@ export const ImageModelBadge = ({
   return (
     <Badge variant="secondary" className="text-xs">
       {formatImageModels(allModels)}
-    </Badge>
-  );
-};
-
-export const VideoModelBadge = ({ model }: { model?: string }) => {
-  if (!model) {
-    return <Skeleton className="w-[100px] h-[20px]" />;
-  }
-
-  const modelConfig = isValidImageToVideoModel(model)
-    ? IMAGE_TO_VIDEO_MODELS[model]
-    : undefined;
-  return (
-    <Badge variant="secondary" className="text-xs">
-      {modelConfig?.name || model}
     </Badge>
   );
 };

--- a/src/components/model/motion-model-selector.tsx
+++ b/src/components/model/motion-model-selector.tsx
@@ -1,4 +1,7 @@
-import { BaseModelSelector } from './base-model-selector';
+import {
+  BaseModelSelector,
+  type ModelGenerationStatus,
+} from './base-model-selector';
 import {
   IMAGE_TO_VIDEO_MODELS,
   isModelCompatibleWithAspectRatio,
@@ -121,6 +124,8 @@ type MotionModelSelectorProps = {
   selectedModel: ImageToVideoModel;
   onModelChange: (model: ImageToVideoModel) => void;
   disabled?: boolean;
+  /** Per-scene generation status by model (#545); renders ✓/⟳/! in the list. */
+  generatedStatuses?: Map<string, ModelGenerationStatus>;
 } & MotionModelFilterProps;
 
 export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
@@ -131,13 +136,22 @@ export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
   styleCategory,
   recommendedVideoModel,
   styleName,
+  generatedStatuses,
 }) => {
-  const models = useMotionModels({
+  const baseModels = useMotionModels({
     aspectRatio,
     styleCategory,
     recommendedVideoModel,
     styleName,
   });
+  const models = useMemo(
+    () =>
+      baseModels.map((m) => ({
+        ...m,
+        generationStatus: generatedStatuses?.get(m.id),
+      })),
+    [baseModels, generatedStatuses]
+  );
   const recommendationStatus = useRecommendationStatus(
     recommendedVideoModel,
     aspectRatio

--- a/src/components/model/motion-model-selector.tsx
+++ b/src/components/model/motion-model-selector.tsx
@@ -10,10 +10,7 @@ import { useMemo } from 'react';
 
 const GROUP_ORDER = ['all'] as const;
 
-type MotionModelSelectorProps = {
-  selectedModel: ImageToVideoModel;
-  onModelChange: (model: ImageToVideoModel) => void;
-  disabled?: boolean;
+type MotionModelFilterProps = {
   aspectRatio?: AspectRatio;
   /** When set, models with a matching `requiredStyleCategory` are included */
   styleCategory?: string;
@@ -23,33 +20,18 @@ type MotionModelSelectorProps = {
   styleName?: string;
 };
 
-export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
-  selectedModel,
-  onModelChange,
-  disabled = false,
+/**
+ * Build the filtered, sorted motion-model option list. Shared by the single-
+ * and multi-select variants so aspect-ratio compatibility, style-category
+ * gating, and the recommendation badge behave identically across both.
+ */
+function useMotionModels({
   aspectRatio,
   styleCategory,
   recommendedVideoModel,
   styleName,
-}) => {
-  // When the recommendation exists in the model catalog but is filtered out by
-  // aspect-ratio compatibility, surface that as a distinct "incompatible with
-  // current ratio" badge rather than hiding the recommendation entirely.
-  const recommendationStatus = useMemo<
-    'matched' | 'incompatible-ratio' | 'unknown' | 'none'
-  >(() => {
-    if (!recommendedVideoModel) return 'none';
-    if (!isValidImageToVideoModel(recommendedVideoModel)) return 'unknown';
-    if (
-      aspectRatio &&
-      !isModelCompatibleWithAspectRatio(recommendedVideoModel, aspectRatio)
-    ) {
-      return 'incompatible-ratio';
-    }
-    return 'matched';
-  }, [recommendedVideoModel, aspectRatio]);
-
-  const models = useMemo(
+}: MotionModelFilterProps) {
+  return useMemo(
     () =>
       Object.entries(IMAGE_TO_VIDEO_MODELS)
         .filter(([key, m]) => {
@@ -82,11 +64,84 @@ export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
         }),
     [aspectRatio, styleCategory, recommendedVideoModel, styleName]
   );
+}
 
+function useRecommendationStatus(
+  recommendedVideoModel: string | null | undefined,
+  aspectRatio: AspectRatio | undefined
+): 'matched' | 'incompatible-ratio' | 'unknown' | 'none' {
+  return useMemo(() => {
+    if (!recommendedVideoModel) return 'none';
+    if (!isValidImageToVideoModel(recommendedVideoModel)) return 'unknown';
+    if (
+      aspectRatio &&
+      !isModelCompatibleWithAspectRatio(recommendedVideoModel, aspectRatio)
+    ) {
+      return 'incompatible-ratio';
+    }
+    return 'matched';
+  }, [recommendedVideoModel, aspectRatio]);
+}
+
+function RecommendationHint({
+  status,
+  recommendedVideoModel,
+  styleName,
+}: {
+  status: 'matched' | 'incompatible-ratio' | 'unknown' | 'none';
+  recommendedVideoModel: string | null | undefined;
+  styleName: string | undefined;
+}) {
   const recommendedModelName =
     recommendedVideoModel && isValidImageToVideoModel(recommendedVideoModel)
       ? IMAGE_TO_VIDEO_MODELS[recommendedVideoModel].name
       : undefined;
+
+  if (status === 'incompatible-ratio' && recommendedModelName) {
+    return (
+      <p className="text-[10px] text-muted-foreground">
+        {styleName ? `${styleName} recommends` : 'Recommended'}{' '}
+        <span className="font-medium">{recommendedModelName}</span>, but it's
+        not compatible with the current aspect ratio.
+      </p>
+    );
+  }
+  if (status === 'unknown') {
+    return (
+      <p className="text-[10px] text-muted-foreground">
+        {styleName ? `${styleName} recommends` : 'Recommended'} a model that's
+        no longer available.
+      </p>
+    );
+  }
+  return null;
+}
+
+type MotionModelSelectorProps = {
+  selectedModel: ImageToVideoModel;
+  onModelChange: (model: ImageToVideoModel) => void;
+  disabled?: boolean;
+} & MotionModelFilterProps;
+
+export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
+  selectedModel,
+  onModelChange,
+  disabled = false,
+  aspectRatio,
+  styleCategory,
+  recommendedVideoModel,
+  styleName,
+}) => {
+  const models = useMotionModels({
+    aspectRatio,
+    styleCategory,
+    recommendedVideoModel,
+    styleName,
+  });
+  const recommendationStatus = useRecommendationStatus(
+    recommendedVideoModel,
+    aspectRatio
+  );
 
   return (
     <div className="flex flex-col gap-1">
@@ -104,20 +159,64 @@ export const MotionModelSelector: React.FC<MotionModelSelectorProps> = ({
         disabled={disabled}
         multiSelect={false}
       />
-      {recommendationStatus === 'incompatible-ratio' &&
-        recommendedModelName && (
-          <p className="text-[10px] text-muted-foreground">
-            {styleName ? `${styleName} recommends` : 'Recommended'}{' '}
-            <span className="font-medium">{recommendedModelName}</span>, but
-            it's not compatible with the current aspect ratio.
-          </p>
-        )}
-      {recommendationStatus === 'unknown' && (
-        <p className="text-[10px] text-muted-foreground">
-          {styleName ? `${styleName} recommends` : 'Recommended'} a model that's
-          no longer available.
-        </p>
-      )}
+      <RecommendationHint
+        status={recommendationStatus}
+        recommendedVideoModel={recommendedVideoModel}
+        styleName={styleName}
+      />
+    </div>
+  );
+};
+
+type MotionModelMultiSelectorProps = {
+  selectedModels: ImageToVideoModel[];
+  onModelsChange: (models: ImageToVideoModel[]) => void;
+  disabled?: boolean;
+} & MotionModelFilterProps;
+
+export const MotionModelMultiSelector: React.FC<
+  MotionModelMultiSelectorProps
+> = ({
+  selectedModels,
+  onModelsChange,
+  disabled = false,
+  aspectRatio,
+  styleCategory,
+  recommendedVideoModel,
+  styleName,
+}) => {
+  const models = useMotionModels({
+    aspectRatio,
+    styleCategory,
+    recommendedVideoModel,
+    styleName,
+  });
+  const recommendationStatus = useRecommendationStatus(
+    recommendedVideoModel,
+    aspectRatio
+  );
+
+  return (
+    <div className="flex flex-col gap-1">
+      <BaseModelSelector
+        label="Motion Models"
+        models={models}
+        groupOrder={GROUP_ORDER}
+        selectedIds={selectedModels}
+        onSelectionChange={(ids) => {
+          const validIds = ids.filter(isValidImageToVideoModel);
+          if (validIds.length > 0) {
+            onModelsChange(validIds);
+          }
+        }}
+        disabled={disabled}
+        multiSelect={true}
+      />
+      <RecommendationHint
+        status={recommendationStatus}
+        recommendedVideoModel={recommendedVideoModel}
+        styleName={styleName}
+      />
     </div>
   );
 };

--- a/src/components/model/sequence-video-model-selector.tsx
+++ b/src/components/model/sequence-video-model-selector.tsx
@@ -1,0 +1,100 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useActiveVideoModel } from '@/hooks/use-active-video-model';
+import { useSequenceVideoModels } from '@/hooks/use-frames';
+import {
+  IMAGE_TO_VIDEO_MODELS,
+  isValidImageToVideoModel,
+} from '@/lib/ai/models';
+import { ChevronDown } from 'lucide-react';
+
+function videoModelName(model: string): string {
+  return isValidImageToVideoModel(model)
+    ? IMAGE_TO_VIDEO_MODELS[model].name
+    : model;
+}
+
+/**
+ * Top-level video-model switcher for the sequence header (#545). Replaces the
+ * old read-only video-model chip once any video variants exist: lists the
+ * distinct models that have generated a video for this sequence (derived from
+ * frame_variants) and lets the viewer pick which model's output to display.
+ * The selection is viewer-local (localStorage via useActiveVideoModel).
+ *
+ * "Mixed" is shown when more than one model has output and the viewer has not
+ * pinned a specific one — i.e. each scene shows its own model's video.
+ */
+export const SequenceVideoModelSelector = ({
+  sequenceId,
+  sequenceVideoModel,
+}: {
+  sequenceId: string;
+  sequenceVideoModel?: string | null;
+}) => {
+  const { data: models } = useSequenceVideoModels(sequenceId);
+  const { activeVideoModel, selectVideoModel } =
+    useActiveVideoModel(sequenceId);
+
+  // No video variants generated yet — fall back to the read-only chip showing
+  // the sequence's configured model (or render nothing when motion is off).
+  if (!models || models.length === 0) {
+    if (!sequenceVideoModel) return null;
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {videoModelName(sequenceVideoModel)}
+      </Badge>
+    );
+  }
+
+  const firstModel = models[0];
+  const label = activeVideoModel
+    ? videoModelName(activeVideoModel)
+    : models.length === 1 && firstModel
+      ? videoModelName(firstModel)
+      : 'Mixed';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" aria-label="Select video model">
+          <Badge variant="secondary" className="text-xs cursor-pointer gap-1">
+            {label}
+            <ChevronDown className="size-3" />
+          </Badge>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[200px]">
+        <DropdownMenuLabel className="text-xs">Video model</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {models.length > 1 && (
+          <DropdownMenuCheckboxItem
+            checked={activeVideoModel === null}
+            onCheckedChange={() => selectVideoModel(null)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            Mixed (per scene)
+          </DropdownMenuCheckboxItem>
+        )}
+        {models.filter(isValidImageToVideoModel).map((model) => (
+          <DropdownMenuCheckboxItem
+            key={model}
+            checked={activeVideoModel === model}
+            onCheckedChange={() => selectVideoModel(model)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            {videoModelName(model)}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -40,6 +40,12 @@ type ScenePlayerProps = {
   wrapperClassName?: string;
   selectedTab?: TabValue;
   overrideImageUrl?: string | null;
+  /**
+   * Per-scene video-variant preview (#545). When set (motion tab), the player
+   * plays this url for the current frame instead of its primary video — the
+   * motion analog of `overrideImageUrl`.
+   */
+  overrideVideoUrl?: string | null;
   badgeMessage?: string | null;
   progressMessage?: string;
   posterUrl?: string;
@@ -55,6 +61,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
   aspectRatio,
   selectedTab,
   overrideImageUrl,
+  overrideVideoUrl,
   badgeMessage,
   progressMessage,
   posterUrl,
@@ -254,6 +261,17 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
   const isVariantPreview =
     !!overrideImageUrl && overrideImageUrl !== currentFrame.thumbnailUrl;
 
+  // Per-scene video-variant preview (#545): on the motion tab, play the
+  // override variant for this frame instead of its primary video.
+  const isVariantVideoPreview =
+    !!overrideVideoUrl &&
+    selectedTab !== 'image-prompt' &&
+    overrideVideoUrl !== currentFrame.videoUrl;
+  const playbackVideoUrl =
+    selectedTab === 'image-prompt'
+      ? ''
+      : (overrideVideoUrl ?? currentFrame.videoUrl ?? '');
+
   return (
     <div className={cn('flex w-full flex-col', wrapperClassName)}>
       {hasFailedVideo ? (
@@ -375,10 +393,8 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
               />
             )}
           <VideoPlayer
-            key={currentFrame.videoUrl} // Force re-render when video changes
-            src={
-              selectedTab === 'image-prompt' ? '' : currentFrame.videoUrl || ''
-            }
+            key={playbackVideoUrl} // Force re-render when video changes
+            src={playbackVideoUrl}
             posterSrc={displayImage}
             aspectRatio={aspectRatio}
             className="w-full"
@@ -390,7 +406,11 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
           {/* Show overlay for image/video generation states */}
           <VideoStateOverlay
             thumbnailUrl={displayImage}
-            videoStatus={currentFrame.videoStatus ?? null}
+            videoStatus={
+              isVariantVideoPreview
+                ? 'completed'
+                : (currentFrame.videoStatus ?? null)
+            }
             progressMessage={progressMessage}
           />
           {badgeMessage && (

--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -35,7 +35,12 @@ type ScenePlayerProps = {
   frames?: Frame[];
   selectedFrameId?: string;
   aspectRatio: AspectRatio;
-  onSelectFrame: (frameId: string) => void;
+  /**
+   * Accepted but unused: the player no longer auto-advances between scenes
+   * (single-scene review shouldn't roll into the next clip — use Theatre for
+   * continuous playback). Frame selection is driven by the scene list.
+   */
+  onSelectFrame?: (frameId: string) => void;
   className?: string;
   wrapperClassName?: string;
   selectedTab?: TabValue;
@@ -65,7 +70,6 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
   badgeMessage,
   progressMessage,
   posterUrl,
-  onSelectFrame,
   onTimeUpdate,
   onEnded,
 }) => {
@@ -146,16 +150,13 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
     setShouldAutoPlay(false);
   }, []);
 
-  // Handle video end - move to next frame or call onEnded
+  // Video end: stop on the current scene. We intentionally do NOT auto-advance
+  // to the next scene — single-scene review shouldn't roll into the next clip.
+  // Continuous playback of the whole sequence lives in Theatre.
   const handleEnded = useCallback(() => {
-    if (nextFrame) {
-      setShouldAutoPlay(true); // Enable autoplay for next video
-      // Select the next frame - not this may cause a re-render of the scene list
-      onSelectFrame(nextFrame.id);
-    } else {
-      onEnded?.();
-    }
-  }, [nextFrame, onEnded, onSelectFrame]);
+    setShouldAutoPlay(false);
+    onEnded?.();
+  }, [onEnded]);
 
   // Show blob loader during generation, skeleton otherwise
   if (!frames || frames.length === 0) {
@@ -261,16 +262,21 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
   const isVariantPreview =
     !!overrideImageUrl && overrideImageUrl !== currentFrame.thumbnailUrl;
 
+  // The image-focused tabs (the still image + the shot-variant grid) keep
+  // showing the image; every other tab (script, motion, cast, location,
+  // elements) shows the scene's video when one exists.
+  const showsStillImage =
+    selectedTab === 'image-prompt' || selectedTab === 'scene-variants';
+
   // Per-scene video-variant preview (#545): on the motion tab, play the
   // override variant for this frame instead of its primary video.
   const isVariantVideoPreview =
     !!overrideVideoUrl &&
-    selectedTab !== 'image-prompt' &&
+    !showsStillImage &&
     overrideVideoUrl !== currentFrame.videoUrl;
-  const playbackVideoUrl =
-    selectedTab === 'image-prompt'
-      ? ''
-      : (overrideVideoUrl ?? currentFrame.videoUrl ?? '');
+  const playbackVideoUrl = showsStillImage
+    ? ''
+    : (overrideVideoUrl ?? currentFrame.videoUrl ?? '');
 
   return (
     <div className={cn('flex w-full flex-col', wrapperClassName)}>
@@ -381,17 +387,20 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          {/* Clickable overlay to open image in new tab when poster is showing */}
-          {currentFrame.thumbnailUrl &&
-            (selectedTab === 'image-prompt' || !currentFrame.videoUrl) && (
-              <a
-                href={currentFrame.thumbnailUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="absolute inset-0 z-[5] cursor-pointer"
-                aria-label="Open image in new tab"
-              />
-            )}
+          {/* Clickable overlay to open the displayed image in a new tab — only
+              when the poster (image) is what's showing, i.e. there's no
+              playable video. Keyed off `playbackVideoUrl` (and href = the
+              image actually displayed) so it never covers the video's play
+              button or opens a different image than the poster. */}
+          {displayImage && !playbackVideoUrl && (
+            <a
+              href={displayImage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="absolute inset-0 z-[5] cursor-pointer"
+              aria-label="Open image in new tab"
+            />
+          )}
           <VideoPlayer
             key={playbackVideoUrl} // Force re-render when video changes
             src={playbackVideoUrl}

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -28,6 +28,7 @@ import {
   useGenerateVariants,
   useSelectVariant,
   useSetImageFromVariant,
+  useSetVideoFromVariant,
 } from '@/hooks/use-frames';
 import {
   type FrameStaleness,
@@ -111,7 +112,11 @@ type SceneScriptPromptsProps = {
   ) => void;
   aspectRatio?: AspectRatio;
   variantForSelectedModel?: FrameVariant;
+  /** The selected scene's video variant for the effective video model (#545). */
+  videoVariantForSelectedModel?: FrameVariant;
   onImageModelChange?: (model: string) => void;
+  /** Per-scene video-model preview switch (#545), mirror of onImageModelChange. */
+  onVideoModelChange?: (model: string) => void;
   /** Current style category, used to show/hide style-restricted motion models */
   styleCategory?: string;
   /** Current style name, used in recommendation tooltips */
@@ -141,7 +146,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   onRegenerateStart,
   aspectRatio,
   variantForSelectedModel,
+  videoVariantForSelectedModel,
   onImageModelChange,
+  onVideoModelChange,
   styleCategory,
   styleName,
   recommendedImageModel,
@@ -200,6 +207,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     [onImageModelChange]
   );
 
+  // Picking a motion model both sets the regen target and (mirroring the image
+  // flow) previews that model's existing video variant for this scene (#545).
+  const handleMotionModelChange = useCallback(
+    (model: ImageToVideoModel) => {
+      setSelectedMotionModel(model);
+      onVideoModelChange?.(model);
+    },
+    [onVideoModelChange]
+  );
+
   // Script tab edit state — `undefined` means "no draft" (textarea mirrors the
   // saved value); a string means "user has typed". We reset to `undefined` when
   // the frame changes so switching scenes never shows the previous scene's draft.
@@ -221,6 +238,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   const generateVariants = useGenerateVariants();
   const selectVariant = useSelectVariant();
   const setImageFromVariant = useSetImageFromVariant();
+  const setVideoFromVariant = useSetVideoFromVariant();
   const {
     needsBillingSetup: falNeedsBillingSetup,
     showGate: showFalGate,
@@ -496,6 +514,33 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       });
     }
   }, [frame, selectedImageModel, setImageFromVariant]);
+
+  // Video equivalents (#545): drive the "Set Video" action from the selected
+  // scene's video variant for the picked model.
+  const videoVariantIsCompleted =
+    videoVariantForSelectedModel?.status === 'completed' &&
+    !!videoVariantForSelectedModel.url;
+  const videoVariantIsGenerating =
+    videoVariantForSelectedModel?.status === 'generating';
+  const videoVariantAlreadySet =
+    videoVariantIsCompleted &&
+    videoVariantForSelectedModel.url === frame?.videoUrl;
+
+  const handleSetVideoFromVariant = useCallback(async () => {
+    if (!frame?.id || !frame.sequenceId || !selectedMotionModel) return;
+
+    try {
+      await setVideoFromVariant.mutateAsync({
+        sequenceId: frame.sequenceId,
+        frameId: frame.id,
+        model: selectedMotionModel,
+      });
+    } catch (error) {
+      toast.error('Failed to set video', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }, [frame, selectedMotionModel, setVideoFromVariant]);
 
   const handleShortenPrompt = useCallback(async () => {
     setShortenStatus({ loading: false, error: null, success: null });
@@ -1157,7 +1202,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
             <span className="text-sm font-medium">Model</span>
             <MotionModelSelector
               selectedModel={effectiveMotionModel}
-              onModelChange={setSelectedMotionModel}
+              onModelChange={handleMotionModelChange}
               disabled={isGenerating || isGeneratingMotion}
               aspectRatio={aspectRatio}
               styleCategory={styleCategory}
@@ -1271,27 +1316,47 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
             </label>
           )}
 
-          {/* Regenerate button */}
-          <Button
-            onClick={() => {
-              if (falNeedsBillingSetup) {
-                showFalGate();
-                return;
+          {/* Motion action button — variant-aware (#545), mirror of the image
+              tab: when the picked model already has a completed video for this
+              scene, offer to Set it; otherwise Generate/Regenerate. */}
+          {videoVariantIsCompleted && !videoVariantAlreadySet ? (
+            <Button
+              onClick={() => void handleSetVideoFromVariant()}
+              disabled={setVideoFromVariant.isPending || !frame}
+              className="w-full"
+            >
+              {setVideoFromVariant.isPending && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              {setVideoFromVariant.isPending ? 'Setting…' : 'Set Video'}
+            </Button>
+          ) : (
+            <Button
+              onClick={() => {
+                if (falNeedsBillingSetup) {
+                  showFalGate();
+                  return;
+                }
+                void handleRegenerateMotion();
+              }}
+              disabled={
+                isGenerating ||
+                isGeneratingMotion ||
+                videoVariantIsGenerating ||
+                !frame
               }
-              void handleRegenerateMotion();
-            }}
-            disabled={isGenerating || isGeneratingMotion || !frame}
-            className="w-full"
-          >
-            {isGeneratingMotion && (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            )}
-            {isGeneratingMotion
-              ? 'Generating…'
-              : frame?.videoUrl
-                ? 'Regenerate Motion'
-                : 'Generate Motion'}
-          </Button>
+              className="w-full"
+            >
+              {(isGeneratingMotion || videoVariantIsGenerating) && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              {isGeneratingMotion || videoVariantIsGenerating
+                ? 'Generating…'
+                : frame?.videoUrl
+                  ? 'Regenerate Motion'
+                  : 'Generate Motion'}
+            </Button>
+          )}
 
           {/* Copy button for assembled prompt */}
           <Button

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1,6 +1,7 @@
 import { BillingGateDialog } from '@/components/billing/billing-gate-dialog';
 import { ImageModelSelector } from '@/components/model/image-model-selector';
 import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
 import { PromptHistorySheet } from '@/components/prompts/prompt-history-sheet';
 import { DivergentAlternateBanner } from '@/components/staleness/divergent-alternate-banner';
 import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
@@ -114,6 +115,9 @@ type SceneScriptPromptsProps = {
   variantForSelectedModel?: FrameVariant;
   /** The selected scene's video variant for the effective video model (#545). */
   videoVariantForSelectedModel?: FrameVariant;
+  /** Per-scene generation status by model — drives the ✓/⟳/! dropdown markers (#545). */
+  imageModelStatuses?: Map<string, ModelGenerationStatus>;
+  videoModelStatuses?: Map<string, ModelGenerationStatus>;
   onImageModelChange?: (model: string) => void;
   /** Per-scene video-model preview switch (#545), mirror of onImageModelChange. */
   onVideoModelChange?: (model: string) => void;
@@ -147,6 +151,8 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   aspectRatio,
   variantForSelectedModel,
   videoVariantForSelectedModel,
+  imageModelStatuses,
+  videoModelStatuses,
   onImageModelChange,
   onVideoModelChange,
   styleCategory,
@@ -499,6 +505,15 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   const variantAlreadySet =
     variantIsCompleted && variantForSelectedModel.url === frame?.thumbnailUrl;
 
+  // Has the selected image model produced an image for this scene — drives
+  // Generate vs Regenerate (mirror of videoModelGenerated). Variant row (any
+  // status) ⇒ attempted; legacy fallback covers frames with a primary
+  // thumbnail but no variant row.
+  const imageModelGenerated =
+    !!variantForSelectedModel ||
+    (!!frame?.thumbnailUrl &&
+      (selectedImageModel || imageModel) === imageModel);
+
   const handleSetImageFromVariant = useCallback(async () => {
     if (!frame?.id || !frame.sequenceId || !selectedImageModel) return;
 
@@ -807,6 +822,17 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   ]);
 
   const motionModel = effectiveMotionModel;
+
+  // Has the *currently-selected* video model produced a video for this scene —
+  // drives Generate vs Regenerate (NOT whether the frame has any video, which
+  // could be from a different model). A variant row (any status) means it was
+  // attempted; the legacy fallback covers pre-#545 frames that carry a primary
+  // video but no variant row.
+  const videoModelGenerated =
+    !!videoVariantForSelectedModel ||
+    (!!frame?.videoUrl &&
+      effectiveMotionModel ===
+        safeImageToVideoModel(frame.motionModel, DEFAULT_VIDEO_MODEL));
   const maxPromptLength = IMAGE_TO_VIDEO_MODELS[motionModel].maxPromptLength;
   const isOverLimit = assembledPrompt.length > maxPromptLength;
 
@@ -1020,6 +1046,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               disabled={isGenerating}
               recommendedImageModel={recommendedImageModel}
               styleName={styleName}
+              generatedStatuses={imageModelStatuses}
             />
           </div>
 
@@ -1132,7 +1159,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               )}
               {isGenerating || variantIsGenerating
                 ? 'Generating…'
-                : variantAlreadySet
+                : imageModelGenerated
                   ? 'Regenerate Image'
                   : 'Generate Image'}
             </Button>
@@ -1208,6 +1235,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               styleCategory={styleCategory}
               recommendedVideoModel={recommendedVideoModel}
               styleName={styleName}
+              generatedStatuses={videoModelStatuses}
             />
           </div>
 
@@ -1352,7 +1380,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               )}
               {isGeneratingMotion || videoVariantIsGenerating
                 ? 'Generating…'
-                : frame?.videoUrl
+                : videoModelGenerated
                   ? 'Regenerate Motion'
                   : 'Generate Motion'}
             </Button>
@@ -1405,6 +1433,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               disabled={isGenerating || isGeneratingSceneVariants}
               recommendedImageModel={recommendedImageModel}
               styleName={styleName}
+              generatedStatuses={imageModelStatuses}
             />
           </div>
 

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -167,6 +167,12 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     null
   );
 
+  // Per-scene video-model preview (#545) — the motion mirror of
+  // imageModelOverride. Transient: resets on frame switch.
+  const [videoModelOverride, setVideoModelOverride] = useState<string | null>(
+    null
+  );
+
   // Poll sequence while a motion batch is in flight so per-frame statuses stay
   // fresh. The refetchInterval fn reads from the query cache each tick to
   // avoid a circular dependency between sequence state and the poll condition.
@@ -363,9 +369,10 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     );
   }, [imageVariants, curSelectedFrameId]);
 
-  // Reset model override when switching frames
+  // Reset model overrides when switching frames
   useEffect(() => {
     setImageModelOverride(null);
+    setVideoModelOverride(null);
   }, [curSelectedFrameId]);
 
   // Derive variant preview state from model override + variants
@@ -378,39 +385,101 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     return selectedFrameVariants.find((v) => v.model === effectiveImageModel);
   }, [selectedFrameVariants, effectiveImageModel]);
 
-  const { previewVariantUrl, playerBadgeMessage } = useMemo(() => {
-    const none = { previewVariantUrl: null, playerBadgeMessage: null };
-    if (selectedTab !== 'image-prompt' || !selectedFrame) return none;
+  // Video equivalent (#545): the selected scene's video variant for the
+  // effective video model (override → frame's own model). Excludes divergent /
+  // discarded alternates so only the primary per-model row is matched.
+  const effectiveVideoModel =
+    videoModelOverride ??
+    safeImageToVideoModel(selectedFrame?.motionModel, DEFAULT_VIDEO_MODEL);
 
-    if (
-      variantForSelectedModel?.status === 'completed' &&
-      variantForSelectedModel.url &&
-      variantForSelectedModel.url !== selectedFrame.thumbnailUrl
-    ) {
-      return {
-        previewVariantUrl: variantForSelectedModel.url,
-        playerBadgeMessage: 'Click Set Image to use',
-      };
-    }
+  const videoVariantForSelectedModel = useMemo(() => {
+    if (!curSelectedFrameId) return undefined;
+    return videoVariantsByFrame
+      .get(curSelectedFrameId)
+      ?.find(
+        (v) =>
+          v.model === effectiveVideoModel &&
+          v.divergedAt === null &&
+          v.discardedAt === null
+      );
+  }, [videoVariantsByFrame, curSelectedFrameId, effectiveVideoModel]);
 
-    const frameImageModel = safeTextToImageModel(
-      selectedFrame.imageModel,
-      DEFAULT_IMAGE_MODEL
-    );
-    if (effectiveImageModel !== frameImageModel && !variantForSelectedModel) {
-      return {
+  const { previewVariantUrl, previewVariantVideoUrl, playerBadgeMessage } =
+    useMemo(() => {
+      const none = {
         previewVariantUrl: null,
-        playerBadgeMessage: 'Click Generate Image to create',
+        previewVariantVideoUrl: null,
+        playerBadgeMessage: null,
       };
-    }
+      if (!selectedFrame) return none;
 
-    return none;
-  }, [
-    selectedTab,
-    selectedFrame,
-    effectiveImageModel,
-    variantForSelectedModel,
-  ]);
+      // Image preview (image-prompt tab)
+      if (selectedTab === 'image-prompt') {
+        if (
+          variantForSelectedModel?.status === 'completed' &&
+          variantForSelectedModel.url &&
+          variantForSelectedModel.url !== selectedFrame.thumbnailUrl
+        ) {
+          return {
+            ...none,
+            previewVariantUrl: variantForSelectedModel.url,
+            playerBadgeMessage: 'Click Set Image to use',
+          };
+        }
+        const frameImageModel = safeTextToImageModel(
+          selectedFrame.imageModel,
+          DEFAULT_IMAGE_MODEL
+        );
+        if (
+          effectiveImageModel !== frameImageModel &&
+          !variantForSelectedModel
+        ) {
+          return {
+            ...none,
+            playerBadgeMessage: 'Click Generate Image to create',
+          };
+        }
+        return none;
+      }
+
+      // Video preview (motion-prompt tab) — mirror of the image flow (#545)
+      if (selectedTab === 'motion-prompt') {
+        if (
+          videoVariantForSelectedModel?.status === 'completed' &&
+          videoVariantForSelectedModel.url &&
+          videoVariantForSelectedModel.url !== selectedFrame.videoUrl
+        ) {
+          return {
+            ...none,
+            previewVariantVideoUrl: videoVariantForSelectedModel.url,
+            playerBadgeMessage: 'Click Set Video to use',
+          };
+        }
+        const frameVideoModel = safeImageToVideoModel(
+          selectedFrame.motionModel,
+          DEFAULT_VIDEO_MODEL
+        );
+        if (
+          effectiveVideoModel !== frameVideoModel &&
+          !videoVariantForSelectedModel
+        ) {
+          return {
+            ...none,
+            playerBadgeMessage: 'Click Generate Motion to create',
+          };
+        }
+        return none;
+      }
+
+      return none;
+    }, [
+      selectedTab,
+      selectedFrame,
+      effectiveImageModel,
+      variantForSelectedModel,
+      effectiveVideoModel,
+      videoVariantForSelectedModel,
+    ]);
 
   // Frames as shown by the player: when a video model is pinned, swap each
   // frame's video for that model's variant (or clear it when the model hasn't
@@ -758,6 +827,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
               onSelectFrame={setSelectedFrameId}
               selectedTab={selectedTab}
               overrideImageUrl={previewVariantUrl}
+              overrideVideoUrl={previewVariantVideoUrl}
               badgeMessage={playerBadgeMessage}
               progressMessage={
                 generationState.phases.find((p) => p.status === 'active')
@@ -779,7 +849,9 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             onRegenerateStart={handleRegenerateStart}
             aspectRatio={aspectRatio}
             variantForSelectedModel={variantForSelectedModel}
+            videoVariantForSelectedModel={videoVariantForSelectedModel}
             onImageModelChange={setImageModelOverride}
+            onVideoModelChange={setVideoModelOverride}
             styleCategory={styleCategory}
             sequenceMotionModel={sequenceMotionModel}
             styleName={styleName}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -19,8 +19,10 @@ import {
   useDivergentVariants,
   useFramesBySequence,
   usePromoteVariantToPrimary,
+  useSequenceVideoVariants,
   useUndiscardVariant,
 } from '@/hooks/use-frames';
+import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
 import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-dialog';
 import { getDivergentVariantPromptDiffFn } from '@/functions/prompt-variants';
@@ -238,6 +240,25 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     enabled: !!sequenceId,
   });
 
+  // Video variants + viewer-local active video model (#545). When the viewer
+  // pins a model in the header dropdown, the player resolves every frame's
+  // video through that model's variant; "Mixed" (null) keeps each frame's own
+  // (legacy) video.
+  const { data: videoVariants } = useSequenceVideoVariants(sequenceId);
+  const { activeVideoModel } = useActiveVideoModel(sequenceId);
+
+  const videoVariantsByFrame = useMemo(() => {
+    const map = new Map<string, FrameVariant[]>();
+    if (!videoVariants) return map;
+    for (const v of videoVariants) {
+      if (v.variantType !== 'video') continue;
+      const list = map.get(v.frameId) ?? [];
+      list.push(v);
+      map.set(v.frameId, list);
+    }
+    return map;
+  }, [videoVariants]);
+
   // Divergent alternates + realtime stale:detected wiring (issue #625).
   // Mirror the frames-list polling fallback so the corner-dot still updates
   // when realtime is down.
@@ -390,6 +411,34 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     effectiveImageModel,
     variantForSelectedModel,
   ]);
+
+  // Frames as shown by the player: when a video model is pinned, swap each
+  // frame's video for that model's variant (or clear it when the model hasn't
+  // produced one for that frame). Only the player display is remapped — every
+  // other consumer keeps the raw `frames` (generation status, selection, etc.).
+  const playerFrames = useMemo(() => {
+    // Until the variants query resolves, keep the legacy videos rather than
+    // blanking every frame (the map would find no variant and clear them all).
+    if (!frames || !activeVideoModel || !videoVariants) return frames;
+    return frames.map((f) => {
+      const variant = videoVariantsByFrame
+        .get(f.id)
+        ?.find(
+          (v) =>
+            v.model === activeVideoModel &&
+            v.divergedAt === null &&
+            v.discardedAt === null
+        );
+      if (!variant) {
+        return { ...f, videoUrl: null, videoStatus: 'pending' as const };
+      }
+      return {
+        ...f,
+        videoUrl: variant.status === 'completed' ? variant.url : null,
+        videoStatus: variant.status,
+      };
+    });
+  }, [frames, activeVideoModel, videoVariants, videoVariantsByFrame]);
 
   const setterForType = useCallback((type: RegenerationType) => {
     switch (type) {
@@ -703,7 +752,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         <ScrollArea className="flex-1 px-4 md:px-8 gap-8 flex flex-col pb-20 md:pb-0 pt-4">
           <div className="flex flex-1 min-h-0 justify-center pb-8">
             <ScenePlayer
-              frames={frames}
+              frames={playerFrames}
               selectedFrameId={curSelectedFrameId}
               aspectRatio={aspectRatio}
               onSelectFrame={setSelectedFrameId}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -389,9 +389,14 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   // Video equivalent (#545): the selected scene's video variant for the
   // effective video model (override → frame's own model). Excludes divergent /
   // discarded alternates so only the primary per-model row is matched.
+  // `null` = unknown: a never-generated frame has no recorded `motionModel`, so
+  // we surface no model rather than silently asserting DEFAULT_VIDEO_MODEL
+  // (which would attribute a model the scene was never generated with).
   const effectiveVideoModel =
     videoModelOverride ??
-    safeImageToVideoModel(selectedFrame?.motionModel, DEFAULT_VIDEO_MODEL);
+    (selectedFrame?.motionModel
+      ? safeImageToVideoModel(selectedFrame.motionModel, DEFAULT_VIDEO_MODEL)
+      : null);
 
   const videoVariantForSelectedModel = useMemo(() => {
     if (!curSelectedFrameId) return undefined;
@@ -513,7 +518,11 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
           selectedFrame.motionModel,
           DEFAULT_VIDEO_MODEL
         );
+        // Only prompt when a specific model is picked (effectiveVideoModel) and
+        // differs from the frame's current one with no variant yet. A null
+        // (unknown) model means there's nothing specific to generate here.
         if (
+          effectiveVideoModel &&
           effectiveVideoModel !== frameVideoModel &&
           !videoVariantForSelectedModel
         ) {

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -23,6 +23,7 @@ import {
   useUndiscardVariant,
 } from '@/hooks/use-frames';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
+import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
 import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
 import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-dialog';
 import { getDivergentVariantPromptDiffFn } from '@/functions/prompt-variants';
@@ -403,6 +404,59 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
           v.discardedAt === null
       );
   }, [videoVariantsByFrame, curSelectedFrameId, effectiveVideoModel]);
+
+  // Per-model generation status for the selected scene (#545) — feeds the
+  // ✓/⟳/! markers in the image + video model dropdowns. Primary rows only
+  // (divergent/discarded alternates are excluded).
+  // The "set" model is the one whose variant is the frame's live primary
+  // (url match), falling back to the frame's recorded model for legacy frames
+  // with no variant row. It gets the distinct ✓-in-circle marker; other
+  // completed models show a plain ✓ (selectable, then "Set" to promote).
+  const imageModelStatuses = useMemo(() => {
+    const map = new Map<string, ModelGenerationStatus>();
+    const variants = (selectedFrameVariants ?? []).filter(
+      (v) => v.divergedAt === null && v.discardedAt === null
+    );
+    const primaryUrl = selectedFrame?.thumbnailUrl ?? null;
+    const setModel = primaryUrl
+      ? (variants.find((v) => v.url === primaryUrl)?.model ??
+        selectedFrame?.imageModel ??
+        null)
+      : null;
+    for (const v of variants) {
+      map.set(v.model, v.model === setModel ? 'set' : v.status);
+    }
+    if (setModel && !map.has(setModel)) map.set(setModel, 'set');
+    return map;
+  }, [
+    selectedFrameVariants,
+    selectedFrame?.thumbnailUrl,
+    selectedFrame?.imageModel,
+  ]);
+
+  const videoModelStatuses = useMemo(() => {
+    const map = new Map<string, ModelGenerationStatus>();
+    if (!curSelectedFrameId) return map;
+    const variants = (
+      videoVariantsByFrame.get(curSelectedFrameId) ?? []
+    ).filter((v) => v.divergedAt === null && v.discardedAt === null);
+    const primaryUrl = selectedFrame?.videoUrl ?? null;
+    const setModel = primaryUrl
+      ? (variants.find((v) => v.url === primaryUrl)?.model ??
+        selectedFrame?.motionModel ??
+        null)
+      : null;
+    for (const v of variants) {
+      map.set(v.model, v.model === setModel ? 'set' : v.status);
+    }
+    if (setModel && !map.has(setModel)) map.set(setModel, 'set');
+    return map;
+  }, [
+    videoVariantsByFrame,
+    curSelectedFrameId,
+    selectedFrame?.videoUrl,
+    selectedFrame?.motionModel,
+  ]);
 
   const { previewVariantUrl, previewVariantVideoUrl, playerBadgeMessage } =
     useMemo(() => {
@@ -850,6 +904,8 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             aspectRatio={aspectRatio}
             variantForSelectedModel={variantForSelectedModel}
             videoVariantForSelectedModel={videoVariantForSelectedModel}
+            imageModelStatuses={imageModelStatuses}
+            videoModelStatuses={videoModelStatuses}
             onImageModelChange={setImageModelOverride}
             onVideoModelChange={setVideoModelOverride}
             styleCategory={styleCategory}

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -136,7 +136,7 @@ export const ScriptView: FC<{
     analysisModels: AnalysisModelId[];
     aspectRatio: AspectRatio;
     imageModels: TextToImageModel[];
-    motionModel: ImageToVideoModel;
+    videoModels: ImageToVideoModel[];
     autoGenerateMotion: boolean;
     musicModel: AudioModel;
     autoGenerateMusic: boolean;
@@ -147,10 +147,10 @@ export const ScriptView: FC<{
       isEditing && sequence.imageModel
         ? [safeTextToImageModel(sequence.imageModel, DEFAULT_IMAGE_MODEL)]
         : savedSettings.imageModels,
-    motionModel:
+    videoModels:
       isEditing && sequence.videoModel
-        ? safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL)
-        : savedSettings.motionModel,
+        ? [safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL)]
+        : savedSettings.videoModels,
     autoGenerateMotion: isEditing ? false : savedSettings.autoGenerateMotion,
     musicModel:
       isEditing && sequence.musicModel
@@ -162,7 +162,7 @@ export const ScriptView: FC<{
     analysisModels,
     aspectRatio,
     imageModels,
-    motionModel,
+    videoModels,
     autoGenerateMotion,
     musicModel,
     autoGenerateMusic,
@@ -300,7 +300,7 @@ export const ScriptView: FC<{
         aspectRatio: savedSettings.aspectRatio,
         analysisModels: savedSettings.analysisModels,
         imageModels: savedSettings.imageModels,
-        motionModel: savedSettings.motionModel,
+        videoModels: savedSettings.videoModels,
         autoGenerateMotion: savedSettings.autoGenerateMotion,
         musicModel: savedSettings.musicModel,
         autoGenerateMusic: savedSettings.autoGenerateMusic,
@@ -339,16 +339,25 @@ export const ScriptView: FC<{
     saveDraft,
   ]);
 
-  // Auto-fallback motion model when style changes away from a required category
+  // Auto-fallback motion models when style changes away from a required
+  // category — any selected model whose requiredStyleCategory no longer matches
+  // is swapped for the default; the result is deduped.
   useEffect(() => {
-    const model = IMAGE_TO_VIDEO_MODELS[motionModel];
+    const coerced = videoModels.map((m) => {
+      const model = IMAGE_TO_VIDEO_MODELS[m];
+      return 'requiredStyleCategory' in model &&
+        model.requiredStyleCategory !== styleCategory
+        ? DEFAULT_VIDEO_MODEL
+        : m;
+    });
+    const deduped = [...new Set(coerced)];
     if (
-      'requiredStyleCategory' in model &&
-      model.requiredStyleCategory !== styleCategory
+      deduped.length !== videoModels.length ||
+      deduped.some((m, i) => m !== videoModels[i])
     ) {
-      updateGen('motionModel', DEFAULT_VIDEO_MODEL);
+      updateGen('videoModels', deduped);
     }
-  }, [styleCategory, motionModel]);
+  }, [styleCategory, videoModels]);
 
   // Auto-apply style recommendations on style change. Issue #716 originally
   // said "suggest, never auto-change", but in practice most users never open
@@ -365,7 +374,7 @@ export const ScriptView: FC<{
   const styleApplySnapshotRef = useRef<{
     aspectRatio: AspectRatio;
     imageModels: TextToImageModel[];
-    motionModel: ImageToVideoModel;
+    videoModels: ImageToVideoModel[];
   } | null>(null);
   const [appliedFromStyle, setAppliedFromStyle] = useState<{
     styleId: string;
@@ -416,14 +425,14 @@ export const ScriptView: FC<{
       const start = baseline ?? {
         aspectRatio: s.aspectRatio,
         imageModels: s.imageModels,
-        motionModel: s.motionModel,
+        videoModels: s.videoModels,
       };
       styleApplySnapshotRef.current = start;
       return {
         ...s,
         aspectRatio: validRatio ?? start.aspectRatio,
         imageModels: validImage ? [validImage] : start.imageModels,
-        motionModel: validVideo ?? start.motionModel,
+        videoModels: validVideo ? [validVideo] : start.videoModels,
       };
     });
     setAppliedFromStyle({
@@ -487,7 +496,7 @@ export const ScriptView: FC<{
       is_editing: isEditing,
       aspect_ratio: aspectRatio,
       image_models: imageModels,
-      motion_model: motionModel,
+      video_models: videoModels,
       auto_generate_motion: autoGenerateMotion,
       auto_generate_music: autoGenerateMusic,
       analysis_model_count: analysisModels.length,
@@ -502,7 +511,8 @@ export const ScriptView: FC<{
         aspectRatio,
         analysisModels,
         imageModels,
-        videoModel: motionModel,
+        videoModels,
+        videoModel: videoModels[0] ?? DEFAULT_VIDEO_MODEL,
         autoGenerateMotion,
         autoGenerateMusic,
         musicModel,
@@ -685,14 +695,14 @@ export const ScriptView: FC<{
             aspectRatio={aspectRatio}
             analysisModels={analysisModels}
             imageModels={imageModels}
-            motionModel={motionModel}
+            videoModels={videoModels}
             autoGenerateMotion={autoGenerateMotion}
             musicModel={musicModel}
             autoGenerateMusic={autoGenerateMusic}
             onAspectRatioChange={(v) => updateGen('aspectRatio', v)}
             onAnalysisModelsChange={(v) => updateGen('analysisModels', v)}
             onImageModelsChange={(v) => updateGen('imageModels', v)}
-            onMotionModelChange={(v) => updateGen('motionModel', v)}
+            onVideoModelsChange={(v) => updateGen('videoModels', v)}
             onAutoGenerateMotionChange={(v) =>
               updateGen('autoGenerateMotion', v)
             }

--- a/src/components/settings/generation-settings.tsx
+++ b/src/components/settings/generation-settings.tsx
@@ -3,7 +3,10 @@ import {
   ImageModelSelector,
 } from '@/components/model/image-model-selector';
 import { ModelSelector } from '@/components/model/model-selector';
-import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import {
+  MotionModelMultiSelector,
+  MotionModelSelector,
+} from '@/components/model/motion-model-selector';
 import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -15,6 +18,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import {
   DEFAULT_IMAGE_MODEL,
+  DEFAULT_VIDEO_MODEL,
   type AudioModel,
   type ImageToVideoModel,
   type TextToImageModel,
@@ -59,14 +63,14 @@ type GenerationSettingsProps = {
   aspectRatio: AspectRatio;
   analysisModels: AnalysisModelId[];
   imageModels: TextToImageModel[];
-  motionModel: ImageToVideoModel;
+  videoModels: ImageToVideoModel[];
   autoGenerateMotion?: boolean;
   musicModel?: AudioModel;
   autoGenerateMusic?: boolean;
   onAspectRatioChange: (value: AspectRatio) => void;
   onAnalysisModelsChange: (value: AnalysisModelId[]) => void;
   onImageModelsChange: (value: TextToImageModel[]) => void;
-  onMotionModelChange: (value: ImageToVideoModel) => void;
+  onVideoModelsChange: (value: ImageToVideoModel[]) => void;
   onAutoGenerateMotionChange?: (value: boolean) => void;
   onMusicModelChange?: (value: AudioModel) => void;
   onAutoGenerateMusicChange?: (value: boolean) => void;
@@ -74,6 +78,8 @@ type GenerationSettingsProps = {
   singleSelectAnalysis?: boolean;
   /** Use single-select for image model (e.g. in regeneration context) */
   singleSelectImage?: boolean;
+  /** Use single-select for motion model (e.g. in regeneration context) */
+  singleSelectMotion?: boolean;
   /** Current style category, used to show/hide style-restricted motion models */
   styleCategory?: string;
   /** Current style name, used in recommendation tooltips */
@@ -97,20 +103,21 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
   aspectRatio,
   analysisModels,
   imageModels,
-  motionModel,
+  videoModels,
   autoGenerateMotion = false,
   musicModel,
   autoGenerateMusic = false,
   onAspectRatioChange,
   onAnalysisModelsChange,
   onImageModelsChange,
-  onMotionModelChange,
+  onVideoModelsChange,
   onAutoGenerateMotionChange,
   onMusicModelChange,
   onAutoGenerateMusicChange,
   disabled = false,
   singleSelectAnalysis = false,
   singleSelectImage = false,
+  singleSelectMotion = false,
   styleCategory,
   styleName,
   recommendedImageModel,
@@ -211,7 +218,7 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
           {/* Motion Model Section */}
           <section className="flex flex-col gap-2">
             <h3 className="text-sm font-medium text-foreground">
-              Motion Model
+              Motion Model{!singleSelectMotion && 's'}
             </h3>
             {onAutoGenerateMotionChange && (
               <AutoToggle
@@ -222,15 +229,27 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
                 disabled={disabled}
               />
             )}
-            <MotionModelSelector
-              selectedModel={motionModel}
-              onModelChange={onMotionModelChange}
-              disabled={disabled || !autoGenerateMotion}
-              aspectRatio={aspectRatio}
-              styleCategory={styleCategory}
-              recommendedVideoModel={recommendedVideoModel}
-              styleName={styleName}
-            />
+            {singleSelectMotion ? (
+              <MotionModelSelector
+                selectedModel={videoModels[0] ?? DEFAULT_VIDEO_MODEL}
+                onModelChange={(model) => onVideoModelsChange([model])}
+                disabled={disabled || !autoGenerateMotion}
+                aspectRatio={aspectRatio}
+                styleCategory={styleCategory}
+                recommendedVideoModel={recommendedVideoModel}
+                styleName={styleName}
+              />
+            ) : (
+              <MotionModelMultiSelector
+                selectedModels={videoModels}
+                onModelsChange={onVideoModelsChange}
+                disabled={disabled || !autoGenerateMotion}
+                aspectRatio={aspectRatio}
+                styleCategory={styleCategory}
+                recommendedVideoModel={recommendedVideoModel}
+                styleName={styleName}
+              />
+            )}
           </section>
 
           {onAutoGenerateMusicChange && onMusicModelChange && musicModel && (

--- a/src/functions/frame-image.ts
+++ b/src/functions/frame-image.ts
@@ -502,3 +502,46 @@ export const setImageFromVariantFn = createServerFn({ method: 'POST' })
 
     return { frameId: frame.id, thumbnailUrl: variant.url };
   });
+
+const setVideoFromVariantInputSchema = z.object({
+  sequenceId: ulidSchema,
+  frameId: ulidSchema,
+  model: z.string().min(1),
+});
+
+/**
+ * Promote a model's video variant to the frame's primary video (#545) — the
+ * motion analog of `setImageFromVariantFn`. Copies the variant's url/path into
+ * `frames.video*` so the player and exports use it, non-destructively (the
+ * variant row is retained, so the viewer can switch back). Unlike the image
+ * version there is nothing downstream to invalidate — video is the terminal
+ * artifact.
+ */
+export const setVideoFromVariantFn = createServerFn({ method: 'POST' })
+  .middleware([frameAccessMiddleware])
+  .inputValidator(zodValidator(setVideoFromVariantInputSchema))
+  .handler(async ({ context, data }) => {
+    const { frame } = context;
+
+    const variant = await context.scopedDb.frameVariants.getByFrameAndModel(
+      frame.id,
+      'video',
+      data.model
+    );
+
+    if (!variant || variant.status !== 'completed' || !variant.url) {
+      throw new Error('No completed video variant found for this model');
+    }
+
+    await context.scopedDb.frames.update(frame.id, {
+      videoUrl: variant.url,
+      videoPath: variant.storagePath,
+      videoStatus: 'completed',
+      videoError: null,
+      videoGeneratedAt: new Date(),
+      durationMs: variant.durationMs,
+      motionModel: data.model,
+    });
+
+    return { frameId: frame.id, videoUrl: variant.url };
+  });

--- a/src/functions/frame-image.ts
+++ b/src/functions/frame-image.ts
@@ -491,7 +491,13 @@ export const setImageFromVariantFn = createServerFn({ method: 'POST' })
       thumbnailStatus: 'completed',
       thumbnailError: null,
       imageModel: data.model,
-      // Clear stale video fields — video must be regenerated
+      // Adopt the promoted variant's input hash so the staleness check (which
+      // re-derives the current hash with the now-updated imageModel) compares
+      // like-for-like. Without this it diffs the new model's hash against the
+      // OLD model's stored hash and always reports a false "stale". (#545)
+      thumbnailInputHash: variant.inputHash,
+      // Clear stale video fields — the video was generated from the previous
+      // image, so it must be regenerated.
       videoUrl: null,
       videoPath: null,
       videoStatus: 'pending',
@@ -539,6 +545,7 @@ export const setVideoFromVariantFn = createServerFn({ method: 'POST' })
       videoStatus: 'completed',
       videoError: null,
       videoGeneratedAt: new Date(),
+      videoInputHash: variant.inputHash,
       durationMs: variant.durationMs,
       motionModel: data.model,
     });

--- a/src/functions/frame-image.ts
+++ b/src/functions/frame-image.ts
@@ -84,10 +84,9 @@ export const generateFramesFn = createServerFn({ method: 'POST' })
           DEFAULT_IMAGE_MODEL
         ),
         aspectRatio: sequence.aspectRatio,
-        videoModel: safeImageToVideoModel(
-          sequence.videoModel,
-          DEFAULT_VIDEO_MODEL
-        ),
+        videoModels: [
+          safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL),
+        ],
       }),
       {
         providers: ['fal', 'openrouter'],

--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -50,6 +50,15 @@ export const getSequenceImageModelsFn = createServerFn({ method: 'GET' })
     );
   });
 
+export const getSequenceVideoModelsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.frameVariants.listModelsForSequence(
+      context.sequence.id,
+      'video'
+    );
+  });
+
 export const getDivergentVariantsFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
   .handler(async ({ context }) => {
@@ -183,6 +192,7 @@ export const promoteVariantFn = createServerFn({ method: 'POST' })
                 frameId: frame.id,
                 status: 'completed',
                 videoUrl: url,
+                model: variant.model,
               }
             : {
                 frameId: frame.id,
@@ -260,6 +270,15 @@ export const getSequenceImageVariantsFn = createServerFn({ method: 'GET' })
     return context.scopedDb.frameVariants.listBySequence(
       context.sequence.id,
       'image'
+    );
+  });
+
+export const getSequenceVideoVariantsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.frameVariants.listBySequence(
+      context.sequence.id,
+      'video'
     );
   });
 

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -11,6 +11,7 @@ import {
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
+import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import { requireTeamMemberAccess } from '@/lib/auth/action-utils';
 import { estimateStoryboardCost } from '@/lib/billing/cost-estimation';
 import { requireCredits } from '@/lib/billing/preflight';
@@ -70,6 +71,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
       imageModel: imageModelLegacy,
       imageModels: imageModelsInput,
       videoModel,
+      videoModels: videoModelsInput,
       autoGenerateMotion = false,
       autoGenerateMusic = true,
       musicModel,
@@ -102,6 +104,23 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
       );
     }
 
+    // Validate and resolve video models (mirrors the image-model handling).
+    const validatedVideoModels = videoModelsInput.map((m) =>
+      safeImageToVideoModel(m, DEFAULT_VIDEO_MODEL)
+    );
+    const videoModels = resolveVideoModels(
+      validatedVideoModels,
+      videoModel
+        ? safeImageToVideoModel(videoModel, DEFAULT_VIDEO_MODEL)
+        : undefined
+    );
+    const [primaryVideoModel] = videoModels;
+    if (!primaryVideoModel) {
+      throw new Error(
+        'Expected resolveVideoModels to return at least one model'
+      );
+    }
+
     if (!styleId || !aspectRatio) {
       throw new Error('Style ID and aspect ratio are required');
     }
@@ -113,7 +132,8 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         imageModelCount: imageModels.length,
         aspectRatio,
         autoGenerateMotion,
-        videoModel: safeImageToVideoModel(videoModel, DEFAULT_VIDEO_MODEL),
+        videoModel: primaryVideoModel,
+        videoModelCount: videoModels.length,
       }),
       {
         providers: ['fal', 'openrouter'],
@@ -142,7 +162,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
           analysisModel:
             getAnalysisModelById(modelId)?.id || DEFAULT_ANALYSIS_MODEL,
           imageModel: primaryImageModel,
-          videoModel: autoGenerateMotion ? videoModel : undefined,
+          videoModel: autoGenerateMotion ? primaryVideoModel : undefined,
           musicModel: persistedMusicModel,
           autoGenerateMotion,
           autoGenerateMusic,
@@ -186,6 +206,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
           teamId,
           sequenceId: sequence.id,
           imageModels,
+          videoModels,
           options: {
             framesPerScene: 3,
             generateThumbnails: true,

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -132,8 +132,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         imageModelCount: imageModels.length,
         aspectRatio,
         autoGenerateMotion,
-        videoModel: primaryVideoModel,
-        videoModelCount: videoModels.length,
+        videoModels,
       }),
       {
         providers: ['fal', 'openrouter'],
@@ -299,10 +298,9 @@ export const updateSequenceFn = createServerFn({ method: 'POST' })
             DEFAULT_IMAGE_MODEL
           ),
           aspectRatio: sequence.aspectRatio,
-          videoModel: safeImageToVideoModel(
-            sequence.videoModel,
-            DEFAULT_VIDEO_MODEL
-          ),
+          videoModels: [
+            safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL),
+          ],
         }),
         {
           providers: ['fal', 'openrouter'],
@@ -363,10 +361,9 @@ export const retryStoryboardFn = createServerFn({ method: 'POST' })
           DEFAULT_IMAGE_MODEL
         ),
         aspectRatio: sequence.aspectRatio,
-        videoModel: safeImageToVideoModel(
-          sequence.videoModel,
-          DEFAULT_VIDEO_MODEL
-        ),
+        videoModels: [
+          safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL),
+        ],
       }),
       {
         providers: ['fal', 'openrouter'],

--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -88,7 +88,7 @@ export const smartRetryFn = createServerFn({ method: 'POST' })
         estimateStoryboardCost({
           imageModel,
           aspectRatio: sequence.aspectRatio,
-          videoModel,
+          videoModels: [videoModel],
         }),
         {
           providers: ['fal', 'openrouter'],

--- a/src/hooks/use-active-video-model.ts
+++ b/src/hooks/use-active-video-model.ts
@@ -1,0 +1,116 @@
+import {
+  isValidImageToVideoModel,
+  type ImageToVideoModel,
+} from '@/lib/ai/models';
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'ui', 'use-active-video-model']);
+
+/**
+ * Viewer-local "active video model" selection for a sequence (#545).
+ *
+ * Which model's video the scenes view displays is a per-viewer preference, not
+ * persisted server-side — stored in localStorage keyed by sequence. A
+ * module-level store + `useSyncExternalStore` keeps every consumer (header
+ * dropdown + scenes view) in sync within the tab without prop-drilling across
+ * route levels, and survives reloads. `null` means "no explicit pick" — the
+ * caller falls back to each frame's own model.
+ */
+
+const KEY_PREFIX = 'openstory:active-video-model:';
+const storageKey = (sequenceId: string) => `${KEY_PREFIX}${sequenceId}`;
+
+// Per-sequence selection cache. `undefined` = not yet hydrated from storage;
+// `null` = hydrated, no explicit pick.
+const store = new Map<string, ImageToVideoModel | null | undefined>();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+// Keep tabs in sync: a write in another tab fires a `storage` event here. Sync
+// the module store from localStorage and notify so the dropdown/player update
+// without a reload. Attached lazily on first subscribe (browser-only).
+let storageListenerAttached = false;
+function ensureStorageListener() {
+  if (storageListenerAttached || typeof window === 'undefined') return;
+  storageListenerAttached = true;
+  window.addEventListener('storage', (event) => {
+    if (!event.key || !event.key.startsWith(KEY_PREFIX)) return;
+    const sequenceId = event.key.slice(KEY_PREFIX.length);
+    const next =
+      event.newValue && isValidImageToVideoModel(event.newValue)
+        ? event.newValue
+        : null;
+    store.set(sequenceId, next);
+    emit();
+  });
+}
+
+function subscribe(listener: () => void) {
+  ensureStorageListener();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function hydrate(sequenceId: string): ImageToVideoModel | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(storageKey(sequenceId));
+    if (raw && isValidImageToVideoModel(raw)) return raw;
+  } catch (error) {
+    logger.warn('Failed to read active video model from localStorage', {
+      err: error,
+    });
+  }
+  return null;
+}
+
+function read(sequenceId: string): ImageToVideoModel | null {
+  const cached = store.get(sequenceId);
+  if (cached !== undefined) return cached;
+  const hydrated = hydrate(sequenceId);
+  store.set(sequenceId, hydrated);
+  return hydrated;
+}
+
+function write(sequenceId: string, model: ImageToVideoModel | null) {
+  store.set(sequenceId, model);
+  if (typeof window !== 'undefined') {
+    try {
+      if (model) {
+        localStorage.setItem(storageKey(sequenceId), model);
+      } else {
+        localStorage.removeItem(storageKey(sequenceId));
+      }
+    } catch (error) {
+      logger.warn('Failed to persist active video model to localStorage', {
+        err: error,
+      });
+    }
+  }
+  emit();
+}
+
+export function useActiveVideoModel(sequenceId: string) {
+  const activeVideoModel = useSyncExternalStore(
+    subscribe,
+    () => read(sequenceId),
+    // Server snapshot: no localStorage, so always "no explicit pick".
+    () => null
+  );
+
+  const selectVideoModel = useCallback(
+    (model: ImageToVideoModel | null) => {
+      write(sequenceId, model);
+    },
+    [sequenceId]
+  );
+
+  return { activeVideoModel, selectVideoModel };
+}

--- a/src/hooks/use-frames.ts
+++ b/src/hooks/use-frames.ts
@@ -24,6 +24,7 @@ import {
   generateFrameVariantsFn,
   selectFrameVariantFn,
   setImageFromVariantFn,
+  setVideoFromVariantFn,
 } from '@/functions/frame-image';
 import type { GenerateVariantInput as SchemaGenerateVariantInput } from '@/lib/schemas/frame.schemas';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
@@ -697,6 +698,69 @@ export function useSetImageFromVariant() {
       });
       await queryClient.invalidateQueries({
         queryKey: frameKeys.list(sequenceId),
+      });
+    },
+  });
+}
+
+// Hook for setting a frame's video from an existing variant (#545) — the
+// motion analog of useSetImageFromVariant. Promotes a model's video variant to
+// the primary frames.video* columns and refreshes the video-variant cache.
+export function useSetVideoFromVariant() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    { frameId: string; videoUrl: string },
+    Error,
+    { sequenceId: string; frameId: string; model: string }
+  >({
+    mutationFn: async (input) => {
+      return setVideoFromVariantFn({ data: input });
+    },
+    onMutate: async ({ sequenceId, frameId }) => {
+      await queryClient.cancelQueries({
+        queryKey: frameKeys.detail(frameId),
+      });
+      await queryClient.cancelQueries({
+        queryKey: frameKeys.list(sequenceId),
+      });
+    },
+    onSuccess: async (data, { sequenceId, frameId, model }) => {
+      queryClient.setQueryData<Frame>(frameKeys.detail(frameId), (oldFrame) => {
+        if (!oldFrame) return oldFrame;
+        return {
+          ...oldFrame,
+          videoUrl: data.videoUrl,
+          videoStatus: 'completed' as const,
+          motionModel: model,
+        };
+      });
+
+      queryClient.setQueryData<Frame[]>(
+        frameKeys.list(sequenceId),
+        (oldFrames) => {
+          if (!oldFrames) return oldFrames;
+          return oldFrames.map((f) =>
+            f.id === frameId
+              ? {
+                  ...f,
+                  videoUrl: data.videoUrl,
+                  videoStatus: 'completed' as const,
+                  motionModel: model,
+                }
+              : f
+          );
+        }
+      );
+
+      await queryClient.invalidateQueries({
+        queryKey: frameKeys.detail(frameId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: frameKeys.list(sequenceId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['sequence-video-variants', sequenceId],
       });
     },
   });

--- a/src/hooks/use-frames.ts
+++ b/src/hooks/use-frames.ts
@@ -15,6 +15,8 @@ import {
   promoteVariantFn,
   discardVariantFn,
   undiscardVariantFn,
+  getSequenceVideoModelsFn,
+  getSequenceVideoVariantsFn,
 } from '@/functions/frames';
 import {
   generateFramesFn,
@@ -80,6 +82,35 @@ export const frameKeys = {
   divergentVariants: (sequenceId: string) =>
     [...frameKeys.all, 'divergent-variants', sequenceId] as const,
 };
+
+// Distinct video models that have generated a variant for this sequence (#545).
+// Drives the header video-model dropdown. The realtime video:progress handler
+// invalidates `['sequence-video-models', sequenceId]`, matching this key's tail.
+export function useSequenceVideoModels(sequenceId?: string) {
+  return useQuery<string[]>({
+    queryKey: ['sequence-video-models', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceVideoModelsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
+
+// All video FrameVariant rows for a sequence (#545). Used by the scenes view to
+// resolve each frame's displayed video through the active model's variant.
+export function useSequenceVideoVariants(sequenceId?: string) {
+  return useQuery<FrameVariant[]>({
+    queryKey: ['sequence-video-variants', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceVideoVariantsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
 
 // Hook to fetch the live (non-discarded) divergent alternates for a sequence.
 // The corner-dot indicator and inline banner both filter this list per frame.

--- a/src/hooks/use-generation-settings.ts
+++ b/src/hooks/use-generation-settings.ts
@@ -33,6 +33,7 @@ type GenerationSettings = {
   imageModel: TextToImageModel;
   imageModels: TextToImageModel[];
   motionModel: ImageToVideoModel;
+  videoModels: ImageToVideoModel[];
   autoGenerateMotion: boolean;
   musicModel: AudioModel;
   autoGenerateMusic: boolean;
@@ -44,6 +45,7 @@ const DEFAULT_SETTINGS: GenerationSettings = {
   imageModel: DEFAULT_IMAGE_MODEL,
   imageModels: [DEFAULT_IMAGE_MODEL],
   motionModel: DEFAULT_VIDEO_MODEL,
+  videoModels: [DEFAULT_VIDEO_MODEL],
   autoGenerateMotion: false,
   musicModel: DEFAULT_MUSIC_MODEL,
   autoGenerateMusic: false,
@@ -130,6 +132,21 @@ function loadSettings(): GenerationSettings {
     // Ensure motion model is compatible with aspect ratio
     const motionModel = getCompatibleModel(rawMotionModel, aspectRatio);
 
+    // Load videoModels array, falling back to [motionModel] for backward
+    // compat. Coerce each element to an aspect-ratio-compatible model and
+    // dedupe so a stored selection from another ratio can't surface an
+    // incompatible model in the picker.
+    const rawVideoModels =
+      'videoModels' in parsed &&
+      Array.isArray(parsed.videoModels) &&
+      parsed.videoModels.length > 0 &&
+      parsed.videoModels.every(isValidImageToVideoModel)
+        ? parsed.videoModels
+        : [motionModel];
+    const videoModels = [
+      ...new Set(rawVideoModels.map((m) => getCompatibleModel(m, aspectRatio))),
+    ];
+
     const autoGenerateMotion =
       'autoGenerateMotion' in parsed &&
       typeof parsed.autoGenerateMotion === 'boolean'
@@ -153,6 +170,7 @@ function loadSettings(): GenerationSettings {
       imageModel,
       imageModels,
       motionModel,
+      videoModels,
       autoGenerateMotion,
       musicModel,
       autoGenerateMusic,
@@ -205,18 +223,25 @@ export function useGenerationSettings() {
     setSettings((prev) => {
       let updated = { ...prev, ...newSettings };
 
-      // If aspect ratio is changing, ensure motion model is compatible
-      if (
-        newSettings.aspectRatio &&
-        newSettings.aspectRatio !== prev.aspectRatio
-      ) {
+      // If aspect ratio is changing, ensure motion model(s) are compatible
+      const nextAspectRatio = newSettings.aspectRatio;
+      if (nextAspectRatio && nextAspectRatio !== prev.aspectRatio) {
         const compatibleModel = getCompatibleModel(
           updated.motionModel,
-          newSettings.aspectRatio
+          nextAspectRatio
         );
-        if (compatibleModel !== updated.motionModel) {
-          updated = { ...updated, motionModel: compatibleModel };
-        }
+        const compatibleVideoModels = [
+          ...new Set(
+            updated.videoModels.map((m) =>
+              getCompatibleModel(m, nextAspectRatio)
+            )
+          ),
+        ];
+        updated = {
+          ...updated,
+          motionModel: compatibleModel,
+          videoModels: compatibleVideoModels,
+        };
       }
 
       saveSettings(updated);

--- a/src/lib/ai/resolve-video-models.test.ts
+++ b/src/lib/ai/resolve-video-models.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from './models';
+import { resolveVideoModels } from './resolve-video-models';
+
+describe('resolveVideoModels', () => {
+  it('returns the videoModels array when non-empty', () => {
+    const models: ImageToVideoModel[] = ['kling_v3_pro', 'veo3_1'];
+    expect(resolveVideoModels(models, undefined)).toEqual(models);
+  });
+
+  it('falls back to the legacy singular videoModel when array is empty/undefined', () => {
+    expect(resolveVideoModels(undefined, 'veo3_1')).toEqual(['veo3_1']);
+    expect(resolveVideoModels([], 'veo3_1')).toEqual(['veo3_1']);
+  });
+
+  it('falls back to the default model when neither is provided', () => {
+    expect(resolveVideoModels(undefined, undefined)).toEqual([
+      DEFAULT_VIDEO_MODEL,
+    ]);
+    expect(resolveVideoModels([], undefined)).toEqual([DEFAULT_VIDEO_MODEL]);
+  });
+
+  it('dedupes repeated models while preserving first-seen order (primary stays first)', () => {
+    expect(
+      resolveVideoModels(['veo3_1', 'kling_v3_pro', 'veo3_1'], undefined)
+    ).toEqual(['veo3_1', 'kling_v3_pro']);
+  });
+
+  it('prefers the array over the legacy singular when both are present', () => {
+    expect(resolveVideoModels(['kling_v3_pro'], 'veo3_1')).toEqual([
+      'kling_v3_pro',
+    ]);
+  });
+});

--- a/src/lib/ai/resolve-video-models.ts
+++ b/src/lib/ai/resolve-video-models.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from './models';
+
+/**
+ * Resolve a video models array from the dual-field pattern
+ * (optional `videoModels[]` + optional legacy `videoModel`).
+ *
+ * Guarantees a non-empty, deduplicated result. Mirrors
+ * {@link resolveImageModels} — the first element is treated as the primary
+ * model (the one whose output also lands in the legacy `frames.video*`
+ * columns); the rest are alternates stored only in `frame_variants`.
+ */
+export function resolveVideoModels(
+  videoModels: ImageToVideoModel[] | undefined,
+  videoModel: ImageToVideoModel | undefined
+): ImageToVideoModel[] {
+  const models =
+    videoModels && videoModels.length > 0
+      ? videoModels
+      : videoModel
+        ? [videoModel]
+        : [DEFAULT_VIDEO_MODEL];
+  return [...new Set(models)];
+}

--- a/src/lib/billing/cost-estimation.test.ts
+++ b/src/lib/billing/cost-estimation.test.ts
@@ -1,26 +1,40 @@
 import { describe, expect, it } from 'vitest';
 import type { TextToImageModel, ImageToVideoModel } from '@/lib/ai/models';
-import { estimateStoryboardCost } from './cost-estimation';
+import {
+  estimateImageCost,
+  estimateStoryboardCost,
+  estimateVideoCost,
+} from './cost-estimation';
 
 const IMAGE_MODEL: TextToImageModel = 'nano_banana_2';
-const VIDEO_MODEL: ImageToVideoModel = 'kling_v3_pro';
+const VIDEO_A: ImageToVideoModel = 'kling_v3_pro';
+const VIDEO_B: ImageToVideoModel = 'veo3_1';
+const SCENE_COUNT = 8;
+const DURATION = 5;
 
 const base = {
   imageModel: IMAGE_MODEL,
   aspectRatio: '16:9' as const,
-  estimatedSceneCount: 8,
+  estimatedSceneCount: SCENE_COUNT,
 };
 
+/** Per-frame motion cost a model contributes across the whole storyboard. */
+const motionContribution = (model: ImageToVideoModel) =>
+  Number(estimateVideoCost(model, DURATION)) * SCENE_COUNT;
+
 describe('estimateStoryboardCost', () => {
-  it('multiplies the per-frame image cost by imageModelCount', () => {
+  it('adds exactly one extra per-frame image pass per image model', () => {
     const one = Number(estimateStoryboardCost({ ...base, imageModelCount: 1 }));
     const two = Number(estimateStoryboardCost({ ...base, imageModelCount: 2 }));
-    // The delta is exactly one extra set of per-frame images (character/location
-    // sheets + LLM are not multiplied), so two-model cost exceeds one-model.
-    expect(two).toBeGreaterThan(one);
+    // Only per-frame images scale with model count — the character/location
+    // sheets and LLM analysis are charged once regardless.
+    const perFrameImagePass = Number(
+      estimateImageCost(IMAGE_MODEL, base.aspectRatio, SCENE_COUNT)
+    );
+    expect(two - one).toBe(perFrameImagePass);
   });
 
-  it('multiplies the per-frame motion cost by videoModelCount', () => {
+  it('sums each selected video model’s own per-frame motion cost', () => {
     const noMotion = Number(
       estimateStoryboardCost({ ...base, autoGenerateMotion: false })
     );
@@ -28,42 +42,72 @@ describe('estimateStoryboardCost', () => {
       estimateStoryboardCost({
         ...base,
         autoGenerateMotion: true,
-        videoModel: VIDEO_MODEL,
-        videoModelCount: 1,
+        videoModels: [VIDEO_A],
       })
     );
     const twoModels = Number(
       estimateStoryboardCost({
         ...base,
         autoGenerateMotion: true,
-        videoModel: VIDEO_MODEL,
-        videoModelCount: 2,
+        videoModels: [VIDEO_A, VIDEO_B],
       })
     );
-    // Each extra video model adds exactly one more full pass of per-frame
-    // motion cost — the invariant the credit pre-flight relies on.
-    const perModelMotionCost = oneModel - noMotion;
-    expect(twoModels - oneModel).toBe(perModelMotionCost);
-    expect(twoModels).toBeGreaterThanOrEqual(oneModel);
+
+    expect(oneModel - noMotion).toBe(motionContribution(VIDEO_A));
+    expect(twoModels - noMotion).toBe(
+      motionContribution(VIDEO_A) + motionContribution(VIDEO_B)
+    );
   });
 
-  it('defaults videoModelCount/imageModelCount to 1 when omitted', () => {
-    const explicit = Number(
+  it('prices a mixed selection per model, not as a flat multiple of the primary', () => {
+    // Guards the regression where N models were charged at N× the primary's
+    // rate. These two models have genuinely different parameter-based pricing,
+    // so the true sum diverges from the flat-multiplier estimate.
+    expect(motionContribution(VIDEO_A)).not.toBe(motionContribution(VIDEO_B));
+
+    const noMotion = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMotion: false })
+    );
+    const mixed = Number(
       estimateStoryboardCost({
         ...base,
-        imageModelCount: 1,
         autoGenerateMotion: true,
-        videoModel: VIDEO_MODEL,
-        videoModelCount: 1,
+        videoModels: [VIDEO_A, VIDEO_B],
       })
     );
-    const omitted = Number(
-      estimateStoryboardCost({
-        ...base,
-        autoGenerateMotion: true,
-        videoModel: VIDEO_MODEL,
-      })
+
+    const trueSum = motionContribution(VIDEO_A) + motionContribution(VIDEO_B);
+    const flatMultiplierEstimate = motionContribution(VIDEO_A) * 2;
+    expect(mixed - noMotion).toBe(trueSum);
+    expect(mixed - noMotion).not.toBe(flatMultiplierEstimate);
+  });
+
+  it('adds no motion cost when motion is off or no models are selected', () => {
+    const noMotion = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMotion: false })
     );
-    expect(omitted).toBe(explicit);
+    // autoGenerateMotion true but no models / empty list → nothing to bill.
+    expect(
+      Number(estimateStoryboardCost({ ...base, autoGenerateMotion: true }))
+    ).toBe(noMotion);
+    expect(
+      Number(
+        estimateStoryboardCost({
+          ...base,
+          autoGenerateMotion: true,
+          videoModels: [],
+        })
+      )
+    ).toBe(noMotion);
+    // Models present but motion disabled → still no motion cost.
+    expect(
+      Number(
+        estimateStoryboardCost({
+          ...base,
+          autoGenerateMotion: false,
+          videoModels: [VIDEO_A, VIDEO_B],
+        })
+      )
+    ).toBe(noMotion);
   });
 });

--- a/src/lib/billing/cost-estimation.test.ts
+++ b/src/lib/billing/cost-estimation.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { TextToImageModel, ImageToVideoModel } from '@/lib/ai/models';
+import { estimateStoryboardCost } from './cost-estimation';
+
+const IMAGE_MODEL: TextToImageModel = 'nano_banana_2';
+const VIDEO_MODEL: ImageToVideoModel = 'kling_v3_pro';
+
+const base = {
+  imageModel: IMAGE_MODEL,
+  aspectRatio: '16:9' as const,
+  estimatedSceneCount: 8,
+};
+
+describe('estimateStoryboardCost', () => {
+  it('multiplies the per-frame image cost by imageModelCount', () => {
+    const one = Number(estimateStoryboardCost({ ...base, imageModelCount: 1 }));
+    const two = Number(estimateStoryboardCost({ ...base, imageModelCount: 2 }));
+    // The delta is exactly one extra set of per-frame images (character/location
+    // sheets + LLM are not multiplied), so two-model cost exceeds one-model.
+    expect(two).toBeGreaterThan(one);
+  });
+
+  it('multiplies the per-frame motion cost by videoModelCount', () => {
+    const noMotion = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMotion: false })
+    );
+    const oneModel = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMotion: true,
+        videoModel: VIDEO_MODEL,
+        videoModelCount: 1,
+      })
+    );
+    const twoModels = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMotion: true,
+        videoModel: VIDEO_MODEL,
+        videoModelCount: 2,
+      })
+    );
+    // Each extra video model adds exactly one more full pass of per-frame
+    // motion cost — the invariant the credit pre-flight relies on.
+    const perModelMotionCost = oneModel - noMotion;
+    expect(twoModels - oneModel).toBe(perModelMotionCost);
+    expect(twoModels).toBeGreaterThanOrEqual(oneModel);
+  });
+
+  it('defaults videoModelCount/imageModelCount to 1 when omitted', () => {
+    const explicit = Number(
+      estimateStoryboardCost({
+        ...base,
+        imageModelCount: 1,
+        autoGenerateMotion: true,
+        videoModel: VIDEO_MODEL,
+        videoModelCount: 1,
+      })
+    );
+    const omitted = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMotion: true,
+        videoModel: VIDEO_MODEL,
+      })
+    );
+    expect(omitted).toBe(explicit);
+  });
+});

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -91,10 +91,13 @@ export function estimateStoryboardCost(opts: {
   estimatedSceneCount?: number;
   autoGenerateMotion?: boolean;
   videoModel?: ImageToVideoModel;
+  /** Number of video models selected (multiplies per-frame motion cost) */
+  videoModelCount?: number;
   videoDurationSeconds?: number;
 }): Microdollars {
   const sceneCount = opts.estimatedSceneCount ?? DEFAULT_ESTIMATED_SCENE_COUNT;
   const imageModelCount = opts.imageModelCount ?? 1;
+  const videoModelCount = opts.videoModelCount ?? 1;
 
   // LLM calls: script analysis + character bible + location bible (~3 calls)
   const llmCost = estimateLLMCost(3);
@@ -116,13 +119,14 @@ export function estimateStoryboardCost(opts: {
     frameCost
   );
 
-  // Optional motion generation for all frames
+  // Optional motion generation for all frames (multiplied by the number of
+  // selected video models — each model produces its own video per frame).
   if (opts.autoGenerateMotion && opts.videoModel) {
     const duration = opts.videoDurationSeconds ?? 5;
     const perFrameMotion = estimateVideoCost(opts.videoModel, duration);
     totalCost = addMicros(
       totalCost,
-      multiplyMicros(perFrameMotion, sceneCount)
+      multiplyMicros(perFrameMotion, sceneCount * videoModelCount)
     );
   }
 

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -8,12 +8,12 @@ import { calculateImageCost, calculateVideoCost } from '@/lib/ai/fal-cost';
 import {
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
-  type TextToImageModel,
   type ImageToVideoModel,
+  type TextToImageModel,
   videoModelSupportsAudio,
 } from '@/lib/ai/models';
-import { aspectRatioToDimensions } from '@/lib/constants/aspect-ratios';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import { aspectRatioToDimensions } from '@/lib/constants/aspect-ratios';
 import { type Microdollars, addMicros, micros, multiplyMicros } from './money';
 
 /**
@@ -90,14 +90,17 @@ export function estimateStoryboardCost(opts: {
   aspectRatio: AspectRatio;
   estimatedSceneCount?: number;
   autoGenerateMotion?: boolean;
-  videoModel?: ImageToVideoModel;
-  /** Number of video models selected (multiplies per-frame motion cost) */
-  videoModelCount?: number;
+  /**
+   * Video models selected for per-frame motion (#545). Each model is priced
+   * individually from its own parameters — fal returns no cost, so a uniform
+   * per-model multiplier would mis-estimate a mixed (e.g. cheap + audio-capable)
+   * selection. First is primary; all are billed once per frame.
+   */
+  videoModels?: ImageToVideoModel[];
   videoDurationSeconds?: number;
 }): Microdollars {
   const sceneCount = opts.estimatedSceneCount ?? DEFAULT_ESTIMATED_SCENE_COUNT;
   const imageModelCount = opts.imageModelCount ?? 1;
-  const videoModelCount = opts.videoModelCount ?? 1;
 
   // LLM calls: script analysis + character bible + location bible (~3 calls)
   const llmCost = estimateLLMCost(3);
@@ -119,15 +122,19 @@ export function estimateStoryboardCost(opts: {
     frameCost
   );
 
-  // Optional motion generation for all frames (multiplied by the number of
-  // selected video models — each model produces its own video per frame).
-  if (opts.autoGenerateMotion && opts.videoModel) {
+  // Optional motion generation for all frames. Each selected video model
+  // produces its own video per frame, so sum each model's own per-frame cost
+  // (priced from its parameters) rather than scaling one model's rate by a
+  // count — a mixed selection has genuinely different per-model costs.
+  if (opts.autoGenerateMotion && opts.videoModels?.length) {
     const duration = opts.videoDurationSeconds ?? 5;
-    const perFrameMotion = estimateVideoCost(opts.videoModel, duration);
-    totalCost = addMicros(
-      totalCost,
-      multiplyMicros(perFrameMotion, sceneCount * videoModelCount)
-    );
+    for (const model of opts.videoModels) {
+      const perFrameMotion = estimateVideoCost(model, duration);
+      totalCost = addMicros(
+        totalCost,
+        multiplyMicros(perFrameMotion, sceneCount)
+      );
+    }
   }
 
   return totalCost;

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -133,6 +133,10 @@ export const realtimeSchema = {
       frameId: z.string(),
       status: z.enum(['pending', 'generating', 'completed', 'failed']),
       videoUrl: z.string().optional(),
+      // Which video model produced this update. Optional for backward compat
+      // with emitters that predate multi-model video (#545); the model-aware
+      // cache invalidation and scenes-view variant switcher key off it.
+      model: z.string().optional(),
     }),
 
     // Audio/music generation progress (frameId optional for sequence-level music)

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -176,6 +176,23 @@ export function updateQueryCacheFromEvent(
             : f
         )
       );
+      // Refresh video variant data so the model switcher and per-model overlay
+      // stay current (#545). Unlike the image handler, refresh on `failed` too:
+      // motion-workflow.onFailure writes a `failed` variant row, and the
+      // switcher should reflect that terminal state without waiting for a
+      // background refetch.
+      if (status === 'completed' || status === 'failed') {
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-video-variants', sequenceId],
+          `video-variants:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-video-models', sequenceId],
+          `video-models:${sequenceId}`
+        );
+      }
       break;
     }
 

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -86,13 +86,22 @@ export const createSequenceSchema = createInsertSchema(sequences, {
       )
       .min(1, 'At least one image model must be selected')
       .default([DEFAULT_IMAGE_MODEL]),
-    // Video model selection (model key, not full ID)
+    // Video model selection (model key, not full ID) — primary / first of videoModels
     videoModel: z
       .string()
       .refine((val) => validVideoModelKeys.includes(val), {
         message: 'Invalid video model',
       })
       .default(DEFAULT_VIDEO_MODEL),
+    // Multiple video models for variant generation (first is primary)
+    videoModels: z
+      .array(
+        z.string().refine((val) => validVideoModelKeys.includes(val), {
+          message: 'Invalid video model',
+        })
+      )
+      .min(1, 'At least one video model must be selected')
+      .default([DEFAULT_VIDEO_MODEL]),
     // Auto-generate motion flag (UI-only, not stored in DB)
     autoGenerateMotion: z.boolean().default(false).optional(),
     // Auto-generate music flag (UI-only, not stored in DB)

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -14,6 +14,7 @@ import type {
   CharacterBibleEntry,
   ElementBibleEntry,
   LocationBibleEntry,
+  MotionPrompt,
   Scene,
 } from '@/lib/ai/scene-analysis.schema';
 import type { AspectRatio, ImageSize } from '@/lib/constants/aspect-ratios';
@@ -122,6 +123,8 @@ export interface StoryboardWorkflowInput extends SequenceWorkflowContext {
   };
   /** Multiple image models for variant generation (first is primary) */
   imageModels?: TextToImageModel[];
+  /** Multiple video models for variant generation (first is primary) */
+  videoModels?: ImageToVideoModel[];
   autoGenerateMotion?: boolean;
   autoGenerateMusic?: boolean;
   musicModel?: keyof typeof AUDIO_MODELS;
@@ -144,6 +147,8 @@ export interface AnalyzeScriptWorkflowInput extends SequenceWorkflowContext {
   /** Multiple image models for variant generation (first is primary) */
   imageModels?: TextToImageModel[];
   videoModel?: ImageToVideoModel;
+  /** Multiple video models for variant generation (first is primary) */
+  videoModels?: ImageToVideoModel[];
   autoGenerateMotion?: boolean;
   autoGenerateMusic?: boolean;
   musicModel?: keyof typeof AUDIO_MODELS;
@@ -714,8 +719,20 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
   frames: Array<{
     frameId: string;
     imageUrl: string;
+    /**
+     * Prompt assembled for the primary model. Used directly for single-model
+     * runs and as the fallback when `motionPrompt` is absent. For multi-model
+     * fan-out, `motion-batch` re-assembles per model from `motionPrompt`.
+     */
     prompt: string;
     model?: ImageToVideoModel;
+    /**
+     * Structured motion prompt (#545). When present, `motion-batch` assembles
+     * a model-specific prompt for each model in `videoModels` via
+     * `assembleMotionPrompt`. Absent on manual single-model paths, which pass
+     * a pre-assembled `prompt` instead.
+     */
+    motionPrompt?: MotionPrompt;
     duration?: number;
     fps?: number;
     motionBucket?: number;
@@ -725,6 +742,13 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
     /** See `MotionWorkflowInput.userEditedPrompt`. */
     userEditedPrompt?: boolean;
   }>;
+  /**
+   * Video models to generate for every frame (#545). First is primary (its
+   * output also lands in the legacy `frames.video*` columns); the rest are
+   * alternates stored only in `frame_variants`. When absent, each frame's own
+   * `model` is used (single-model behaviour).
+   */
+  videoModels?: ImageToVideoModel[];
   /** When true, generate music in parallel and mux into final video */
   includeMusic: boolean;
   /** Music config (required when includeMusic=true) */
@@ -793,6 +817,13 @@ export interface MotionMusicPromptsWorkflowInput extends SequenceWorkflowContext
   styleConfig: StyleConfig;
   analysisModelId: AnalysisModelId;
   videoModel?: ImageToVideoModel;
+  /**
+   * Multiple video models for variant generation (first is primary). Only the
+   * primary is used here for model-aware duration snapping; the structured
+   * motion prompts produced are model-independent and assembled per-model
+   * downstream in `motion-batch`.
+   */
+  videoModels?: ImageToVideoModel[];
 }
 
 export interface MotionMusicPromptsWorkflowResult {

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -26,6 +26,7 @@
 
 import { sanitizeScriptContent } from '@/lib/ai/prompt-validation';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
+import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
@@ -93,6 +94,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
       imageModel,
       imageModels: imageModelsInput,
       videoModel,
+      videoModels: videoModelsInput,
       autoGenerateMotion = false,
       autoGenerateMusic = false,
       musicModel,
@@ -101,6 +103,10 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
     } = input;
 
     const imageModels = resolveImageModels(imageModelsInput, imageModel);
+    const videoModels = resolveVideoModels(videoModelsInput, videoModel);
+    // First selected model is primary: it drives the legacy `frames.video*`
+    // columns and the model-aware duration snapping; the rest are alternates.
+    const primaryVideoModel = videoModels[0] ?? videoModel;
 
     // Top-level validation — base class re-wraps as CF NonRetryableError.
     if (!script) {
@@ -522,6 +528,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
           styleConfig,
           analysisModelId,
           videoModel,
+          videoModels,
         },
         spawnStepName: 'spawn-motion-music-prompts',
         awaitStepName: 'await-motion-music-prompts',
@@ -556,7 +563,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
     // PHASE 5: motion (+ optional music + merge) batch — single child
     // ----------------------------------------------------------------------
     const shouldGenerateMotion =
-      autoGenerateMotion && videoModel && imageUrls.length > 0;
+      autoGenerateMotion && primaryVideoModel && imageUrls.length > 0;
     const shouldGenerateMusic = Boolean(
       autoGenerateMusic &&
       sequenceId &&
@@ -593,11 +600,14 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
         return {
           frameId: matchedFrame?.frameId ?? '',
           imageUrl,
+          // Primary-model prompt (fallback / single-model). `motion-batch`
+          // re-assembles per model from `motionPrompt` for the alternates.
           prompt: assembleMotionPrompt({
             motionPrompt: motionPromptData,
-            model: videoModel,
+            model: primaryVideoModel,
           }),
-          model: videoModel,
+          model: primaryVideoModel,
+          motionPrompt: motionPromptData,
           duration: scene.metadata?.durationSeconds || 3,
           aspectRatio,
         };
@@ -634,6 +644,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
           sequenceId,
           includeMusic: shouldGenerateMusic,
           frames: batchFrames,
+          videoModels,
           music: shouldGenerateMusic
             ? {
                 prompt: musicPrompt,

--- a/src/lib/workflows/motion-batch-jobs.test.ts
+++ b/src/lib/workflows/motion-batch-jobs.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from '@/lib/ai/models';
+import { buildMotionJobs } from './motion-batch-jobs';
+
+type Frame = { frameId: string; model?: ImageToVideoModel };
+
+const A: ImageToVideoModel = 'kling_v3_pro';
+const B: ImageToVideoModel = 'veo3_1';
+
+const frames: Frame[] = [
+  { frameId: 'f0' },
+  { frameId: 'f1' },
+  { frameId: 'f2' },
+];
+
+describe('buildMotionJobs', () => {
+  it('expands each frame across every top-level video model (N×M jobs)', () => {
+    const jobs = buildMotionJobs(frames, [A, B]);
+    expect(jobs.length).toBe(frames.length * 2);
+    // Frames keep their order; each frame gets one job per model.
+    expect(jobs.map((j) => [j.frameIndex, j.model])).toEqual([
+      [0, A],
+      [0, B],
+      [1, A],
+      [1, B],
+      [2, A],
+      [2, B],
+    ]);
+    // The original frame object is carried through unchanged.
+    expect(jobs[0]?.frame).toBe(frames[0]);
+  });
+
+  it('dedupes the top-level model list so a model is never billed twice per frame', () => {
+    const oneFrame: Frame[] = [{ frameId: 'f0' }];
+    const jobs = buildMotionJobs(oneFrame, [A, A, B, A]);
+    expect(jobs.map((j) => j.model)).toEqual([A, B]);
+  });
+
+  it('keeps each (frameIndex, model) pair unique so child instance ids never collide', () => {
+    const jobs = buildMotionJobs(frames, [A, B, A]);
+    const keys = jobs.map((j) => `${j.frameIndex}:${j.model}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('falls back to each frame’s own model when no top-level models are given', () => {
+    const perFrame: Frame[] = [
+      { frameId: 'f0', model: A },
+      { frameId: 'f1', model: B },
+    ];
+    expect(buildMotionJobs(perFrame, undefined).map((j) => j.model)).toEqual([
+      A,
+      B,
+    ]);
+    // An empty list is treated the same as absent (single-model fallback).
+    expect(buildMotionJobs(perFrame, []).map((j) => j.model)).toEqual([A, B]);
+  });
+
+  it('falls back to DEFAULT_VIDEO_MODEL when a frame has no model and none are given', () => {
+    const oneFrame: Frame[] = [{ frameId: 'f0' }];
+    const jobs = buildMotionJobs(oneFrame, undefined);
+    expect(jobs.map((j) => j.model)).toEqual([DEFAULT_VIDEO_MODEL]);
+  });
+
+  it('top-level models win over per-frame model', () => {
+    const perFrame: Frame[] = [{ frameId: 'f0', model: A }];
+    expect(buildMotionJobs(perFrame, [B]).map((j) => j.model)).toEqual([B]);
+  });
+
+  it('returns no jobs for no frames', () => {
+    expect(buildMotionJobs([], [A, B])).toEqual([]);
+  });
+});

--- a/src/lib/workflows/motion-batch-jobs.ts
+++ b/src/lib/workflows/motion-batch-jobs.ts
@@ -1,0 +1,40 @@
+/**
+ * N+M fan-out expansion for `MotionBatchWorkflow` (#545).
+ *
+ * Multi-model video generation runs one motion child per `(frame, model)` —
+ * the motion analog of frame-images' per-`(scene, model)` fan-out. Pulled out
+ * of the workflow body (mirroring `motion-workflow-persist`) so the expansion's
+ * invariants are unit-testable without bootstrapping a `WorkflowEntrypoint`.
+ *
+ * Resolution rules (kept deliberately distinct from `resolveVideoModels`, which
+ * has different defaulting):
+ *   - top-level `videoModels` (deduped) applies to every frame when present;
+ *   - otherwise each frame falls back to its own `model` (single-model paths);
+ *   - a frame with neither falls back to `DEFAULT_VIDEO_MODEL`.
+ *
+ * Models are deduped per the top-level list so a model is never generated (or
+ * billed) twice for the same frame, which also keeps the `(frameIndex, model)`
+ * pair — and therefore each child's CF instance id — unique.
+ */
+
+import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from '@/lib/ai/models';
+
+export type MotionJob<F> = {
+  frame: F;
+  frameIndex: number;
+  model: ImageToVideoModel;
+};
+
+export function buildMotionJobs<F extends { model?: ImageToVideoModel }>(
+  frames: readonly F[],
+  videoModels: readonly ImageToVideoModel[] | undefined
+): MotionJob<F>[] {
+  const topVideoModels =
+    videoModels && videoModels.length > 0 ? [...new Set(videoModels)] : null;
+
+  return frames.flatMap((frame, frameIndex) => {
+    const models: ImageToVideoModel[] =
+      topVideoModels ?? (frame.model ? [frame.model] : [DEFAULT_VIDEO_MODEL]);
+    return models.map((model) => ({ frame, frameIndex, model }));
+  });
+}

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -21,7 +21,9 @@
  *     rather than a silently-skipped child), `Promise.allSettled` on await
  *     so a single bad frame doesn't kill the rest of the batch. */
 
+import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from '@/lib/ai/models';
 import type { ScopedDb } from '@/lib/db/scoped';
+import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
@@ -83,19 +85,43 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
       );
     }
 
-    // Step 1: Fan out motion workflows (one per frame) + optional music
-    // workflow in parallel. Pattern 3 spawns + awaits each child via
-    // `spawnAndAwaitChild`; Promise.allSettled lets a single failing frame
-    // not poison the rest of the batch.
-    const motionAwaits = input.frames.map((frame, index) => {
+    // Step 1: Fan out motion workflows + optional music workflow in parallel.
+    // Multi-model video (#545): one MOTION_WORKFLOW child per (frame, model)
+    // — the motion analog of frame-images' per-(scene, model) fan-out. The
+    // top-level `videoModels` (if present) applies to every frame; otherwise
+    // each frame falls back to its own `model` (single-model behaviour). The
+    // first model is primary (its output also lands in the legacy
+    // `frames.video*` columns); the rest are alternates in `frame_variants`.
+    // Pattern 3 spawns + awaits each child via `spawnAndAwaitChild`;
+    // Promise.allSettled lets a single failing (frame, model) not poison the
+    // rest of the batch.
+    const topVideoModels =
+      input.videoModels && input.videoModels.length > 0
+        ? [...new Set(input.videoModels)]
+        : null;
+
+    const motionJobs = input.frames.flatMap((frame, frameIndex) => {
+      const models: ImageToVideoModel[] =
+        topVideoModels ?? (frame.model ? [frame.model] : [DEFAULT_VIDEO_MODEL]);
+      return models.map((model) => ({ frame, frameIndex, model }));
+    });
+
+    const motionAwaits = motionJobs.map(({ frame, frameIndex, model }) => {
+      // Per-model prompt: re-assemble from the structured motion prompt when
+      // present so audio-capable models get dialogue/audio sections, falling
+      // back to the pre-assembled `prompt` for manual single-model paths.
+      const prompt = frame.motionPrompt
+        ? assembleMotionPrompt({ motionPrompt: frame.motionPrompt, model })
+        : frame.prompt;
+
       const motionBody: MotionWorkflowInput = {
         userId: input.userId,
         teamId: input.teamId,
         frameId: frame.frameId,
         sequenceId,
         imageUrl: frame.imageUrl,
-        prompt: frame.prompt,
-        model: frame.model,
+        prompt,
+        model,
         duration: frame.duration,
         fps: frame.fps,
         motionBucket: frame.motionBucket,
@@ -110,10 +136,12 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
           binding: motionBinding,
           parentBindingName: 'MOTION_BATCH_WORKFLOW',
           parentInstanceId,
-          childId: `motion:${sequenceId}:${frame.frameId}`,
+          // The model token keeps sibling-model children from colliding on the
+          // global CF instance id (mirrors frame-images' childId scheme).
+          childId: `motion:${sequenceId}:${frame.frameId}:${model}`,
           childPayload: motionBody,
-          spawnStepName: `spawn-motion-${index}`,
-          awaitStepName: `await-motion-${index}`,
+          spawnStepName: `spawn-motion-${frameIndex}-${model}`,
+          awaitStepName: `await-motion-${frameIndex}-${model}`,
           timeout: '30 minutes',
         }
       );
@@ -154,9 +182,9 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
     for (let i = 0; i < motionResults.length; i++) {
       const r = motionResults[i];
       if (r?.status === 'rejected') {
-        const frame = input.frames[i];
+        const job = motionJobs[i];
         logger.warn(
-          `[MotionBatchWorkflow:cf] Motion failed for frame ${frame?.frameId ?? '(unknown)'}:`,
+          `[MotionBatchWorkflow:cf] Motion failed for frame ${job?.frame.frameId ?? '(unknown)'} model ${job?.model ?? '(unknown)'}:`,
           {
             err: r.reason,
           }

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -21,13 +21,13 @@
  *     rather than a silently-skipped child), `Promise.allSettled` on await
  *     so a single bad frame doesn't kill the rest of the batch. */
 
-import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from '@/lib/ai/models';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
+import { buildMotionJobs } from '@/lib/workflows/motion-batch-jobs';
 import type {
   BatchMotionMusicWorkflowInput,
   MotionWorkflowInput,
@@ -87,24 +87,13 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
 
     // Step 1: Fan out motion workflows + optional music workflow in parallel.
     // Multi-model video (#545): one MOTION_WORKFLOW child per (frame, model)
-    // — the motion analog of frame-images' per-(scene, model) fan-out. The
-    // top-level `videoModels` (if present) applies to every frame; otherwise
-    // each frame falls back to its own `model` (single-model behaviour). The
-    // first model is primary (its output also lands in the legacy
-    // `frames.video*` columns); the rest are alternates in `frame_variants`.
-    // Pattern 3 spawns + awaits each child via `spawnAndAwaitChild`;
-    // Promise.allSettled lets a single failing (frame, model) not poison the
-    // rest of the batch.
-    const topVideoModels =
-      input.videoModels && input.videoModels.length > 0
-        ? [...new Set(input.videoModels)]
-        : null;
-
-    const motionJobs = input.frames.flatMap((frame, frameIndex) => {
-      const models: ImageToVideoModel[] =
-        topVideoModels ?? (frame.model ? [frame.model] : [DEFAULT_VIDEO_MODEL]);
-      return models.map((model) => ({ frame, frameIndex, model }));
-    });
+    // — the motion analog of frame-images' per-(scene, model) fan-out (see
+    // `buildMotionJobs` for the resolution/dedupe rules). The first model is
+    // primary (its output also lands in the legacy `frames.video*` columns);
+    // the rest are alternates in `frame_variants`. Pattern 3 spawns + awaits
+    // each child via `spawnAndAwaitChild`; Promise.allSettled lets a single
+    // failing (frame, model) not poison the rest of the batch.
+    const motionJobs = buildMotionJobs(input.frames, input.videoModels);
 
     const motionAwaits = motionJobs.map(({ frame, frameIndex, model }) => {
       // Per-model prompt: re-assemble from the structured motion prompt when

--- a/src/lib/workflows/motion-music-prompts-workflow.ts
+++ b/src/lib/workflows/motion-music-prompts-workflow.ts
@@ -53,6 +53,7 @@ export class MotionMusicPromptsWorkflow extends OpenStoryWorkflowEntrypoint<Moti
       scenesWithVisualPrompts,
       analysisModelId,
       videoModel,
+      videoModels,
       sequenceId,
       userId,
       teamId,
@@ -64,7 +65,10 @@ export class MotionMusicPromptsWorkflow extends OpenStoryWorkflowEntrypoint<Moti
       frameMapping,
     } = input;
 
-    const modelKey = videoModel || DEFAULT_VIDEO_MODEL;
+    // Snap durations against the primary video model. The structured motion
+    // prompts produced here are model-independent; per-model assembly happens
+    // downstream in motion-batch (#545).
+    const modelKey = videoModels?.[0] ?? videoModel ?? DEFAULT_VIDEO_MODEL;
 
     // Snap durations upfront so both motion prompts and music design see
     // identical, model-accurate duration values.

--- a/src/lib/workflows/motion-workflow-persist.test.ts
+++ b/src/lib/workflows/motion-workflow-persist.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Behavioural tests for the motion-workflow dual-write helpers (#545).
+ *
+ * `MotionWorkflow` writes each model's output to the legacy `frames.video*`
+ * columns AND a per-model `frame_variants` row. These tests pin the three
+ * states the workflow transitions through:
+ *
+ *   - generating: open the variant row + stamp the legacy columns
+ *   - completed:  stamp both, clearing any prior error (frame-deleted short-circuit)
+ *   - failed:     record the error on both — via UPSERT so a pre-generating
+ *                 failure still lands a visible `failed` variant
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { NewFrame, NewFrameVariant } from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
+import {
+  buildMotionCompletedWrites,
+  buildMotionFailedWrites,
+  buildMotionGeneratingWrites,
+  type MotionVideoProgressPayload,
+  persistMotionCompletion,
+  persistMotionFailure,
+  type PersistMotionScopedDb,
+} from './motion-workflow-persist';
+
+const upload = {
+  url: 'https://r2/seq/frame-veo.mp4',
+  path: 'team/seq/frame.mp4',
+};
+const NOW = new Date('2026-06-02T00:00:00Z');
+
+describe('buildMotionGeneratingWrites', () => {
+  it('stamps the legacy columns with the model + run id and opens the variant row', () => {
+    const writes = buildMotionGeneratingWrites({
+      model: 'veo3',
+      workflowRunId: 'run-1',
+    });
+    expect(writes.frame).toEqual({
+      videoStatus: 'generating',
+      videoWorkflowRunId: 'run-1',
+      motionModel: 'veo3',
+    });
+    expect(writes.variant).toEqual({
+      status: 'generating',
+      workflowRunId: 'run-1',
+    });
+  });
+});
+
+describe('buildMotionCompletedWrites', () => {
+  it('stamps the final video on both the frame and the variant and clears errors', () => {
+    const writes = buildMotionCompletedWrites({
+      upload,
+      durationMs: 5000,
+      promptHash: 'prompt-abc',
+      generatedAt: NOW,
+    });
+    expect(writes.frame).toEqual({
+      videoPath: upload.path,
+      videoUrl: upload.url,
+      durationMs: 5000,
+      videoStatus: 'completed',
+      videoGeneratedAt: NOW,
+      videoError: null,
+    });
+    expect(writes.variant).toEqual({
+      url: upload.url,
+      storagePath: upload.path,
+      status: 'completed',
+      generatedAt: NOW,
+      error: null,
+      durationMs: 5000,
+      promptHash: 'prompt-abc',
+    });
+  });
+
+  it('carries a null promptHash through unchanged', () => {
+    const writes = buildMotionCompletedWrites({
+      upload,
+      durationMs: 5000,
+      promptHash: null,
+      generatedAt: NOW,
+    });
+    expect(writes.variant.promptHash).toBeNull();
+  });
+});
+
+describe('buildMotionFailedWrites', () => {
+  it('records the error on both the frame and the variant', () => {
+    const writes = buildMotionFailedWrites({ error: 'fal 500' });
+    expect(writes.frame).toEqual({
+      videoStatus: 'failed',
+      videoError: 'fal 500',
+    });
+    expect(writes.variant).toEqual({ status: 'failed', error: 'fal 500' });
+  });
+});
+
+type FrameUpdateCall = { frameId: string; data: Partial<NewFrame> };
+type VariantUpdateCall = {
+  frameId: string;
+  variantType: VariantType;
+  model: string;
+  data: Partial<NewFrameVariant>;
+};
+type CallName =
+  | 'frames.update'
+  | 'frameVariants.updateByFrameAndModel'
+  | 'frameVariants.upsert';
+
+function buildScopedDbSpy(opts: { frameMissing?: boolean } = {}): {
+  scopedDb: PersistMotionScopedDb;
+  framesUpdates: FrameUpdateCall[];
+  variantsUpdates: VariantUpdateCall[];
+  variantsUpserts: NewFrameVariant[];
+  callOrder: CallName[];
+} {
+  const framesUpdates: FrameUpdateCall[] = [];
+  const variantsUpdates: VariantUpdateCall[] = [];
+  const variantsUpserts: NewFrameVariant[] = [];
+  const callOrder: CallName[] = [];
+  const scopedDb: PersistMotionScopedDb = {
+    frames: {
+      update: async (frameId, data) => {
+        framesUpdates.push({ frameId, data });
+        callOrder.push('frames.update');
+        if (opts.frameMissing) return undefined;
+        return { id: frameId };
+      },
+    },
+    frameVariants: {
+      updateByFrameAndModel: async (frameId, variantType, model, data) => {
+        variantsUpdates.push({ frameId, variantType, model, data });
+        callOrder.push('frameVariants.updateByFrameAndModel');
+        return { id: 'v1' };
+      },
+      upsert: async (data) => {
+        variantsUpserts.push(data);
+        callOrder.push('frameVariants.upsert');
+        return { id: 'v2' };
+      },
+    },
+  };
+  return {
+    scopedDb,
+    framesUpdates,
+    variantsUpdates,
+    variantsUpserts,
+    callOrder,
+  };
+}
+
+describe('persistMotionCompletion', () => {
+  it('stamps the legacy columns + this model variant, emits completed, returns the url', async () => {
+    const { scopedDb, framesUpdates, variantsUpdates, callOrder } =
+      buildScopedDbSpy();
+    const emits: Array<{ event: string; payload: MotionVideoProgressPayload }> =
+      [];
+
+    const outcome = await persistMotionCompletion({
+      scopedDb,
+      frameId: 'f1',
+      model: 'veo3',
+      upload,
+      durationMs: 5000,
+      promptHash: 'prompt-abc',
+      emit: async (event, payload) => {
+        emits.push({ event, payload });
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'completed', videoUrl: upload.url });
+    expect(callOrder).toEqual([
+      'frames.update',
+      'frameVariants.updateByFrameAndModel',
+    ]);
+
+    const [frameUpdate] = framesUpdates;
+    if (!frameUpdate) throw new Error('expected frames.update call');
+    expect(frameUpdate.data.videoStatus).toBe('completed');
+    expect(frameUpdate.data.videoUrl).toBe(upload.url);
+    expect(frameUpdate.data.videoError).toBeNull();
+
+    const [variantUpdate] = variantsUpdates;
+    if (!variantUpdate) throw new Error('expected variant update call');
+    expect(variantUpdate.frameId).toBe('f1');
+    expect(variantUpdate.variantType).toBe('video');
+    expect(variantUpdate.model).toBe('veo3');
+    expect(variantUpdate.data.status).toBe('completed');
+    expect(variantUpdate.data.url).toBe(upload.url);
+
+    expect(emits).toEqual([
+      {
+        event: 'generation.video:progress',
+        payload: {
+          frameId: 'f1',
+          status: 'completed',
+          videoUrl: upload.url,
+          model: 'veo3',
+        },
+      },
+    ]);
+  });
+
+  it('frame deleted mid-flight: short-circuits without touching frame_variants or emitting', async () => {
+    const { scopedDb, framesUpdates, variantsUpdates, callOrder } =
+      buildScopedDbSpy({ frameMissing: true });
+    const emits: MotionVideoProgressPayload[] = [];
+
+    const outcome = await persistMotionCompletion({
+      scopedDb,
+      frameId: 'f1',
+      model: 'veo3',
+      upload,
+      durationMs: 5000,
+      promptHash: null,
+      emit: async (_event, payload) => {
+        emits.push(payload);
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'frame-deleted' });
+    expect(framesUpdates.length).toBe(1);
+    expect(variantsUpdates).toEqual([]);
+    expect(emits).toEqual([]);
+    expect(callOrder).toEqual(['frames.update']);
+  });
+});
+
+describe('persistMotionFailure', () => {
+  it('records failed on the legacy columns and UPSERTS the variant (not update), then emits', async () => {
+    const {
+      scopedDb,
+      framesUpdates,
+      variantsUpdates,
+      variantsUpserts,
+      callOrder,
+    } = buildScopedDbSpy();
+    const emits: Array<{ event: string; payload: MotionVideoProgressPayload }> =
+      [];
+
+    await persistMotionFailure({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'veo3',
+      error: 'Insufficient credits for motion generation',
+      workflowRunId: 'run-9',
+      emit: async (event, payload) => {
+        emits.push({ event, payload });
+      },
+    });
+
+    // Critically: upsert, NOT updateByFrameAndModel — so a failure that
+    // happened before the generating row was written still lands a row.
+    expect(callOrder).toEqual(['frames.update', 'frameVariants.upsert']);
+    expect(variantsUpdates).toEqual([]);
+
+    const [frameUpdate] = framesUpdates;
+    if (!frameUpdate) throw new Error('expected frames.update call');
+    expect(frameUpdate.data.videoStatus).toBe('failed');
+    expect(frameUpdate.data.videoError).toBe(
+      'Insufficient credits for motion generation'
+    );
+
+    const [upserted] = variantsUpserts;
+    if (!upserted) throw new Error('expected frameVariants.upsert call');
+    expect(upserted).toMatchObject({
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      variantType: 'video',
+      model: 'veo3',
+      status: 'failed',
+      error: 'Insufficient credits for motion generation',
+      workflowRunId: 'run-9',
+    });
+
+    expect(emits).toEqual([
+      {
+        event: 'generation.video:progress',
+        payload: { frameId: 'f1', status: 'failed', model: 'veo3' },
+      },
+    ]);
+  });
+});

--- a/src/lib/workflows/motion-workflow-persist.test.ts
+++ b/src/lib/workflows/motion-workflow-persist.test.ts
@@ -7,8 +7,9 @@
  *
  *   - generating: open the variant row + stamp the legacy columns
  *   - completed:  stamp both, clearing any prior error (frame-deleted short-circuit)
- *   - failed:     record the error on both — via UPSERT so a pre-generating
- *                 failure still lands a visible `failed` variant
+ *   - failed:     record the error on both — updating the existing variant row
+ *                 (preserving a completed url), falling back to UPSERT only when
+ *                 no row exists so a pre-generating failure still lands a row
  */
 
 import { describe, expect, it } from 'vitest';
@@ -109,7 +110,9 @@ type CallName =
   | 'frameVariants.updateByFrameAndModel'
   | 'frameVariants.upsert';
 
-function buildScopedDbSpy(opts: { frameMissing?: boolean } = {}): {
+function buildScopedDbSpy(
+  opts: { frameMissing?: boolean; variantMissing?: boolean } = {}
+): {
   scopedDb: PersistMotionScopedDb;
   framesUpdates: FrameUpdateCall[];
   variantsUpdates: VariantUpdateCall[];
@@ -133,7 +136,8 @@ function buildScopedDbSpy(opts: { frameMissing?: boolean } = {}): {
       updateByFrameAndModel: async (frameId, variantType, model, data) => {
         variantsUpdates.push({ frameId, variantType, model, data });
         callOrder.push('frameVariants.updateByFrameAndModel');
-        return { id: 'v1' };
+        // null = no matching primary row exists (caller decides whether to insert).
+        return opts.variantMissing ? null : { id: 'v1' };
       },
       upsert: async (data) => {
         variantsUpserts.push(data);
@@ -231,7 +235,7 @@ describe('persistMotionCompletion', () => {
 });
 
 describe('persistMotionFailure', () => {
-  it('records failed on the legacy columns and UPSERTS the variant (not update), then emits', async () => {
+  it('updates the existing variant row to failed (preserving its url, no upsert), then emits', async () => {
     const {
       scopedDb,
       framesUpdates,
@@ -247,24 +251,66 @@ describe('persistMotionFailure', () => {
       frameId: 'f1',
       sequenceId: 'seq1',
       model: 'veo3',
-      error: 'Insufficient credits for motion generation',
+      error: 'fal 500',
       workflowRunId: 'run-9',
       emit: async (event, payload) => {
         emits.push({ event, payload });
       },
     });
 
-    // Critically: upsert, NOT updateByFrameAndModel — so a failure that
-    // happened before the generating row was written still lands a row.
-    expect(callOrder).toEqual(['frames.update', 'frameVariants.upsert']);
-    expect(variantsUpdates).toEqual([]);
+    // A row exists: update only (status/error). No upsert — a blind upsert
+    // would null the completed url/storagePath from the failure payload.
+    expect(callOrder).toEqual([
+      'frames.update',
+      'frameVariants.updateByFrameAndModel',
+    ]);
+    expect(variantsUpserts).toEqual([]);
 
     const [frameUpdate] = framesUpdates;
     if (!frameUpdate) throw new Error('expected frames.update call');
     expect(frameUpdate.data.videoStatus).toBe('failed');
-    expect(frameUpdate.data.videoError).toBe(
-      'Insufficient credits for motion generation'
-    );
+    expect(frameUpdate.data.videoError).toBe('fal 500');
+
+    const [variantUpdate] = variantsUpdates;
+    if (!variantUpdate) throw new Error('expected variant update call');
+    expect(variantUpdate.frameId).toBe('f1');
+    expect(variantUpdate.variantType).toBe('video');
+    expect(variantUpdate.model).toBe('veo3');
+    expect(variantUpdate.data).toEqual({ status: 'failed', error: 'fal 500' });
+    // The update payload carries no url/storagePath, so an existing completed
+    // artifact is left untouched.
+    expect(variantUpdate.data.url).toBeUndefined();
+    expect(variantUpdate.data.storagePath).toBeUndefined();
+
+    expect(emits).toEqual([
+      {
+        event: 'generation.video:progress',
+        payload: { frameId: 'f1', status: 'failed', model: 'veo3' },
+      },
+    ]);
+  });
+
+  it('no existing variant row (pre-generating failure): UPSERTS a failed row so it stays visible', async () => {
+    const { scopedDb, variantsUpdates, variantsUpserts, callOrder } =
+      buildScopedDbSpy({ variantMissing: true });
+
+    await persistMotionFailure({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'veo3',
+      error: 'Insufficient credits for motion generation',
+      workflowRunId: 'run-9',
+      emit: async () => {},
+    });
+
+    // Update first (no-op, returns null), then upsert to land a visible row.
+    expect(callOrder).toEqual([
+      'frames.update',
+      'frameVariants.updateByFrameAndModel',
+      'frameVariants.upsert',
+    ]);
+    expect(variantsUpdates.length).toBe(1);
 
     const [upserted] = variantsUpserts;
     if (!upserted) throw new Error('expected frameVariants.upsert call');
@@ -277,12 +323,5 @@ describe('persistMotionFailure', () => {
       error: 'Insufficient credits for motion generation',
       workflowRunId: 'run-9',
     });
-
-    expect(emits).toEqual([
-      {
-        event: 'generation.video:progress',
-        payload: { frameId: 'f1', status: 'failed', model: 'veo3' },
-      },
-    ]);
   });
 });

--- a/src/lib/workflows/motion-workflow-persist.ts
+++ b/src/lib/workflows/motion-workflow-persist.ts
@@ -1,0 +1,232 @@
+/**
+ * Dual-write builders + persist orchestration for `MotionWorkflow` (#545).
+ *
+ * Motion generation writes each model's output in two places: the legacy
+ * `frames.video*` columns (a last-write-wins default across models, kept so
+ * single-model consumers and the "Mixed" player keep working) AND a per-model
+ * `frame_variants` row (`variantType='video'`) that the scenes-view video-model
+ * switcher resolves against.
+ *
+ * Pulled out of the workflow body — mirroring `image-workflow-snapshot.ts`'s
+ * `persistImageResult` — so the generating → completed → failed state machine
+ * is testable without bootstrapping a `WorkflowEntrypoint`. The workflow keeps
+ * the `step.do` boundaries and the realtime-emit error handling; these helpers
+ * own the write shapes and call sequence.
+ */
+
+import type { NewFrame, NewFrameVariant } from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
+
+export type MotionStorageResult = { url: string; path: string };
+
+/**
+ * Minimum scopedDb surface for the persist orchestrators. Production
+ * `ScopedDb` is a structural superset and assigns cleanly; tests build literal
+ * spies against this type without casting (same pattern as
+ * `PersistImageScopedDb`).
+ */
+export type PersistMotionScopedDb = {
+  frames: {
+    update: (
+      id: string,
+      data: Partial<NewFrame>,
+      opts?: { throwOnMissing?: boolean }
+    ) => Promise<{ id: string } | undefined>;
+  };
+  frameVariants: {
+    updateByFrameAndModel: (
+      frameId: string,
+      type: VariantType,
+      model: string,
+      data: Partial<NewFrameVariant>
+    ) => Promise<{ id: string } | null>;
+    upsert: (data: NewFrameVariant) => Promise<{ id: string }>;
+  };
+};
+
+/**
+ * Payload shape for `generation.video:progress`. A subset of the realtime
+ * schema (see `src/lib/realtime/index.ts`) — assignable to the channel's
+ * emitter so the workflow can forward it directly.
+ */
+export type MotionVideoProgressPayload =
+  | { frameId: string; status: 'completed'; videoUrl: string; model: string }
+  | { frameId: string; status: 'failed'; model: string };
+
+export type MotionEmit = (
+  event: 'generation.video:progress',
+  payload: MotionVideoProgressPayload
+) => Promise<void>;
+
+type MotionWrites = {
+  frame: Partial<NewFrame>;
+  variant: Partial<NewFrameVariant>;
+};
+
+/**
+ * `set-generating-status` writes: stamp the legacy columns with the model and
+ * run id, and open this model's `frame_variants` row in `generating`.
+ */
+export function buildMotionGeneratingWrites(opts: {
+  model: string;
+  workflowRunId: string;
+}): MotionWrites {
+  return {
+    frame: {
+      videoStatus: 'generating',
+      videoWorkflowRunId: opts.workflowRunId,
+      motionModel: opts.model,
+    },
+    variant: {
+      status: 'generating',
+      workflowRunId: opts.workflowRunId,
+    },
+  };
+}
+
+/** Completed writes: stamp the final video onto both the legacy columns and
+ *  this model's variant row, clearing any prior `videoError`. */
+export function buildMotionCompletedWrites(opts: {
+  upload: MotionStorageResult;
+  durationMs: number;
+  promptHash: string | null;
+  generatedAt: Date;
+}): MotionWrites {
+  const { upload, durationMs, promptHash, generatedAt } = opts;
+  return {
+    frame: {
+      videoPath: upload.path,
+      videoUrl: upload.url,
+      durationMs,
+      videoStatus: 'completed',
+      videoGeneratedAt: generatedAt,
+      videoError: null,
+    },
+    variant: {
+      url: upload.url,
+      storagePath: upload.path,
+      status: 'completed',
+      generatedAt,
+      error: null,
+      durationMs,
+      promptHash,
+    },
+  };
+}
+
+/** Failed writes: record the error on both the legacy columns and the variant. */
+export function buildMotionFailedWrites(opts: { error: string }): MotionWrites {
+  return {
+    frame: {
+      videoStatus: 'failed',
+      videoError: opts.error,
+    },
+    variant: {
+      status: 'failed',
+      error: opts.error,
+    },
+  };
+}
+
+export type PersistMotionOutcome =
+  | { status: 'completed'; videoUrl: string }
+  | { status: 'frame-deleted' };
+
+/**
+ * Completed dual-write. Stamps the legacy `frames.video*` columns first; if the
+ * frame was deleted mid-flight (`update` returns undefined) it short-circuits
+ * without touching `frame_variants` or emitting — mirroring
+ * `persistImageResult`. Otherwise updates this model's existing (generating)
+ * variant row to `completed` and emits progress.
+ *
+ * `now` is injectable so tests can pin the `generatedAt` timestamp.
+ */
+export async function persistMotionCompletion(opts: {
+  scopedDb: PersistMotionScopedDb;
+  frameId: string;
+  model: string;
+  upload: MotionStorageResult;
+  durationMs: number;
+  promptHash: string | null;
+  emit: MotionEmit;
+  now?: () => Date;
+}): Promise<PersistMotionOutcome> {
+  const {
+    scopedDb,
+    frameId,
+    model,
+    upload,
+    durationMs,
+    promptHash,
+    emit,
+    now = () => new Date(),
+  } = opts;
+
+  const writes = buildMotionCompletedWrites({
+    upload,
+    durationMs,
+    promptHash,
+    generatedAt: now(),
+  });
+
+  const updatedFrame = await scopedDb.frames.update(frameId, writes.frame, {
+    throwOnMissing: false,
+  });
+  if (!updatedFrame) return { status: 'frame-deleted' };
+
+  await scopedDb.frameVariants.updateByFrameAndModel(
+    frameId,
+    'video',
+    model,
+    writes.variant
+  );
+
+  await emit('generation.video:progress', {
+    frameId,
+    status: 'completed',
+    videoUrl: upload.url,
+    model,
+  });
+
+  return { status: 'completed', videoUrl: upload.url };
+}
+
+/**
+ * Failure dual-write (called from the workflow's `onFailure`). Records `failed`
+ * on the legacy columns and on this model's variant row, then emits.
+ *
+ * Uses `upsert` (not `updateByFrameAndModel`) so a `failed` row is recorded
+ * even when the failure happened before `set-generating-status` ran (e.g. an
+ * insufficient-credit throw in `check-credits`, or the top-level imageUrl
+ * guard) — at that point no generating row exists yet, and a bare update would
+ * no-op, leaving this model's variant invisible in the scenes-view switcher.
+ */
+export async function persistMotionFailure(opts: {
+  scopedDb: PersistMotionScopedDb;
+  frameId: string;
+  sequenceId: string;
+  model: string;
+  error: string;
+  workflowRunId: string;
+  emit: MotionEmit;
+}): Promise<void> {
+  const { scopedDb, frameId, sequenceId, model, error, workflowRunId, emit } =
+    opts;
+
+  const writes = buildMotionFailedWrites({ error });
+
+  await scopedDb.frames.update(frameId, writes.frame, {
+    throwOnMissing: false,
+  });
+
+  await scopedDb.frameVariants.upsert({
+    frameId,
+    sequenceId,
+    variantType: 'video',
+    model,
+    workflowRunId,
+    ...writes.variant,
+  });
+
+  await emit('generation.video:progress', { frameId, status: 'failed', model });
+}

--- a/src/lib/workflows/motion-workflow-persist.ts
+++ b/src/lib/workflows/motion-workflow-persist.ts
@@ -195,11 +195,15 @@ export async function persistMotionCompletion(opts: {
  * Failure dual-write (called from the workflow's `onFailure`). Records `failed`
  * on the legacy columns and on this model's variant row, then emits.
  *
- * Uses `upsert` (not `updateByFrameAndModel`) so a `failed` row is recorded
- * even when the failure happened before `set-generating-status` ran (e.g. an
+ * Flips an *existing* variant row to `failed` via `updateByFrameAndModel` —
+ * which only touches `status`/`error`, so a previously-completed `url`/
+ * `storagePath` is preserved (a re-run that fails before producing a new video
+ * must not erase the last good one). Falls back to `upsert` only when no row
+ * exists yet — e.g. a failure before `set-generating-status` ran (an
  * insufficient-credit throw in `check-credits`, or the top-level imageUrl
- * guard) — at that point no generating row exists yet, and a bare update would
- * no-op, leaving this model's variant invisible in the scenes-view switcher.
+ * guard) — so the `failed` state is still visible in the scenes-view switcher.
+ * (A blind `upsert` would set `url`/`storagePath` from the failure payload,
+ * i.e. NULL, silently dropping the completed artifact.)
  */
 export async function persistMotionFailure(opts: {
   scopedDb: PersistMotionScopedDb;
@@ -219,14 +223,22 @@ export async function persistMotionFailure(opts: {
     throwOnMissing: false,
   });
 
-  await scopedDb.frameVariants.upsert({
+  const updated = await scopedDb.frameVariants.updateByFrameAndModel(
     frameId,
-    sequenceId,
-    variantType: 'video',
+    'video',
     model,
-    workflowRunId,
-    ...writes.variant,
-  });
+    writes.variant
+  );
+  if (!updated) {
+    await scopedDb.frameVariants.upsert({
+      frameId,
+      sequenceId,
+      variantType: 'video',
+      model,
+      workflowRunId,
+      ...writes.variant,
+    });
+  }
 
   await emit('generation.video:progress', { frameId, status: 'failed', model });
 }

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -30,6 +30,7 @@ import {
 import { uploadVideoToStorage } from '@/lib/motion/video-storage';
 import { endSpanSuccess, startGenAISpan } from '@/lib/observability/tracer';
 import { getGenerationChannel } from '@/lib/realtime';
+import { simpleHash } from '@/lib/utils/hash';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type { MotionWorkflowInput } from '@/lib/workflow/types';
@@ -194,10 +195,26 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           });
         }
 
+        // Dual-write: stamp a `generating` frame_variants row for this model so
+        // the scenes-view video-model switcher (#545) shows it in flight. The
+        // legacy `frames.video*` columns above are a last-write-wins default
+        // across models (matching the image template — whichever model child
+        // finishes last lands there); per-model output lives in frame_variants.
+        if (input.sequenceId) {
+          await scopedDb.frameVariants.upsert({
+            frameId: input.frameId,
+            sequenceId: input.sequenceId,
+            variantType: 'video',
+            model,
+            status: 'generating',
+            workflowRunId,
+          });
+        }
+
         try {
           await getGenerationChannel(input.sequenceId).emit(
             'generation.video:progress',
-            { frameId: input.frameId, status: 'generating' }
+            { frameId: input.frameId, status: 'generating', model }
           );
         } catch (emitError) {
           logger.error(
@@ -429,10 +446,28 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           return;
         }
 
+        // Dual-write the completed video into this model's frame_variants row.
+        if (input.sequenceId) {
+          await scopedDb.frameVariants.updateByFrameAndModel(
+            frameId,
+            'video',
+            model,
+            {
+              url: storageResult.url,
+              storagePath: storageResult.path,
+              status: 'completed',
+              generatedAt: new Date(),
+              error: null,
+              durationMs: duration * 1000,
+              promptHash: input.prompt ? simpleHash(input.prompt) : null,
+            }
+          );
+        }
+
         try {
           await getGenerationChannel(input.sequenceId).emit(
             'generation.video:progress',
-            { frameId, status: 'completed', videoUrl: storageResult.url }
+            { frameId, status: 'completed', videoUrl: storageResult.url, model }
           );
         } catch (emitError) {
           logger.error(
@@ -459,6 +494,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     scopedDb: ScopedDb;
   }): Promise<void> {
     const input = event.payload;
+    const model = input.model || DEFAULT_VIDEO_MODEL;
 
     if (input.frameId && input.teamId) {
       await scopedDb.frames.update(
@@ -472,10 +508,25 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     }
 
     if (input.sequenceId && input.frameId) {
+      // Upsert (not update) so a `failed` row is recorded even when the failure
+      // happened before `set-generating-status` ran (e.g. an insufficient-credit
+      // throw in `check-credits`, or the top-level imageUrl guard) — at that
+      // point no generating row exists yet, and a bare update would no-op,
+      // leaving this model's variant invisible in the scenes-view switcher.
+      await scopedDb.frameVariants.upsert({
+        frameId: input.frameId,
+        sequenceId: input.sequenceId,
+        variantType: 'video',
+        model,
+        status: 'failed',
+        error,
+        workflowRunId: event.instanceId,
+      });
+
       try {
         await getGenerationChannel(input.sequenceId).emit(
           'generation.video:progress',
-          { frameId: input.frameId, status: 'failed' }
+          { frameId: input.frameId, status: 'failed', model }
         );
       } catch (emitError) {
         logger.error(

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -99,6 +99,18 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
       );
     }
 
+    // Motion's dual-write (#545) opens this model's `frame_variants` row in
+    // `set-generating-status` and closes it in completion/`onFailure`, all of
+    // which need `sequenceId`. Every trigger sets both ids; assert it once here
+    // so a `sequenceId`-less caller fails loudly at the boundary rather than
+    // silently writing the legacy columns while skipping the variant half
+    // (which would leave the model invisible in the scenes-view switcher).
+    if (input.frameId && !input.sequenceId) {
+      throw new WorkflowValidationError(
+        'sequenceId is required when frameId is set (motion dual-write)'
+      );
+    }
+
     // Step 0: Get cost and check if team has enough credits
     const { cost, duration } = await step.do('check-credits', async () => {
       const { cost, duration } = calculateMotionMetadata({

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -34,6 +34,11 @@ import { simpleHash } from '@/lib/utils/hash';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type { MotionWorkflowInput } from '@/lib/workflow/types';
+import {
+  buildMotionGeneratingWrites,
+  persistMotionCompletion,
+  persistMotionFailure,
+} from '@/lib/workflows/motion-workflow-persist';
 import { shouldRecordUserEdit } from '@/lib/workflows/user-edit-predicate';
 import { NonRetryableError } from 'cloudflare:workflows';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
@@ -129,13 +134,14 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
       async () => {
         if (!input.frameId) return { frameDeleted: false };
 
+        const generatingWrites = buildMotionGeneratingWrites({
+          model,
+          workflowRunId,
+        });
+
         const frame = await scopedDb.frames.update(
           input.frameId,
-          {
-            videoStatus: 'generating',
-            videoWorkflowRunId: workflowRunId,
-            motionModel: model,
-          },
+          generatingWrites.frame,
           { throwOnMissing: false }
         );
 
@@ -206,8 +212,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
             sequenceId: input.sequenceId,
             variantType: 'video',
             model,
-            status: 'generating',
-            workflowRunId,
+            ...generatingWrites.variant,
           });
         }
 
@@ -424,57 +429,32 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
 
       videoUrl = storageResult.url;
 
-      // Step 5: Update frame with video path, URL, and status
+      // Step 5: Update frame with video path, URL, and status — dual-writing
+      // the completed video onto the legacy columns AND this model's
+      // frame_variants row (see motion-workflow-persist).
       await step.do('update-frame', async () => {
-        const updatedFrame = await scopedDb.frames.update(
+        const outcome = await persistMotionCompletion({
+          scopedDb,
           frameId,
-          {
-            videoPath: storageResult.path,
-            videoUrl: storageResult.url,
-            durationMs: duration * 1000,
-            videoStatus: 'completed',
-            videoGeneratedAt: new Date(),
-            videoError: null,
+          model,
+          upload: { url: storageResult.url, path: storageResult.path },
+          durationMs: duration * 1000,
+          promptHash: input.prompt ? simpleHash(input.prompt) : null,
+          emit: async (event, payload) => {
+            try {
+              await getGenerationChannel(input.sequenceId).emit(event, payload);
+            } catch (emitError) {
+              logger.error(
+                `[MotionWorkflow:cf] Failed to emit generation.video:progress for frame ${frameId}:`,
+                { err: emitError }
+              );
+            }
           },
-          { throwOnMissing: false }
-        );
+        });
 
-        if (!updatedFrame) {
+        if (outcome.status === 'frame-deleted') {
           logger.info(
             `[MotionWorkflow:cf] Frame ${frameId} was deleted, skipping final update`
-          );
-          return;
-        }
-
-        // Dual-write the completed video into this model's frame_variants row.
-        if (input.sequenceId) {
-          await scopedDb.frameVariants.updateByFrameAndModel(
-            frameId,
-            'video',
-            model,
-            {
-              url: storageResult.url,
-              storagePath: storageResult.path,
-              status: 'completed',
-              generatedAt: new Date(),
-              error: null,
-              durationMs: duration * 1000,
-              promptHash: input.prompt ? simpleHash(input.prompt) : null,
-            }
-          );
-        }
-
-        try {
-          await getGenerationChannel(input.sequenceId).emit(
-            'generation.video:progress',
-            { frameId, status: 'completed', videoUrl: storageResult.url, model }
-          );
-        } catch (emitError) {
-          logger.error(
-            `[MotionWorkflow:cf] Failed to emit generation.video:progress for frame ${frameId}:`,
-            {
-              err: emitError,
-            }
           );
         }
       });
@@ -496,46 +476,28 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     const input = event.payload;
     const model = input.model || DEFAULT_VIDEO_MODEL;
 
-    if (input.frameId && input.teamId) {
-      await scopedDb.frames.update(
-        input.frameId,
-        {
-          videoStatus: 'failed',
-          videoError: error,
-        },
-        { throwOnMissing: false }
-      );
-    }
-
-    if (input.sequenceId && input.frameId) {
-      // Upsert (not update) so a `failed` row is recorded even when the failure
-      // happened before `set-generating-status` ran (e.g. an insufficient-credit
-      // throw in `check-credits`, or the top-level imageUrl guard) — at that
-      // point no generating row exists yet, and a bare update would no-op,
-      // leaving this model's variant invisible in the scenes-view switcher.
-      await scopedDb.frameVariants.upsert({
-        frameId: input.frameId,
-        sequenceId: input.sequenceId,
-        variantType: 'video',
+    // Motion is always sequence-scoped (every trigger sets both ids), and the
+    // dual-write needs sequenceId for the frame_variants row — so gate on both.
+    if (input.frameId && input.sequenceId) {
+      const { frameId, sequenceId } = input;
+      await persistMotionFailure({
+        scopedDb,
+        frameId,
+        sequenceId,
         model,
-        status: 'failed',
         error,
         workflowRunId: event.instanceId,
-      });
-
-      try {
-        await getGenerationChannel(input.sequenceId).emit(
-          'generation.video:progress',
-          { frameId: input.frameId, status: 'failed', model }
-        );
-      } catch (emitError) {
-        logger.error(
-          `[MotionWorkflow:cf] Failed to emit generation.video:progress for frame ${input.frameId}:`,
-          {
-            err: emitError,
+        emit: async (event2, payload) => {
+          try {
+            await getGenerationChannel(sequenceId).emit(event2, payload);
+          } catch (emitError) {
+            logger.error(
+              `[MotionWorkflow:cf] Failed to emit generation.video:progress for frame ${frameId}:`,
+              { err: emitError }
+            );
           }
-        );
-      }
+        },
+      });
     }
 
     logger.error(

--- a/src/lib/workflows/storyboard-workflow.ts
+++ b/src/lib/workflows/storyboard-workflow.ts
@@ -192,6 +192,7 @@ export class StoryboardWorkflow extends OpenStoryWorkflowEntrypoint<StoryboardWo
         imageModel,
         imageModels: input.imageModels ?? [imageModel],
         videoModel,
+        videoModels: input.videoModels ?? [videoModel],
         autoGenerateMotion: input.autoGenerateMotion ?? false,
         autoGenerateMusic: input.autoGenerateMusic ?? false,
         musicModel: input.musicModel,

--- a/src/routes/_protected/sequences/$id/route.tsx
+++ b/src/routes/_protected/sequences/$id/route.tsx
@@ -3,8 +3,8 @@ import {
   ImageModelBadge,
   ModelBadge,
   MusicModelBadge,
-  VideoModelBadge,
 } from '@/components/model/model-badge';
+import { SequenceVideoModelSelector } from '@/components/model/sequence-video-model-selector';
 import { getSequenceImageModelsFn } from '@/functions/frames';
 import { frameKeys } from '@/hooks/use-frames';
 import { routeParams } from '@/components/layout/breadcrumbs';
@@ -94,7 +94,10 @@ function SequenceLayout() {
               models={imageModels}
               model={sequence?.imageModel}
             />
-            <VideoModelBadge model={sequence?.videoModel} />
+            <SequenceVideoModelSelector
+              sequenceId={sequenceId}
+              sequenceVideoModel={sequence?.videoModel}
+            />
             <MusicModelBadge model={sequence?.musicModel ?? undefined} />
           </div>
         </PageHeader>


### PR DESCRIPTION
Closes #545

Phase 2 of the multi-model variant system (#542 was Phase 1 / images). Users select multiple video models; each produces its own video per frame, stored as `frame_variants` (`variantType='video'`).

## Workflows
- `motion-workflow` dual-writes the legacy `frames.video*` columns **and** a `frame_variants` row (generating/completed/failed); `onFailure` upserts so a failed row is recorded even on an early throw.
- `motion-batch` fans out one child per `(frame, model)` — the motion analog of `frame-images` — with the model token in `childId` and per-model prompt assembly.
- `videoModels[]` threads `createSequence → storyboard → analyze-script → motion-batch`.

## Creation / viewing / realtime
- `MotionModelMultiSelector` (keeps aspect-ratio filtering); `videoModelCount` in cost estimation.
- `useActiveVideoModel` + header `SequenceVideoModelSelector` dropdown ("Mixed" state); scenes-view resolves player videos through the active model's variants.
- `video:progress` carries `model`; model-aware cache invalidation.

Reviewed by an adversarial multi-agent pass; confirmed findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)