### PR TITLE
feat(music): multi-select audio models with sequence variants (#546)

### DIFF
--- a/src/components/model/model-badge.tsx
+++ b/src/components/model/model-badge.tsx
@@ -1,11 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  AUDIO_MODELS,
-  IMAGE_MODELS,
-  isValidAudioModel,
-  isValidTextToImageModel,
-} from '@/lib/ai/models';
+import { IMAGE_MODELS, isValidTextToImageModel } from '@/lib/ai/models';
 import { getAnalysisModelById } from '@/lib/ai/models.config';
 
 export const ModelBadge = ({ model }: { model?: string }) => {
@@ -65,21 +60,6 @@ export const ImageModelBadge = ({
   return (
     <Badge variant="secondary" className="text-xs">
       {formatImageModels(allModels)}
-    </Badge>
-  );
-};
-
-export const MusicModelBadge = ({ model }: { model?: string }) => {
-  if (!model) {
-    return <Skeleton className="w-[100px] h-[20px]" />;
-  }
-
-  const modelConfig = isValidAudioModel(model)
-    ? AUDIO_MODELS[model]
-    : undefined;
-  return (
-    <Badge variant="secondary" className="text-xs">
-      {modelConfig?.name || model}
     </Badge>
   );
 };

--- a/src/components/model/music-model-selector.tsx
+++ b/src/components/model/music-model-selector.tsx
@@ -8,18 +8,9 @@ import { useMemo } from 'react';
 
 const GROUP_ORDER = ['all'] as const;
 
-type MusicModelSelectorProps = {
-  selectedModel: AudioModel;
-  onModelChange: (model: AudioModel) => void;
-  disabled?: boolean;
-};
-
-export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
-  selectedModel,
-  onModelChange,
-  disabled = false,
-}) => {
-  const models = useMemo(
+// Shared option list — only music models (not SFX), sorted by quality.
+function useMusicModels() {
+  return useMemo(
     () =>
       Object.entries(AUDIO_MODELS)
         .filter(([key, m]) => {
@@ -38,6 +29,20 @@ export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
         })),
     []
   );
+}
+
+type MusicModelSelectorProps = {
+  selectedModel: AudioModel;
+  onModelChange: (model: AudioModel) => void;
+  disabled?: boolean;
+};
+
+export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
+  selectedModel,
+  onModelChange,
+  disabled = false,
+}) => {
+  const models = useMusicModels();
 
   return (
     <BaseModelSelector
@@ -53,6 +58,35 @@ export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
       }}
       disabled={disabled}
       multiSelect={false}
+    />
+  );
+};
+
+type MusicModelMultiSelectorProps = {
+  selectedModels: AudioModel[];
+  onModelsChange: (models: AudioModel[]) => void;
+  disabled?: boolean;
+};
+
+export const MusicModelMultiSelector: React.FC<
+  MusicModelMultiSelectorProps
+> = ({ selectedModels, onModelsChange, disabled = false }) => {
+  const models = useMusicModels();
+
+  return (
+    <BaseModelSelector
+      label="Music Models"
+      models={models}
+      groupOrder={GROUP_ORDER}
+      selectedIds={selectedModels}
+      onSelectionChange={(ids) => {
+        const validIds = ids.filter(isValidAudioModel);
+        if (validIds.length > 0) {
+          onModelsChange(validIds);
+        }
+      }}
+      disabled={disabled}
+      multiSelect={true}
     />
   );
 };

