### PR TITLE
feat(models): add image/video/audio models to an existing sequence (#547)

### DIFF
--- a/src/components/model/add-model-menu.tsx
+++ b/src/components/model/add-model-menu.tsx
@@ -156,7 +156,11 @@ export const AddModelMenuSection = ({
                 { sequenceId, variantType, model: key },
                 {
                   onSuccess: (r) =>
-                    toast.success(`Generating ${name} (${r.count})…`),
+                    toast.success(
+                      r.failed > 0
+                        ? `Generating ${name} (${r.count}) — ${r.failed} failed to start`
+                        : `Generating ${name} (${r.count})…`
+                    ),
                   onError: (e) => toast.error(e.message),
                 }
               );

--- a/src/components/model/add-model-menu.tsx
+++ b/src/components/model/add-model-menu.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useAddModelToSequence, useSequence } from '@/hooks/use-sequences';
 import { useFramesBySequence } from '@/hooks/use-frames';
+import { useStyle } from '@/hooks/use-styles';
 import {
   AUDIO_MODELS,
   IMAGE_MODELS,
@@ -58,7 +59,12 @@ export const AddModelMenuSection = ({
   const addModel = useAddModelToSequence();
   const { data: frames } = useFramesBySequence(sequenceId);
   const { data: sequence } = useSequence(sequenceId);
+  const { data: style } = useStyle(sequence?.styleId ?? '');
   const aspectRatio = sequence?.aspectRatio ?? DEFAULT_ASPECT_RATIO;
+  // Style-category gating (mirrors motion-model-selector): a model declaring a
+  // `requiredStyleCategory` (e.g. Seedance 2 → 'animation') is only offered when
+  // the sequence's style matches — otherwise it isn't a valid choice here.
+  const styleCategory = style?.category ?? undefined;
 
   const candidates = useMemo<Candidate[]>(() => {
     const used = new Set(usedModels);
@@ -94,12 +100,18 @@ export const AddModelMenuSection = ({
       ).length;
       return Object.keys(IMAGE_TO_VIDEO_MODELS)
         .filter(isValidImageToVideoModel)
-        .filter(
-          (key) =>
-            !used.has(key) &&
-            !('hidden' in IMAGE_TO_VIDEO_MODELS[key]) &&
-            isModelCompatibleWithAspectRatio(key, aspectRatio)
-        )
+        .filter((key) => {
+          const model = IMAGE_TO_VIDEO_MODELS[key];
+          if (used.has(key) || 'hidden' in model) return false;
+          // Exclude models gated to a different style category (e.g. Seedance 2
+          // is animation-only) — same rule as the motion-model selector.
+          if (
+            'requiredStyleCategory' in model &&
+            model.requiredStyleCategory !== styleCategory
+          )
+            return false;
+          return isModelCompatibleWithAspectRatio(key, aspectRatio);
+        })
         .sort(
           (a, b) =>
             IMAGE_TO_VIDEO_MODELS[a].qualityRank -
@@ -136,7 +148,7 @@ export const AddModelMenuSection = ({
         cost: estimateAudioCost(key, totalDurationSecs),
         scope: '1 track',
       }));
-  }, [variantType, usedModels, frames, aspectRatio]);
+  }, [variantType, usedModels, frames, aspectRatio, styleCategory]);
 
   if (candidates.length === 0) return null;
 

--- a/src/components/model/add-model-menu.tsx
+++ b/src/components/model/add-model-menu.tsx
@@ -21,7 +21,7 @@ import {
   estimateVideoCost,
 } from '@/lib/billing/cost-estimation';
 import {
-  microsToUsd,
+  microsToDisplayUsd,
   multiplyMicros,
   type Microdollars,
 } from '@/lib/billing/money';
@@ -35,6 +35,8 @@ type Candidate = {
   cost: Microdollars;
   scope: string;
 };
+
+const scenes = (n: number) => `${n} scene${n === 1 ? '' : 's'}`;
 
 /**
  * "Add a model" section for the header model dropdowns (#547). Lists models of
@@ -61,15 +63,6 @@ export const AddModelMenuSection = ({
   const candidates = useMemo<Candidate[]>(() => {
     const used = new Set(usedModels);
     const frameList = frames ?? [];
-    const totalDurationSecs =
-      frameList.reduce(
-        (sum, f) =>
-          sum +
-          (f.durationMs
-            ? f.durationMs / 1000
-            : (f.metadata?.metadata?.durationSeconds ?? 10)),
-        0
-      ) || 30;
 
     if (variantType === 'image') {
       const count = frameList.filter(
@@ -91,7 +84,7 @@ export const AddModelMenuSection = ({
             estimateImageCost(key, aspectRatio, 1),
             count || 1
           ),
-          scope: `${count || 'all'} scene${count === 1 ? '' : 's'}`,
+          scope: count ? scenes(count) : 'all scenes',
         }));
     }
 
@@ -116,11 +109,20 @@ export const AddModelMenuSection = ({
           key,
           name: IMAGE_TO_VIDEO_MODELS[key].name,
           cost: multiplyMicros(estimateVideoCost(key, 5), count || 1),
-          scope: `${count || 0} scene${count === 1 ? '' : 's'}`,
+          scope: scenes(count),
         }));
     }
 
-    // audio — one track for the whole sequence
+    // audio — one track for the whole sequence; cost scales with total runtime.
+    const totalDurationSecs =
+      frameList.reduce(
+        (sum, f) =>
+          sum +
+          (f.durationMs
+            ? f.durationMs / 1000
+            : (f.metadata?.metadata?.durationSeconds ?? 10)),
+        0
+      ) || 30;
     return Object.keys(AUDIO_MODELS)
       .filter(isValidAudioModel)
       .filter(
@@ -142,11 +144,11 @@ export const AddModelMenuSection = ({
   const audioBlocked =
     variantType === 'audio' && !(sequence?.musicPrompt && sequence.musicTags);
 
-  const handleAdd = (key: string, name: string, cost: Microdollars) => {
+  const handleAdd = ({ key, name, cost }: Candidate) => {
     toast(`Add ${name}?`, {
       description: audioBlocked
         ? 'Generate music once before adding another audio model.'
-        : `Generates ~$${microsToUsd(cost).toFixed(2)} of content using the existing prompts.`,
+        : `Generates ~${microsToDisplayUsd(cost)} of content using the existing prompts.`,
       action: audioBlocked
         ? undefined
         : {
@@ -181,13 +183,13 @@ export const AddModelMenuSection = ({
           disabled={addModel.isPending}
           onSelect={(e) => {
             e.preventDefault();
-            handleAdd(c.key, c.name, c.cost);
+            handleAdd(c);
           }}
           className="cursor-pointer flex items-center justify-between gap-3"
         >
           <span className="truncate">{c.name}</span>
           <span className="shrink-0 text-[10px] text-muted-foreground">
-            {c.scope} · ~${microsToUsd(c.cost).toFixed(2)}
+            {c.scope} · ~{microsToDisplayUsd(c.cost)}
           </span>
         </DropdownMenuItem>
       ))}

--- a/src/components/model/add-model-menu.tsx
+++ b/src/components/model/add-model-menu.tsx
@@ -1,0 +1,192 @@
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from '@/components/ui/dropdown-menu';
+import { useAddModelToSequence, useSequence } from '@/hooks/use-sequences';
+import { useFramesBySequence } from '@/hooks/use-frames';
+import {
+  AUDIO_MODELS,
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+  isModelCompatibleWithAspectRatio,
+  isValidAudioModel,
+  isValidImageToVideoModel,
+  isValidTextToImageModel,
+} from '@/lib/ai/models';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
+import {
+  estimateAudioCost,
+  estimateImageCost,
+  estimateVideoCost,
+} from '@/lib/billing/cost-estimation';
+import {
+  microsToUsd,
+  multiplyMicros,
+  type Microdollars,
+} from '@/lib/billing/money';
+import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
+import { useMemo } from 'react';
+import { toast } from 'sonner';
+
+type Candidate = {
+  key: string;
+  name: string;
+  cost: Microdollars;
+  scope: string;
+};
+
+/**
+ * "Add a model" section for the header model dropdowns (#547). Lists models of
+ * the given type that have NOT yet generated for this sequence, with a rough
+ * cost + scope estimate; clicking confirms via a toast then triggers
+ * addModelToSequenceFn (which generates the new model for every frame / the
+ * whole sequence using the existing prompts). The server runs the authoritative
+ * credit pre-flight; the estimate here is advisory.
+ */
+export const AddModelMenuSection = ({
+  sequenceId,
+  variantType,
+  usedModels,
+}: {
+  sequenceId: string;
+  variantType: VariantType;
+  usedModels: string[];
+}) => {
+  const addModel = useAddModelToSequence();
+  const { data: frames } = useFramesBySequence(sequenceId);
+  const { data: sequence } = useSequence(sequenceId);
+  const aspectRatio = sequence?.aspectRatio ?? DEFAULT_ASPECT_RATIO;
+
+  const candidates = useMemo<Candidate[]>(() => {
+    const used = new Set(usedModels);
+    const frameList = frames ?? [];
+    const totalDurationSecs =
+      frameList.reduce(
+        (sum, f) =>
+          sum +
+          (f.durationMs
+            ? f.durationMs / 1000
+            : (f.metadata?.metadata?.durationSeconds ?? 10)),
+        0
+      ) || 30;
+
+    if (variantType === 'image') {
+      const count = frameList.filter(
+        (f) =>
+          f.imagePrompt ||
+          f.metadata?.prompts?.visual?.fullPrompt ||
+          f.description
+      ).length;
+      return Object.keys(IMAGE_MODELS)
+        .filter(isValidTextToImageModel)
+        .filter((key) => !used.has(key) && !('hidden' in IMAGE_MODELS[key]))
+        .sort(
+          (a, b) => IMAGE_MODELS[a].qualityRank - IMAGE_MODELS[b].qualityRank
+        )
+        .map((key) => ({
+          key,
+          name: IMAGE_MODELS[key].name,
+          cost: multiplyMicros(
+            estimateImageCost(key, aspectRatio, 1),
+            count || 1
+          ),
+          scope: `${count || 'all'} scene${count === 1 ? '' : 's'}`,
+        }));
+    }
+
+    if (variantType === 'video') {
+      const count = frameList.filter(
+        (f) => f.thumbnailStatus === 'completed' && f.thumbnailUrl
+      ).length;
+      return Object.keys(IMAGE_TO_VIDEO_MODELS)
+        .filter(isValidImageToVideoModel)
+        .filter(
+          (key) =>
+            !used.has(key) &&
+            !('hidden' in IMAGE_TO_VIDEO_MODELS[key]) &&
+            isModelCompatibleWithAspectRatio(key, aspectRatio)
+        )
+        .sort(
+          (a, b) =>
+            IMAGE_TO_VIDEO_MODELS[a].qualityRank -
+            IMAGE_TO_VIDEO_MODELS[b].qualityRank
+        )
+        .map((key) => ({
+          key,
+          name: IMAGE_TO_VIDEO_MODELS[key].name,
+          cost: multiplyMicros(estimateVideoCost(key, 5), count || 1),
+          scope: `${count || 0} scene${count === 1 ? '' : 's'}`,
+        }));
+    }
+
+    // audio — one track for the whole sequence
+    return Object.keys(AUDIO_MODELS)
+      .filter(isValidAudioModel)
+      .filter(
+        // oxlint-disable-next-line typescript/no-unnecessary-condition
+        (key) => !used.has(key) && AUDIO_MODELS[key].type === 'music'
+      )
+      .sort((a, b) => AUDIO_MODELS[a].qualityRank - AUDIO_MODELS[b].qualityRank)
+      .map((key) => ({
+        key,
+        name: AUDIO_MODELS[key].name,
+        cost: estimateAudioCost(key, totalDurationSecs),
+        scope: '1 track',
+      }));
+  }, [variantType, usedModels, frames, aspectRatio]);
+
+  if (candidates.length === 0) return null;
+
+  // Audio requires a generated music prompt; gate the section in that case.
+  const audioBlocked =
+    variantType === 'audio' && !(sequence?.musicPrompt && sequence.musicTags);
+
+  const handleAdd = (key: string, name: string, cost: Microdollars) => {
+    toast(`Add ${name}?`, {
+      description: audioBlocked
+        ? 'Generate music once before adding another audio model.'
+        : `Generates ~$${microsToUsd(cost).toFixed(2)} of content using the existing prompts.`,
+      action: audioBlocked
+        ? undefined
+        : {
+            label: 'Add',
+            onClick: () => {
+              addModel.mutate(
+                { sequenceId, variantType, model: key },
+                {
+                  onSuccess: (r) =>
+                    toast.success(`Generating ${name} (${r.count})…`),
+                  onError: (e) => toast.error(e.message),
+                }
+              );
+            },
+          },
+    });
+  };
+
+  return (
+    <>
+      <DropdownMenuSeparator />
+      <DropdownMenuLabel className="text-[10px] text-muted-foreground uppercase tracking-wider font-normal">
+        Add a model
+      </DropdownMenuLabel>
+      {candidates.map((c) => (
+        <DropdownMenuItem
+          key={c.key}
+          disabled={addModel.isPending}
+          onSelect={(e) => {
+            e.preventDefault();
+            handleAdd(c.key, c.name, c.cost);
+          }}
+          className="cursor-pointer flex items-center justify-between gap-3"
+        >
+          <span className="truncate">{c.name}</span>
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            {c.scope} · ~${microsToUsd(c.cost).toFixed(2)}
+          </span>
+        </DropdownMenuItem>
+      ))}
+    </>
+  );
+};

--- a/src/components/model/model-badge.tsx
+++ b/src/components/model/model-badge.tsx
@@ -1,6 +1,5 @@
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import { IMAGE_MODELS, isValidTextToImageModel } from '@/lib/ai/models';
 import { getAnalysisModelById } from '@/lib/ai/models.config';
 
 export const ModelBadge = ({ model }: { model?: string }) => {
@@ -18,48 +17,6 @@ export const ModelBadge = ({ model }: { model?: string }) => {
       className="text-xs"
     >
       {getAnalysisModelById(model)?.name || model}
-    </Badge>
-  );
-};
-
-function getImageModelDisplayName(model: string): string {
-  return isValidTextToImageModel(model) ? IMAGE_MODELS[model].name : model;
-}
-
-function formatImageModels(models: string[]): string {
-  const [first, second] = models;
-  if (!first) return '';
-  if (models.length === 1) return getImageModelDisplayName(first);
-  if (models.length === 2 && second)
-    return `${getImageModelDisplayName(first)}, ${getImageModelDisplayName(second)}`;
-  return `${getImageModelDisplayName(first)} + ${models.length - 1} others`;
-}
-
-function resolveModelList(
-  models: string[] | undefined,
-  model: string | undefined
-): string[] {
-  if (models && models.length > 0) return models;
-  if (model) return [model];
-  return [];
-}
-
-export const ImageModelBadge = ({
-  model,
-  models,
-}: {
-  model?: string;
-  models?: string[];
-}) => {
-  const allModels = resolveModelList(models, model);
-
-  if (allModels.length === 0) {
-    return <Skeleton className="w-[100px] h-[20px]" />;
-  }
-
-  return (
-    <Badge variant="secondary" className="text-xs">
-      {formatImageModels(allModels)}
     </Badge>
   );
 };

--- a/src/components/model/model-coverage-marker.tsx
+++ b/src/components/model/model-coverage-marker.tsx
@@ -1,0 +1,77 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import type { ModelCoverage } from '@/lib/model/sequence-model-coverage';
+import { Check, CircleAlert, CircleCheck, Loader2 } from 'lucide-react';
+
+/**
+ * Sequence-wide per-model coverage marker for the header image/video dropdowns
+ * (#547). Mirrors the per-scene status icons but reads "for the whole sequence":
+ * ⊙ live primary / ✓ generated (with an N/M count while only partially filled)
+ * / ⟳ generating / ! failed. `pending` renders nothing.
+ */
+export const ModelCoverageMarker = ({
+  coverage,
+}: {
+  coverage?: ModelCoverage;
+}) => {
+  if (!coverage || coverage.status === 'pending') return null;
+  const { status, completed, total } = coverage;
+  const partial =
+    status === 'completed' && total > 0 && completed > 0 && completed < total;
+
+  const { Icon, className, label } = (() => {
+    switch (status) {
+      case 'set':
+        return {
+          Icon: CircleCheck,
+          className: 'text-emerald-500',
+          label: 'Live primary across the sequence',
+        };
+      case 'generating':
+        return {
+          Icon: Loader2,
+          className: 'text-muted-foreground animate-spin',
+          label: 'Generating…',
+        };
+      case 'failed':
+        return {
+          Icon: CircleAlert,
+          className: 'text-destructive',
+          label: 'Generation failed',
+        };
+      default:
+        return {
+          Icon: Check,
+          className: 'text-muted-foreground',
+          label: partial
+            ? `Generated for ${completed} of ${total} scenes — select, then Set to use`
+            : 'Generated for every scene — select, then Set to use',
+        };
+    }
+  })();
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="flex shrink-0 items-center gap-1 text-[10px] text-muted-foreground"
+            aria-label={label}
+          >
+            {partial && (
+              <span className="tabular-nums">
+                {completed}/{total}
+              </span>
+            )}
+            <Icon className={`size-3.5 ${className}`} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/components/model/sequence-audio-model-selector.tsx
+++ b/src/components/model/sequence-audio-model-selector.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { AddModelMenuSection } from '@/components/model/add-model-menu';
 import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
 import { useSequenceAudioModels } from '@/hooks/use-sequences';
 import { AUDIO_MODELS, isValidAudioModel } from '@/lib/ai/models';
@@ -92,6 +93,11 @@ export const SequenceAudioModelSelector = ({
             </DropdownMenuCheckboxItem>
           );
         })}
+        <AddModelMenuSection
+          sequenceId={sequenceId}
+          variantType="audio"
+          usedModels={models}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/model/sequence-image-model-selector.tsx
+++ b/src/components/model/sequence-image-model-selector.tsx
@@ -1,0 +1,96 @@
+import { AddModelMenuSection } from '@/components/model/add-model-menu';
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useActiveImageModel } from '@/hooks/use-active-image-model';
+import { useSequenceImageModels } from '@/hooks/use-frames';
+import { IMAGE_MODELS, isValidTextToImageModel } from '@/lib/ai/models';
+import { ChevronDown } from 'lucide-react';
+
+function imageModelName(model: string): string {
+  return isValidTextToImageModel(model) ? IMAGE_MODELS[model].name : model;
+}
+
+/**
+ * Top-level image-model switcher for the sequence header. Lists the distinct
+ * image models that have generated for this sequence (frame_variants) and lets
+ * the viewer pick which model's image the scenes view shows; also hosts the
+ * "Add a model" picker (#547). "Mixed" when more than one model has output and
+ * none is pinned. Replaces the read-only ImageModelBadge.
+ */
+export const SequenceImageModelSelector = ({
+  sequenceId,
+  sequenceImageModel,
+}: {
+  sequenceId: string;
+  sequenceImageModel?: string | null;
+}) => {
+  const { data: models } = useSequenceImageModels(sequenceId);
+  const { activeImageModel, selectImageModel } =
+    useActiveImageModel(sequenceId);
+
+  if (!models || models.length === 0) {
+    if (!sequenceImageModel) return null;
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {imageModelName(sequenceImageModel)}
+      </Badge>
+    );
+  }
+
+  const firstModel = models[0];
+  const label = activeImageModel
+    ? imageModelName(activeImageModel)
+    : models.length === 1 && firstModel
+      ? imageModelName(firstModel)
+      : 'Mixed';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" aria-label="Select image model">
+          <Badge variant="secondary" className="text-xs cursor-pointer gap-1">
+            {label}
+            <ChevronDown className="size-3" />
+          </Badge>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[220px]">
+        <DropdownMenuLabel className="text-xs">Image model</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {models.length > 1 && (
+          <DropdownMenuCheckboxItem
+            checked={activeImageModel === null}
+            onCheckedChange={() => selectImageModel(null)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            Mixed (per scene)
+          </DropdownMenuCheckboxItem>
+        )}
+        {models.filter(isValidTextToImageModel).map((model) => (
+          <DropdownMenuCheckboxItem
+            key={model}
+            checked={activeImageModel === model}
+            onCheckedChange={() => selectImageModel(model)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            {imageModelName(model)}
+          </DropdownMenuCheckboxItem>
+        ))}
+        <AddModelMenuSection
+          sequenceId={sequenceId}
+          variantType="image"
+          usedModels={models}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/model/sequence-image-model-selector.tsx
+++ b/src/components/model/sequence-image-model-selector.tsx
@@ -8,10 +8,17 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { ModelCoverageMarker } from '@/components/model/model-coverage-marker';
+import { SetModelButton } from '@/components/model/set-model-button';
 import { useActiveImageModel } from '@/hooks/use-active-image-model';
-import { useSequenceImageModels } from '@/hooks/use-frames';
+import {
+  useSequenceImageModels,
+  useSequenceImageVariants,
+} from '@/hooks/use-frames';
 import { IMAGE_MODELS, isValidTextToImageModel } from '@/lib/ai/models';
+import { computeSequenceModelCoverage } from '@/lib/model/sequence-model-coverage';
 import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
 
 function imageModelName(model: string): string {
   return isValidTextToImageModel(model) ? IMAGE_MODELS[model].name : model;
@@ -32,8 +39,19 @@ export const SequenceImageModelSelector = ({
   sequenceImageModel?: string | null;
 }) => {
   const { data: models } = useSequenceImageModels(sequenceId);
+  const { data: variants } = useSequenceImageVariants(sequenceId);
   const { activeImageModel, selectImageModel } =
     useActiveImageModel(sequenceId);
+
+  const coverage = useMemo(
+    () =>
+      computeSequenceModelCoverage({
+        variants,
+        variantType: 'image',
+        primaryModel: sequenceImageModel,
+      }),
+    [variants, sequenceImageModel]
+  );
 
   if (!models || models.length === 0) {
     if (!sequenceImageModel) return null;
@@ -82,7 +100,19 @@ export const SequenceImageModelSelector = ({
             onSelect={(e) => e.preventDefault()}
             className="cursor-pointer"
           >
-            {imageModelName(model)}
+            <span className="flex w-full items-center justify-between gap-2">
+              <span className="truncate">{imageModelName(model)}</span>
+              <span className="flex shrink-0 items-center gap-1.5">
+                <ModelCoverageMarker coverage={coverage.get(model)} />
+                <SetModelButton
+                  sequenceId={sequenceId}
+                  variantType="image"
+                  model={model}
+                  modelName={imageModelName(model)}
+                  coverage={coverage.get(model)}
+                />
+              </span>
+            </span>
           </DropdownMenuCheckboxItem>
         ))}
         <AddModelMenuSection

--- a/src/components/model/sequence-video-model-selector.tsx
+++ b/src/components/model/sequence-video-model-selector.tsx
@@ -8,13 +8,20 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { AddModelMenuSection } from '@/components/model/add-model-menu';
+import { ModelCoverageMarker } from '@/components/model/model-coverage-marker';
+import { SetModelButton } from '@/components/model/set-model-button';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
-import { useSequenceVideoModels } from '@/hooks/use-frames';
+import {
+  useSequenceVideoModels,
+  useSequenceVideoVariants,
+} from '@/hooks/use-frames';
 import {
   IMAGE_TO_VIDEO_MODELS,
   isValidImageToVideoModel,
 } from '@/lib/ai/models';
+import { computeSequenceModelCoverage } from '@/lib/model/sequence-model-coverage';
 import { ChevronDown } from 'lucide-react';
+import { useMemo } from 'react';
 
 function videoModelName(model: string): string {
   return isValidImageToVideoModel(model)
@@ -40,8 +47,19 @@ export const SequenceVideoModelSelector = ({
   sequenceVideoModel?: string | null;
 }) => {
   const { data: models } = useSequenceVideoModels(sequenceId);
+  const { data: variants } = useSequenceVideoVariants(sequenceId);
   const { activeVideoModel, selectVideoModel } =
     useActiveVideoModel(sequenceId);
+
+  const coverage = useMemo(
+    () =>
+      computeSequenceModelCoverage({
+        variants,
+        variantType: 'video',
+        primaryModel: sequenceVideoModel,
+      }),
+    [variants, sequenceVideoModel]
+  );
 
   // No video variants generated yet — fall back to the read-only chip showing
   // the sequence's configured model (or render nothing when motion is off).
@@ -92,7 +110,19 @@ export const SequenceVideoModelSelector = ({
             onSelect={(e) => e.preventDefault()}
             className="cursor-pointer"
           >
-            {videoModelName(model)}
+            <span className="flex w-full items-center justify-between gap-2">
+              <span className="truncate">{videoModelName(model)}</span>
+              <span className="flex shrink-0 items-center gap-1.5">
+                <ModelCoverageMarker coverage={coverage.get(model)} />
+                <SetModelButton
+                  sequenceId={sequenceId}
+                  variantType="video"
+                  model={model}
+                  modelName={videoModelName(model)}
+                  coverage={coverage.get(model)}
+                />
+              </span>
+            </span>
           </DropdownMenuCheckboxItem>
         ))}
         <AddModelMenuSection

--- a/src/components/model/sequence-video-model-selector.tsx
+++ b/src/components/model/sequence-video-model-selector.tsx
@@ -7,6 +7,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { AddModelMenuSection } from '@/components/model/add-model-menu';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { useSequenceVideoModels } from '@/hooks/use-frames';
 import {
@@ -94,6 +95,11 @@ export const SequenceVideoModelSelector = ({
             {videoModelName(model)}
           </DropdownMenuCheckboxItem>
         ))}
+        <AddModelMenuSection
+          sequenceId={sequenceId}
+          variantType="video"
+          usedModels={models}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/model/set-model-button.tsx
+++ b/src/components/model/set-model-button.tsx
@@ -1,0 +1,54 @@
+import { useSetSequenceModel } from '@/hooks/use-sequences';
+import type { ModelCoverage } from '@/lib/model/sequence-model-coverage';
+import { toast } from 'sonner';
+
+/**
+ * Sequence-wide "Set" action for a header model dropdown row (#547). Promotes
+ * this model to the live primary across every scene that has generated it.
+ * Renders nothing for the model that is already the live primary, or for a
+ * model that hasn't generated anything yet (nothing to promote).
+ */
+export const SetModelButton = ({
+  sequenceId,
+  variantType,
+  model,
+  modelName,
+  coverage,
+}: {
+  sequenceId: string;
+  variantType: 'image' | 'video';
+  model: string;
+  modelName: string;
+  coverage?: ModelCoverage;
+}) => {
+  const setModel = useSetSequenceModel();
+
+  if (!coverage || coverage.status === 'set' || coverage.completed === 0) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      disabled={setModel.isPending}
+      // Stop the click from toggling the row's pin / closing the menu.
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setModel.mutate(
+          { sequenceId, variantType, model },
+          {
+            onSuccess: (r) =>
+              toast.success(
+                `Set ${modelName} on ${r.count} scene${r.count === 1 ? '' : 's'}`
+              ),
+            onError: (err) => toast.error(err.message),
+          }
+        );
+      }}
+      className="rounded border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground hover:bg-accent hover:text-foreground disabled:opacity-50"
+    >
+      Set
+    </button>
+  );
+};

--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -52,6 +52,12 @@ type ScenePlayerProps = {
    */
   overrideVideoUrl?: string | null;
   badgeMessage?: string | null;
+  /**
+   * Warning badge shown when the pinned image model has not generated this
+   * scene (#547) — the displayed image is the primary fallback, not the
+   * pinned model's output.
+   */
+  modelMismatchLabel?: string | null;
   progressMessage?: string;
   posterUrl?: string;
   onTimeUpdate?: (currentTime: number) => void;
@@ -68,6 +74,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
   overrideImageUrl,
   overrideVideoUrl,
   badgeMessage,
+  modelMismatchLabel,
   progressMessage,
   posterUrl,
   onTimeUpdate,
@@ -425,6 +432,11 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
           {badgeMessage && (
             <span className="absolute top-2 left-2 z-10 rounded bg-primary/80 px-2 py-1 text-xs font-medium text-primary-foreground backdrop-blur-sm">
               {badgeMessage}
+            </span>
+          )}
+          {modelMismatchLabel && !badgeMessage && (
+            <span className="absolute top-2 left-2 z-10 rounded bg-amber-500/90 px-2 py-1 text-xs font-medium text-white backdrop-blur-sm">
+              {modelMismatchLabel}
             </span>
           )}
           {isPreviewImage && !isVariantPreview && (

--- a/src/components/music/music-view.tsx
+++ b/src/components/music/music-view.tsx
@@ -7,12 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
-import {
-  DEFAULT_MUSIC_MODEL,
-  getAudioModelDurationLimits,
-  safeAudioModel,
-  type AudioModel,
-} from '@/lib/ai/models';
+import { getAudioModelDurationLimits, type AudioModel } from '@/lib/ai/models';
 import type { Sequence } from '@/types/database';
 import {
   AlertCircle,
@@ -43,6 +38,14 @@ type MusicViewProps = {
    * Drives the model markers and the Set/Regenerate/Generate action button.
    */
   audioModelStatuses?: Map<string, ModelGenerationStatus>;
+  /**
+   * The viewer's active audio model, owned by `useActiveAudioModel` in the
+   * route (#546). Controlled here (not local state) so the music-tab selector
+   * and the sequence-header dropdown stay in sync — switching either one moves
+   * both, and the player remaps to the picked model's track.
+   */
+  selectedModel: AudioModel;
+  onModelChange: (model: AudioModel) => void;
   /** Promote the selected model's track to the sequence primary ("Set Music"). */
   onSetModel: (model: AudioModel) => void;
   isSettingModel?: boolean;
@@ -145,6 +148,8 @@ export const MusicView: React.FC<MusicViewProps> = ({
   onGenerateMusic,
   isGeneratingMusic,
   audioModelStatuses,
+  selectedModel,
+  onModelChange,
   onSetModel,
   isSettingModel = false,
   divergentBanner,
@@ -152,19 +157,10 @@ export const MusicView: React.FC<MusicViewProps> = ({
   onRegenerateMusicPrompt,
   isRegeneratingMusicPrompt,
 }) => {
-  const {
-    musicStatus,
-    musicUrl,
-    musicError,
-    musicModel,
-    musicPrompt,
-    musicTags,
-  } = sequence;
+  const { musicStatus, musicUrl, musicError, musicPrompt, musicTags } =
+    sequence;
 
   const [editPrompt, setEditPrompt] = useState(musicPrompt ?? '');
-  const [editModel, setEditModel] = useState<AudioModel>(() =>
-    safeAudioModel(musicModel, DEFAULT_MUSIC_MODEL)
-  );
   const [editDuration, setEditDuration] = useState<number | undefined>(
     () => videoDuration
   );
@@ -220,7 +216,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
     setEditDuration(videoDuration);
   }
 
-  const durationLimits = getAudioModelDurationLimits(editModel);
+  const durationLimits = getAudioModelDurationLimits(selectedModel);
   const effectiveDuration =
     editDuration ?? videoDuration ?? durationLimits.default;
   const durationExceedsMax = effectiveDuration > durationLimits.max;
@@ -229,7 +225,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
     onGenerateMusic({
       prompt: editPrompt || undefined,
       tags: musicTags || undefined,
-      model: editModel,
+      model: selectedModel,
       duration: editDuration,
     });
   }
@@ -237,13 +233,13 @@ export const MusicView: React.FC<MusicViewProps> = ({
   // Action for the selected model, mirroring the video/image scene-detail
   // button: a completed alternate promotes ("Set Music"); the live primary
   // regenerates; anything without a track generates for the first time.
-  const selectedStatus = audioModelStatuses?.get(editModel);
+  const selectedStatus = audioModelStatuses?.get(selectedModel);
   const selectedIsSet = selectedStatus === 'set';
   const selectedIsCompletedAlternate = selectedStatus === 'completed';
 
   const actionButton = selectedIsCompletedAlternate ? (
     <LoadingButton
-      onClick={() => onSetModel(editModel)}
+      onClick={() => onSetModel(selectedModel)}
       isLoading={isSettingModel}
       loadingText="Setting…"
     >
@@ -279,8 +275,8 @@ export const MusicView: React.FC<MusicViewProps> = ({
 
         <FormField label="Model" muted>
           <MusicModelSelector
-            selectedModel={editModel}
-            onModelChange={setEditModel}
+            selectedModel={selectedModel}
+            onModelChange={onModelChange}
             generatedStatuses={audioModelStatuses}
           />
         </FormField>
@@ -323,8 +319,8 @@ export const MusicView: React.FC<MusicViewProps> = ({
 
         <FormField label="Model" muted>
           <MusicModelSelector
-            selectedModel={editModel}
-            onModelChange={setEditModel}
+            selectedModel={selectedModel}
+            onModelChange={onModelChange}
             generatedStatuses={audioModelStatuses}
           />
         </FormField>
@@ -367,8 +363,8 @@ export const MusicView: React.FC<MusicViewProps> = ({
 
       <FormField label="Model">
         <MusicModelSelector
-          selectedModel={editModel}
-          onModelChange={setEditModel}
+          selectedModel={selectedModel}
+          onModelChange={onModelChange}
           generatedStatuses={audioModelStatuses}
         />
       </FormField>
@@ -385,7 +381,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
         {durationExceedsMax && (
           <p className="flex items-center gap-1.5 text-xs text-warning">
             <AlertTriangle className="h-3.5 w-3.5" />
-            Video is {Math.round(effectiveDuration)}s but {editModel} max is{' '}
+            Video is {Math.round(effectiveDuration)}s but {selectedModel} max is{' '}
             {durationLimits.max}s — music will be clamped.
           </p>
         )}

--- a/src/components/scenes/scene-list-item.tsx
+++ b/src/components/scenes/scene-list-item.tsx
@@ -30,6 +30,10 @@ type SceneListItemProps = {
    */
   divergentVariantId?: string;
   onCompareDivergent?: () => void;
+  /** Pinned image model hasn't generated this scene (#547) — show a badge. */
+  modelMissing?: boolean;
+  /** Name of the pinned image model, for the "No {model}" badge. */
+  modelMissingLabel?: string | null;
 };
 
 const SceneListItemComponent: React.FC<SceneListItemProps> = ({
@@ -43,6 +47,8 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
   isRegeneratingMotion = false,
   divergentVariantId,
   onCompareDivergent,
+  modelMissing = false,
+  modelMissingLabel,
 }) => {
   // Divergent alternate takes precedence: promoting it resolves staleness too.
   const showDivergentDot = !!divergentVariantId;
@@ -139,28 +145,42 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
             variant === 'horizontal' && 'flex-row gap-4'
           )}
         >
-          <SceneThumbnail
-            thumbnailUrl={frame?.thumbnailUrl}
-            previewThumbnailUrl={frame?.previewThumbnailUrl}
-            thumbnailStatus={frame?.thumbnailStatus || undefined}
-            alt={title ?? 'Scene thumbnail'}
-            aspectRatio={aspectRatio}
+          <div
             className={cn(
-              'w-full rounded-md',
-              // Portrait (9:16) uses smaller width to reduce height
+              'relative w-full',
               aspectRatio === '9:16' && [
                 variant === 'responsive' &&
                   '@[280px]/scene:w-20 @[280px]/scene:shrink-0',
                 variant === 'horizontal' && 'w-20 shrink-0',
               ],
-              // Landscape (16:9) and square (1:1) use standard width
               aspectRatio !== '9:16' && [
                 variant === 'responsive' &&
                   '@[280px]/scene:w-32 @[280px]/scene:shrink-0',
                 variant === 'horizontal' && 'w-32 shrink-0',
               ]
             )}
-          />
+          >
+            <SceneThumbnail
+              thumbnailUrl={frame?.thumbnailUrl}
+              previewThumbnailUrl={frame?.previewThumbnailUrl}
+              thumbnailStatus={frame?.thumbnailStatus || undefined}
+              alt={title ?? 'Scene thumbnail'}
+              aspectRatio={aspectRatio}
+              className="w-full rounded-md"
+            />
+            {modelMissing && (
+              <span
+                className="absolute bottom-1 left-1 rounded bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white"
+                aria-label={
+                  modelMissingLabel
+                    ? `Not generated with ${modelMissingLabel}`
+                    : 'Not generated with the selected model'
+                }
+              >
+                No {modelMissingLabel}
+              </span>
+            )}
+          </div>
 
           <div className="flex flex-col gap-1.5">
             <CardTitle className="text-sm">
@@ -190,7 +210,9 @@ const areEqual = (
     prevProps.variant !== nextProps.variant ||
     prevProps.isRegeneratingImage !== nextProps.isRegeneratingImage ||
     prevProps.isRegeneratingMotion !== nextProps.isRegeneratingMotion ||
-    prevProps.divergentVariantId !== nextProps.divergentVariantId
+    prevProps.divergentVariantId !== nextProps.divergentVariantId ||
+    prevProps.modelMissing !== nextProps.modelMissing ||
+    prevProps.modelMissingLabel !== nextProps.modelMissingLabel
   ) {
     return false;
   }

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -45,6 +45,14 @@ type SceneListProps = {
   initialMusicModel?: AudioModel;
   /** Current style category — used to filter style-restricted motion models. */
   styleCategory?: string;
+  /**
+   * Scenes the pinned image model hasn't generated yet (#547). Those cards show
+   * a "No {model}" badge so the thumbnail (which still shows the primary image)
+   * isn't mistaken for the pinned model's output.
+   */
+  modelMissingFrameIds?: Set<string>;
+  /** Name of the pinned image model, for the per-card "No {model}" badge. */
+  modelMissingLabel?: string | null;
 };
 
 const isCompleted = (frame: Frame) => {
@@ -68,6 +76,8 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   initialMotionModel,
   initialMusicModel,
   styleCategory,
+  modelMissingFrameIds,
+  modelMissingLabel,
 }) => {
   const divergentByFrameId = useMemo(() => {
     const map = new Map<string, FrameVariant>();
@@ -202,6 +212,11 @@ const SceneListComponent: React.FC<SceneListProps> = ({
                       ? () => onCompareDivergent?.(divergent)
                       : undefined
                   }
+                  modelMissing={
+                    !!modelMissingLabel &&
+                    (modelMissingFrameIds?.has(frame.id) ?? false)
+                  }
+                  modelMissingLabel={modelMissingLabel}
                 />
               );
             })}
@@ -308,7 +323,9 @@ const areEqual = (
     prevProps.musicPromptsReady !== nextProps.musicPromptsReady ||
     prevProps.initialMotionModel !== nextProps.initialMotionModel ||
     prevProps.initialMusicModel !== nextProps.initialMusicModel ||
-    prevProps.styleCategory !== nextProps.styleCategory
+    prevProps.styleCategory !== nextProps.styleCategory ||
+    prevProps.modelMissingLabel !== nextProps.modelMissingLabel ||
+    prevProps.modelMissingFrameIds !== nextProps.modelMissingFrameIds
   ) {
     return false;
   }

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -243,9 +243,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
 
   // Previous value tracking for prop-to-state sync (refs avoid extra re-renders)
   const prevImagePromptRef = useRef<string | undefined>(undefined);
-  const prevImageModelRef = useRef<string | undefined>(undefined);
   const prevMotionPromptRef = useRef<string | undefined>(undefined);
-  const prevMotionModelKeyRef = useRef<string>('');
 
   const queryClient = useQueryClient();
   const generateVariants = useGenerateVariants();
@@ -505,21 +503,20 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // The model this scene's image tab targets, mirroring scenes-view's
   // effectiveImageModel so the selector, the Generate/Set state, and the
   // previewed image all agree. Precedence: explicit per-scene pick → the
-  // sequence-level header pin (#547) → the frame's own model. `regenImageModel`
-  // is the same minus the frame fallback, so "nothing chosen" still passes
-  // undefined and lets the server default rather than re-asserting a model.
+  // sequence-level header pin (#547) → the frame's own model. `selectedImageModel`
+  // is ONLY a deliberate dropdown pick (reset on frame switch), so the pin isn't
+  // shadowed by a frame-synced value. `regenImageModel` drops the frame fallback
+  // so "nothing chosen" passes undefined and lets the server default.
   const effectiveImageModel =
     selectedImageModel ?? activeImageModel ?? imageModel;
   const regenImageModel = selectedImageModel ?? activeImageModel ?? undefined;
   // Resolved motion model for this scene. Precedence:
-  //   1. user picked one in the dropdown right now
+  //   1. explicit per-scene dropdown pick
   //   2. sequence-level header pin (#547) — switching it moves this selector
   //   3. frame already has completed motion → show what it was generated with
   //   4. sequence-level model (reflects most recent batch pick or creation)
   //   5. global default
-  // Without (3) and (4) the per-frame label would just show DEFAULT_VIDEO_MODEL
-  // regardless of what was actually used or what batch-generate just selected.
-  const effectiveMotionModel: ImageToVideoModel =
+  const baseMotionModel: ImageToVideoModel =
     selectedMotionModel ||
     activeVideoModel ||
     (frame?.videoStatus === 'completed' && frame.motionModel
@@ -527,6 +524,20 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       : undefined) ||
     sequenceMotionModel ||
     DEFAULT_VIDEO_MODEL;
+  // Keep the resolved model usable for this scene: snap to an aspect-ratio
+  // compatible model, then fall back to the default when it's gated to a
+  // different style category (e.g. Seedance 2 is animation-only). This used to
+  // live in a render-phase frame→state sync, which pre-filled the dropdown
+  // selection and shadowed the header pin — folding it here lets the pin drive.
+  const aspectCompatibleMotion = aspectRatio
+    ? getCompatibleModel(baseMotionModel, aspectRatio)
+    : baseMotionModel;
+  const motionModelConfig = IMAGE_TO_VIDEO_MODELS[aspectCompatibleMotion];
+  const effectiveMotionModel: ImageToVideoModel =
+    'requiredStyleCategory' in motionModelConfig &&
+    motionModelConfig.requiredStyleCategory !== styleCategory
+      ? DEFAULT_VIDEO_MODEL
+      : aspectCompatibleMotion;
   // Regen target (mirror of regenImageModel): explicit pick → header pin, else
   // undefined so the server defaults rather than re-asserting a model.
   const regenMotionModel = selectedMotionModel ?? activeVideoModel ?? undefined;
@@ -860,6 +871,12 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     prevScriptFrameIdRef.current = frame?.id;
     setEditedScript(undefined);
     setEditedDurationSeconds(undefined);
+    // Clear per-scene dropdown picks so the next scene starts from its header
+    // pin / own model (#547). Storing the frame's model here previously shadowed
+    // the pin; aspect-ratio + style-category fallback now lives in
+    // effectiveMotionModel instead.
+    setSelectedImageModel(undefined);
+    setSelectedMotionModel(undefined);
   }
 
   if (imagePrompt !== prevImagePromptRef.current) {
@@ -867,35 +884,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     setEditedImagePrompt(imagePrompt || '');
   }
 
-  if (frame?.imageModel !== prevImageModelRef.current) {
-    prevImageModelRef.current = frame?.imageModel;
-    setSelectedImageModel(
-      safeTextToImageModel(frame?.imageModel, DEFAULT_IMAGE_MODEL)
-    );
-  }
-
   if (rawMotionPrompt !== prevMotionPromptRef.current) {
     prevMotionPromptRef.current = rawMotionPrompt;
     setEditedMotionPrompt(rawMotionPrompt);
-  }
-
-  const motionModelKey = `${frame?.motionModel ?? ''}:${aspectRatio ?? ''}:${styleCategory ?? ''}`;
-  if (motionModelKey !== prevMotionModelKeyRef.current) {
-    prevMotionModelKeyRef.current = motionModelKey;
-    const currentModel = frame?.motionModel
-      ? safeImageToVideoModel(frame.motionModel)
-      : DEFAULT_VIDEO_MODEL;
-    const compatibleModel = aspectRatio
-      ? getCompatibleModel(currentModel, aspectRatio)
-      : currentModel;
-    // Fall back if the model requires a style category that doesn't match
-    const modelConfig = IMAGE_TO_VIDEO_MODELS[compatibleModel];
-    const finalModel =
-      'requiredStyleCategory' in modelConfig &&
-      modelConfig.requiredStyleCategory !== styleCategory
-        ? DEFAULT_VIDEO_MODEL
-        : compatibleModel;
-    setSelectedMotionModel(finalModel);
   }
 
   // Check if image is currently generating

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -22,6 +22,8 @@ import { updateFrameFn } from '@/functions/frames';
 import { generateFrameImageFn } from '@/functions/frame-image';
 import { generateFrameMotionFn } from '@/functions/motion-functions';
 import { regenerateFramePromptFn } from '@/functions/prompt-variants';
+import { useActiveImageModel } from '@/hooks/use-active-image-model';
+import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { useFalBillingGate } from '@/hooks/use-billing-gate';
 import {
@@ -172,6 +174,11 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     [frameDivergentVariants]
   );
   const [copiedTab, setCopiedTab] = useState<string | null>(null);
+  // Sequence-level model pins from the header dropdowns (#547). Fold them into
+  // the per-scene effective model below so switching a header model also moves
+  // this scene's image/video tab selector.
+  const { activeImageModel } = useActiveImageModel(sequenceId);
+  const { activeVideoModel } = useActiveVideoModel(sequenceId);
   const [historyOpen, setHistoryOpen] = useState<'visual' | 'motion' | null>(
     null
   );
@@ -495,6 +502,34 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     frame?.imageModel,
     DEFAULT_IMAGE_MODEL
   );
+  // The model this scene's image tab targets, mirroring scenes-view's
+  // effectiveImageModel so the selector, the Generate/Set state, and the
+  // previewed image all agree. Precedence: explicit per-scene pick → the
+  // sequence-level header pin (#547) → the frame's own model. `regenImageModel`
+  // is the same minus the frame fallback, so "nothing chosen" still passes
+  // undefined and lets the server default rather than re-asserting a model.
+  const effectiveImageModel =
+    selectedImageModel ?? activeImageModel ?? imageModel;
+  const regenImageModel = selectedImageModel ?? activeImageModel ?? undefined;
+  // Resolved motion model for this scene. Precedence:
+  //   1. user picked one in the dropdown right now
+  //   2. sequence-level header pin (#547) — switching it moves this selector
+  //   3. frame already has completed motion → show what it was generated with
+  //   4. sequence-level model (reflects most recent batch pick or creation)
+  //   5. global default
+  // Without (3) and (4) the per-frame label would just show DEFAULT_VIDEO_MODEL
+  // regardless of what was actually used or what batch-generate just selected.
+  const effectiveMotionModel: ImageToVideoModel =
+    selectedMotionModel ||
+    activeVideoModel ||
+    (frame?.videoStatus === 'completed' && frame.motionModel
+      ? safeImageToVideoModel(frame.motionModel, DEFAULT_VIDEO_MODEL)
+      : undefined) ||
+    sequenceMotionModel ||
+    DEFAULT_VIDEO_MODEL;
+  // Regen target (mirror of regenImageModel): explicit pick → header pin, else
+  // undefined so the server defaults rather than re-asserting a model.
+  const regenMotionModel = selectedMotionModel ?? activeVideoModel ?? undefined;
   const imagePrompt =
     frame?.imagePrompt || frame?.metadata?.prompts?.visual?.fullPrompt;
 
@@ -511,24 +546,23 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // thumbnail but no variant row.
   const imageModelGenerated =
     !!variantForSelectedModel ||
-    (!!frame?.thumbnailUrl &&
-      (selectedImageModel || imageModel) === imageModel);
+    (!!frame?.thumbnailUrl && effectiveImageModel === imageModel);
 
   const handleSetImageFromVariant = useCallback(async () => {
-    if (!frame?.id || !frame.sequenceId || !selectedImageModel) return;
+    if (!frame?.id || !frame.sequenceId) return;
 
     try {
       await setImageFromVariant.mutateAsync({
         sequenceId: frame.sequenceId,
         frameId: frame.id,
-        model: selectedImageModel,
+        model: effectiveImageModel,
       });
     } catch (error) {
       toast.error('Failed to set image', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-  }, [frame, selectedImageModel, setImageFromVariant]);
+  }, [frame, effectiveImageModel, setImageFromVariant]);
 
   // Video equivalents (#545): drive the "Set Video" action from the selected
   // scene's video variant for the picked model.
@@ -542,20 +576,20 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     videoVariantForSelectedModel.url === frame?.videoUrl;
 
   const handleSetVideoFromVariant = useCallback(async () => {
-    if (!frame?.id || !frame.sequenceId || !selectedMotionModel) return;
+    if (!frame?.id || !frame.sequenceId) return;
 
     try {
       await setVideoFromVariant.mutateAsync({
         sequenceId: frame.sequenceId,
         frameId: frame.id,
-        model: selectedMotionModel,
+        model: effectiveMotionModel,
       });
     } catch (error) {
       toast.error('Failed to set video', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-  }, [frame, selectedMotionModel, setVideoFromVariant]);
+  }, [frame, effectiveMotionModel, setVideoFromVariant]);
 
   const handleShortenPrompt = useCallback(async () => {
     setShortenStatus({ loading: false, error: null, success: null });
@@ -606,7 +640,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 ...f,
                 thumbnailStatus: 'generating' as const,
                 imagePrompt: editedImagePrompt || f.imagePrompt,
-                imageModel: selectedImageModel || f.imageModel,
+                imageModel: regenImageModel ?? f.imageModel,
               }
             : f
         );
@@ -620,7 +654,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
         ...oldFrame,
         thumbnailStatus: 'generating' as const,
         imagePrompt: editedImagePrompt || oldFrame.imagePrompt,
-        imageModel: selectedImageModel || oldFrame.imageModel,
+        imageModel: regenImageModel ?? oldFrame.imageModel,
       };
     });
 
@@ -629,7 +663,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
         data: {
           sequenceId: frame.sequenceId,
           frameId: frame.id,
-          model: selectedImageModel,
+          model: regenImageModel,
           prompt: editedImagePrompt || undefined,
         },
       });
@@ -659,7 +693,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     }
   }, [
     frame,
-    selectedImageModel,
+    regenImageModel,
     editedImagePrompt,
     queryClient,
     onRegenerateStart,
@@ -682,7 +716,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 ...f,
                 videoStatus: 'generating' as const,
                 motionPrompt: editedMotionPrompt || f.motionPrompt,
-                motionModel: selectedMotionModel || f.motionModel,
+                motionModel: regenMotionModel ?? f.motionModel,
               }
             : f
         );
@@ -696,11 +730,11 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
         ...oldFrame,
         videoStatus: 'generating' as const,
         motionPrompt: editedMotionPrompt || oldFrame.motionPrompt,
-        motionModel: selectedMotionModel || oldFrame.motionModel,
+        motionModel: regenMotionModel ?? oldFrame.motionModel,
       };
     });
 
-    const motionModelForCall = selectedMotionModel || DEFAULT_VIDEO_MODEL;
+    const motionModelForCall = regenMotionModel || DEFAULT_VIDEO_MODEL;
     const supportsAudio = videoModelSupportsAudio(motionModelForCall);
 
     try {
@@ -708,7 +742,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
         data: {
           sequenceId: frame.sequenceId,
           frameId: frame.id,
-          model: selectedMotionModel,
+          model: regenMotionModel,
           prompt: editedMotionPrompt || undefined,
           generateAudio: supportsAudio ? generateAudio : undefined,
         },
@@ -737,7 +771,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     }
   }, [
     frame,
-    selectedMotionModel,
+    regenMotionModel,
     editedMotionPrompt,
     generateAudio,
     queryClient,
@@ -754,14 +788,14 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       await generateVariants.mutateAsync({
         sequenceId: frame.sequenceId,
         frameId: frame.id,
-        model: selectedImageModel,
+        model: regenImageModel,
       });
     } catch (error) {
       toast.error('Scene variants generation failed', {
         description: error instanceof Error ? error.message : 'Unknown error',
       });
     }
-  }, [frame, generateVariants, selectedImageModel, onRegenerateStart]);
+  }, [frame, generateVariants, regenImageModel, onRegenerateStart]);
 
   const handleVariantSelect = useCallback(
     async (index: number) => {
@@ -786,21 +820,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // Raw prompt for editing (just motion direction, no dialogue/audio)
   const rawMotionPrompt =
     frame?.motionPrompt || motionPromptData?.fullPrompt || '';
-
-  // Resolved motion model for this scene. Precedence:
-  //   1. user picked one in the dropdown right now
-  //   2. frame already has completed motion → show what it was generated with
-  //   3. sequence-level model (reflects most recent batch pick or creation)
-  //   4. global default
-  // Without (2) and (3) the per-frame label would just show DEFAULT_VIDEO_MODEL
-  // regardless of what was actually used or what batch-generate just selected.
-  const effectiveMotionModel: ImageToVideoModel =
-    selectedMotionModel ||
-    (frame?.videoStatus === 'completed' && frame.motionModel
-      ? safeImageToVideoModel(frame.motionModel, DEFAULT_VIDEO_MODEL)
-      : undefined) ||
-    sequenceMotionModel ||
-    DEFAULT_VIDEO_MODEL;
 
   // Assembled preview: exactly what resolveMotionPrompt produces on the server
   const assembledPrompt = useMemo(() => {
@@ -977,7 +996,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           frame={frame}
           sequenceId={sequenceId}
           scriptText={scriptText}
-          motionModel={selectedMotionModel || DEFAULT_VIDEO_MODEL}
+          motionModel={effectiveMotionModel}
           editedScript={editedScript}
           onEditedScriptChange={setEditedScript}
           editedDurationSeconds={editedDurationSeconds}
@@ -1041,7 +1060,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           <div className="space-y-2">
             <span className="text-sm font-medium">Model</span>
             <ImageModelSelector
-              selectedModel={selectedImageModel || imageModel}
+              selectedModel={effectiveImageModel}
               onModelChange={handleImageModelChange}
               disabled={isGenerating}
               recommendedImageModel={recommendedImageModel}
@@ -1325,9 +1344,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           )}
 
           {/* SFX/dialogue toggle — only for audio-capable models */}
-          {videoModelSupportsAudio(
-            selectedMotionModel || DEFAULT_VIDEO_MODEL
-          ) && (
+          {videoModelSupportsAudio(effectiveMotionModel) && (
             <label
               htmlFor="scene-generate-audio"
               className="flex items-center gap-2 text-sm text-muted-foreground"
@@ -1428,7 +1445,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           <div className="space-y-2">
             <span className="text-sm font-medium">Model</span>
             <ImageModelSelector
-              selectedModel={selectedImageModel || imageModel}
+              selectedModel={effectiveImageModel}
               onModelChange={handleImageModelChange}
               disabled={isGenerating || isGeneratingSceneVariants}
               recommendedImageModel={recommendedImageModel}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -34,6 +34,8 @@ import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
+  IMAGE_MODELS,
+  isValidTextToImageModel,
   safeAudioModel,
   safeImageToVideoModel,
   safeTextToImageModel,
@@ -282,6 +284,32 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     }
     return map;
   }, [imageVariants]);
+
+  // Scenes the pinned image model has NOT generated yet (#547). When a model is
+  // pinned, the player + scene list flag these so a viewer isn't shown the
+  // primary image as if it were the pinned model's output.
+  const activeImageModelLabel =
+    activeImageModel && isValidTextToImageModel(activeImageModel)
+      ? IMAGE_MODELS[activeImageModel].name
+      : null;
+  const framesMissingActiveImage = useMemo(() => {
+    const missing = new Set<string>();
+    if (!activeImageModel || !frames) return missing;
+    for (const f of frames) {
+      const hasModel = imageVariantsByFrame
+        .get(f.id)
+        ?.some(
+          (v) =>
+            v.model === activeImageModel &&
+            v.divergedAt === null &&
+            v.discardedAt === null &&
+            v.status === 'completed' &&
+            v.url
+        );
+      if (!hasModel) missing.add(f.id);
+    }
+    return missing;
+  }, [activeImageModel, frames, imageVariantsByFrame]);
 
   // Divergent alternates + realtime stale:detected wiring (issue #625).
   // Mirror the frames-list polling fallback so the corner-dot still updates
@@ -910,6 +938,8 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             initialMotionModel={sequenceMotionModel}
             initialMusicModel={sequenceMusicModel}
             styleCategory={styleCategory}
+            modelMissingFrameIds={framesMissingActiveImage}
+            modelMissingLabel={activeImageModelLabel}
           />
         </div>
 
@@ -945,6 +975,14 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
               overrideImageUrl={previewVariantUrl}
               overrideVideoUrl={previewVariantVideoUrl}
               badgeMessage={playerBadgeMessage}
+              modelMismatchLabel={
+                selectedTab === 'scene-variants' &&
+                activeImageModelLabel &&
+                curSelectedFrameId &&
+                framesMissingActiveImage.has(curSelectedFrameId)
+                  ? `Not generated with ${activeImageModelLabel}`
+                  : null
+              }
               progressMessage={
                 generationState.phases.find((p) => p.status === 'active')
                   ?.phaseName

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -22,6 +22,7 @@ import {
   useSequenceVideoVariants,
   useUndiscardVariant,
 } from '@/hooks/use-frames';
+import { useActiveImageModel } from '@/hooks/use-active-image-model';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
 import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
@@ -265,6 +266,22 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     }
     return map;
   }, [videoVariants]);
+
+  // Viewer-local active image model (#547). When pinned, the player shows that
+  // model's image for each frame (falling back to the legacy thumbnail when the
+  // model has no completed image for a frame).
+  const { activeImageModel } = useActiveImageModel(sequenceId);
+  const imageVariantsByFrame = useMemo(() => {
+    const map = new Map<string, FrameVariant[]>();
+    if (!imageVariants) return map;
+    for (const v of imageVariants) {
+      if (v.variantType !== 'image') continue;
+      const list = map.get(v.frameId) ?? [];
+      list.push(v);
+      map.set(v.frameId, list);
+    }
+    return map;
+  }, [imageVariants]);
 
   // Divergent alternates + realtime stale:detected wiring (issue #625).
   // Mirror the frames-list polling fallback so the corner-dot still updates
@@ -544,33 +561,69 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
       videoVariantForSelectedModel,
     ]);
 
-  // Frames as shown by the player: when a video model is pinned, swap each
-  // frame's video for that model's variant (or clear it when the model hasn't
-  // produced one for that frame). Only the player display is remapped — every
-  // other consumer keeps the raw `frames` (generation status, selection, etc.).
+  // Frames as shown by the player: when an image and/or video model is pinned,
+  // swap each frame's image / video for that model's variant. Only the player
+  // display is remapped — every other consumer keeps the raw `frames`
+  // (generation status, selection, the per-frame preview overlay, etc.).
   const playerFrames = useMemo(() => {
-    // Until the variants query resolves, keep the legacy videos rather than
-    // blanking every frame (the map would find no variant and clear them all).
-    if (!frames || !activeVideoModel || !videoVariants) return frames;
+    if (!frames) return frames;
+    // Wait for the relevant variants query before remapping, so we don't blank
+    // a pinned type while its data is still loading. The image pin is suppressed
+    // on the image-prompt tab, where the per-frame preview overlay + prompt
+    // panel govern the displayed image (avoids desyncing them from the header).
+    const pinImage =
+      activeImageModel && imageVariants && selectedTab !== 'image-prompt';
+    const pinVideo = activeVideoModel && videoVariants;
+    if (!pinImage && !pinVideo) return frames;
     return frames.map((f) => {
-      const variant = videoVariantsByFrame
-        .get(f.id)
-        ?.find(
-          (v) =>
-            v.model === activeVideoModel &&
-            v.divergedAt === null &&
-            v.discardedAt === null
-        );
-      if (!variant) {
-        return { ...f, videoUrl: null, videoStatus: 'pending' as const };
+      let next = f;
+      if (pinImage) {
+        // Image: swap the displayed image; fall back to the legacy thumbnail
+        // when the pinned model has no completed image for this frame (never
+        // leave a frame imageless).
+        const iv = imageVariantsByFrame
+          .get(f.id)
+          ?.find(
+            (v) =>
+              v.model === activeImageModel &&
+              v.divergedAt === null &&
+              v.discardedAt === null &&
+              v.status === 'completed' &&
+              v.url
+          );
+        if (iv?.url) next = { ...next, thumbnailUrl: iv.url };
       }
-      return {
-        ...f,
-        videoUrl: variant.status === 'completed' ? variant.url : null,
-        videoStatus: variant.status,
-      };
+      if (pinVideo) {
+        // Video: show only the pinned model's output (no fallback — a missing
+        // variant means that model hasn't produced this frame yet).
+        const vv = videoVariantsByFrame
+          .get(f.id)
+          ?.find(
+            (v) =>
+              v.model === activeVideoModel &&
+              v.divergedAt === null &&
+              v.discardedAt === null
+          );
+        next = vv
+          ? {
+              ...next,
+              videoUrl: vv.status === 'completed' ? vv.url : null,
+              videoStatus: vv.status,
+            }
+          : { ...next, videoUrl: null, videoStatus: 'pending' as const };
+      }
+      return next;
     });
-  }, [frames, activeVideoModel, videoVariants, videoVariantsByFrame]);
+  }, [
+    frames,
+    selectedTab,
+    activeImageModel,
+    imageVariants,
+    imageVariantsByFrame,
+    activeVideoModel,
+    videoVariants,
+    videoVariantsByFrame,
+  ]);
 
   const setterForType = useCallback((type: RegenerationType) => {
     switch (type) {

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -421,9 +421,13 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     setVideoModelOverride(null);
   }, [curSelectedFrameId]);
 
-  // Derive variant preview state from model override + variants
+  // Derive variant preview state from model override + variants. The
+  // sequence-level header pin (#547) sits below an explicit per-scene override
+  // but above the frame's own model, so the previewed variant + Set/Generate
+  // state track whatever the header switched to.
   const effectiveImageModel =
     imageModelOverride ??
+    activeImageModel ??
     safeTextToImageModel(selectedFrame?.imageModel, DEFAULT_IMAGE_MODEL);
 
   const variantForSelectedModel = useMemo(() => {
@@ -439,6 +443,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   // (which would attribute a model the scene was never generated with).
   const effectiveVideoModel =
     videoModelOverride ??
+    activeVideoModel ??
     (selectedFrame?.motionModel
       ? safeImageToVideoModel(selectedFrame.motionModel, DEFAULT_VIDEO_MODEL)
       : null);

--- a/src/functions/__tests__/sequences.test.ts
+++ b/src/functions/__tests__/sequences.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for the pure decision helpers extracted from the add-model /
+ * set-model server fns (#547). The TanStack server-fn middleware chain (auth,
+ * sequence access, scoped DB, workflow triggers) is exercised end-to-end by the
+ * e2e suite; here we pin the logic that decides:
+ *   - which variant rows are promotable to the live primary
+ *     (`selectPromotableVariants`) — guards against resurrecting a
+ *     divergent/discarded alternate across the whole sequence,
+ *   - the per-variantType promote update (`buildSequencePromoteUpdate`),
+ *   - the duplicate-model guard (`assertModelNotAlreadyAdded`) — a failed add
+ *     must be re-addable,
+ *   - the video eligibility filter (`selectEligibleVideoFrames`).
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Frame, FrameVariant } from '@/lib/db/schema';
+import {
+  assertModelNotAlreadyAdded,
+  buildSequencePromoteUpdate,
+  selectEligibleVideoFrames,
+  selectPromotableVariants,
+} from '@/functions/sequences';
+
+const NOW = new Date('2026-06-03T00:00:00.000Z');
+
+function makeVariant(overrides: Partial<FrameVariant> = {}): FrameVariant {
+  return {
+    id: 'variant-1',
+    frameId: 'frame-1',
+    sequenceId: 'seq-1',
+    variantType: 'image',
+    model: 'flux_pro',
+    url: 'https://cdn/variant.png',
+    storagePath: 'sequences/seq-1/frame-1/flux_pro.png',
+    previewUrl: null,
+    shotVariantUrl: null,
+    shotVariantPath: null,
+    shotVariantStatus: 'pending',
+    shotVariantWorkflowRunId: null,
+    status: 'completed',
+    workflowRunId: null,
+    generatedAt: NOW,
+    error: null,
+    promptHash: 'prompt-1',
+    inputHash: 'input-1',
+    divergedAt: null,
+    discardedAt: null,
+    durationMs: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeFrame(overrides: Partial<Frame> = {}): Frame {
+  return {
+    id: 'frame-1',
+    sequenceId: 'seq-1',
+    orderIndex: 0,
+    description: 'A scene',
+    durationMs: 3000,
+    thumbnailUrl: 'https://cdn/thumb.jpg',
+    thumbnailPath: null,
+    thumbnailStatus: 'completed',
+    thumbnailWorkflowRunId: null,
+    thumbnailGeneratedAt: null,
+    thumbnailError: null,
+    imageModel: 'nano_banana_2',
+    imagePrompt: null,
+    variantImageUrl: null,
+    variantImageStatus: 'pending',
+    variantWorkflowRunId: null,
+    variantImageGeneratedAt: null,
+    variantImageError: null,
+    videoUrl: null,
+    videoPath: null,
+    videoStatus: 'pending',
+    videoWorkflowRunId: null,
+    videoGeneratedAt: null,
+    videoError: null,
+    motionPrompt: null,
+    motionModel: null,
+    audioUrl: null,
+    audioPath: null,
+    audioStatus: 'pending',
+    audioWorkflowRunId: null,
+    audioGeneratedAt: null,
+    audioError: null,
+    audioModel: null,
+    thumbnailInputHash: null,
+    variantImageInputHash: null,
+    videoInputHash: null,
+    audioInputHash: null,
+    visualPromptInputHash: null,
+    motionPromptInputHash: null,
+    previewThumbnailUrl: null,
+    metadata: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('selectPromotableVariants (#547)', () => {
+  it('includes a live, completed row with a url for the target model', () => {
+    const variants = [makeVariant()];
+    expect(selectPromotableVariants(variants, 'flux_pro')).toHaveLength(1);
+  });
+
+  it('excludes rows for a different model', () => {
+    const variants = [makeVariant({ model: 'other_model' })];
+    expect(selectPromotableVariants(variants, 'flux_pro')).toEqual([]);
+  });
+
+  it('excludes rows that are not completed', () => {
+    const variants = [
+      makeVariant({ id: 'v-pending', status: 'pending' }),
+      makeVariant({ id: 'v-generating', status: 'generating' }),
+      makeVariant({ id: 'v-failed', status: 'failed' }),
+    ];
+    expect(selectPromotableVariants(variants, 'flux_pro')).toEqual([]);
+  });
+
+  it('excludes rows with no url (null or empty)', () => {
+    const variants = [
+      makeVariant({ id: 'v-null', url: null }),
+      makeVariant({ id: 'v-empty', url: '' }),
+    ];
+    expect(selectPromotableVariants(variants, 'flux_pro')).toEqual([]);
+  });
+
+  it('excludes divergent alternates (would resurrect a non-primary output)', () => {
+    const variants = [makeVariant({ divergedAt: NOW })];
+    expect(selectPromotableVariants(variants, 'flux_pro')).toEqual([]);
+  });
+
+  it('excludes user-discarded alternates', () => {
+    const variants = [makeVariant({ discardedAt: NOW })];
+    expect(selectPromotableVariants(variants, 'flux_pro')).toEqual([]);
+  });
+
+  it('returns only the matching live rows from a mixed set', () => {
+    const variants = [
+      makeVariant({ id: 'keep-1', frameId: 'f1' }),
+      makeVariant({ id: 'keep-2', frameId: 'f2' }),
+      makeVariant({ id: 'drop-model', model: 'other' }),
+      makeVariant({ id: 'drop-diverged', frameId: 'f3', divergedAt: NOW }),
+      makeVariant({ id: 'drop-pending', frameId: 'f4', status: 'pending' }),
+    ];
+    const result = selectPromotableVariants(variants, 'flux_pro');
+    expect(result.map((v) => v.id)).toEqual(['keep-1', 'keep-2']);
+  });
+});
+
+describe('buildSequencePromoteUpdate (#547)', () => {
+  it('image: promotes the thumbnail and clears the now-stale video, no video-parity fields', () => {
+    const variant = makeVariant({
+      variantType: 'image',
+      url: 'https://cdn/img.png',
+      storagePath: 'path/img.png',
+      inputHash: 'hash-img',
+    });
+    const update = buildSequencePromoteUpdate(
+      variant,
+      'image',
+      'flux_pro',
+      () => NOW
+    );
+    expect(update.thumbnailUrl).toBe('https://cdn/img.png');
+    expect(update.thumbnailStatus).toBe('completed');
+    expect(update.imageModel).toBe('flux_pro');
+    // The downstream video is invalidated by a new primary image.
+    expect(update.videoUrl).toBeNull();
+    expect(update.videoStatus).toBe('pending');
+    // Image promotion must not stamp the video-parity fields: motionModel is
+    // never set, and videoGeneratedAt is cleared to null (not stamped with a
+    // promotion timestamp the way the video case does).
+    expect(update.motionModel).toBeUndefined();
+    expect(update.videoGeneratedAt).toBeNull();
+  });
+
+  it('video: layers motionModel/durationMs/videoGeneratedAt on top of the base promote update', () => {
+    const variant = makeVariant({
+      variantType: 'video',
+      url: 'https://cdn/vid.mp4',
+      storagePath: 'path/vid.mp4',
+      inputHash: 'hash-vid',
+      durationMs: 5000,
+    });
+    const update = buildSequencePromoteUpdate(
+      variant,
+      'video',
+      'kling_25',
+      () => NOW
+    );
+    expect(update.videoUrl).toBe('https://cdn/vid.mp4');
+    expect(update.videoStatus).toBe('completed');
+    expect(update.videoInputHash).toBe('hash-vid');
+    // The three fields buildPromoteUpdate's video case omits, layered for
+    // parity with the per-scene setVideoFromVariantFn.
+    expect(update.motionModel).toBe('kling_25');
+    expect(update.durationMs).toBe(5000);
+    expect(update.videoGeneratedAt).toBe(NOW);
+  });
+});
+
+describe('assertModelNotAlreadyAdded (#547)', () => {
+  it('throws when a non-failed row exists for the model', () => {
+    for (const status of ['pending', 'generating', 'completed']) {
+      expect(() =>
+        assertModelNotAlreadyAdded(
+          [{ model: 'flux_pro', status }],
+          'flux_pro',
+          'image'
+        )
+      ).toThrow(/already on this sequence/);
+    }
+  });
+
+  it('does NOT throw when only a failed row exists (re-add is allowed)', () => {
+    expect(() =>
+      assertModelNotAlreadyAdded(
+        [{ model: 'flux_pro', status: 'failed' }],
+        'flux_pro',
+        'image'
+      )
+    ).not.toThrow();
+  });
+
+  it('does NOT throw when no row exists for the model', () => {
+    expect(() =>
+      assertModelNotAlreadyAdded(
+        [{ model: 'other', status: 'completed' }],
+        'flux_pro',
+        'video'
+      )
+    ).not.toThrow();
+  });
+
+  it('uses the label in the error message', () => {
+    expect(() =>
+      assertModelNotAlreadyAdded(
+        [{ model: 'suno', status: 'completed' }],
+        'suno',
+        'audio'
+      )
+    ).toThrow('That audio model is already on this sequence');
+  });
+});
+
+describe('selectEligibleVideoFrames (#547)', () => {
+  it('includes frames with a completed image', () => {
+    const frames = [makeFrame()];
+    expect(selectEligibleVideoFrames(frames)).toHaveLength(1);
+  });
+
+  it('excludes frames whose image is not completed', () => {
+    const frames = [
+      makeFrame({ id: 'pending', thumbnailStatus: 'pending' }),
+      makeFrame({ id: 'generating', thumbnailStatus: 'generating' }),
+      makeFrame({ id: 'failed', thumbnailStatus: 'failed' }),
+    ];
+    expect(selectEligibleVideoFrames(frames)).toEqual([]);
+  });
+
+  it('excludes frames completed but missing a thumbnail url', () => {
+    const frames = [
+      makeFrame({ id: 'null-url', thumbnailUrl: null }),
+      makeFrame({ id: 'empty-url', thumbnailUrl: '' }),
+    ];
+    expect(selectEligibleVideoFrames(frames)).toEqual([]);
+  });
+
+  it('returns only the eligible frames from a mixed set', () => {
+    const frames = [
+      makeFrame({ id: 'ok-1' }),
+      makeFrame({ id: 'no-image', thumbnailStatus: 'pending' }),
+      makeFrame({ id: 'ok-2' }),
+    ];
+    expect(selectEligibleVideoFrames(frames).map((f) => f.id)).toEqual([
+      'ok-1',
+      'ok-2',
+    ]);
+  });
+});

--- a/src/functions/__tests__/sequences.test.ts
+++ b/src/functions/__tests__/sequences.test.ts
@@ -16,9 +16,11 @@ import { describe, expect, it } from 'vitest';
 import type { Frame, FrameVariant } from '@/lib/db/schema';
 import {
   assertModelNotAlreadyAdded,
+  buildAddAudioMusicInput,
   buildSequencePromoteUpdate,
   selectEligibleVideoFrames,
   selectPromotableVariants,
+  sumFrameDurationsSeconds,
 } from '@/functions/sequences';
 
 const NOW = new Date('2026-06-03T00:00:00.000Z');
@@ -281,5 +283,66 @@ describe('selectEligibleVideoFrames (#547)', () => {
       'ok-1',
       'ok-2',
     ]);
+  });
+});
+
+describe('sumFrameDurationsSeconds (#547)', () => {
+  it('sums durationMs (ms → seconds) across frames', () => {
+    const frames = [
+      makeFrame({ id: 'f1', durationMs: 3000 }),
+      makeFrame({ id: 'f2', durationMs: 4500 }),
+    ];
+    expect(sumFrameDurationsSeconds(frames)).toBe(7.5);
+  });
+
+  it('falls back to 10s per frame when durationMs and metadata are absent', () => {
+    const frames = [
+      makeFrame({ id: 'unknown-1', durationMs: null, metadata: null }),
+      makeFrame({ id: 'unknown-2', durationMs: null, metadata: null }),
+    ];
+    expect(sumFrameDurationsSeconds(frames)).toBe(20);
+  });
+
+  it('returns 0 for an empty sequence (so the caller `|| 30` floor applies)', () => {
+    expect(sumFrameDurationsSeconds([])).toBe(0);
+    // Mirrors the add-audio / generate-music call sites.
+    expect(sumFrameDurationsSeconds([]) || 30).toBe(30);
+  });
+});
+
+describe('buildAddAudioMusicInput (#547)', () => {
+  const baseCtx = { userId: 'u1', teamId: 't1', sequenceId: 'seq-1' };
+
+  it('always sets isPrimary:false so an added audio model never repoints the primary track', () => {
+    const input = buildAddAudioMusicInput({
+      baseCtx,
+      prompt: 'epic score',
+      tags: 'cinematic',
+      durationSeconds: 42,
+      model: 'elevenlabs_music',
+    });
+    // The regression guard: the music workflow defaults isPrimary to true, which
+    // would clobber the live sequences.music* columns on success AND failure.
+    expect(input.isPrimary).toBe(false);
+  });
+
+  it('threads the context, prompt, tags, duration and model through unchanged', () => {
+    const input = buildAddAudioMusicInput({
+      baseCtx,
+      prompt: 'epic score',
+      tags: 'cinematic',
+      durationSeconds: 42,
+      model: 'elevenlabs_music',
+    });
+    expect(input).toEqual({
+      userId: 'u1',
+      teamId: 't1',
+      sequenceId: 'seq-1',
+      prompt: 'epic score',
+      tags: 'cinematic',
+      duration: 42,
+      model: 'elevenlabs_music',
+      isPrimary: false,
+    });
   });
 });

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -3,6 +3,8 @@ import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
   isValidAudioModel,
+  isValidImageToVideoModel,
+  isValidTextToImageModel,
   safeAudioModel,
   safeImageToVideoModel,
   safeTextToImageModel,
@@ -15,10 +17,19 @@ import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import { requireTeamMemberAccess } from '@/lib/auth/action-utils';
-import { estimateStoryboardCost } from '@/lib/billing/cost-estimation';
+import {
+  estimateAudioCost,
+  estimateImageCost,
+  estimateStoryboardCost,
+  estimateVideoCost,
+} from '@/lib/billing/cost-estimation';
+import { multiplyMicros } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
 import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
 import type { Frame } from '@/lib/db/schema';
+import { buildFrameImageWorkflowInput } from '@/lib/image/build-frame-image-input';
+import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
+import { VARIANT_TYPES } from '@/lib/db/schema/frame-variants';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import {
   createSequenceSchema,
@@ -27,6 +38,7 @@ import {
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import type {
+  BatchMotionMusicWorkflowInput,
   MusicSceneSummary,
   MusicWorkflowInput,
   StoryboardWorkflowInput,
@@ -473,6 +485,273 @@ export const getSequenceAudioVariantsFn = createServerFn({ method: 'GET' })
     return context.scopedDb.sequenceVariants.listMusicBySequence(
       context.sequence.id
     );
+  });
+
+/**
+ * Add a new image / video / audio model to an existing sequence (#547).
+ * Generates that model's output for every eligible frame (image/video) or the
+ * whole sequence (audio) using the EXISTING prompts — no re-analysis. Each unit
+ * lands as a `frame_variants` row (image/video) or `sequence_music_variants`
+ * row (audio), pre-stamped `pending` so the new model appears in the header
+ * dropdown immediately. Reuses the per-frame image / motion-batch / music
+ * workflows unchanged.
+ */
+export const addModelToSequenceFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        variantType: z.enum(VARIANT_TYPES),
+        model: z.string().min(1),
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
+    const { sequence, scopedDb, user } = context;
+    const { variantType, model } = data;
+    const baseCtx = {
+      userId: user.id,
+      teamId: sequence.teamId,
+      sequenceId: sequence.id,
+    };
+
+    // ── Audio: one new track for the sequence ──────────────────────────────
+    if (variantType === 'audio') {
+      if (!isValidAudioModel(model)) {
+        throw new Error('Invalid audio model');
+      }
+      // Block only when a non-failed (pending/generating/completed) track for
+      // this model already exists — a previously failed add can be retried.
+      const existing = await scopedDb.sequenceVariants.listMusicBySequence(
+        sequence.id
+      );
+      if (existing.some((v) => v.model === model && v.status !== 'failed')) {
+        throw new Error('That audio model is already on this sequence');
+      }
+      if (!sequence.musicPrompt || !sequence.musicTags) {
+        throw new Error(
+          'Generate music once before adding another audio model'
+        );
+      }
+      const allFrames = await scopedDb.frames.listBySequence(sequence.id);
+      const totalDuration =
+        allFrames.reduce(
+          (sum, f) =>
+            sum +
+            (f.durationMs
+              ? f.durationMs / 1000
+              : (f.metadata?.metadata?.durationSeconds ?? 10)),
+          0
+        ) || 30;
+
+      await requireCredits(scopedDb, estimateAudioCost(model, totalDuration), {
+        errorMessage: 'Insufficient credits to add this audio model',
+      });
+
+      await scopedDb.sequenceVariants.upsertMusicPrimary({
+        sequenceId: sequence.id,
+        model,
+        prompt: sequence.musicPrompt,
+        tags: sequence.musicTags,
+        durationSeconds: Math.round(totalDuration),
+        status: 'pending',
+      });
+
+      const musicInput: MusicWorkflowInput = {
+        ...baseCtx,
+        prompt: sequence.musicPrompt,
+        tags: sequence.musicTags,
+        duration: totalDuration,
+        model,
+      };
+      try {
+        const workflowRunId = await triggerWorkflow('/music', musicInput, {
+          deduplicationId: `add-audio-${sequence.id}-${model}-${Date.now()}`,
+          label: buildWorkflowLabel(sequence.id),
+        });
+        return { workflowRunId, variantType, model, count: 1 };
+      } catch (error) {
+        // Mark the pre-stamped row failed so the model can be re-added.
+        await scopedDb.sequenceVariants.upsertMusicPrimary({
+          sequenceId: sequence.id,
+          model,
+          prompt: sequence.musicPrompt,
+          tags: sequence.musicTags,
+          durationSeconds: Math.round(totalDuration),
+          status: 'failed',
+        });
+        throw error;
+      }
+    }
+
+    // ── Video: animate every frame that already has an image ───────────────
+    if (variantType === 'video') {
+      if (!isValidImageToVideoModel(model)) {
+        throw new Error('Invalid video model');
+      }
+      const existing = await scopedDb.frameVariants.listBySequence(
+        sequence.id,
+        'video'
+      );
+      if (existing.some((v) => v.model === model && v.status !== 'failed')) {
+        throw new Error('That video model is already on this sequence');
+      }
+      const allFrames = await scopedDb.frames.listBySequence(sequence.id);
+      const eligible = allFrames.filter(
+        (f) => f.thumbnailStatus === 'completed' && f.thumbnailUrl
+      );
+      if (eligible.length === 0) {
+        throw new Error('No frames have a completed image to animate yet');
+      }
+
+      await requireCredits(
+        scopedDb,
+        multiplyMicros(estimateVideoCost(model, 5), eligible.length),
+        { errorMessage: 'Insufficient credits to add this video model' }
+      );
+
+      for (const f of eligible) {
+        await scopedDb.frameVariants.upsert({
+          frameId: f.id,
+          sequenceId: sequence.id,
+          variantType: 'video',
+          model,
+          status: 'pending',
+        });
+      }
+
+      const workflowInput: BatchMotionMusicWorkflowInput = {
+        ...baseCtx,
+        includeMusic: false,
+        videoModels: [model],
+        frames: eligible.map((f) => ({
+          frameId: f.id,
+          imageUrl: f.thumbnailUrl ?? '',
+          prompt: resolveMotionPrompt(f, model),
+          model,
+          motionPrompt: f.metadata?.prompts?.motion,
+          duration: f.durationMs
+            ? f.durationMs / 1000
+            : (f.metadata?.metadata?.durationSeconds ?? 3),
+          aspectRatio: sequence.aspectRatio,
+        })),
+      };
+      try {
+        const workflowRunId = await triggerWorkflow(
+          '/motion-batch',
+          workflowInput,
+          {
+            deduplicationId: `add-video-${sequence.id}-${model}-${Date.now()}`,
+            label: buildWorkflowLabel(sequence.id),
+          }
+        );
+        return { workflowRunId, variantType, model, count: eligible.length };
+      } catch (error) {
+        // Mark the pre-stamped pending rows failed so the model can be re-added.
+        await Promise.all(
+          eligible.map((f) =>
+            scopedDb.frameVariants.updateByFrameAndModel(f.id, 'video', model, {
+              status: 'failed',
+              error: 'Failed to trigger motion batch',
+            })
+          )
+        );
+        throw error;
+      }
+    }
+
+    // ── Image: re-render every frame's prompt with the new model ───────────
+    if (!isValidTextToImageModel(model)) {
+      throw new Error('Invalid image model');
+    }
+    const existingImage = await scopedDb.frameVariants.listBySequence(
+      sequence.id,
+      'image'
+    );
+    if (existingImage.some((v) => v.model === model && v.status !== 'failed')) {
+      throw new Error('That image model is already on this sequence');
+    }
+    const allFrames = await scopedDb.frames.listBySequence(sequence.id);
+    const [characters, locations, elements] = await Promise.all([
+      scopedDb.characters.listWithSheets(sequence.id),
+      scopedDb.sequenceLocations.listWithReferences(sequence.id),
+      scopedDb.sequenceElements.list(sequence.id),
+    ]);
+
+    const inputs: NonNullable<
+      Awaited<ReturnType<typeof buildFrameImageWorkflowInput>>
+    >[] = [];
+    for (const f of allFrames) {
+      const input = await buildFrameImageWorkflowInput({
+        frame: f,
+        model,
+        userId: user.id,
+        teamId: sequence.teamId,
+        sequenceId: sequence.id,
+        aspectRatio: sequence.aspectRatio,
+        characters,
+        locations,
+        elements,
+      });
+      if (input) inputs.push(input);
+    }
+    if (inputs.length === 0) {
+      throw new Error('No frames have a prompt to generate from');
+    }
+
+    await requireCredits(
+      scopedDb,
+      multiplyMicros(
+        estimateImageCost(model, sequence.aspectRatio, 1),
+        inputs.length
+      ),
+      { errorMessage: 'Insufficient credits to add this image model' }
+    );
+
+    // Trigger one image workflow per frame. A single frame's trigger failure
+    // shouldn't abort the rest of the batch — mark that frame's pending row
+    // failed (so it doesn't block a future re-add) and continue. Only throw if
+    // every frame failed to trigger.
+    let workflowRunId = '';
+    let triggered = 0;
+    for (const input of inputs) {
+      if (input.frameId) {
+        await scopedDb.frameVariants.upsert({
+          frameId: input.frameId,
+          sequenceId: sequence.id,
+          variantType: 'image',
+          model,
+          status: 'pending',
+        });
+      }
+      try {
+        workflowRunId = await triggerWorkflow('/image', input, {
+          deduplicationId: `add-image-${input.frameId}-${model}-${Date.now()}`,
+          label: buildWorkflowLabel(sequence.id),
+        });
+        triggered++;
+      } catch (error) {
+        if (input.frameId) {
+          await scopedDb.frameVariants.updateByFrameAndModel(
+            input.frameId,
+            'image',
+            model,
+            {
+              status: 'failed',
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to trigger image generation',
+            }
+          );
+        }
+      }
+    }
+    if (triggered === 0) {
+      throw new Error('Failed to start image generation for any frame');
+    }
+    return { workflowRunId, variantType, model, count: triggered };
   });
 
 /**

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -27,6 +27,7 @@ import { multiplyMicros } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
 import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
 import type { Frame } from '@/lib/db/schema';
+import { buildPromoteUpdate } from '@/functions/frames';
 import { buildFrameImageWorkflowInput } from '@/lib/image/build-frame-image-input';
 import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
 import { VARIANT_TYPES } from '@/lib/db/schema/frame-variants';
@@ -625,6 +626,9 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
         ...baseCtx,
         includeMusic: false,
         videoModels: [model],
+        // Adding a video model lands as an alternate only — never the primary
+        // video. Promote later with "Set". (#547)
+        variantOnly: true,
         frames: eligible.map((f) => ({
           frameId: f.id,
           imageUrl: f.thumbnailUrl ?? '',
@@ -693,6 +697,9 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
         characters,
         locations,
         elements,
+        // Adding a model never repoints the primary — it lands as an alternate
+        // variant only. Promote later with "Set". (#547)
+        variantOnly: true,
       });
       if (input) inputs.push(input);
     }
@@ -752,6 +759,83 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
       throw new Error('Failed to start image generation for any frame');
     }
     return { workflowRunId, variantType, model, count: triggered };
+  });
+
+/**
+ * Promote a model to the live primary across the WHOLE sequence (#547) — the
+ * sequence-wide "Set" that pairs with the header image/video dropdowns. For
+ * every frame that has a completed `frame_variants` row for `model`, copies that
+ * row onto the legacy primary columns (the per-scene `setImageFromVariantFn` /
+ * `setVideoFromVariantFn` applied in bulk, reusing `buildPromoteUpdate`). Frames
+ * the model never generated are left on their current primary. Image promotion
+ * invalidates each affected frame's video (the start image changed); video
+ * promotion is terminal. Audio is per-sequence — use `setMusicFromVariantFn`.
+ */
+export const setSequenceModelFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        variantType: z.enum(['image', 'video']),
+        model: z.string().min(1),
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
+    const { sequence, scopedDb } = context;
+    const { variantType, model } = data;
+
+    if (variantType === 'image' && !isValidTextToImageModel(model)) {
+      throw new Error('Invalid image model');
+    }
+    if (variantType === 'video' && !isValidImageToVideoModel(model)) {
+      throw new Error('Invalid video model');
+    }
+
+    const variants = await scopedDb.frameVariants.listBySequence(
+      sequence.id,
+      variantType
+    );
+    const promotable = variants.filter(
+      (v) =>
+        v.model === model &&
+        v.status === 'completed' &&
+        v.url &&
+        v.divergedAt === null &&
+        v.discardedAt === null
+    );
+    if (promotable.length === 0) {
+      throw new Error('That model has not generated anything to set');
+    }
+
+    let count = 0;
+    for (const variant of promotable) {
+      // `buildPromoteUpdate` matches `setImageFromVariantFn` exactly for image
+      // (incl. clearing the now-stale video). Its video case omits the
+      // motion-model / duration / timestamp that `setVideoFromVariantFn`
+      // records, so layer those on for parity.
+      const { update } = buildPromoteUpdate(variant);
+      const frameUpdate =
+        variantType === 'video'
+          ? {
+              ...update,
+              motionModel: model,
+              durationMs: variant.durationMs,
+              videoGeneratedAt: new Date(),
+            }
+          : update;
+      const updated = await scopedDb.frames.update(
+        variant.frameId,
+        frameUpdate,
+        {
+          throwOnMissing: false,
+        }
+      );
+      if (updated) count++;
+    }
+
+    return { count, variantType, model };
   });
 
 /**

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -26,11 +26,14 @@ import {
 import { multiplyMicros } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
 import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
-import type { Frame } from '@/lib/db/schema';
+import type { Frame, FrameVariant, NewFrame } from '@/lib/db/schema';
 import { buildPromoteUpdate } from '@/functions/frames';
 import { buildFrameImageWorkflowInput } from '@/lib/image/build-frame-image-input';
 import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
-import { VARIANT_TYPES } from '@/lib/db/schema/frame-variants';
+import {
+  VARIANT_TYPES,
+  type VariantType,
+} from '@/lib/db/schema/frame-variants';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import {
   createSequenceSchema,
@@ -51,6 +54,25 @@ import { authWithTeamMiddleware, sequenceAccessMiddleware } from './middleware';
 import { copySequenceElements } from '@/lib/sequence-elements/copy-sequence-elements';
 import { promoteTempElements } from '@/lib/sequence-elements/promote-temp-elements';
 import { bumpStylePopularity } from '@/lib/style/bump-style-popularity';
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'serverFn', 'sequences']);
+
+/**
+ * Result of {@link addModelToSequenceFn}. `count` is the number of generation
+ * units actually started (1 track for audio; eligible frames for video; frames
+ * whose `/image` workflow successfully triggered for image). `failed` is the
+ * number of units that failed to start — only ever non-zero for the image path,
+ * which triggers one workflow per frame and tolerates partial failure. Mirrored
+ * by `useAddModelToSequence`'s mutation generic.
+ */
+export type AddModelResult = {
+  workflowRunId: string;
+  variantType: VariantType;
+  model: string;
+  count: number;
+  failed: number;
+};
 
 export const getSequencesFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