--- a/src/components/model/sequence-audio-model-selector.tsx
+++ b/src/components/model/sequence-audio-model-selector.tsx
@@ -1,0 +1,91 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
+import { useSequenceAudioModels } from '@/hooks/use-sequences';
+import { AUDIO_MODELS, isValidAudioModel } from '@/lib/ai/models';
+import { ChevronDown } from 'lucide-react';
+
+function audioModelName(model: string): string {
+  return isValidAudioModel(model) ? AUDIO_MODELS[model].name : model;
+}
+
+/**
+ * Top-level audio-model switcher for the sequence header (#546). Replaces the
+ * old read-only music chip once any music variants exist: lists the distinct
+ * models that have generated a track for this sequence (derived from
+ * sequence_music_variants) and lets the viewer pick which model's track plays.
+ * Viewer-local (localStorage via useActiveAudioModel). "Mixed" is shown when
+ * more than one model has output and no specific one is pinned.
+ */
+export const SequenceAudioModelSelector = ({
+  sequenceId,
+  sequenceMusicModel,
+}: {
+  sequenceId: string;
+  sequenceMusicModel?: string | null;
+}) => {
+  const { data: models } = useSequenceAudioModels(sequenceId);
+  const { activeAudioModel, selectAudioModel } =
+    useActiveAudioModel(sequenceId);
+
+  if (!models || models.length === 0) {
+    if (!sequenceMusicModel) return null;
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {audioModelName(sequenceMusicModel)}
+      </Badge>
+    );
+  }
+
+  const firstModel = models[0];
+  const label = activeAudioModel
+    ? audioModelName(activeAudioModel)
+    : models.length === 1 && firstModel
+      ? audioModelName(firstModel)
+      : 'Mixed';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" aria-label="Select audio model">
+          <Badge variant="secondary" className="text-xs cursor-pointer gap-1">
+            {label}
+            <ChevronDown className="size-3" />
+          </Badge>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[200px]">
+        <DropdownMenuLabel className="text-xs">Audio model</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {models.length > 1 && (
+          <DropdownMenuCheckboxItem
+            checked={activeAudioModel === null}
+            onCheckedChange={() => selectAudioModel(null)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            Mixed (primary)
+          </DropdownMenuCheckboxItem>
+        )}
+        {models.filter(isValidAudioModel).map((model) => (
+          <DropdownMenuCheckboxItem
+            key={model}
+            checked={activeAudioModel === model}
+            onCheckedChange={() => selectAudioModel(model)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            {audioModelName(model)}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -138,7 +138,7 @@ export const ScriptView: FC<{
     imageModels: TextToImageModel[];
     videoModels: ImageToVideoModel[];
     autoGenerateMotion: boolean;
-    musicModel: AudioModel;
+    audioModels: AudioModel[];
     autoGenerateMusic: boolean;
   }>(() => ({
     analysisModels: sequenceAnalysisModels,
@@ -152,10 +152,10 @@ export const ScriptView: FC<{
         ? [safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL)]
         : savedSettings.videoModels,
     autoGenerateMotion: isEditing ? false : savedSettings.autoGenerateMotion,
-    musicModel:
+    audioModels:
       isEditing && sequence.musicModel
-        ? safeAudioModel(sequence.musicModel, DEFAULT_MUSIC_MODEL)
-        : savedSettings.musicModel,
+        ? [safeAudioModel(sequence.musicModel, DEFAULT_MUSIC_MODEL)]
+        : savedSettings.audioModels,
     autoGenerateMusic: isEditing ? false : savedSettings.autoGenerateMusic,
   }));
   const {
@@ -164,7 +164,7 @@ export const ScriptView: FC<{
     imageModels,
     videoModels,
     autoGenerateMotion,
-    musicModel,
+    audioModels,
     autoGenerateMusic,
   } = genSettings;
   const updateGen = <K extends keyof typeof genSettings>(
@@ -302,7 +302,7 @@ export const ScriptView: FC<{
         imageModels: savedSettings.imageModels,
         videoModels: savedSettings.videoModels,
         autoGenerateMotion: savedSettings.autoGenerateMotion,
-        musicModel: savedSettings.musicModel,
+        audioModels: savedSettings.audioModels,
         autoGenerateMusic: savedSettings.autoGenerateMusic,
       });
       hasSyncedRef.current = true;
@@ -497,6 +497,7 @@ export const ScriptView: FC<{
       aspect_ratio: aspectRatio,
       image_models: imageModels,
       video_models: videoModels,
+      audio_models: audioModels,
       auto_generate_motion: autoGenerateMotion,
       auto_generate_music: autoGenerateMusic,
       analysis_model_count: analysisModels.length,
@@ -515,7 +516,8 @@ export const ScriptView: FC<{
         videoModel: videoModels[0] ?? DEFAULT_VIDEO_MODEL,
         autoGenerateMotion,
         autoGenerateMusic,
-        musicModel,
+        musicModel: audioModels[0] ?? DEFAULT_MUSIC_MODEL,
+        audioModels,
         suggestedTalentIds:
           selectedTalentIds.length > 0 ? selectedTalentIds : undefined,
         suggestedLocationIds:
@@ -697,7 +699,7 @@ export const ScriptView: FC<{
             imageModels={imageModels}
             videoModels={videoModels}
             autoGenerateMotion={autoGenerateMotion}
-            musicModel={musicModel}
+            audioModels={audioModels}
             autoGenerateMusic={autoGenerateMusic}
             onAspectRatioChange={(v) => updateGen('aspectRatio', v)}
             onAnalysisModelsChange={(v) => updateGen('analysisModels', v)}
@@ -706,7 +708,7 @@ export const ScriptView: FC<{
             onAutoGenerateMotionChange={(v) =>
               updateGen('autoGenerateMotion', v)
             }
-            onMusicModelChange={(v) => updateGen('musicModel', v)}
+            onAudioModelsChange={(v) => updateGen('audioModels', v)}
             onAutoGenerateMusicChange={(v) => updateGen('autoGenerateMusic', v)}
             disabled={loading}
             styleCategory={styleCategory}

--- a/src/components/settings/generation-settings.tsx
+++ b/src/components/settings/generation-settings.tsx
@@ -7,7 +7,10 @@ import {
   MotionModelMultiSelector,
   MotionModelSelector,
 } from '@/components/model/motion-model-selector';
-import { MusicModelSelector } from '@/components/model/music-model-selector';
+import {
+  MusicModelMultiSelector,
+  MusicModelSelector,
+} from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -18,6 +21,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import {
   DEFAULT_IMAGE_MODEL,
+  DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
   type AudioModel,
   type ImageToVideoModel,
@@ -65,14 +69,14 @@ type GenerationSettingsProps = {
   imageModels: TextToImageModel[];
   videoModels: ImageToVideoModel[];
   autoGenerateMotion?: boolean;
-  musicModel?: AudioModel;
+  audioModels?: AudioModel[];
   autoGenerateMusic?: boolean;
   onAspectRatioChange: (value: AspectRatio) => void;
   onAnalysisModelsChange: (value: AnalysisModelId[]) => void;
   onImageModelsChange: (value: TextToImageModel[]) => void;
   onVideoModelsChange: (value: ImageToVideoModel[]) => void;
   onAutoGenerateMotionChange?: (value: boolean) => void;
-  onMusicModelChange?: (value: AudioModel) => void;
+  onAudioModelsChange?: (value: AudioModel[]) => void;
   onAutoGenerateMusicChange?: (value: boolean) => void;
   disabled?: boolean;
   singleSelectAnalysis?: boolean;
@@ -80,6 +84,8 @@ type GenerationSettingsProps = {
   singleSelectImage?: boolean;
   /** Use single-select for motion model (e.g. in regeneration context) */
   singleSelectMotion?: boolean;
+  /** Use single-select for music model (e.g. in regeneration context) */
+  singleSelectMusic?: boolean;
   /** Current style category, used to show/hide style-restricted motion models */
   styleCategory?: string;
   /** Current style name, used in recommendation tooltips */
@@ -105,19 +111,20 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
   imageModels,
   videoModels,
   autoGenerateMotion = false,
-  musicModel,
+  audioModels,
   autoGenerateMusic = false,
   onAspectRatioChange,
   onAnalysisModelsChange,
   onImageModelsChange,
   onVideoModelsChange,
   onAutoGenerateMotionChange,
-  onMusicModelChange,
+  onAudioModelsChange,
   onAutoGenerateMusicChange,
   disabled = false,
   singleSelectAnalysis = false,
   singleSelectImage = false,
   singleSelectMotion = false,
+  singleSelectMusic = false,
   styleCategory,
   styleName,
   recommendedImageModel,
@@ -252,13 +259,15 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
             )}
           </section>
 
-          {onAutoGenerateMusicChange && onMusicModelChange && musicModel && (
+          {onAutoGenerateMusicChange && onAudioModelsChange && audioModels && (
             <>
               <Separator />
 
               {/* Music Model Section */}
               <section className="flex flex-col gap-2">
-                <h3 className="text-sm font-medium text-foreground">Music</h3>
+                <h3 className="text-sm font-medium text-foreground">
+                  Music Model{!singleSelectMusic && 's'}
+                </h3>
                 <AutoToggle
                   id="auto-generate-music"
                   label="Auto-generate music"
@@ -266,11 +275,19 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
                   onChange={onAutoGenerateMusicChange}
                   disabled={disabled}
                 />
-                <MusicModelSelector
-                  selectedModel={musicModel}
-                  onModelChange={onMusicModelChange}
-                  disabled={disabled || !autoGenerateMusic}
-                />
+                {singleSelectMusic ? (
+                  <MusicModelSelector
+                    selectedModel={audioModels[0] ?? DEFAULT_MUSIC_MODEL}
+                    onModelChange={(model) => onAudioModelsChange([model])}
+                    disabled={disabled || !autoGenerateMusic}
+                  />
+                ) : (
+                  <MusicModelMultiSelector
+                    selectedModels={audioModels}
+                    onModelsChange={onAudioModelsChange}
+                    disabled={disabled || !autoGenerateMusic}
+                  />
+                )}
               </section>
             </>
           )}

--- a/src/functions/sequence-variants.ts
+++ b/src/functions/sequence-variants.ts
@@ -102,6 +102,7 @@ export const promoteSequenceMusicVariantFn = createServerFn({ method: 'POST' })
         'generation.audio:progress',
         {
           status: 'completed',
+          model: variant.model,
           ...(updatedSequence.musicUrl
             ? { audioUrl: updatedSequence.musicUrl }
             : {}),

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
   isValidAudioModel,
+  safeAudioModel,
   safeImageToVideoModel,
   safeTextToImageModel,
 } from '@/lib/ai/models';
@@ -10,6 +11,7 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
+import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import { requireTeamMemberAccess } from '@/lib/auth/action-utils';
@@ -75,6 +77,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
       autoGenerateMotion = false,
       autoGenerateMusic = true,
       musicModel,
+      audioModels: audioModelsInput,
       suggestedTalentIds,
       suggestedLocationIds,
       elementUploads,
@@ -121,6 +124,23 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
       );
     }
 
+    // Validate and resolve audio models (sequence-level, mirrors the pattern).
+    const validatedAudioModels = audioModelsInput?.map((m) =>
+      safeAudioModel(m, DEFAULT_MUSIC_MODEL)
+    );
+    const audioModels = resolveAudioModels(
+      validatedAudioModels,
+      musicModel && isValidAudioModel(musicModel)
+        ? safeAudioModel(musicModel, DEFAULT_MUSIC_MODEL)
+        : undefined
+    );
+    const [primaryAudioModel] = audioModels;
+    if (!primaryAudioModel) {
+      throw new Error(
+        'Expected resolveAudioModels to return at least one model'
+      );
+    }
+
     if (!styleId || !aspectRatio) {
       throw new Error('Style ID and aspect ratio are required');
     }
@@ -134,6 +154,11 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         autoGenerateMotion,
         videoModel: primaryVideoModel,
         videoModelCount: videoModels.length,
+        // Music only actually generates when motion is also on (it spawns from
+        // inside motion-batch), so don't charge for music tracks that won't run.
+        autoGenerateMusic: autoGenerateMotion && autoGenerateMusic,
+        audioModel: primaryAudioModel,
+        audioModelCount: audioModels.length,
       }),
       {
         providers: ['fal', 'openrouter'],
@@ -147,12 +172,9 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         // into auto-generation. Otherwise the sequence ends up with a "ghost"
         // model preference the user never picked, which surfaces stale values
         // in the header chip and batch footer. Tracked in #714.
-        const persistedMusicModel =
-          autoGenerateMusic && musicModel && isValidAudioModel(musicModel)
-            ? musicModel
-            : autoGenerateMusic
-              ? DEFAULT_MUSIC_MODEL
-              : undefined;
+        const persistedMusicModel = autoGenerateMusic
+          ? primaryAudioModel
+          : undefined;
 
         const sequence = await context.scopedDb.sequences.create({
           title: data.title || 'Untitled Sequence',
@@ -216,10 +238,8 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
           },
           autoGenerateMotion,
           autoGenerateMusic,
-          musicModel:
-            musicModel && isValidAudioModel(musicModel)
-              ? musicModel
-              : undefined,
+          musicModel: autoGenerateMusic ? primaryAudioModel : undefined,
+          audioModels: autoGenerateMusic ? audioModels : undefined,
           suggestedTalentIds,
           suggestedLocationIds,
         };
@@ -442,6 +462,27 @@ export function buildSceneSummaries(frames: Frame[]): MusicSceneSummary[] {
  * Trigger sequence-level music generation.
  * Uses pre-generated prompt/tags when available, otherwise builds from frame audio specs.
  */
+/**
+ * Distinct audio models that have generated a track for this sequence (#546).
+ * Drives the header audio-model dropdown.
+ */
+export const getSequenceAudioModelsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.sequenceVariants.listMusicModels(
+      context.sequence.id
+    );
+  });
+
+/** All music variant rows for a sequence (#546). */
+export const getSequenceAudioVariantsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.sequenceVariants.listMusicBySequence(
+      context.sequence.id
+    );
+  });
+
 export const generateMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
   .inputValidator(

--- a/src/hooks/use-active-audio-model.ts
+++ b/src/hooks/use-active-audio-model.ts
@@ -1,0 +1,108 @@
+import { isValidAudioModel, type AudioModel } from '@/lib/ai/models';
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'ui', 'use-active-audio-model']);
+
+/**
+ * Viewer-local "active audio model" selection for a sequence (#546).
+ *
+ * Audio is generated per-sequence (one track per model in
+ * `sequence_music_variants`); which model's track the music tab plays is a
+ * per-viewer preference, stored in localStorage keyed by sequence. Same
+ * module-store + `useSyncExternalStore` pattern as {@link useActiveVideoModel}
+ * so the header dropdown and the music tab stay in sync within the tab and
+ * across tabs. `null` means "no explicit pick" — fall back to the live
+ * `sequences.music*` primary.
+ */
+
+const KEY_PREFIX = 'openstory:active-audio-model:';
+const storageKey = (sequenceId: string) => `${KEY_PREFIX}${sequenceId}`;
+
+const store = new Map<string, AudioModel | null | undefined>();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+let storageListenerAttached = false;
+function ensureStorageListener() {
+  if (storageListenerAttached || typeof window === 'undefined') return;
+  storageListenerAttached = true;
+  window.addEventListener('storage', (event) => {
+    if (!event.key || !event.key.startsWith(KEY_PREFIX)) return;
+    const sequenceId = event.key.slice(KEY_PREFIX.length);
+    const next =
+      event.newValue && isValidAudioModel(event.newValue)
+        ? event.newValue
+        : null;
+    store.set(sequenceId, next);
+    emit();
+  });
+}
+
+function subscribe(listener: () => void) {
+  ensureStorageListener();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function hydrate(sequenceId: string): AudioModel | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(storageKey(sequenceId));
+    if (raw && isValidAudioModel(raw)) return raw;
+  } catch (error) {
+    logger.warn('Failed to read active audio model from localStorage', {
+      err: error,
+    });
+  }
+  return null;
+}
+
+function read(sequenceId: string): AudioModel | null {
+  const cached = store.get(sequenceId);
+  if (cached !== undefined) return cached;
+  const hydrated = hydrate(sequenceId);
+  store.set(sequenceId, hydrated);
+  return hydrated;
+}
+
+function write(sequenceId: string, model: AudioModel | null) {
+  store.set(sequenceId, model);
+  if (typeof window !== 'undefined') {
+    try {
+      if (model) {
+        localStorage.setItem(storageKey(sequenceId), model);
+      } else {
+        localStorage.removeItem(storageKey(sequenceId));
+      }
+    } catch (error) {
+      logger.warn('Failed to persist active audio model to localStorage', {
+        err: error,
+      });
+    }
+  }
+  emit();
+}
+
+export function useActiveAudioModel(sequenceId: string) {
+  const activeAudioModel = useSyncExternalStore(
+    subscribe,
+    () => read(sequenceId),
+    () => null
+  );
+
+  const selectAudioModel = useCallback(
+    (model: AudioModel | null) => {
+      write(sequenceId, model);
+    },
+    [sequenceId]
+  );
+
+  return { activeAudioModel, selectAudioModel };
+}

--- a/src/hooks/use-generation-settings.ts
+++ b/src/hooks/use-generation-settings.ts
@@ -36,6 +36,7 @@ type GenerationSettings = {
   videoModels: ImageToVideoModel[];
   autoGenerateMotion: boolean;
   musicModel: AudioModel;
+  audioModels: AudioModel[];
   autoGenerateMusic: boolean;
 };
 
@@ -48,6 +49,7 @@ const DEFAULT_SETTINGS: GenerationSettings = {
   videoModels: [DEFAULT_VIDEO_MODEL],
   autoGenerateMotion: false,
   musicModel: DEFAULT_MUSIC_MODEL,
+  audioModels: [DEFAULT_MUSIC_MODEL],
   autoGenerateMusic: false,
 };
 
@@ -158,6 +160,15 @@ function loadSettings(): GenerationSettings {
         ? parsed.musicModel
         : DEFAULT_MUSIC_MODEL;
 
+    // Load audioModels array, falling back to [musicModel] for backward compat.
+    const audioModels =
+      'audioModels' in parsed &&
+      Array.isArray(parsed.audioModels) &&
+      parsed.audioModels.length > 0 &&
+      parsed.audioModels.every(isValidAudioModel)
+        ? parsed.audioModels
+        : [musicModel];
+
     const autoGenerateMusic =
       'autoGenerateMusic' in parsed &&
       typeof parsed.autoGenerateMusic === 'boolean'
@@ -173,6 +184,7 @@ function loadSettings(): GenerationSettings {
       videoModels,
       autoGenerateMotion,
       musicModel,
+      audioModels,
       autoGenerateMusic,
     };
   } catch (error) {

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -1,11 +1,14 @@
 import {
   archiveSequenceFn,
   createSequenceFn,
+  getSequenceAudioModelsFn,
+  getSequenceAudioVariantsFn,
   getSequenceFn,
   getSequencesFn,
   updateSequenceFn,
 } from '@/functions/sequences';
 import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
+import type { SequenceMusicVariant } from '@/lib/db/schema';
 import {
   type CreateSequenceInput,
   type UpdateSequenceInput,
@@ -25,6 +28,35 @@ export const sequenceKeys = {
   details: () => [...sequenceKeys.all, 'detail'] as const,
   detail: (id?: string) => [...sequenceKeys.details(), id] as const,
 };
+
+// Distinct audio models that have generated a track for this sequence (#546).
+// Drives the header audio-model dropdown. The realtime audio:progress handler
+// invalidates `['sequence-audio-models', sequenceId]`, matching this key.
+export function useSequenceAudioModels(sequenceId?: string) {
+  return useQuery<string[]>({
+    queryKey: ['sequence-audio-models', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceAudioModelsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
+
+// All music variant rows for a sequence (#546). Used by the music tab to
+// resolve playback through the active model's track.
+export function useSequenceAudioVariants(sequenceId?: string) {
+  return useQuery<SequenceMusicVariant[]>({
+    queryKey: ['sequence-audio-variants', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceAudioVariantsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
 
 // Hook for listing sequences
 export function useSequences(teamId?: string) {
@@ -84,9 +116,14 @@ export function useCreateSequence() {
           aspectRatio: input.aspectRatio,
           imageModels: input.imageModels,
           videoModel: input.videoModel,
+          // Forward the multi-model arrays — without these the server only ever
+          // sees the singular primary and resolveVideoModels/resolveAudioModels
+          // collapse the user's selection to one model (#545/#546).
+          videoModels: input.videoModels,
           autoGenerateMotion: input.autoGenerateMotion,
           autoGenerateMusic: input.autoGenerateMusic,
           musicModel: input.musicModel,
+          audioModels: input.audioModels,
           suggestedTalentIds: input.suggestedTalentIds,
           suggestedLocationIds: input.suggestedLocationIds,
           elementUploads: input.elementUploads,

--- a/src/lib/ai/resolve-audio-models.test.ts
+++ b/src/lib/ai/resolve-audio-models.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from './models';
+import { resolveAudioModels } from './resolve-audio-models';
+
+describe('resolveAudioModels', () => {
+  it('returns the audioModels array when non-empty', () => {
+    const models: AudioModel[] = [DEFAULT_MUSIC_MODEL];
+    expect(resolveAudioModels(models, undefined)).toEqual(models);
+  });
+
+  it('falls back to the legacy singular musicModel when array is empty/undefined', () => {
+    expect(resolveAudioModels(undefined, DEFAULT_MUSIC_MODEL)).toEqual([
+      DEFAULT_MUSIC_MODEL,
+    ]);
+    expect(resolveAudioModels([], DEFAULT_MUSIC_MODEL)).toEqual([
+      DEFAULT_MUSIC_MODEL,
+    ]);
+  });
+
+  it('falls back to the default model when neither is provided', () => {
+    expect(resolveAudioModels(undefined, undefined)).toEqual([
+      DEFAULT_MUSIC_MODEL,
+    ]);
+  });
+
+  it('dedupes repeated models, preserving first-seen order', () => {
+    expect(
+      resolveAudioModels([DEFAULT_MUSIC_MODEL, DEFAULT_MUSIC_MODEL], undefined)
+    ).toEqual([DEFAULT_MUSIC_MODEL]);
+  });
+});

--- a/src/lib/ai/resolve-audio-models.ts
+++ b/src/lib/ai/resolve-audio-models.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from './models';
+
+/**
+ * Resolve an audio models array from the dual-field pattern
+ * (optional `audioModels[]` + optional legacy `musicModel`).
+ *
+ * Guarantees a non-empty, deduplicated result. Mirrors
+ * {@link resolveImageModels} / {@link resolveVideoModels}. Audio is generated
+ * per-sequence (one track per model in `sequence_music_variants`), so the
+ * first element is the primary whose track also lands on the live
+ * `sequences.music*` columns; the rest are alternates.
+ */
+export function resolveAudioModels(
+  audioModels: AudioModel[] | undefined,
+  musicModel: AudioModel | undefined
+): AudioModel[] {
+  const models =
+    audioModels && audioModels.length > 0
+      ? audioModels
+      : musicModel
+        ? [musicModel]
+        : [DEFAULT_MUSIC_MODEL];
+  return [...new Set(models)];
+}

--- a/src/lib/billing/cost-estimation.test.ts
+++ b/src/lib/billing/cost-estimation.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import type { TextToImageModel, ImageToVideoModel } from '@/lib/ai/models';
+import {
+  DEFAULT_MUSIC_MODEL,
+  type AudioModel,
+  type TextToImageModel,
+  type ImageToVideoModel,
+} from '@/lib/ai/models';
 import { estimateStoryboardCost } from './cost-estimation';
 
 const IMAGE_MODEL: TextToImageModel = 'nano_banana_2';
 const VIDEO_MODEL: ImageToVideoModel = 'kling_v3_pro';
+const AUDIO_MODEL: AudioModel = DEFAULT_MUSIC_MODEL;
 
 const base = {
   imageModel: IMAGE_MODEL,
@@ -44,6 +50,31 @@ describe('estimateStoryboardCost', () => {
     // motion cost — the invariant the credit pre-flight relies on.
     const perModelMotionCost = oneModel - noMotion;
     expect(twoModels - oneModel).toBe(perModelMotionCost);
+    expect(twoModels).toBeGreaterThanOrEqual(oneModel);
+  });
+
+  it('multiplies the per-sequence music cost by audioModelCount', () => {
+    const noMusic = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMusic: false })
+    );
+    const oneModel = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMusic: true,
+        audioModel: AUDIO_MODEL,
+        audioModelCount: 1,
+      })
+    );
+    const twoModels = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMusic: true,
+        audioModel: AUDIO_MODEL,
+        audioModelCount: 2,
+      })
+    );
+    const perModelMusicCost = oneModel - noMusic;
+    expect(twoModels - oneModel).toBe(perModelMusicCost);
     expect(twoModels).toBeGreaterThanOrEqual(oneModel);
   });
 

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -4,10 +4,16 @@
  * All functions return Microdollars for exact arithmetic.
  */
 
-import { calculateImageCost, calculateVideoCost } from '@/lib/ai/fal-cost';
 import {
+  calculateAudioCost,
+  calculateImageCost,
+  calculateVideoCost,
+} from '@/lib/ai/fal-cost';
+import {
+  AUDIO_MODELS,
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
+  type AudioModel,
   type TextToImageModel,
   type ImageToVideoModel,
   videoModelSupportsAudio,
@@ -65,6 +71,20 @@ export function estimateVideoCost(
 }
 
 /**
+ * Estimate the raw cost (before markup) of generating one music track.
+ * Internal — used by `estimateStoryboardCost`'s music component.
+ */
+function estimateAudioCost(
+  model: AudioModel,
+  durationSeconds: number
+): Microdollars {
+  return calculateAudioCost({
+    endpointId: AUDIO_MODELS[model].id,
+    durationSeconds,
+  });
+}
+
+/**
  * Rough estimate of LLM cost per call for pre-flight credit checks.
  * Based on average token usage for script analysis calls.
  * Only used for client-side gate affordability checks, not actual deduction.
@@ -94,10 +114,17 @@ export function estimateStoryboardCost(opts: {
   /** Number of video models selected (multiplies per-frame motion cost) */
   videoModelCount?: number;
   videoDurationSeconds?: number;
+  autoGenerateMusic?: boolean;
+  audioModel?: AudioModel;
+  /** Number of audio models selected (multiplies per-sequence music cost) */
+  audioModelCount?: number;
+  /** Total sequence duration in seconds (one music track spans the sequence) */
+  audioDurationSeconds?: number;
 }): Microdollars {
   const sceneCount = opts.estimatedSceneCount ?? DEFAULT_ESTIMATED_SCENE_COUNT;
   const imageModelCount = opts.imageModelCount ?? 1;
   const videoModelCount = opts.videoModelCount ?? 1;
+  const audioModelCount = opts.audioModelCount ?? 1;
 
   // LLM calls: script analysis + character bible + location bible (~3 calls)
   const llmCost = estimateLLMCost(3);
@@ -127,6 +154,16 @@ export function estimateStoryboardCost(opts: {
     totalCost = addMicros(
       totalCost,
       multiplyMicros(perFrameMotion, sceneCount * videoModelCount)
+    );
+  }
+
+  // Optional music generation — one track per sequence per audio model.
+  if (opts.autoGenerateMusic && opts.audioModel) {
+    const audioDuration = opts.audioDurationSeconds ?? sceneCount * 5;
+    const perTrackMusic = estimateAudioCost(opts.audioModel, audioDuration);
+    totalCost = addMicros(
+      totalCost,
+      multiplyMicros(perTrackMusic, audioModelCount)
     );
   }
 

--- a/src/lib/db/scoped/sequence-variants.ts
+++ b/src/lib/db/scoped/sequence-variants.ts
@@ -108,6 +108,23 @@ export function createSequenceVariantsMethods(db: Database) {
         .where(eq(sequenceMusicVariants.sequenceId, sequenceId));
     },
 
+    /**
+     * Distinct audio models that have a primary (non-divergent) variant for
+     * this sequence (#546). Drives the header audio-model dropdown.
+     */
+    listMusicModels: async (sequenceId: string): Promise<string[]> => {
+      const result = await db
+        .selectDistinct({ model: sequenceMusicVariants.model })
+        .from(sequenceMusicVariants)
+        .where(
+          and(
+            eq(sequenceMusicVariants.sequenceId, sequenceId),
+            sql`${sequenceMusicVariants.divergedAt} IS NULL`
+          )
+        );
+      return result.map((r) => r.model);
+    },
+
     getMusicPrimary,
     upsertMusicPrimary,
     insertDivergentMusic,

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -144,6 +144,10 @@ export const realtimeSchema = {
       frameId: z.string().optional(),
       status: z.enum(['pending', 'generating', 'completed', 'failed']),
       audioUrl: z.string().optional(),
+      // Which audio model produced this update. Optional for backward compat
+      // with emitters that predate multi-model audio (#546); the model-aware
+      // cache invalidation and the music-view track switcher key off it.
+      model: z.string().optional(),
     }),
 
     // Character sheet generation progress (during recasting)

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -231,6 +231,22 @@ export function updateQueryCacheFromEvent(
               : old
         );
       }
+      // Refresh per-model audio data so the header model dropdown and the
+      // music-tab track switcher stay current (#546). Audio is sequence-level
+      // (sequence_music_variants), so these are separate queries from the frame
+      // image/video variant ones.
+      if (status === 'completed' || status === 'failed') {
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-audio-variants', sequenceId],
+          `audio-variants:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-audio-models', sequenceId],
+          `audio-models:${sequenceId}`
+        );
+      }
       break;
     }
 

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -106,12 +106,22 @@ export const createSequenceSchema = createInsertSchema(sequences, {
     autoGenerateMotion: z.boolean().default(false).optional(),
     // Auto-generate music flag (UI-only, not stored in DB)
     autoGenerateMusic: z.boolean().default(false).optional(),
-    // Music model selection (model key, not full ID)
+    // Music model selection (model key, not full ID) — primary / first of audioModels
     musicModel: z
       .string()
       .refine((val) => validAudioModelKeys.includes(val), {
         message: 'Invalid music model',
       })
+      .optional(),
+    // Multiple audio models for variant generation (first is primary). Optional
+    // (music is opt-in via autoGenerateMusic); when present must be non-empty.
+    audioModels: z
+      .array(
+        z.string().refine((val) => validAudioModelKeys.includes(val), {
+          message: 'Invalid audio model',
+        })
+      )
+      .min(1, 'At least one audio model must be selected')
       .optional(),
     // Suggested talent IDs for AI-assisted casting during generation
     suggestedTalentIds: z.array(z.string()).optional(),

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -128,6 +128,8 @@ export interface StoryboardWorkflowInput extends SequenceWorkflowContext {
   autoGenerateMotion?: boolean;
   autoGenerateMusic?: boolean;
   musicModel?: keyof typeof AUDIO_MODELS;
+  /** Multiple audio models for variant generation (first is primary) */
+  audioModels?: (keyof typeof AUDIO_MODELS)[];
   /** Talent IDs suggested by user for AI-assisted casting */
   suggestedTalentIds?: string[];
   /** Location IDs suggested by user for visual consistency */
@@ -152,6 +154,8 @@ export interface AnalyzeScriptWorkflowInput extends SequenceWorkflowContext {
   autoGenerateMotion?: boolean;
   autoGenerateMusic?: boolean;
   musicModel?: keyof typeof AUDIO_MODELS;
+  /** Multiple audio models for variant generation (first is primary) */
+  audioModels?: (keyof typeof AUDIO_MODELS)[];
   /** Talent IDs suggested by user for AI-assisted casting */
   suggestedTalentIds?: string[];
   /** Location IDs suggested by user for visual consistency */
@@ -758,6 +762,14 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
     duration: number;
     model?: keyof typeof AUDIO_MODELS;
   };
+  /**
+   * Audio models to generate for the sequence (#546). First is primary (its
+   * track also lands on the live `sequences.music*` columns); the rest are
+   * alternates stored as separate primary rows in `sequence_music_variants`
+   * keyed by (sequenceId, model). When absent, falls back to `music.model`
+   * (single-model behaviour). Each model reuses `music.prompt/tags/duration`.
+   */
+  audioModels?: (keyof typeof AUDIO_MODELS)[];
 }
 
 /**

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -25,6 +25,7 @@
  * `motion-batch` (Phase 5 motion + music + merge tree). */
 
 import { sanitizeScriptContent } from '@/lib/ai/prompt-validation';
+import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
@@ -98,12 +99,14 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
       autoGenerateMotion = false,
       autoGenerateMusic = false,
       musicModel,
+      audioModels: audioModelsInput,
       suggestedTalentIds,
       suggestedLocationIds,
     } = input;
 
     const imageModels = resolveImageModels(imageModelsInput, imageModel);
     const videoModels = resolveVideoModels(videoModelsInput, videoModel);
+    const audioModels = resolveAudioModels(audioModelsInput, musicModel);
     // First selected model is primary: it drives the legacy `frames.video*`
     // columns and the model-aware duration snapping; the rest are alternates.
     const primaryVideoModel = videoModels[0] ?? videoModel;
@@ -645,6 +648,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
           includeMusic: shouldGenerateMusic,
           frames: batchFrames,
           videoModels,
+          audioModels: shouldGenerateMusic ? audioModels : undefined,
           music: shouldGenerateMusic
             ? {
                 prompt: musicPrompt,

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -22,6 +22,7 @@
  *     so a single bad frame doesn't kill the rest of the batch. */
 
 import { DEFAULT_VIDEO_MODEL, type ImageToVideoModel } from '@/lib/ai/models';
+import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
@@ -147,31 +148,49 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
       );
     });
 
-    const musicAwait =
+    // Multi-model audio (#546): one MUSIC_WORKFLOW child per selected model,
+    // each reusing the same prompt/tags/duration and writing its own primary
+    // row in sequence_music_variants (keyed by (sequenceId, model)). Falls back
+    // to the single `music.model` when no audioModels were threaded through.
+    const audioModels =
+      includeMusic && input.music
+        ? resolveAudioModels(input.audioModels, input.music.model)
+        : [];
+
+    const musicJobs =
       includeMusic && input.music && musicBinding
-        ? spawnAndAwaitChild<MusicWorkflowInput, MusicWorkflowResult>(step, {
-            binding: musicBinding,
-            parentBindingName: 'MOTION_BATCH_WORKFLOW',
-            parentInstanceId,
-            childId: `music:${sequenceId}`,
-            childPayload: {
-              userId: input.userId,
-              teamId: input.teamId,
-              sequenceId,
-              prompt: input.music.prompt,
-              tags: input.music.tags,
-              duration: input.music.duration,
-              model: input.music.model,
-            },
-            spawnStepName: 'spawn-music',
-            awaitStepName: 'await-music',
-            timeout: '30 minutes',
-          })
-        : null;
+        ? audioModels.map((model) => ({ model }))
+        : [];
+
+    const musicAwaits = musicJobs.map(({ model }, index) => {
+      // input.music is narrowed truthy by musicJobs construction above.
+      const music = input.music;
+      if (!music || !musicBinding) {
+        throw new WorkflowValidationError('music config missing for batch');
+      }
+      return spawnAndAwaitChild<MusicWorkflowInput, MusicWorkflowResult>(step, {
+        binding: musicBinding,
+        parentBindingName: 'MOTION_BATCH_WORKFLOW',
+        parentInstanceId,
+        childId: `music:${sequenceId}:${model}`,
+        childPayload: {
+          userId: input.userId,
+          teamId: input.teamId,
+          sequenceId,
+          prompt: music.prompt,
+          tags: music.tags,
+          duration: music.duration,
+          model,
+        },
+        spawnStepName: `spawn-music-${index}-${model}`,
+        awaitStepName: `await-music-${index}-${model}`,
+        timeout: '30 minutes',
+      });
+    });
 
     const motionResults = await Promise.allSettled(motionAwaits);
-    const musicResult = musicAwait
-      ? await Promise.allSettled([musicAwait])
+    const musicResults = musicAwaits.length
+      ? await Promise.allSettled(musicAwaits)
       : null;
 
     // Log per-frame motion failures for visibility; we don't throw here — the
@@ -191,15 +210,17 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
         );
       }
     }
-    if (musicResult) {
-      const [m] = musicResult;
-      if (m.status === 'rejected') {
-        logger.warn(
-          `[MotionBatchWorkflow:cf] Music generation failed for sequence ${sequenceId}:`,
-          {
-            err: m.reason,
-          }
-        );
+    if (musicResults) {
+      for (let i = 0; i < musicResults.length; i++) {
+        const m = musicResults[i];
+        if (m?.status === 'rejected') {
+          logger.warn(
+            `[MotionBatchWorkflow:cf] Music generation failed for sequence ${sequenceId} model ${musicJobs[i]?.model ?? '(unknown)'}:`,
+            {
+              err: m.reason,
+            }
+          );
+        }
       }
     }
 

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -59,6 +59,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
           'generation.audio:progress',
           {
             status: 'generating',
+            model,
           }
         );
       });
@@ -178,6 +179,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
           const channel = getGenerationChannel(sequenceId);
           await channel.emit('generation.audio:progress', {
             status: 'completed',
+            model,
             ...(status?.musicUrl ? { audioUrl: status.musicUrl } : {}),
           });
           await channel.emit('generation.stale:detected', {
@@ -206,6 +208,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
             {
               status: 'completed',
               audioUrl: audioUrl,
+              model,
             }
           );
         });
@@ -227,6 +230,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
     scopedDb: ScopedDb;
   }): Promise<void> {
     const input = event.payload;
+    const model = input.model || DEFAULT_MUSIC_MODEL;
     if (input.sequenceId) {
       const failSeq = scopedDb.sequence(input.sequenceId);
 
@@ -238,7 +242,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
       try {
         await getGenerationChannel(input.sequenceId).emit(
           'generation.audio:progress',
-          { status: 'failed' }
+          { status: 'failed', model }
         );
       } catch (emitError) {
         logger.error(

--- a/src/lib/workflows/storyboard-workflow.ts
+++ b/src/lib/workflows/storyboard-workflow.ts
@@ -196,6 +196,7 @@ export class StoryboardWorkflow extends OpenStoryWorkflowEntrypoint<StoryboardWo
         autoGenerateMotion: input.autoGenerateMotion ?? false,
         autoGenerateMusic: input.autoGenerateMusic ?? false,
         musicModel: input.musicModel,
+        audioModels: input.audioModels,
         suggestedTalentIds: input.suggestedTalentIds,
         suggestedLocationIds: input.suggestedLocationIds,
       },

--- a/src/routes/_protected/sequences/$id/music.tsx
+++ b/src/routes/_protected/sequences/$id/music.tsx
@@ -5,8 +5,13 @@ import {
   regenerateMusicPromptFn,
 } from '@/functions/prompt-variants';
 import { generateMusicFn } from '@/functions/sequences';
+import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
 import { useFramesBySequence } from '@/hooks/use-frames';
-import { useSequence, sequenceKeys } from '@/hooks/use-sequences';
+import {
+  useSequence,
+  useSequenceAudioVariants,
+  sequenceKeys,
+} from '@/hooks/use-sequences';
 import {
   useDiscardSequenceMusicVariant,
   usePromoteSequenceMusicVariant,
@@ -35,6 +40,31 @@ function MusicPage() {
   const { data: frames } = useFramesBySequence(sequenceId, {
     refetchInterval: false,
   });
+  // Resolve the music tab through the viewer's active audio model (#546). When
+  // a model is pinned in the header, play that model's primary track instead
+  // of the live `sequences.music*` primary; "Mixed" (null) keeps the primary.
+  const { activeAudioModel } = useActiveAudioModel(sequenceId);
+  const { data: audioVariants } = useSequenceAudioVariants(sequenceId);
+  const resolvedSequence = useMemo<Sequence | undefined>(() => {
+    if (!sequence || !activeAudioModel || !audioVariants) return sequence;
+    // Player-only remap (mirrors scenes-view's playerFrames): swap ONLY the
+    // playback URL to the pinned model's completed track. Status / error /
+    // prompt / tags stay sourced from the live sequence so a regeneration of
+    // the pinned model still surfaces the generating spinner + failure UI and
+    // never clobbers an in-progress prompt edit. Only swap while the live track
+    // is completed — never mask a live generating/failed state.
+    if (sequence.musicStatus !== 'completed') return sequence;
+    const variant = audioVariants.find(
+      (v) =>
+        v.model === activeAudioModel &&
+        v.divergedAt === null &&
+        v.discardedAt === null &&
+        v.status === 'completed' &&
+        v.url
+    );
+    if (!variant?.url) return sequence;
+    return { ...sequence, musicUrl: variant.url };
+  }, [sequence, activeAudioModel, audioVariants]);
   const queryClient = useQueryClient();
   const posthog = usePostHog();
 
@@ -204,7 +234,7 @@ function MusicPage() {
     <div className="flex-1 overflow-auto p-4">
       <div className="max-w-4xl mx-auto">
         <MusicView
-          sequence={sequence}
+          sequence={resolvedSequence ?? sequence}
           videoDuration={videoDuration}
           onGenerateMusic={(args) => generateMusic.mutate(args)}
           isGeneratingMusic={generateMusic.isPending}

--- a/src/routes/_protected/sequences/$id/route.tsx
+++ b/src/routes/_protected/sequences/$id/route.tsx
@@ -1,9 +1,6 @@
 import { RouteErrorFallback } from '@/components/error/route-error-fallback';
-import {
-  ImageModelBadge,
-  ModelBadge,
-  MusicModelBadge,
-} from '@/components/model/model-badge';
+import { ImageModelBadge, ModelBadge } from '@/components/model/model-badge';
+import { SequenceAudioModelSelector } from '@/components/model/sequence-audio-model-selector';
 import { SequenceVideoModelSelector } from '@/components/model/sequence-video-model-selector';
 import { getSequenceImageModelsFn } from '@/functions/frames';
 import { frameKeys } from '@/hooks/use-frames';
@@ -98,7 +95,10 @@ function SequenceLayout() {
               sequenceId={sequenceId}
               sequenceVideoModel={sequence?.videoModel}
             />
-            <MusicModelBadge model={sequence?.musicModel ?? undefined} />
+            <SequenceAudioModelSelector
+              sequenceId={sequenceId}
+              sequenceMusicModel={sequence?.musicModel}
+            />
           </div>
         </PageHeader>
         <SequenceTabs sequenceId={sequenceId} />


### PR DESCRIPTION
Closes #546

Phase 3 of the multi-model variant system. **Stacked on #781 (#545).**

Audio/music is **per-sequence**, so multi-model audio extends the existing `sequence_music_variants` table (already keyed `(sequenceId, model)`) rather than `frame_variants` — the correct architecture vs the issue's per-frame premise.

## Workflows
- `motion-batch` fans out one `MUSIC_WORKFLOW` child per audio model (each writes its own primary row); `music-workflow` + the music-promote fn emit `audio:progress` with `model`; `audioModels[]` threads through the chain.

## Creation / viewing / realtime
- `MusicModelMultiSelector`; audio cost added to the estimate (gated on motion, since music only spawns via motion-batch).
- `useActiveAudioModel` + header `SequenceAudioModelSelector` dropdown ("Mixed"); music tab resolves playback through the active model's track (player-only remap — live status/error/prompt stay authoritative).
- `audio:progress` carries `model`; model-aware cache invalidation.

Also fixes a latent bug from #545: the create mutation dropped `videoModels[]`/`audioModels[]` before the server call, collapsing multi-select to one model on creation.

Reviewed by an adversarial multi-agent pass; confirmed findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)