@@ -489,6 +511,34 @@ export const getSequenceAudioVariantsFn = createServerFn({ method: 'GET' })
   });
 
 /**
+ * Throw if `model` is already on the sequence (#547). A model counts as
+ * "already added" only when a NON-failed (pending/generating/completed) variant
+ * row exists for it — a previously failed add can always be retried. Shared by
+ * all three add-model branches; `label` ('image' | 'video' | 'audio') shapes
+ * the error message.
+ */
+export function assertModelNotAlreadyAdded(
+  existing: ReadonlyArray<{ model: string; status: string }>,
+  model: string,
+  label: VariantType
+): void {
+  if (existing.some((v) => v.model === model && v.status !== 'failed')) {
+    throw new Error(`That ${label} model is already on this sequence`);
+  }
+}
+
+/**
+ * Frames eligible for a video add-model run (#547): only those with a completed
+ * primary image to animate. A frame with no usable image is skipped — there is
+ * nothing to feed image-to-video.
+ */
+export function selectEligibleVideoFrames(frames: readonly Frame[]): Frame[] {
+  return frames.filter(
+    (f) => f.thumbnailStatus === 'completed' && Boolean(f.thumbnailUrl)
+  );
+}
+
+/**
  * Add a new image / video / audio model to an existing sequence (#547).
  * Generates that model's output for every eligible frame (image/video) or the
  * whole sequence (audio) using the EXISTING prompts — no re-analysis. Each unit
@@ -522,14 +572,10 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
       if (!isValidAudioModel(model)) {
         throw new Error('Invalid audio model');
       }
-      // Block only when a non-failed (pending/generating/completed) track for
-      // this model already exists — a previously failed add can be retried.
       const existing = await scopedDb.sequenceVariants.listMusicBySequence(
         sequence.id
       );
-      if (existing.some((v) => v.model === model && v.status !== 'failed')) {
-        throw new Error('That audio model is already on this sequence');
-      }
+      assertModelNotAlreadyAdded(existing, model, 'audio');
       if (!sequence.musicPrompt || !sequence.musicTags) {
         throw new Error(
           'Generate music once before adding another audio model'
@@ -571,17 +617,38 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
           deduplicationId: `add-audio-${sequence.id}-${model}-${Date.now()}`,
           label: buildWorkflowLabel(sequence.id),
         });
-        return { workflowRunId, variantType, model, count: 1 };
+        return {
+          workflowRunId,
+          variantType,
+          model,
+          count: 1,
+          failed: 0,
+        } satisfies AddModelResult;
       } catch (error) {
-        // Mark the pre-stamped row failed so the model can be re-added.
-        await scopedDb.sequenceVariants.upsertMusicPrimary({
+        logger.error('add-model: failed to trigger music workflow', {
+          err: error,
           sequenceId: sequence.id,
           model,
-          prompt: sequence.musicPrompt,
-          tags: sequence.musicTags,
-          durationSeconds: Math.round(totalDuration),
-          status: 'failed',
         });
+        // Mark the pre-stamped row failed so the model can be re-added. Guard
+        // the compensating write so its own failure can't mask the original
+        // trigger error (which is what we want to surface to the user).
+        try {
+          await scopedDb.sequenceVariants.upsertMusicPrimary({
+            sequenceId: sequence.id,
+            model,
+            prompt: sequence.musicPrompt,
+            tags: sequence.musicTags,
+            durationSeconds: Math.round(totalDuration),
+            status: 'failed',
+          });
+        } catch (cleanupError) {
+          logger.error('add-model: failed to mark music row failed', {
+            err: cleanupError,
+            sequenceId: sequence.id,
+            model,
+          });
+        }
         throw error;
       }
     }
@@ -595,13 +662,9 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
         sequence.id,
         'video'
       );
-      if (existing.some((v) => v.model === model && v.status !== 'failed')) {
-        throw new Error('That video model is already on this sequence');
-      }
+      assertModelNotAlreadyAdded(existing, model, 'video');
       const allFrames = await scopedDb.frames.listBySequence(sequence.id);
-      const eligible = allFrames.filter(
-        (f) => f.thumbnailStatus === 'completed' && f.thumbnailUrl
-      );
+      const eligible = selectEligibleVideoFrames(allFrames);
       if (eligible.length === 0) {
         throw new Error('No frames have a completed image to animate yet');
       }
@@ -650,17 +713,44 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
             label: buildWorkflowLabel(sequence.id),
           }
         );
-        return { workflowRunId, variantType, model, count: eligible.length };
+        return {
+          workflowRunId,
+          variantType,
+          model,
+          count: eligible.length,
+          failed: 0,
+        } satisfies AddModelResult;
       } catch (error) {
+        logger.error('add-model: failed to trigger motion batch', {
+          err: error,
+          sequenceId: sequence.id,
+          model,
+          frames: eligible.length,
+        });
         // Mark the pre-stamped pending rows failed so the model can be re-added.
-        await Promise.all(
-          eligible.map((f) =>
-            scopedDb.frameVariants.updateByFrameAndModel(f.id, 'video', model, {
-              status: 'failed',
-              error: 'Failed to trigger motion batch',
-            })
-          )
-        );
+        // Guard the compensating writes so they can't mask the original trigger
+        // error that we re-throw to the user.
+        try {
+          await Promise.all(
+            eligible.map((f) =>
+              scopedDb.frameVariants.updateByFrameAndModel(
+                f.id,
+                'video',
+                model,
+                {
+                  status: 'failed',
+                  error: 'Failed to trigger motion batch',
+                }
+              )
+            )
+          );
+        } catch (cleanupError) {
+          logger.error('add-model: failed to mark video rows failed', {
+            err: cleanupError,
+            sequenceId: sequence.id,
+            model,
+          });
+        }
         throw error;
       }
     }
@@ -673,9 +763,7 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
       sequence.id,
       'image'
     );
-    if (existingImage.some((v) => v.model === model && v.status !== 'failed')) {
-      throw new Error('That image model is already on this sequence');
-    }
+    assertModelNotAlreadyAdded(existingImage, model, 'image');
     const allFrames = await scopedDb.frames.listBySequence(sequence.id);
     const [characters, locations, elements] = await Promise.all([
       scopedDb.characters.listWithSheets(sequence.id),
@@ -739,6 +827,15 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
         });
         triggered++;
       } catch (error) {
+        // Log every per-frame trigger failure so a systemic cause (e.g. a
+        // transient binding issue hitting half the batch) leaves an aggregated
+        // Sentry trace rather than only a row's `error` column.
+        logger.error('add-model: failed to trigger image workflow for frame', {
+          err: error,
+          sequenceId: sequence.id,
+          frameId: input.frameId,
+          model,
+        });
         if (input.frameId) {
           await scopedDb.frameVariants.updateByFrameAndModel(
             input.frameId,
@@ -758,8 +855,62 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
     if (triggered === 0) {
       throw new Error('Failed to start image generation for any frame');
     }
-    return { workflowRunId, variantType, model, count: triggered };
+    return {
+      workflowRunId,
+      variantType,
+      model,
+      count: triggered,
+      failed: inputs.length - triggered,
+    } satisfies AddModelResult;
   });
+
+/**
+ * Select the variant rows eligible to be promoted to the live primary for
+ * `model` (#547). A row qualifies only when it is this model's LIVE completed
+ * output: `status === 'completed'` with a `url`, and neither a divergent
+ * (`divergedAt`) nor a user-discarded (`discardedAt`) alternate. Excluding
+ * divergent/discarded is load-bearing — promoting one would resurrect an output
+ * the user explicitly rejected onto the primary across the whole sequence.
+ */
+export function selectPromotableVariants(
+  variants: readonly FrameVariant[],
+  model: string
+): FrameVariant[] {
+  return variants.filter(
+    (v) =>
+      v.model === model &&
+      v.status === 'completed' &&
+      Boolean(v.url) &&
+      v.divergedAt === null &&
+      v.discardedAt === null
+  );
+}
+
+/**
+ * Build the primary-column update that promotes `variant` to the live primary
+ * (#547). Reuses `buildPromoteUpdate` (which matches the per-scene
+ * `setImageFromVariantFn` exactly for image, incl. clearing the now-stale
+ * video). `buildPromoteUpdate`'s video case omits the motion-model / duration /
+ * generated-at that `setVideoFromVariantFn` records, so layer those on for
+ * parity. `now` is injectable for deterministic tests.
+ */
+export function buildSequencePromoteUpdate(
+  variant: FrameVariant,
+  variantType: 'image' | 'video',
+  model: string,
+  now: () => Date = () => new Date()
+): Partial<NewFrame> {
+  const { update } = buildPromoteUpdate(variant);
+  if (variantType === 'video') {
+    return {
+      ...update,
+      motionModel: model,
+      durationMs: variant.durationMs,
+      videoGeneratedAt: now(),
+    };
+  }
+  return update;
+}
 
 /**
  * Promote a model to the live primary across the WHOLE sequence (#547) — the
@@ -797,34 +948,18 @@ export const setSequenceModelFn = createServerFn({ method: 'POST' })
       sequence.id,
       variantType
     );
-    const promotable = variants.filter(
-      (v) =>
-        v.model === model &&
-        v.status === 'completed' &&
-        v.url &&
-        v.divergedAt === null &&
-        v.discardedAt === null
-    );
+    const promotable = selectPromotableVariants(variants, model);
     if (promotable.length === 0) {
       throw new Error('That model has not generated anything to set');
     }
 
     let count = 0;
     for (const variant of promotable) {
-      // `buildPromoteUpdate` matches `setImageFromVariantFn` exactly for image
-      // (incl. clearing the now-stale video). Its video case omits the
-      // motion-model / duration / timestamp that `setVideoFromVariantFn`
-      // records, so layer those on for parity.
-      const { update } = buildPromoteUpdate(variant);
-      const frameUpdate =
-        variantType === 'video'
-          ? {
-              ...update,
-              motionModel: model,
-              durationMs: variant.durationMs,
-              videoGeneratedAt: new Date(),
-            }
-          : update;
+      const frameUpdate = buildSequencePromoteUpdate(
+        variant,
+        variantType,
+        model
+      );
       const updated = await scopedDb.frames.update(
         variant.frameId,
         frameUpdate,
@@ -833,6 +968,20 @@ export const setSequenceModelFn = createServerFn({ method: 'POST' })
         }
       );
       if (updated) count++;
+    }
+
+    // A frame deleted mid-promotion is benign (throwOnMissing:false skips it),
+    // but a promoted count short of the promotable set otherwise points at a
+    // real problem (e.g. a scoping mismatch) — surface it rather than letting
+    // the lower count pass silently.
+    if (count !== promotable.length) {
+      logger.warn('set-model: promoted fewer frames than promotable', {
+        sequenceId: sequence.id,
+        model,
+        variantType,
+        promotable: promotable.length,
+        promoted: count,
+      });
     }
 
     return { count, variantType, model };

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -539,6 +539,47 @@ export function selectEligibleVideoFrames(frames: readonly Frame[]): Frame[] {
 }
 
 /**
+ * Sum a sequence's per-frame durations in seconds, falling back to 10s for any
+ * frame whose duration is unknown. Shared by the add-audio and generate-music
+ * paths; callers apply their own empty-sequence floor (`|| 30`).
+ */
+export function sumFrameDurationsSeconds(
+  frames: ReadonlyArray<Pick<Frame, 'durationMs' | 'metadata'>>
+): number {
+  return frames.reduce((sum, frame) => {
+    const seconds = frame.durationMs
+      ? frame.durationMs / 1000
+      : (frame.metadata?.metadata?.durationSeconds ?? 10);
+    return sum + seconds;
+  }, 0);
+}
+
+/**
+ * Build the music-workflow input for an ADD-MODEL audio run (#547). Always
+ * `isPrimary: false`: an added audio model lands as an alternate in
+ * `sequence_music_variants` and must never repoint the live `sequences.music*`
+ * primary track. The music workflow defaults `isPrimary` to true (#546), so
+ * omitting it here would clobber the user's working primary on both success AND
+ * failure — the exact regression this helper exists to prevent.
+ */
+export function buildAddAudioMusicInput(args: {
+  baseCtx: { userId: string; teamId: string; sequenceId: string };
+  prompt: string;
+  tags: string;
+  durationSeconds: number;
+  model: MusicWorkflowInput['model'];
+}): MusicWorkflowInput {
+  return {
+    ...args.baseCtx,
+    prompt: args.prompt,
+    tags: args.tags,
+    duration: args.durationSeconds,
+    model: args.model,
+    isPrimary: false,
+  };
+}
+
+/**
  * Add a new image / video / audio model to an existing sequence (#547).
  * Generates that model's output for every eligible frame (image/video) or the
  * whole sequence (audio) using the EXISTING prompts — no re-analysis. Each unit
@@ -582,15 +623,7 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
         );
       }
       const allFrames = await scopedDb.frames.listBySequence(sequence.id);
-      const totalDuration =
-        allFrames.reduce(
-          (sum, f) =>
-            sum +
-            (f.durationMs
-              ? f.durationMs / 1000
-              : (f.metadata?.metadata?.durationSeconds ?? 10)),
-          0
-        ) || 30;
+      const totalDuration = sumFrameDurationsSeconds(allFrames) || 30;
 
       await requireCredits(scopedDb, estimateAudioCost(model, totalDuration), {
         errorMessage: 'Insufficient credits to add this audio model',
@@ -605,13 +638,13 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
         status: 'pending',
       });
 
-      const musicInput: MusicWorkflowInput = {
-        ...baseCtx,
+      const musicInput = buildAddAudioMusicInput({
+        baseCtx,
         prompt: sequence.musicPrompt,
         tags: sequence.musicTags,
-        duration: totalDuration,
+        durationSeconds: totalDuration,
         model,
-      };
+      });
       try {
         const workflowRunId = await triggerWorkflow('/music', musicInput, {
           deduplicationId: `add-audio-${sequence.id}-${model}-${Date.now()}`,
@@ -1037,12 +1070,7 @@ export const generateMusicFn = createServerFn({ method: 'POST' })
       data.sequenceId
     );
 
-    const totalDuration = allFrames.reduce((sum, frame) => {
-      const seconds = frame.durationMs
-        ? frame.durationMs / 1000
-        : (frame.metadata?.metadata?.durationSeconds ?? 10);
-      return sum + seconds;
-    }, 0);
+    const totalDuration = sumFrameDurationsSeconds(allFrames);
 
     const baseInput = {
       userId: user.id,

--- a/src/hooks/use-active-image-model.ts
+++ b/src/hooks/use-active-image-model.ts
@@ -1,0 +1,107 @@
+import {
+  isValidTextToImageModel,
+  type TextToImageModel,
+} from '@/lib/ai/models';
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'ui', 'use-active-image-model']);
+
+/**
+ * Viewer-local "active image model" selection for a sequence. Mirrors
+ * {@link useActiveVideoModel} — which model's image the scenes view displays is
+ * a per-viewer preference stored in localStorage keyed by sequence, kept in
+ * sync within and across tabs via a module store + `useSyncExternalStore`.
+ * `null` means "no explicit pick" — fall back to each frame's own image.
+ */
+
+const KEY_PREFIX = 'openstory:active-image-model:';
+const storageKey = (sequenceId: string) => `${KEY_PREFIX}${sequenceId}`;
+
+const store = new Map<string, TextToImageModel | null | undefined>();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+let storageListenerAttached = false;
+function ensureStorageListener() {
+  if (storageListenerAttached || typeof window === 'undefined') return;
+  storageListenerAttached = true;
+  window.addEventListener('storage', (event) => {
+    if (!event.key || !event.key.startsWith(KEY_PREFIX)) return;
+    const sequenceId = event.key.slice(KEY_PREFIX.length);
+    const next =
+      event.newValue && isValidTextToImageModel(event.newValue)
+        ? event.newValue
+        : null;
+    store.set(sequenceId, next);
+    emit();
+  });
+}
+
+function subscribe(listener: () => void) {
+  ensureStorageListener();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function hydrate(sequenceId: string): TextToImageModel | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(storageKey(sequenceId));
+    if (raw && isValidTextToImageModel(raw)) return raw;
+  } catch (error) {
+    logger.warn('Failed to read active image model from localStorage', {
+      err: error,
+    });
+  }
+  return null;
+}
+
+function read(sequenceId: string): TextToImageModel | null {
+  const cached = store.get(sequenceId);
+  if (cached !== undefined) return cached;
+  const hydrated = hydrate(sequenceId);
+  store.set(sequenceId, hydrated);
+  return hydrated;
+}
+
+function write(sequenceId: string, model: TextToImageModel | null) {
+  store.set(sequenceId, model);
+  if (typeof window !== 'undefined') {
+    try {
+      if (model) {
+        localStorage.setItem(storageKey(sequenceId), model);
+      } else {
+        localStorage.removeItem(storageKey(sequenceId));
+      }
+    } catch (error) {
+      logger.warn('Failed to persist active image model to localStorage', {
+        err: error,
+      });
+    }
+  }
+  emit();
+}
+
+export function useActiveImageModel(sequenceId: string) {
+  const activeImageModel = useSyncExternalStore(
+    subscribe,
+    () => read(sequenceId),
+    () => null
+  );
+
+  const selectImageModel = useCallback(
+    (model: TextToImageModel | null) => {
+      write(sequenceId, model);
+    },
+    [sequenceId]
+  );
+
+  return { activeImageModel, selectImageModel };
+}

--- a/src/hooks/use-frames.ts
+++ b/src/hooks/use-frames.ts
@@ -15,6 +15,7 @@ import {
   promoteVariantFn,
   discardVariantFn,
   undiscardVariantFn,
+  getSequenceImageModelsFn,
   getSequenceVideoModelsFn,
   getSequenceVideoVariantsFn,
 } from '@/functions/frames';
@@ -78,11 +79,24 @@ export const frameKeys = {
   list: (sequenceId: string) => [...frameKeys.lists(), sequenceId] as const,
   details: () => [...frameKeys.all, 'detail'] as const,
   detail: (id: string) => [...frameKeys.details(), id] as const,
-  imageModels: (sequenceId: string) =>
-    [...frameKeys.all, 'image-models', sequenceId] as const,
   divergentVariants: (sequenceId: string) =>
     [...frameKeys.all, 'divergent-variants', sequenceId] as const,
 };
+
+// Distinct image models that have generated a variant for this sequence.
+// Drives the header image-model dropdown (#547). Flat key matches the
+// image:progress cache invalidation in query-cache-updater.
+export function useSequenceImageModels(sequenceId?: string) {
+  return useQuery<string[]>({
+    queryKey: ['sequence-image-models', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceImageModelsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
 
 // Distinct video models that have generated a variant for this sequence (#545).
 // Drives the header video-model dropdown. The realtime video:progress handler

--- a/src/hooks/use-frames.ts
+++ b/src/hooks/use-frames.ts
@@ -16,6 +16,7 @@ import {
   discardVariantFn,
   undiscardVariantFn,
   getSequenceImageModelsFn,
+  getSequenceImageVariantsFn,
   getSequenceVideoModelsFn,
   getSequenceVideoVariantsFn,
 } from '@/functions/frames';
@@ -121,6 +122,22 @@ export function useSequenceVideoVariants(sequenceId?: string) {
     queryFn: async () => {
       if (!sequenceId) throw new Error('sequenceId is required');
       return getSequenceVideoVariantsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
+
+// All image FrameVariant rows for a sequence (#547). Used by the header image
+// dropdown for sequence-wide per-model coverage, and by the scenes view to
+// resolve each frame's displayed image through the active model's variant. Key
+// matches the scenes-view query + the image:progress cache invalidation.
+export function useSequenceImageVariants(sequenceId?: string) {
+  return useQuery<FrameVariant[]>({
+    queryKey: ['sequence-image-variants', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceImageVariantsFn({ data: { sequenceId } });
     },
     enabled: !!sequenceId,
     staleTime: 30_000,

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -1,4 +1,5 @@
 import {
+  addModelToSequenceFn,
   archiveSequenceFn,
   createSequenceFn,
   getSequenceAudioModelsFn,
@@ -9,6 +10,7 @@ import {
 } from '@/functions/sequences';
 import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
 import type { SequenceMusicVariant } from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
 import {
   type CreateSequenceInput,
   type UpdateSequenceInput,
@@ -55,6 +57,47 @@ export function useSequenceAudioVariants(sequenceId?: string) {
     },
     enabled: !!sequenceId,
     staleTime: 30_000,
+  });
+}
+
+const MODEL_LIST_KEY: Record<VariantType, (id: string) => string[]> = {
+  image: (id) => ['sequence-image-models', id],
+  video: (id) => ['sequence-video-models', id],
+  audio: (id) => ['sequence-audio-models', id],
+};
+const VARIANTS_KEY: Record<VariantType, (id: string) => string[]> = {
+  image: (id) => ['sequence-image-variants', id],
+  video: (id) => ['sequence-video-variants', id],
+  audio: (id) => ['sequence-audio-variants', id],
+};
+
+// Add a new model to an existing sequence (#547): generates its output for
+// every frame (image/video) or the whole sequence (audio) using existing
+// prompts. Invalidates the matching model-list + variants queries so the new
+// model surfaces in the header dropdown immediately (pre-stamped pending).
+export function useAddModelToSequence() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    {
+      workflowRunId: string;
+      variantType: VariantType;
+      model: string;
+      count: number;
+    },
+    Error,
+    { sequenceId: string; variantType: VariantType; model: string }
+  >({
+    mutationFn: async (input) => addModelToSequenceFn({ data: input }),
+    onSuccess: async (_, { sequenceId, variantType }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: MODEL_LIST_KEY[variantType](sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: VARIANTS_KEY[variantType](sequenceId),
+        }),
+      ]);
+    },
   });
 }
 

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -6,6 +6,7 @@ import {
   getSequenceAudioVariantsFn,
   getSequenceFn,
   getSequencesFn,
+  setSequenceModelFn,
   updateSequenceFn,
 } from '@/functions/sequences';
 import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
@@ -95,6 +96,36 @@ export function useAddModelToSequence() {
         }),
         queryClient.invalidateQueries({
           queryKey: VARIANTS_KEY[variantType](sequenceId),
+        }),
+      ]);
+    },
+  });
+}
+
+/**
+ * Promote a model to the live primary across the whole sequence (#547) — the
+ * sequence-wide "Set". Invalidates the model list + variants (so the dropdown's
+ * ⊙ primary marker moves) and the frames list (the primary image/video changed,
+ * and an image Set also reset each frame's video).
+ */
+export function useSetSequenceModel() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { count: number; variantType: 'image' | 'video'; model: string },
+    Error,
+    { sequenceId: string; variantType: 'image' | 'video'; model: string }
+  >({
+    mutationFn: async (input) => setSequenceModelFn({ data: input }),
+    onSuccess: async (_, { sequenceId, variantType }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: MODEL_LIST_KEY[variantType](sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: VARIANTS_KEY[variantType](sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['frames', 'list', sequenceId],
         }),
       ]);
     },

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -8,6 +8,7 @@ import {
   getSequencesFn,
   setSequenceModelFn,
   updateSequenceFn,
+  type AddModelResult,
 } from '@/functions/sequences';
 import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
 import type { SequenceMusicVariant } from '@/lib/db/schema';
@@ -79,12 +80,7 @@ const VARIANTS_KEY: Record<VariantType, (id: string) => string[]> = {
 export function useAddModelToSequence() {
   const queryClient = useQueryClient();
   return useMutation<
-    {
-      workflowRunId: string;
-      variantType: VariantType;
-      model: string;
-      count: number;
-    },
+    AddModelResult,
     Error,
     { sequenceId: string; variantType: VariantType; model: string }
   >({

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -72,9 +72,8 @@ export function estimateVideoCost(
 
 /**
  * Estimate the raw cost (before markup) of generating one music track.
- * Internal — used by `estimateStoryboardCost`'s music component.
  */
-function estimateAudioCost(
+export function estimateAudioCost(
   model: AudioModel,
   durationSeconds: number
 ): Microdollars {

--- a/src/lib/db/scoped/sequence-variants.test.ts
+++ b/src/lib/db/scoped/sequence-variants.test.ts
@@ -228,6 +228,54 @@ describe('createSequenceVariantsMethods — music', () => {
   });
 });
 
+describe('createSequenceVariantsMethods — markMusicFailed (#547)', () => {
+  it('flips a pre-stamped pending variant row to failed', async () => {
+    const methods = createSequenceVariantsMethods(db);
+    await methods.upsertMusicPrimary({
+      sequenceId,
+      model: 'cassette',
+      prompt: 'p',
+      tags: 't',
+      durationSeconds: 60,
+      status: 'pending',
+    });
+
+    await methods.markMusicFailed(sequenceId, 'cassette', 'boom');
+
+    const row = await methods.getMusicPrimary(sequenceId, 'cassette');
+    expect(row?.status).toBe('failed');
+    expect(row?.error).toBe('boom');
+  });
+
+  it('is update-only — never inserts a row for a model that has none', async () => {
+    const methods = createSequenceVariantsMethods(db);
+
+    await methods.markMusicFailed(sequenceId, 'cassette', 'boom');
+
+    const rows = await methods.listMusicBySequence(sequenceId);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('never overwrites a completed alternate', async () => {
+    const methods = createSequenceVariantsMethods(db);
+    await methods.upsertMusicPrimary({
+      sequenceId,
+      model: 'cassette',
+      url: 'https://example.com/done.mp3',
+      prompt: 'p',
+      tags: 't',
+      durationSeconds: 60,
+      status: 'completed',
+    });
+
+    await methods.markMusicFailed(sequenceId, 'cassette', 'boom');
+
+    const row = await methods.getMusicPrimary(sequenceId, 'cassette');
+    expect(row?.status).toBe('completed');
+    expect(row?.error).toBeNull();
+  });
+});
+
 describe('listDivergentByTeam', () => {
   it('excludes variants belonging to a different team and excludes discarded rows', async () => {
     const methods = createSequenceVariantsMethods(db);

--- a/src/lib/db/scoped/sequence-variants.ts
+++ b/src/lib/db/scoped/sequence-variants.ts
@@ -155,6 +155,32 @@ export function createSequenceVariantsMethods(db: Database) {
       return { variant, divergent: false };
     },
 
+    /**
+     * Flip an EXISTING primary (non-divergent) music variant row to `failed`
+     * (#547). Update-only: it never inserts — a primary model's first generation
+     * has no pre-stamped row — and never overwrites a `completed` alternate.
+     * Mirrors the image/motion `onFailure` variant write so an added audio model
+     * whose generation fails leaves `pending` and becomes re-addable instead of
+     * spinning `generating` forever.
+     */
+    markMusicFailed: async (
+      sequenceId: string,
+      model: string,
+      error: string
+    ): Promise<void> => {
+      await db
+        .update(sequenceMusicVariants)
+        .set({ status: 'failed', error, updatedAt: new Date() })
+        .where(
+          and(
+            eq(sequenceMusicVariants.sequenceId, sequenceId),
+            eq(sequenceMusicVariants.model, model),
+            sql`${sequenceMusicVariants.divergedAt} IS NULL`,
+            sql`${sequenceMusicVariants.status} != 'completed'`
+          )
+        );
+    },
+
     getMusicById: async (
       variantId: string
     ): Promise<SequenceMusicVariant | null> => {

--- a/src/lib/image/build-frame-image-input.test.ts
+++ b/src/lib/image/build-frame-image-input.test.ts
@@ -11,11 +11,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
-import {
-  continuitySchema,
-  sceneSchema,
-  type Scene,
-} from '@/lib/ai/scene-analysis.schema';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { CharacterMinimal, Frame } from '@/lib/db/schema';
 import { buildFrameImageWorkflowInput } from '@/lib/image/build-frame-image-input';
 
@@ -82,22 +78,34 @@ const VISUAL_COMPONENTS = {
   atmosphere: '',
 };
 
-/** A valid, fully-typed Scene built through the schema (no casts). */
+/**
+ * A complete, fully-typed `Scene`. Built as a plain literal (the `: Scene`
+ * return type makes tsgo enforce completeness at compile time) rather than via
+ * `schema.parse()` — so the fixture never leans on `.catch()` defaults filling
+ * missing keys, a behavior that isn't portable across zod versions.
+ */
 function makeScene(
   opts: { sceneId?: string; visualFullPrompt?: string } = {}
 ): Scene {
-  return sceneSchema.parse({
+  return {
     sceneId: opts.sceneId ?? 'scene-1',
     sceneNumber: 1,
     originalScript: { extract: '', dialogue: [] },
-    metadata: { location: '' },
+    metadata: {
+      title: 'Scene',
+      durationSeconds: 3,
+      location: '',
+      timeOfDay: '',
+      storyBeat: '',
+    },
     prompts: {
       visual: {
         fullPrompt: opts.visualFullPrompt ?? '',
+        negativePrompt: '',
         components: VISUAL_COMPONENTS,
       },
     },
-  });
+  };
 }
 
 const baseOpts = {
@@ -241,7 +249,14 @@ describe('buildFrameImageWorkflowInput — reference images', () => {
       frame,
       characters: [character],
       // Matching continuity passed directly (avoids building frame metadata).
-      continuity: continuitySchema.parse({ characterTags: ['Jack'] }),
+      continuity: {
+        characterTags: ['Jack'],
+        environmentTag: '',
+        elementTags: [],
+        colorPalette: '',
+        lightingSetup: '',
+        styleTag: '',
+      },
     });
     expect(input?.referenceImages?.[0]).toMatchObject({
       referenceImageUrl: 'https://cdn/jack-sheet.png',

--- a/src/lib/image/build-frame-image-input.test.ts
+++ b/src/lib/image/build-frame-image-input.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for `buildFrameImageWorkflowInput` (#547) — the per-frame image input
+ * assembly shared by the single-frame regenerate and the bulk add-model paths.
+ * Focus on the logic unique to this file: the prompt fallback chain (whose
+ * `null` return controls whether a frame is silently skipped by callers), the
+ * `variantOnly` flag (the whole safety mechanism of #547), and the `sceneId`
+ * fallback. The character/location/element matchers and reference builders are
+ * pure and tested separately (scene-matching, *-prompt); here we only check the
+ * wiring + ordering.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
+import {
+  continuitySchema,
+  sceneSchema,
+  type Scene,
+} from '@/lib/ai/scene-analysis.schema';
+import type { CharacterMinimal, Frame } from '@/lib/db/schema';
+import { buildFrameImageWorkflowInput } from '@/lib/image/build-frame-image-input';
+
+const NOW = new Date('2026-06-03T00:00:00.000Z');
+
+function makeFrame(overrides: Partial<Frame> = {}): Frame {
+  return {
+    id: 'frame-1',
+    sequenceId: 'seq-1',
+    orderIndex: 0,
+    description: '',
+    durationMs: 3000,
+    thumbnailUrl: null,
+    thumbnailPath: null,
+    thumbnailStatus: 'pending',
+    thumbnailWorkflowRunId: null,
+    thumbnailGeneratedAt: null,
+    thumbnailError: null,
+    imageModel: 'nano_banana_2',
+    imagePrompt: null,
+    variantImageUrl: null,
+    variantImageStatus: 'pending',
+    variantWorkflowRunId: null,
+    variantImageGeneratedAt: null,
+    variantImageError: null,
+    videoUrl: null,
+    videoPath: null,
+    videoStatus: 'pending',
+    videoWorkflowRunId: null,
+    videoGeneratedAt: null,
+    videoError: null,
+    motionPrompt: null,
+    motionModel: null,
+    audioUrl: null,
+    audioPath: null,
+    audioStatus: 'pending',
+    audioWorkflowRunId: null,
+    audioGeneratedAt: null,
+    audioError: null,
+    audioModel: null,
+    thumbnailInputHash: null,
+    variantImageInputHash: null,
+    videoInputHash: null,
+    audioInputHash: null,
+    visualPromptInputHash: null,
+    motionPromptInputHash: null,
+    previewThumbnailUrl: null,
+    metadata: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+const VISUAL_COMPONENTS = {
+  sceneDescription: '',
+  subject: '',
+  environment: '',
+  lighting: '',
+  camera: '',
+  composition: '',
+  style: '',
+  technical: '',
+  atmosphere: '',
+};
+
+/** A valid, fully-typed Scene built through the schema (no casts). */
+function makeScene(
+  opts: { sceneId?: string; visualFullPrompt?: string } = {}
+): Scene {
+  return sceneSchema.parse({
+    sceneId: opts.sceneId ?? 'scene-1',
+    sceneNumber: 1,
+    originalScript: { extract: '', dialogue: [] },
+    metadata: { location: '' },
+    prompts: {
+      visual: {
+        fullPrompt: opts.visualFullPrompt ?? '',
+        components: VISUAL_COMPONENTS,
+      },
+    },
+  });
+}
+
+const baseOpts = {
+  model: DEFAULT_IMAGE_MODEL,
+  userId: 'user-1',
+  teamId: 'team-1',
+  sequenceId: 'seq-1',
+  aspectRatio: '16:9' as const,
+  characters: [] as CharacterMinimal[],
+  locations: [],
+  elements: [],
+};
+
+describe('buildFrameImageWorkflowInput — prompt fallback chain (#547)', () => {
+  it('prefers opts.prompt over every stored source', async () => {
+    const frame = makeFrame({
+      imagePrompt: 'STORED',
+      description: 'DESC',
+      metadata: makeScene({ visualFullPrompt: 'AI' }),
+    });
+    const input = await buildFrameImageWorkflowInput({
+      ...baseOpts,
+      frame,
+      prompt: 'OVERRIDE',
+    });
+    expect(input?.prompt).toBe('OVERRIDE');
+    expect(input?.sceneSnapshot?.visualPrompt).toBe('OVERRIDE');
+  });
+
+  it('falls back to frame.imagePrompt when no override', async () => {
+    const frame = makeFrame({ imagePrompt: 'STORED', description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.prompt).toBe('STORED');
+  });
+
+  it('falls back to metadata.prompts.visual.fullPrompt before description', async () => {
+    const frame = makeFrame({
+      imagePrompt: null,
+      description: 'DESC',
+      metadata: makeScene({ visualFullPrompt: 'AI' }),
+    });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.prompt).toBe('AI');
+  });
+
+  it('falls back to frame.description last', async () => {
+    const frame = makeFrame({ imagePrompt: null, description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.prompt).toBe('DESC');
+  });
+
+  it('returns null when no prompt is available anywhere (caller skips the frame)', async () => {
+    const frame = makeFrame({
+      imagePrompt: null,
+      description: '',
+      metadata: null,
+    });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input).toBeNull();
+  });
+});
+
+describe('buildFrameImageWorkflowInput — variantOnly (#547)', () => {
+  it('propagates variantOnly: true', async () => {
+    const frame = makeFrame({ description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({
+      ...baseOpts,
+      frame,
+      variantOnly: true,
+    });
+    expect(input?.variantOnly).toBe(true);
+  });
+
+  it('defaults variantOnly to false (the single-frame regenerate path keeps writing the primary)', async () => {
+    const frame = makeFrame({ description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.variantOnly).toBe(false);
+  });
+});
+
+describe('buildFrameImageWorkflowInput — sceneId + core shape', () => {
+  it('uses metadata.sceneId for the snapshot when present', async () => {
+    const frame = makeFrame({
+      description: 'DESC',
+      metadata: makeScene({ sceneId: 'scene-xyz' }),
+    });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.sceneSnapshot?.sceneId).toBe('scene-xyz');
+  });
+
+  it('falls back to frame.id when metadata is absent', async () => {
+    const frame = makeFrame({ id: 'frame-99', description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.sceneSnapshot?.sceneId).toBe('frame-99');
+  });
+
+  it('sets the workflow fields (frameId, sequenceId, numImages, userEditedPrompt default, hash)', async () => {
+    const frame = makeFrame({ id: 'frame-7', description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.frameId).toBe('frame-7');
+    expect(input?.sequenceId).toBe('seq-1');
+    expect(input?.numImages).toBe(1);
+    expect(input?.model).toBe(DEFAULT_IMAGE_MODEL);
+    expect(input?.userEditedPrompt).toBe(false);
+    expect(typeof input?.snapshotInputHash).toBe('string');
+    expect(input?.snapshotInputHash?.length).toBeGreaterThan(0);
+  });
+
+  it('forwards userEditedPrompt when set', async () => {
+    const frame = makeFrame({ description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({
+      ...baseOpts,
+      frame,
+      userEditedPrompt: true,
+    });
+    expect(input?.userEditedPrompt).toBe(true);
+  });
+});
+
+describe('buildFrameImageWorkflowInput — reference images', () => {
+  it('has no reference images when nothing matches', async () => {
+    const frame = makeFrame({ description: 'DESC' });
+    const input = await buildFrameImageWorkflowInput({ ...baseOpts, frame });
+    expect(input?.referenceImages).toEqual([]);
+  });
+
+  it('includes a matching character (with a sheet) as a character-role reference', async () => {
+    const frame = makeFrame({ description: 'DESC' });
+    const character: CharacterMinimal = {
+      id: 'c1',
+      characterId: 'jack',
+      name: 'Jack',
+      sheetImageUrl: 'https://cdn/jack-sheet.png',
+      sheetStatus: 'completed',
+      sheetInputHash: 'hash-jack',
+      physicalDescription: 'tall',
+      consistencyTag: null,
+    };
+    const input = await buildFrameImageWorkflowInput({
+      ...baseOpts,
+      frame,
+      characters: [character],
+      // Matching continuity passed directly (avoids building frame metadata).
+      continuity: continuitySchema.parse({ characterTags: ['Jack'] }),
+    });
+    expect(input?.referenceImages?.[0]).toMatchObject({
+      referenceImageUrl: 'https://cdn/jack-sheet.png',
+      role: 'character',
+    });
+  });
+});

--- a/src/lib/image/build-frame-image-input.ts
+++ b/src/lib/image/build-frame-image-input.ts
@@ -1,0 +1,163 @@
+/**
+ * Builds the per-frame `ImageWorkflowInput` for an image generation — the
+ * reference-image attachment + per-scene snapshot hash that both the
+ * single-frame regenerate (`generateFrameImageFn`) and the bulk add-model
+ * (`addModelToSequenceFn`, #547) paths need. Extracted so the two callers stay
+ * consistent: same prompt fallback chain, same character/location/element
+ * matching, same snapshot hash.
+ */
+
+import type { TextToImageModel } from '@/lib/ai/models';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
+import type {
+  CharacterMinimal,
+  Frame,
+  SequenceElement,
+  SequenceLocation,
+} from '@/lib/db/schema';
+import { locationMatchesTag } from '@/lib/db/scoped/sequence-locations';
+import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
+import { buildElementReferenceImages } from '@/lib/prompts/element-prompt';
+import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type {
+  FrameImageSceneSnapshot,
+  ImageWorkflowInput,
+} from '@/lib/workflow/types';
+import {
+  matchCharactersToScene,
+  matchElementsToScene,
+  matchLocationsToScene,
+} from '@/lib/workflows/scene-matching';
+import { computeFrameImageSceneHash } from '@/lib/workflows/sheet-snapshots';
+
+function sortedHashes(
+  values: ReadonlyArray<string | null | undefined>
+): string[] {
+  return values
+    .filter((v): v is string => typeof v === 'string' && v.length > 0)
+    .sort();
+}
+
+/** Match locations by environmentTag or scene location and return reference images. */
+function getSceneLocationReferenceImages(
+  allLocations: SequenceLocation[],
+  environmentTag: string,
+  sceneLocation: string
+) {
+  if (!environmentTag && !sceneLocation) return [];
+  const matched = allLocations.filter(
+    (loc) =>
+      (environmentTag && locationMatchesTag(loc, environmentTag)) ||
+      (sceneLocation && locationMatchesTag(loc, sceneLocation))
+  );
+  return buildLocationReferenceImages(matched);
+}
+
+export async function buildFrameImageWorkflowInput(opts: {
+  frame: Frame;
+  model: TextToImageModel;
+  userId: string;
+  teamId: string;
+  sequenceId: string;
+  aspectRatio: AspectRatio;
+  characters: CharacterMinimal[];
+  locations: SequenceLocation[];
+  elements: SequenceElement[];
+  /**
+   * Continuity to match references against. Defaults to the frame's stored
+   * continuity; callers that just edited a prompt pass a rescanned one.
+   */
+  continuity?: Scene['continuity'];
+  /** Prompt override (e.g. a user edit). Defaults to the frame's prompt chain. */
+  prompt?: string;
+  userEditedPrompt?: boolean;
+}): Promise<ImageWorkflowInput | null> {
+  const {
+    frame,
+    model,
+    userId,
+    teamId,
+    sequenceId,
+    aspectRatio,
+    characters,
+    locations,
+    elements,
+  } = opts;
+
+  // Priority: provided > stored > AI-generated > description.
+  const prompt =
+    opts.prompt ||
+    frame.imagePrompt ||
+    frame.metadata?.prompts?.visual?.fullPrompt ||
+    frame.description;
+  if (!prompt) return null;
+
+  const continuity = opts.continuity ?? frame.metadata?.continuity;
+
+  const matchedCharacters = matchCharactersToScene(
+    characters,
+    continuity?.characterTags ?? []
+  );
+  const characterReferences = buildCharacterReferenceImages(matchedCharacters);
+
+  const environmentTag = continuity?.environmentTag ?? '';
+  const sceneLocation = frame.metadata?.metadata?.location ?? '';
+  const matchedLocations = matchLocationsToScene(
+    locations,
+    environmentTag,
+    sceneLocation
+  );
+  const locationReferences = getSceneLocationReferenceImages(
+    locations,
+    environmentTag,
+    sceneLocation
+  );
+
+  const matchedElements = matchElementsToScene(
+    elements,
+    continuity?.elementTags ?? [],
+    frame.metadata?.originalScript.extract ?? ''
+  );
+  const elementReferences = buildElementReferenceImages(matchedElements);
+
+  const sceneSnapshot: FrameImageSceneSnapshot = {
+    sceneId: frame.metadata?.sceneId ?? frame.id,
+    visualPrompt: prompt,
+    characterSheetHashes: sortedHashes(
+      matchedCharacters.map((c) => c.sheetInputHash)
+    ),
+    locationSheetHashes: sortedHashes(
+      matchedLocations.map((l) => l.referenceInputHash)
+    ),
+    elementReferenceHashes: sortedHashes(
+      matchedElements.map((e) => e.imageUrl)
+    ),
+  };
+  const snapshotInputHash = await computeFrameImageSceneHash(
+    sceneSnapshot,
+    model,
+    aspectRatio
+  );
+
+  return {
+    userId,
+    teamId,
+    prompt,
+    model,
+    imageSize: aspectRatioToImageSize(aspectRatio),
+    numImages: 1,
+    frameId: frame.id,
+    sequenceId,
+    aspectRatio,
+    sceneSnapshot,
+    snapshotInputHash,
+    referenceImages: [
+      ...characterReferences,
+      ...locationReferences,
+      ...elementReferences,
+    ],
+    userEditedPrompt: opts.userEditedPrompt ?? false,
+  };
+}

--- a/src/lib/image/build-frame-image-input.ts
+++ b/src/lib/image/build-frame-image-input.ts
@@ -73,6 +73,11 @@ export async function buildFrameImageWorkflowInput(opts: {
   /** Prompt override (e.g. a user edit). Defaults to the frame's prompt chain. */
   prompt?: string;
   userEditedPrompt?: boolean;
+  /**
+   * Variant-only (#547): the resulting `/image` run writes only this model's
+   * `frame_variants` row, never the primary columns. Set by the add-model path.
+   */
+  variantOnly?: boolean;
 }): Promise<ImageWorkflowInput | null> {
   const {
     frame,
@@ -159,5 +164,6 @@ export async function buildFrameImageWorkflowInput(opts: {
       ...elementReferences,
     ],
     userEditedPrompt: opts.userEditedPrompt ?? false,
+    variantOnly: opts.variantOnly ?? false,
   };
 }

--- a/src/lib/model/sequence-model-coverage.test.ts
+++ b/src/lib/model/sequence-model-coverage.test.ts
@@ -88,6 +88,57 @@ describe('computeSequenceModelCoverage', () => {
     expect(coverage.get('flux_pro')?.completed).toBe(0);
   });
 
+  it('reports failed when an added model has only failed rows', () => {
+    const variants = [
+      variant({ id: 'a1', frameId: 'f1', model: 'nano_banana_2' }),
+      variant({
+        id: 'b1',
+        frameId: 'f1',
+        model: 'flux_pro',
+        status: 'failed',
+        url: null,
+      }),
+    ];
+
+    const coverage = computeSequenceModelCoverage({
+      variants,
+      variantType: 'image',
+      primaryModel: 'nano_banana_2',
+    });
+
+    expect(coverage.get('flux_pro')?.status).toBe('failed');
+    expect(coverage.get('flux_pro')?.completed).toBe(0);
+  });
+
+  it('reports completed (not generating) when a model has both completed and in-flight rows', () => {
+    const variants = [
+      variant({ id: 'a1', frameId: 'f1', model: 'nano_banana_2' }),
+      variant({ id: 'a2', frameId: 'f2', model: 'nano_banana_2' }),
+      // flux_pro: one scene done, another still generating.
+      variant({ id: 'b1', frameId: 'f1', model: 'flux_pro' }),
+      variant({
+        id: 'b2',
+        frameId: 'f2',
+        model: 'flux_pro',
+        status: 'generating',
+        url: null,
+      }),
+    ];
+
+    const coverage = computeSequenceModelCoverage({
+      variants,
+      variantType: 'image',
+      primaryModel: 'nano_banana_2',
+    });
+
+    // At least one completed scene wins over a concurrent generating row.
+    expect(coverage.get('flux_pro')).toEqual({
+      status: 'completed',
+      completed: 1,
+      total: 2,
+    });
+  });
+
   it('ignores divergent and discarded alternates', () => {
     const variants = [
       variant({ id: 'a1', frameId: 'f1', model: 'nano_banana_2' }),

--- a/src/lib/model/sequence-model-coverage.test.ts
+++ b/src/lib/model/sequence-model-coverage.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import type { FrameVariant } from '@/lib/db/schema';
+import { computeSequenceModelCoverage } from './sequence-model-coverage';
+
+/**
+ * Tests for the header dropdowns' sequence-wide per-model coverage (#547):
+ * "has this model generated across the whole sequence, and is it the primary".
+ */
+
+const baseVariant: FrameVariant = {
+  id: 'v',
+  frameId: 'f1',
+  sequenceId: 'seq1',
+  variantType: 'image',
+  model: 'nano_banana_2',
+  url: 'https://r2/img.png',
+  storagePath: 'team/seq/img.png',
+  previewUrl: null,
+  shotVariantUrl: null,
+  shotVariantPath: null,
+  shotVariantStatus: null,
+  shotVariantWorkflowRunId: null,
+  status: 'completed',
+  workflowRunId: null,
+  generatedAt: null,
+  error: null,
+  promptHash: null,
+  inputHash: null,
+  divergedAt: null,
+  discardedAt: null,
+  durationMs: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function variant(overrides: Partial<FrameVariant>): FrameVariant {
+  return { ...baseVariant, ...overrides };
+}
+
+describe('computeSequenceModelCoverage', () => {
+  it('marks the primary model as set and reports partial coverage for an added model', () => {
+    const variants = [
+      // Primary model: generated for all 3 frames.
+      variant({ id: 'a1', frameId: 'f1', model: 'nano_banana_2' }),
+      variant({ id: 'a2', frameId: 'f2', model: 'nano_banana_2' }),
+      variant({ id: 'a3', frameId: 'f3', model: 'nano_banana_2' }),
+      // Added model: generated for only 1 of the 3.
+      variant({ id: 'b1', frameId: 'f1', model: 'flux_pro' }),
+    ];
+
+    const coverage = computeSequenceModelCoverage({
+      variants,
+      variantType: 'image',
+      primaryModel: 'nano_banana_2',
+    });
+
+    expect(coverage.get('nano_banana_2')).toEqual({
+      status: 'set',
+      completed: 3,
+      total: 3,
+    });
+    expect(coverage.get('flux_pro')).toEqual({
+      status: 'completed',
+      completed: 1,
+      total: 3,
+    });
+  });
+
+  it('reports generating when an added model has pending rows and nothing completed', () => {
+    const variants = [
+      variant({ id: 'a1', frameId: 'f1', model: 'nano_banana_2' }),
+      variant({
+        id: 'b1',
+        frameId: 'f1',
+        model: 'flux_pro',
+        status: 'generating',
+        url: null,
+      }),
+    ];
+
+    const coverage = computeSequenceModelCoverage({
+      variants,
+      variantType: 'image',
+      primaryModel: 'nano_banana_2',
+    });
+
+    expect(coverage.get('flux_pro')?.status).toBe('generating');
+    expect(coverage.get('flux_pro')?.completed).toBe(0);
+  });
+
+  it('ignores divergent and discarded alternates', () => {
+    const variants = [
+      variant({ id: 'a1', frameId: 'f1', model: 'nano_banana_2' }),
+      variant({
+        id: 'd1',
+        frameId: 'f1',
+        model: 'flux_pro',
+        divergedAt: new Date(),
+      }),
+      variant({
+        id: 'x1',
+        frameId: 'f2',
+        model: 'flux_pro',
+        discardedAt: new Date(),
+      }),
+    ];
+
+    const coverage = computeSequenceModelCoverage({
+      variants,
+      variantType: 'image',
+      primaryModel: 'nano_banana_2',
+    });
+
+    // flux_pro had only divergent/discarded rows → no live coverage.
+    expect(coverage.get('flux_pro')).toBeUndefined();
+    expect(coverage.get('nano_banana_2')?.total).toBe(1);
+  });
+
+  it('filters by variant type', () => {
+    const variants = [
+      variant({ id: 'a1', frameId: 'f1', variantType: 'image', model: 'm1' }),
+      variant({ id: 'v1', frameId: 'f1', variantType: 'video', model: 'm1' }),
+    ];
+
+    const videoCoverage = computeSequenceModelCoverage({
+      variants,
+      variantType: 'video',
+      primaryModel: null,
+    });
+    expect(videoCoverage.get('m1')).toEqual({
+      status: 'completed',
+      completed: 1,
+      total: 1,
+    });
+  });
+
+  it('returns an empty map for undefined variants', () => {
+    expect(
+      computeSequenceModelCoverage({
+        variants: undefined,
+        variantType: 'image',
+      }).size
+    ).toBe(0);
+  });
+});

--- a/src/lib/model/sequence-model-coverage.ts
+++ b/src/lib/model/sequence-model-coverage.ts
@@ -1,0 +1,92 @@
+import type { ModelGenerationStatus } from '@/components/model/base-model-selector';
+import type { FrameVariant } from '@/lib/db/schema';
+import type { VariantType } from '@/lib/db/schema/frame-variants';
+
+/**
+ * Sequence-wide generation coverage for one model (#547). Drives the header
+ * image/video dropdown markers — "has this model generated across the whole
+ * sequence yet, and is it the live primary".
+ */
+export type ModelCoverage = {
+  /**
+   * Per-model marker: `set` (live primary), `completed` (generated for ≥1
+   * scene), `generating`, `failed`, or `pending` (nothing yet).
+   */
+  status: ModelGenerationStatus;
+  /** Distinct scenes with a completed variant for this model. */
+  completed: number;
+  /**
+   * Coverage denominator: scenes covered by ANY model of this type (the union
+   * of every model's completed scenes). A model is "fully generated" when
+   * `completed === total`.
+   */
+  total: number;
+};
+
+/**
+ * Build a per-model coverage map for a sequence from its `frame_variants` rows
+ * of one type. Only primary rows count (divergent/discarded alternates are
+ * excluded). The live primary model (when supplied) is marked `set`; every
+ * other model reports how many scenes it has generated for so the dropdown can
+ * show e.g. "8/10" while an added model is still filling in.
+ */
+export function computeSequenceModelCoverage(opts: {
+  variants: readonly FrameVariant[] | undefined;
+  variantType: VariantType;
+  /** The live primary model (marked `set`), if any. */
+  primaryModel?: string | null;
+}): Map<string, ModelCoverage> {
+  const { variants, variantType, primaryModel } = opts;
+  const map = new Map<string, ModelCoverage>();
+  if (!variants) return map;
+
+  const completedFramesByModel = new Map<string, Set<string>>();
+  const generating = new Set<string>();
+  const failed = new Set<string>();
+  const allCompletedFrames = new Set<string>();
+
+  for (const v of variants) {
+    if (v.variantType !== variantType) continue;
+    if (v.divergedAt !== null || v.discardedAt !== null) continue;
+    if (v.status === 'completed' && v.url) {
+      let frames = completedFramesByModel.get(v.model);
+      if (!frames) {
+        frames = new Set();
+        completedFramesByModel.set(v.model, frames);
+      }
+      frames.add(v.frameId);
+      allCompletedFrames.add(v.frameId);
+    } else if (v.status === 'generating' || v.status === 'pending') {
+      generating.add(v.model);
+    } else if (v.status === 'failed') {
+      failed.add(v.model);
+    }
+  }
+
+  const total = allCompletedFrames.size;
+  const models = new Set<string>([
+    ...completedFramesByModel.keys(),
+    ...generating,
+    ...failed,
+  ]);
+  if (primaryModel) models.add(primaryModel);
+
+  for (const model of models) {
+    const completed = completedFramesByModel.get(model)?.size ?? 0;
+    let status: ModelGenerationStatus;
+    if (model === primaryModel) {
+      status = 'set';
+    } else if (completed > 0) {
+      status = 'completed';
+    } else if (generating.has(model)) {
+      status = 'generating';
+    } else if (failed.has(model)) {
+      status = 'failed';
+    } else {
+      status = 'pending';
+    }
+    map.set(model, { status, completed, total });
+  }
+
+  return map;
+}

--- a/src/lib/model/sequence-model-coverage.ts
+++ b/src/lib/model/sequence-model-coverage.ts
@@ -10,15 +10,18 @@ import type { VariantType } from '@/lib/db/schema/frame-variants';
 export type ModelCoverage = {
   /**
    * Per-model marker: `set` (live primary), `completed` (generated for ≥1
-   * scene), `generating`, `failed`, or `pending` (nothing yet).
+   * scene), `generating` (≥1 row pending or in flight, none completed yet —
+   * `pending` rows fold into this so a just-added model reads as generating),
+   * `failed`, or `pending` (nothing yet).
    */
   status: ModelGenerationStatus;
   /** Distinct scenes with a completed variant for this model. */
   completed: number;
   /**
-   * Coverage denominator: scenes covered by ANY model of this type (the union
-   * of every model's completed scenes). A model is "fully generated" when
-   * `completed === total`.
+   * Coverage denominator: scenes covered by ANY model of this type — the union
+   * of every model's *completed* scenes (in-flight/failed rows don't count, so
+   * `total` is 0 until at least one model completes a scene). A model is "fully
+   * generated" when `completed === total`.
    */
   total: number;
 };

--- a/src/lib/realtime/__tests__/query-cache-updater.test.ts
+++ b/src/lib/realtime/__tests__/query-cache-updater.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for `updateQueryCacheFromEvent` — focused on the variant-only guard
+ * (#547). An added (alternate) model's image/video completion must NOT repoint
+ * the live primary in the frames-list cache; it should only refresh the
+ * per-model variant/model-list queries so the new model surfaces in the
+ * dropdown. The primary-model path (no `variantOnly`) keeps optimistically
+ * writing the primary as before.
+ */
+
+import { QueryClient } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { frameKeys } from '@/hooks/use-frames';
+import type { Frame } from '@/lib/db/schema';
+import { updateQueryCacheFromEvent } from '@/lib/realtime/query-cache-updater';
+
+const SEQ = 'seq-1';
+const OLD_THUMB = 'https://cdn/old-thumb.jpg';
+const OLD_VIDEO = 'https://cdn/old-video.mp4';
+const NEW_URL = 'https://cdn/added-model-output.mp4';
+
+function makeFrame(overrides: Partial<Frame> = {}): Frame {
+  return {
+    id: 'frame-1',
+    sequenceId: SEQ,
+    orderIndex: 0,
+    description: 'A scene',
+    durationMs: 3000,
+    thumbnailUrl: OLD_THUMB,
+    thumbnailPath: null,
+    thumbnailStatus: 'completed',
+    thumbnailWorkflowRunId: null,
+    thumbnailGeneratedAt: null,
+    thumbnailError: null,
+    imageModel: 'nano_banana_2',
+    imagePrompt: null,
+    variantImageUrl: null,
+    variantImageStatus: 'pending',
+    variantWorkflowRunId: null,
+    variantImageGeneratedAt: null,
+    variantImageError: null,
+    videoUrl: OLD_VIDEO,
+    videoPath: null,
+    videoStatus: 'completed',
+    videoWorkflowRunId: null,
+    videoGeneratedAt: null,
+    videoError: null,
+    motionPrompt: null,
+    motionModel: 'veo3',
+    audioUrl: null,
+    audioPath: null,
+    audioStatus: 'pending',
+    audioWorkflowRunId: null,
+    audioGeneratedAt: null,
+    audioError: null,
+    audioModel: null,
+    thumbnailInputHash: null,
+    variantImageInputHash: null,
+    videoInputHash: null,
+    audioInputHash: null,
+    visualPromptInputHash: null,
+    motionPromptInputHash: null,
+    previewThumbnailUrl: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+function getCachedFrame(qc: QueryClient): Frame | undefined {
+  return qc.getQueryData<Frame[]>(frameKeys.list(SEQ))?.[0];
+}
+
+describe('updateQueryCacheFromEvent — variant-only guard (#547)', () => {
+  let qc: QueryClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    qc = new QueryClient();
+    qc.setQueryData(frameKeys.list(SEQ), [makeFrame()]);
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  describe('generation.image:progress', () => {
+    it('variant-only completion leaves the primary thumbnail untouched but still refreshes the model/variant queries', () => {
+      const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.image:progress', {
+        frameId: 'frame-1',
+        status: 'completed',
+        thumbnailUrl: NEW_URL,
+        model: 'flux_pro',
+        variantOnly: true,
+      });
+
+      // Primary frame is NOT repointed to the added model's output.
+      const frame = getCachedFrame(qc);
+      expect(frame?.thumbnailUrl).toBe(OLD_THUMB);
+      expect(frame?.thumbnailStatus).toBe('completed');
+
+      // The per-model variant + model-list queries still refresh so the added
+      // model appears in the dropdown (debounced — flush the timer).
+      vi.advanceTimersByTime(200);
+      const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
+      expect(invalidatedKeys).toContainEqual(['sequence-image-variants', SEQ]);
+      expect(invalidatedKeys).toContainEqual(['sequence-image-models', SEQ]);
+      // The frames list itself is never invalidated by this handler.
+      expect(invalidatedKeys).not.toContainEqual(frameKeys.list(SEQ));
+    });
+
+    it('primary completion (no variantOnly) still writes the thumbnail onto the frame', () => {
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.image:progress', {
+        frameId: 'frame-1',
+        status: 'completed',
+        thumbnailUrl: NEW_URL,
+        model: 'nano_banana_2',
+      });
+
+      const frame = getCachedFrame(qc);
+      expect(frame?.thumbnailUrl).toBe(NEW_URL);
+      expect(frame?.thumbnailStatus).toBe('completed');
+    });
+  });
+
+  describe('generation.video:progress', () => {
+    it('variant-only completion leaves the primary video untouched but still refreshes the model/variant queries', () => {
+      const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.video:progress', {
+        frameId: 'frame-1',
+        status: 'completed',
+        videoUrl: NEW_URL,
+        model: 'kling_25',
+        variantOnly: true,
+      });
+
+      const frame = getCachedFrame(qc);
+      expect(frame?.videoUrl).toBe(OLD_VIDEO);
+      expect(frame?.videoStatus).toBe('completed');
+
+      vi.advanceTimersByTime(200);
+      const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
+      expect(invalidatedKeys).toContainEqual(['sequence-video-variants', SEQ]);
+      expect(invalidatedKeys).toContainEqual(['sequence-video-models', SEQ]);
+    });
+
+    it('variant-only failure does not flip the primary video to failed', () => {
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.video:progress', {
+        frameId: 'frame-1',
+        status: 'failed',
+        model: 'kling_25',
+        variantOnly: true,
+      });
+
+      const frame = getCachedFrame(qc);
+      expect(frame?.videoStatus).toBe('completed');
+      expect(frame?.videoUrl).toBe(OLD_VIDEO);
+    });
+
+    it('primary completion (no variantOnly) still writes the video onto the frame', () => {
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.video:progress', {
+        frameId: 'frame-1',
+        status: 'completed',
+        videoUrl: NEW_URL,
+        model: 'veo3',
+      });
+
+      const frame = getCachedFrame(qc);
+      expect(frame?.videoUrl).toBe(NEW_URL);
+      expect(frame?.videoStatus).toBe('completed');
+    });
+  });
+});

--- a/src/lib/realtime/__tests__/query-cache-updater.test.ts
+++ b/src/lib/realtime/__tests__/query-cache-updater.test.ts
@@ -125,6 +125,29 @@ describe('updateQueryCacheFromEvent — variant-only guard (#547)', () => {
       expect(frame?.thumbnailUrl).toBe(NEW_URL);
       expect(frame?.thumbnailStatus).toBe('completed');
     });
+
+    it('variant-only failure refreshes the model/variant queries so the coverage marker leaves the spinner', () => {
+      const invalidate = vi.spyOn(qc, 'invalidateQueries');
+
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.image:progress', {
+        frameId: 'frame-1',
+        status: 'failed',
+        model: 'flux_pro',
+        variantOnly: true,
+      });
+
+      // The failed alternate must not flip the primary thumbnail to failed.
+      const frame = getCachedFrame(qc);
+      expect(frame?.thumbnailUrl).toBe(OLD_THUMB);
+      expect(frame?.thumbnailStatus).toBe('completed');
+
+      // ...but the per-model queries must refresh so the added model's marker
+      // shows `failed` instead of spinning `generating` until staleTime lapses.
+      vi.advanceTimersByTime(200);
+      const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
+      expect(invalidatedKeys).toContainEqual(['sequence-image-variants', SEQ]);
+      expect(invalidatedKeys).toContainEqual(['sequence-image-models', SEQ]);
+    });
   });
 
   describe('generation.video:progress', () => {

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -115,6 +115,12 @@ export const realtimeSchema = {
       thumbnailUrl: z.string().optional(),
       previewThumbnailUrl: z.string().optional(),
       model: z.string().optional(),
+      // Variant-only (#547): this update belongs to an added (alternate) model,
+      // not the live primary. The cache updater must NOT write it onto the
+      // primary `thumbnailUrl`/`thumbnailStatus` — it only refreshes the
+      // per-model variant/model-list queries so the new model surfaces in the
+      // dropdown without clobbering the displayed primary thumbnail.
+      variantOnly: z.boolean().optional(),
     }),
 
     // Fast preview frames replaced by AI-analyzed frames
@@ -138,6 +144,12 @@ export const realtimeSchema = {
       // with emitters that predate multi-model video (#545); the model-aware
       // cache invalidation and scenes-view variant switcher key off it.
       model: z.string().optional(),
+      // Variant-only (#547): this update belongs to an added (alternate) model,
+      // not the live primary. The cache updater must NOT write it onto the
+      // primary `videoUrl`/`videoStatus` — it only refreshes the per-model
+      // variant/model-list queries so the new model surfaces in the dropdown
+      // without clobbering the displayed primary video.
+      variantOnly: z.boolean().optional(),
     }),
 
     // Audio/music generation progress (frameId optional for sequence-level music)

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -129,21 +129,29 @@ export function updateQueryCacheFromEvent(
         'previewThumbnailUrl'
       );
       const status = data.status;
-      queryClient.setQueryData<Frame[]>(frameKeys.list(sequenceId), (old) =>
-        old?.map((f) =>
-          f.id === frameId
-            ? {
-                ...f,
-                thumbnailUrl: thumbnailUrl ?? f.thumbnailUrl,
-                previewThumbnailUrl:
-                  previewThumbnailUrl ?? f.previewThumbnailUrl,
-                thumbnailStatus: isValidFrameStatus(status)
-                  ? status
-                  : f.thumbnailStatus,
-              }
-            : f
-        )
-      );
+      // Variant-only (#547): an added (alternate) model finished — its output
+      // belongs in `frame_variants`, NOT on the live primary. Skip the
+      // primary frames-list write (which would flip the displayed thumbnail to
+      // the alternate) and only refresh the per-model variant/model-list
+      // queries below so the new model appears in the dropdown.
+      const variantOnly = data.variantOnly === true;
+      if (!variantOnly) {
+        queryClient.setQueryData<Frame[]>(frameKeys.list(sequenceId), (old) =>
+          old?.map((f) =>
+            f.id === frameId
+              ? {
+                  ...f,
+                  thumbnailUrl: thumbnailUrl ?? f.thumbnailUrl,
+                  previewThumbnailUrl:
+                    previewThumbnailUrl ?? f.previewThumbnailUrl,
+                  thumbnailStatus: isValidFrameStatus(status)
+                    ? status
+                    : f.thumbnailStatus,
+                }
+              : f
+          )
+        );
+      }
       // Refresh variant data so model switcher and variant overlay stay current
       if (status === 'completed') {
         debouncedInvalidate(
@@ -163,19 +171,27 @@ export function updateQueryCacheFromEvent(
     case 'generation.video:progress': {
       const videoUrl = getOptionalString(data, 'videoUrl');
       const status = data.status;
-      queryClient.setQueryData<Frame[]>(frameKeys.list(sequenceId), (old) =>
-        old?.map((f) =>
-          f.id === frameId
-            ? {
-                ...f,
-                videoUrl: videoUrl ?? f.videoUrl,
-                videoStatus: isValidFrameStatus(status)
-                  ? status
-                  : f.videoStatus,
-              }
-            : f
-        )
-      );
+      // Variant-only (#547): an added (alternate) video model finished/failed —
+      // its output belongs in `frame_variants`, NOT the live primary. Skip the
+      // primary frames-list write (which would flip the displayed video to the
+      // alternate) and only refresh the per-model variant/model-list queries
+      // below so the new model appears in the dropdown.
+      const variantOnly = data.variantOnly === true;
+      if (!variantOnly) {
+        queryClient.setQueryData<Frame[]>(frameKeys.list(sequenceId), (old) =>
+          old?.map((f) =>
+            f.id === frameId
+              ? {
+                  ...f,
+                  videoUrl: videoUrl ?? f.videoUrl,
+                  videoStatus: isValidFrameStatus(status)
+                    ? status
+                    : f.videoStatus,
+                }
+              : f
+          )
+        );
+      }
       // Refresh video variant data so the model switcher and per-model overlay
       // stay current (#545). Unlike the image handler, refresh on `failed` too:
       // motion-workflow.onFailure writes a `failed` variant row, and the

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -152,8 +152,12 @@ export function updateQueryCacheFromEvent(
           )
         );
       }
-      // Refresh variant data so model switcher and variant overlay stay current
-      if (status === 'completed') {
+      // Refresh variant data so model switcher and variant overlay stay current.
+      // Refresh on `failed` too (#547): image-workflow.onFailure writes a `failed`
+      // variant row, and an added model's coverage marker must reflect that
+      // terminal state instead of spinning `generating` until staleTime lapses —
+      // matching the video/audio handlers below.
+      if (status === 'completed' || status === 'failed') {
         debouncedInvalidate(
           queryClient,
           ['sequence-image-variants', sequenceId],

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -83,10 +83,11 @@ export interface ImageWorkflowInput extends SequenceWorkflowContext {
   userEditedPrompt?: boolean;
   /**
    * Variant-only mode (#547). When true, the run NEVER touches the live primary
-   * columns (`frames.imageModel` / `thumbnailUrl` / `thumbnailStatus` /
-   * `thumbnailInputHash` / video*) — it writes only this model's
-   * `frame_variants` row. Used by "add a model to an existing sequence" so a
-   * new model lands as a selectable alternate without repointing the primary,
+   * `frames.*` image/video columns — it writes only this model's
+   * `frame_variants` row. (See `persistImageResult`'s `variantOnly` branch and
+   * the workflow's set-generating/onFailure guards for the authoritative set of
+   * skipped columns.) Used by "add a model to an existing sequence" so a new
+   * model lands as a selectable alternate without repointing the primary,
    * tripping staleness, or invalidating the frame's video. Promotion to primary
    * happens later via an explicit "Set". Skips divergence detection entirely
    * (there is no primary to protect).

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -81,6 +81,17 @@ export interface ImageWorkflowInput extends SequenceWorkflowContext {
    * workflow appends a `user-edit` variant row.
    */
   userEditedPrompt?: boolean;
+  /**
+   * Variant-only mode (#547). When true, the run NEVER touches the live primary
+   * columns (`frames.imageModel` / `thumbnailUrl` / `thumbnailStatus` /
+   * `thumbnailInputHash` / video*) — it writes only this model's
+   * `frame_variants` row. Used by "add a model to an existing sequence" so a
+   * new model lands as a selectable alternate without repointing the primary,
+   * tripping staleness, or invalidating the frame's video. Promotion to primary
+   * happens later via an explicit "Set". Skips divergence detection entirely
+   * (there is no primary to protect).
+   */
+  variantOnly?: boolean;
 }
 
 /**
@@ -210,6 +221,14 @@ export interface MotionWorkflowInput extends SequenceWorkflowContext {
    * the workflow appends a `user-edit` variant row.
    */
   userEditedPrompt?: boolean;
+  /**
+   * Variant-only mode (#547). When true, the run NEVER touches the legacy
+   * `frames.video*` / `motionModel` columns — it writes only this model's
+   * `frame_variants` row. Used by "add a video model to an existing sequence"
+   * so the new model lands as a selectable alternate without repointing the
+   * primary video. Promotion happens later via an explicit "Set".
+   */
+  variantOnly?: boolean;
 }
 
 /**
@@ -778,6 +797,13 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
    * (single-model behaviour). Each model reuses `music.prompt/tags/duration`.
    */
   audioModels?: (keyof typeof AUDIO_MODELS)[];
+  /**
+   * Variant-only mode (#547), threaded onto every per-frame motion child. When
+   * true, no frame writes its video to the legacy `frames.video*` columns —
+   * each model lands only in `frame_variants`. Used by "add a video model to an
+   * existing sequence" so it never repoints the primary video.
+   */
+  variantOnly?: boolean;
 }
 
 /**

--- a/src/lib/workflows/image-workflow-snapshot.test.ts
+++ b/src/lib/workflows/image-workflow-snapshot.test.ts
@@ -28,6 +28,19 @@ import {
   type SceneForHash,
 } from './image-workflow-snapshot';
 
+/** The `generation.image:progress` payloads `persistImageResult` emits — typed
+ *  so the emit spies don't fall back to `unknown`. */
+type EmittedImageProgress = {
+  event: string;
+  payload: {
+    frameId: string;
+    status: 'pending' | 'completed';
+    model: string;
+    thumbnailUrl?: string;
+    variantOnly?: boolean;
+  };
+};
+
 const baseScene: FrameImageSceneSnapshot = {
   sceneId: 's1',
   visualPrompt: 'A wide establishing shot of Jack at the docks at dusk',
@@ -460,7 +473,7 @@ describe('persistImageResult — orchestration', () => {
       variantsInserts,
       callOrder,
     } = buildScopedDbSpy();
-    const emits: Array<{ event: string; payload: unknown }> = [];
+    const emits: EmittedImageProgress[] = [];
 
     const outcome = await persistImageResult({
       scopedDb,
@@ -534,7 +547,7 @@ describe('persistImageResult — orchestration', () => {
       variantsInserts,
       callOrder,
     } = buildScopedDbSpy();
-    const emits: Array<{ event: string; payload: unknown }> = [];
+    const emits: EmittedImageProgress[] = [];
 
     const outcome = await persistImageResult({
       scopedDb,
@@ -593,7 +606,7 @@ describe('persistImageResult — orchestration', () => {
   it('non-snapshot mode (snapshotHash null): convergent write with null inputHash, NO insertDivergent', async () => {
     const { scopedDb, framesUpdates, variantsUpdates, variantsInserts } =
       buildScopedDbSpy();
-    const emits: Array<{ event: string; payload: unknown }> = [];
+    const emits: EmittedImageProgress[] = [];
 
     const outcome = await persistImageResult({
       scopedDb,
@@ -653,7 +666,7 @@ describe('persistImageResult — orchestration', () => {
       variantsInserts,
       callOrder,
     } = buildScopedDbSpy();
-    const emits: Array<{ event: string; payload: unknown }> = [];
+    const emits: EmittedImageProgress[] = [];
 
     const outcome = await persistImageResult({
       scopedDb,
@@ -695,6 +708,8 @@ describe('persistImageResult — orchestration', () => {
           status: 'completed',
           thumbnailUrl: upload.url,
           model: 'nano_banana_2',
+          // Flags the cache updater not to repoint the primary thumbnail (#547).
+          variantOnly: true,
         },
       },
     ]);

--- a/src/lib/workflows/image-workflow-snapshot.test.ts
+++ b/src/lib/workflows/image-workflow-snapshot.test.ts
@@ -644,4 +644,59 @@ describe('persistImageResult — orchestration', () => {
     expect(variantsUpdates).toEqual([]);
     expect(variantsInserts).toEqual([]);
   });
+
+  it('variant-only (#547): writes ONLY the variant row — no frames.update, no divergence, even when hashes differ', async () => {
+    const {
+      scopedDb,
+      framesUpdates,
+      variantsUpdates,
+      variantsInserts,
+      callOrder,
+    } = buildScopedDbSpy();
+    const emits: Array<{ event: string; payload: unknown }> = [];
+
+    const outcome = await persistImageResult({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'nano_banana_2',
+      upload,
+      // Hashes differ — convergent/divergent would diverge, but variant-only
+      // skips that path entirely (there is no primary to protect).
+      snapshotHash: 'snapshot-abc',
+      currentHash: 'current-xyz',
+      promptHash: 'prompt-1',
+      variantOnly: true,
+      emit: async (event, payload) => {
+        emits.push({ event, payload });
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'variant-only', imageUrl: upload.url });
+    // The primary columns are never touched, and nothing diverges.
+    expect(framesUpdates).toEqual([]);
+    expect(variantsInserts).toEqual([]);
+    expect(callOrder).toEqual(['frameVariants.updateByFrameAndModel']);
+
+    const [variantWrite] = variantsUpdates;
+    if (!variantWrite) throw new Error('expected variant update call');
+    expect(variantWrite.variantType).toBe('image');
+    expect(variantWrite.model).toBe('nano_banana_2');
+    expect(variantWrite.data.url).toBe(upload.url);
+    expect(variantWrite.data.status).toBe('completed');
+    expect(variantWrite.data.inputHash).toBe('snapshot-abc');
+
+    expect(emits).toEqual([
+      {
+        event: 'generation.image:progress',
+        payload: {
+          frameId: 'f1',
+          status: 'completed',
+          thumbnailUrl: upload.url,
+          model: 'nano_banana_2',
+        },
+      },
+    ]);
+  });
 });

--- a/src/lib/workflows/image-workflow-snapshot.ts
+++ b/src/lib/workflows/image-workflow-snapshot.ts
@@ -309,6 +309,7 @@ export async function persistImageResult(opts: {
       status: 'pending' | 'completed';
       model: string;
       thumbnailUrl?: string;
+      variantOnly?: boolean;
     }
   ) => Promise<void>;
   /**
@@ -357,6 +358,8 @@ export async function persistImageResult(opts: {
       status: 'completed',
       thumbnailUrl: upload.url,
       model,
+      // Alternate model — the cache updater must not repoint the primary.
+      variantOnly: true,
     });
 
     return { status: 'variant-only', imageUrl: upload.url };

--- a/src/lib/workflows/image-workflow-snapshot.ts
+++ b/src/lib/workflows/image-workflow-snapshot.ts
@@ -279,6 +279,7 @@ export function buildImageDivergentWrites(opts: {
 export type PersistImageOutcome =
   | { status: 'divergent'; imageUrl: string; snapshotHash: string }
   | { status: 'convergent'; imageUrl: string }
+  | { status: 'variant-only'; imageUrl: string }
   | { status: 'frame-deleted' };
 
 /**
@@ -310,6 +311,12 @@ export async function persistImageResult(opts: {
       thumbnailUrl?: string;
     }
   ) => Promise<void>;
+  /**
+   * Variant-only (#547): write only this model's `frame_variants` row, never
+   * the primary `frames.*`. Skips divergence detection — with no primary to
+   * protect, there is nothing to diverge from.
+   */
+  variantOnly?: boolean;
   now?: () => Date;
 }): Promise<PersistImageOutcome> {
   const {
@@ -322,8 +329,38 @@ export async function persistImageResult(opts: {
     currentHash,
     promptHash,
     emit,
+    variantOnly,
     now = () => new Date(),
   } = opts;
+
+  if (variantOnly) {
+    // Reuse the convergent variant payload (url/path/status/hashes), but apply
+    // it ONLY to the variant row — the primary `frames.*` stay exactly as they
+    // were. A null update means the frame (and its cascade-deleted variant) is
+    // gone.
+    const { variant } = buildImageConvergentWrites({
+      upload,
+      snapshotHash,
+      promptHash,
+      generatedAt: now(),
+    });
+    const updated = await scopedDb.frameVariants.updateByFrameAndModel(
+      frameId,
+      'image',
+      model,
+      variant
+    );
+    if (!updated) return { status: 'frame-deleted' };
+
+    await emit('generation.image:progress', {
+      frameId,
+      status: 'completed',
+      thumbnailUrl: upload.url,
+      model,
+    });
+
+    return { status: 'variant-only', imageUrl: upload.url };
+  }
 
   if (snapshotHash && currentHash !== snapshotHash) {
     const writes = buildImageDivergentWrites({

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -177,7 +177,14 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
 
           await getGenerationChannel(input.sequenceId).emit(
             'generation.image:progress',
-            { frameId: input.frameId, status: 'generating', model }
+            {
+              frameId: input.frameId,
+              status: 'generating',
+              model,
+              // Variant-only (#547): don't flip the primary frame to
+              // "generating" in cache — this run only fills a variant row.
+              variantOnly: input.variantOnly,
+            }
           );
         }
 
@@ -361,7 +368,15 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
       try {
         await getGenerationChannel(input.sequenceId).emit(
           'generation.image:progress',
-          { frameId: input.frameId, status: 'failed', model }
+          {
+            frameId: input.frameId,
+            status: 'failed',
+            model,
+            // Variant-only (#547): a failed alternate must not flip the primary
+            // thumbnail to "failed" in cache (the DB write above is already
+            // guarded on variantOnly).
+            variantOnly: input.variantOnly,
+          }
         );
       } catch (emitError) {
         logger.error(

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -91,15 +91,22 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
         const model = input.model ?? DEFAULT_IMAGE_MODEL;
 
         if (input.frameId) {
-          const frame = await scopedDb.frames.update(
-            input.frameId,
-            {
-              thumbnailStatus: 'generating',
-              thumbnailWorkflowRunId: workflowRunId,
-              imageModel: model,
-            },
-            { throwOnMissing: false }
-          );
+          // Variant-only (#547) must not touch the live primary columns — read
+          // the frame instead of stamping `imageModel`/`thumbnailStatus`, so
+          // adding a model can't flip the primary or trip staleness. The
+          // per-model `frame_variants` row (opened below) carries the in-flight
+          // state instead.
+          const frame = input.variantOnly
+            ? await scopedDb.frames.getById(input.frameId)
+            : await scopedDb.frames.update(
+                input.frameId,
+                {
+                  thumbnailStatus: 'generating',
+                  thumbnailWorkflowRunId: workflowRunId,
+                  imageModel: model,
+                },
+                { throwOnMissing: false }
+              );
 
           if (!frame) {
             logger.info(
@@ -262,6 +269,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
           snapshotHash,
           currentHash,
           promptHash,
+          variantOnly: input.variantOnly,
           emit: async (event2, payload) => {
             await getGenerationChannel(sequenceId).emit(event2, payload);
           },
@@ -331,11 +339,15 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
 
     if (!input.frameId || !input.teamId) return;
 
-    await scopedDb.frames.update(
-      input.frameId,
-      { thumbnailStatus: 'failed', thumbnailError: error },
-      { throwOnMissing: false }
-    );
+    // Variant-only (#547): leave the primary columns untouched on failure too —
+    // only this model's variant row is flipped to `failed` below.
+    if (!input.variantOnly) {
+      await scopedDb.frames.update(
+        input.frameId,
+        { thumbnailStatus: 'failed', thumbnailError: error },
+        { throwOnMissing: false }
+      );
+    }
 
     const model = input.model ?? DEFAULT_IMAGE_MODEL;
     if (input.sequenceId) {

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -118,6 +118,9 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
         aspectRatio: frame.aspectRatio,
         generateAudio: frame.generateAudio,
         userEditedPrompt: frame.userEditedPrompt,
+        // Add-model (#547) batches generate alternates only — the child must
+        // not write the legacy `frames.video*` columns.
+        variantOnly: input.variantOnly,
       };
 
       return spawnAndAwaitChild<MotionWorkflowInput, MotionWorkflowResult>(

--- a/src/lib/workflows/motion-workflow-persist.test.ts
+++ b/src/lib/workflows/motion-workflow-persist.test.ts
@@ -360,6 +360,8 @@ describe('variant-only (#547)', () => {
         status: 'completed',
         videoUrl: upload.url,
         model: 'veo3',
+        // Flags the cache updater not to repoint the primary video (#547).
+        variantOnly: true,
       },
     ]);
   });

--- a/src/lib/workflows/motion-workflow-persist.test.ts
+++ b/src/lib/workflows/motion-workflow-persist.test.ts
@@ -325,3 +325,90 @@ describe('persistMotionFailure', () => {
     });
   });
 });
+
+describe('variant-only (#547)', () => {
+  it('persistMotionCompletion: writes only the variant row, never the legacy frames.video* columns', async () => {
+    const { scopedDb, framesUpdates, variantsUpdates, callOrder } =
+      buildScopedDbSpy();
+    const emits: MotionVideoProgressPayload[] = [];
+
+    const outcome = await persistMotionCompletion({
+      scopedDb,
+      frameId: 'f1',
+      model: 'veo3',
+      upload,
+      durationMs: 5000,
+      promptHash: 'prompt-abc',
+      variantOnly: true,
+      emit: async (_event, payload) => {
+        emits.push(payload);
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'completed', videoUrl: upload.url });
+    // The primary columns are untouched — only the per-model variant is written.
+    expect(framesUpdates).toEqual([]);
+    expect(callOrder).toEqual(['frameVariants.updateByFrameAndModel']);
+    const [variantUpdate] = variantsUpdates;
+    if (!variantUpdate) throw new Error('expected variant update call');
+    expect(variantUpdate.data.url).toBe(upload.url);
+    expect(variantUpdate.data.status).toBe('completed');
+    expect(emits).toEqual([
+      {
+        frameId: 'f1',
+        status: 'completed',
+        videoUrl: upload.url,
+        model: 'veo3',
+      },
+    ]);
+  });
+
+  it('persistMotionCompletion: variant-only frame-deleted (no variant row) short-circuits without emitting', async () => {
+    const { scopedDb, framesUpdates, callOrder } = buildScopedDbSpy({
+      variantMissing: true,
+    });
+    const emits: MotionVideoProgressPayload[] = [];
+
+    const outcome = await persistMotionCompletion({
+      scopedDb,
+      frameId: 'f1',
+      model: 'veo3',
+      upload,
+      durationMs: 5000,
+      promptHash: null,
+      variantOnly: true,
+      emit: async (_event, payload) => {
+        emits.push(payload);
+      },
+      now: () => NOW,
+    });
+
+    expect(outcome).toEqual({ status: 'frame-deleted' });
+    expect(framesUpdates).toEqual([]);
+    expect(callOrder).toEqual(['frameVariants.updateByFrameAndModel']);
+    expect(emits).toEqual([]);
+  });
+
+  it('persistMotionFailure: records failed only on the variant, never the legacy columns', async () => {
+    const { scopedDb, framesUpdates, variantsUpdates, callOrder } =
+      buildScopedDbSpy();
+
+    await persistMotionFailure({
+      scopedDb,
+      frameId: 'f1',
+      sequenceId: 'seq1',
+      model: 'veo3',
+      error: 'fal 500',
+      workflowRunId: 'run-9',
+      variantOnly: true,
+      emit: async () => {},
+    });
+
+    expect(framesUpdates).toEqual([]);
+    expect(callOrder).toEqual(['frameVariants.updateByFrameAndModel']);
+    const [variantUpdate] = variantsUpdates;
+    if (!variantUpdate) throw new Error('expected variant update call');
+    expect(variantUpdate.data).toEqual({ status: 'failed', error: 'fal 500' });
+  });
+});

--- a/src/lib/workflows/motion-workflow-persist.ts
+++ b/src/lib/workflows/motion-workflow-persist.ts
@@ -149,6 +149,12 @@ export async function persistMotionCompletion(opts: {
   durationMs: number;
   promptHash: string | null;
   emit: MotionEmit;
+  /**
+   * Variant-only (#547): write only this model's `frame_variants` row, never
+   * the legacy `frames.video*` columns — adding a video model leaves the
+   * primary video intact.
+   */
+  variantOnly?: boolean;
   now?: () => Date;
 }): Promise<PersistMotionOutcome> {
   const {
@@ -159,6 +165,7 @@ export async function persistMotionCompletion(opts: {
     durationMs,
     promptHash,
     emit,
+    variantOnly,
     now = () => new Date(),
   } = opts;
 
@@ -168,6 +175,27 @@ export async function persistMotionCompletion(opts: {
     promptHash,
     generatedAt: now(),
   });
+
+  if (variantOnly) {
+    // Only this model's variant row; the primary `frames.video*` are untouched.
+    // A null update means the frame (and its cascade-deleted variant) is gone.
+    const updated = await scopedDb.frameVariants.updateByFrameAndModel(
+      frameId,
+      'video',
+      model,
+      writes.variant
+    );
+    if (!updated) return { status: 'frame-deleted' };
+
+    await emit('generation.video:progress', {
+      frameId,
+      status: 'completed',
+      videoUrl: upload.url,
+      model,
+    });
+
+    return { status: 'completed', videoUrl: upload.url };
+  }
 
   const updatedFrame = await scopedDb.frames.update(frameId, writes.frame, {
     throwOnMissing: false,
@@ -213,15 +241,28 @@ export async function persistMotionFailure(opts: {
   error: string;
   workflowRunId: string;
   emit: MotionEmit;
+  /** Variant-only (#547): record `failed` only on the variant, never the
+   * legacy `frames.video*` columns. */
+  variantOnly?: boolean;
 }): Promise<void> {
-  const { scopedDb, frameId, sequenceId, model, error, workflowRunId, emit } =
-    opts;
+  const {
+    scopedDb,
+    frameId,
+    sequenceId,
+    model,
+    error,
+    workflowRunId,
+    emit,
+    variantOnly,
+  } = opts;
 
   const writes = buildMotionFailedWrites({ error });
 
-  await scopedDb.frames.update(frameId, writes.frame, {
-    throwOnMissing: false,
-  });
+  if (!variantOnly) {
+    await scopedDb.frames.update(frameId, writes.frame, {
+      throwOnMissing: false,
+    });
+  }
 
   const updated = await scopedDb.frameVariants.updateByFrameAndModel(
     frameId,

--- a/src/lib/workflows/motion-workflow-persist.ts
+++ b/src/lib/workflows/motion-workflow-persist.ts
@@ -50,8 +50,16 @@ export type PersistMotionScopedDb = {
  * emitter so the workflow can forward it directly.
  */
 export type MotionVideoProgressPayload =
-  | { frameId: string; status: 'completed'; videoUrl: string; model: string }
-  | { frameId: string; status: 'failed'; model: string };
+  | {
+      frameId: string;
+      status: 'completed';
+      videoUrl: string;
+      model: string;
+      // Variant-only (#547): added model — cache updater must not repoint the
+      // primary video.
+      variantOnly?: boolean;
+    }
+  | { frameId: string; status: 'failed'; model: string; variantOnly?: boolean };
 
 export type MotionEmit = (
   event: 'generation.video:progress',
@@ -192,6 +200,8 @@ export async function persistMotionCompletion(opts: {
       status: 'completed',
       videoUrl: upload.url,
       model,
+      // Alternate model — the cache updater must not repoint the primary.
+      variantOnly: true,
     });
 
     return { status: 'completed', videoUrl: upload.url };
@@ -281,5 +291,11 @@ export async function persistMotionFailure(opts: {
     });
   }
 
-  await emit('generation.video:progress', { frameId, status: 'failed', model });
+  await emit('generation.video:progress', {
+    frameId,
+    status: 'failed',
+    model,
+    // A failed alternate must not flip the primary video to `failed` in cache.
+    variantOnly,
+  });
 }

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -151,11 +151,16 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           workflowRunId,
         });
 
-        const frame = await scopedDb.frames.update(
-          input.frameId,
-          generatingWrites.frame,
-          { throwOnMissing: false }
-        );
+        // Variant-only (#547): don't stamp the legacy `frames.video*` columns —
+        // read the frame instead. The per-model `frame_variants` row (opened
+        // below) carries the in-flight state; the primary video is left intact.
+        const frame = input.variantOnly
+          ? await scopedDb.frames.getById(input.frameId)
+          : await scopedDb.frames.update(
+              input.frameId,
+              generatingWrites.frame,
+              { throwOnMissing: false }
+            );
 
         if (!frame) {
           logger.info(
@@ -452,6 +457,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           upload: { url: storageResult.url, path: storageResult.path },
           durationMs: duration * 1000,
           promptHash: input.prompt ? simpleHash(input.prompt) : null,
+          variantOnly: input.variantOnly,
           emit: async (event, payload) => {
             try {
               await getGenerationChannel(input.sequenceId).emit(event, payload);
@@ -499,6 +505,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
         model,
         error,
         workflowRunId: event.instanceId,
+        variantOnly: input.variantOnly,
         emit: async (event2, payload) => {
           try {
             await getGenerationChannel(sequenceId).emit(event2, payload);

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -236,7 +236,14 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
         try {
           await getGenerationChannel(input.sequenceId).emit(
             'generation.video:progress',
-            { frameId: input.frameId, status: 'generating', model }
+            {
+              frameId: input.frameId,
+              status: 'generating',
+              model,
+              // Variant-only (#547): don't flip the primary frame to
+              // "generating" in cache — this run only fills a variant row.
+              variantOnly: input.variantOnly,
+            }
           );
         } catch (emitError) {
           logger.error(

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -258,6 +258,16 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
         });
       }
 
+      // Flip this model's own variant row to `failed` regardless of `isPrimary`
+      // (#547). An added (secondary) model's row was pre-stamped `pending`; left
+      // alone it would spin `generating` forever and block re-adding the model.
+      // Update-only — never inserts a row for a primary that never had one.
+      await scopedDb.sequenceVariants.markMusicFailed(
+        input.sequenceId,
+        model,
+        error
+      );
+
       try {
         await getGenerationChannel(input.sequenceId).emit(
           'generation.audio:progress',

--- a/src/routes/_app/sequences/$id/music.tsx
+++ b/src/routes/_app/sequences/$id/music.tsx
@@ -20,7 +20,11 @@ import {
   useUndiscardSequenceMusicVariant,
 } from '@/hooks/use-sequence-variants';
 import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
-import { type AudioModel } from '@/lib/ai/models';
+import {
+  DEFAULT_MUSIC_MODEL,
+  safeAudioModel,
+  type AudioModel,
+} from '@/lib/ai/models';
 import type { SequenceMusicVariant } from '@/lib/db/schema';
 import { useGenerationStream } from '@/lib/realtime/use-generation-stream';
 import { useSequenceStaleDetected } from '@/lib/realtime/use-sequence-stale-detected';
@@ -46,7 +50,8 @@ function MusicPage() {
   // Resolve the music tab through the viewer's active audio model (#546). When
   // a model is pinned in the header, play that model's track instead of the
   // live `sequences.music*` primary; unpinned (null) follows the primary.
-  const { activeAudioModel } = useActiveAudioModel(sequenceId);
+  const { activeAudioModel, selectAudioModel } =
+    useActiveAudioModel(sequenceId);
   const { data: audioVariants } = useSequenceAudioVariants(sequenceId);
   const resolvedSequence = useMemo<Sequence | undefined>(() => {
     if (!sequence || !activeAudioModel || !audioVariants) return sequence;
@@ -280,6 +285,22 @@ function MusicPage() {
     },
   });
 
+  // The music-tab model selector is controlled by the viewer's active audio
+  // model (#546) so it stays in sync with the sequence-header dropdown — both
+  // read/write the same useActiveAudioModel store. Null (no pin) follows the
+  // live primary; picking the primary clears the pin.
+  const primaryAudioModel = safeAudioModel(
+    sequence?.musicModel,
+    DEFAULT_MUSIC_MODEL
+  );
+  const selectedAudioModel = activeAudioModel ?? primaryAudioModel;
+  const handleSelectModel = useCallback(
+    (model: AudioModel) => {
+      selectAudioModel(model === primaryAudioModel ? null : model);
+    },
+    [selectAudioModel, primaryAudioModel]
+  );
+
   if (isLoading || !sequence) {
     return (
       <div className="flex-1 p-4">
@@ -297,6 +318,8 @@ function MusicPage() {
           sequence={resolvedSequence ?? sequence}
           videoDuration={videoDuration}
           audioModelStatuses={audioModelStatuses}
+          selectedModel={selectedAudioModel}
+          onModelChange={handleSelectModel}
           onSetModel={handleSetModel}
           isSettingModel={setMusicModel.isPending}
           onGenerateMusic={(args) => generateMusic.mutate(args)}

--- a/src/routes/_app/sequences/$id/route.tsx
+++ b/src/routes/_app/sequences/$id/route.tsx
@@ -1,9 +1,8 @@
 import { RouteErrorFallback } from '@/components/error/route-error-fallback';
-import { ImageModelBadge, ModelBadge } from '@/components/model/model-badge';
+import { ModelBadge } from '@/components/model/model-badge';
 import { SequenceAudioModelSelector } from '@/components/model/sequence-audio-model-selector';
+import { SequenceImageModelSelector } from '@/components/model/sequence-image-model-selector';
 import { SequenceVideoModelSelector } from '@/components/model/sequence-video-model-selector';
-import { getSequenceImageModelsFn } from '@/functions/frames';
-import { frameKeys } from '@/hooks/use-frames';
 import { routeParams } from '@/components/layout/breadcrumbs';
 import {
   SequenceTabs,
@@ -17,7 +16,6 @@ import { useSwipeNavigation } from '@/hooks/use-swipe-navigation';
 import { useUser } from '@/hooks/use-user';
 import { requireSessionOrRedirect } from '@/lib/auth/route-guards';
 import { isValidId } from '@/lib/db/id';
-import { useQuery } from '@tanstack/react-query';
 import {
   createFileRoute,
   notFound,
@@ -69,12 +67,6 @@ function SequenceLayout() {
 
   const { data: sequence } = useSequence(sequenceId);
 
-  const { data: imageModels } = useQuery({
-    queryKey: frameKeys.imageModels(sequenceId),
-    queryFn: () => getSequenceImageModelsFn({ data: { sequenceId } }),
-    staleTime: 30_000,
-  });
-
   const tabs = useSequenceTabItems(sequenceId);
   const currentPath = useRouterState({
     select: (s) => s.location.pathname,
@@ -91,9 +83,9 @@ function SequenceLayout() {
         <PageHeader>
           <div className="hidden md:flex flex-row flex-wrap items-center gap-2">
             <ModelBadge model={sequence?.analysisModel} />
-            <ImageModelBadge
-              models={imageModels}
-              model={sequence?.imageModel}
+            <SequenceImageModelSelector
+              sequenceId={sequenceId}
+              sequenceImageModel={sequence?.imageModel}
             />
             <SequenceVideoModelSelector
               sequenceId={sequenceId}


### PR DESCRIPTION
## Summary

Phase 4 of the multi-model variant system: add image/video/audio models to an existing sequence after creation, generating each model's output for every frame (image/video) or the whole sequence (audio) from the **existing** prompts — no re-analysis.

This PR also reworks how adding a model interacts with the live primary, fixing a staleness bug, and adds the missing UI to make multi-model sequences usable.

### Add-model is now **variant-only** (bug fix)

Adding a model no longer repoints the live primary columns — it creates a `frame_variants` row only. This fixes the false **"Inputs changed — generated from earlier inputs"** banner that fired on every scene the moment a model was added: the old path eagerly flipped `frames.imageModel` to the new model at workflow start, so `getFrameStalenessFn` re-hashed the still-current image against the new model and reported it stale (and the convergent write also reset the frame's video).

- New `variantOnly` flag threaded through `ImageWorkflowInput` / `BatchMotionMusicWorkflowInput` / `MotionWorkflowInput`. The image + motion workflows skip **all** `frames.*` primary writes (start, persist, `onFailure`) and write only the per-model variant row.
- `persistImageResult` gains a `variant-only` branch (skips divergence entirely — no primary to protect); `persistMotionCompletion` / `persistMotionFailure` + motion `set-generating-status` gate the `frames.update`.
- `addModelToSequenceFn` passes `variantOnly: true` (image + video). Per-scene **Generate** on the image/motion tabs still converges to primary (unchanged).

### New UI

- **Sequence-wide per-model status** in the image/video header dropdowns (`computeSequenceModelCoverage` + `ModelCoverageMarker`): ⊙ live primary / ✓ generated (with an N/M count while partial) / ⟳ generating / ! failed.
- **"Not generated for this model" badge** on the player + scene list when a pinned image model has no image for a scene (instead of silently showing the primary).
- **Sequence-level Set button** (`setSequenceModelFn` reusing `buildPromoteUpdate`, `useSetSequenceModel`, `SetModelButton`) — bulk-promotes a model to the live primary across every scene that has it. Audio keeps its existing per-sequence "Set Music".

## Tests

- Variant-only persist branches (image + motion) in `image-workflow-snapshot.test.ts` / `motion-workflow-persist.test.ts`.
- `sequence-model-coverage.test.ts` for the header coverage computation.
- `bun typecheck` + `bun lint` clean (0 errors).

> Note: a pre-existing unrelated failure in `src/lib/ai/llm-client.test.ts` (OpenRouter `web_search` vs `openrouter:web_search`, from the `@tanstack/ai` web-search merge on main) is not touched by this PR.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)
