### PR TITLE
feat(music): multi-select audio models with sequence variants (#546)

### DIFF
--- a/src/components/model/model-badge.tsx
+++ b/src/components/model/model-badge.tsx
@@ -1,11 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
-import {
-  AUDIO_MODELS,
-  IMAGE_MODELS,
-  isValidAudioModel,
-  isValidTextToImageModel,
-} from '@/lib/ai/models';
+import { IMAGE_MODELS, isValidTextToImageModel } from '@/lib/ai/models';
 import { getAnalysisModelById } from '@/lib/ai/models.config';
 
 export const ModelBadge = ({ model }: { model?: string }) => {
@@ -65,21 +60,6 @@ export const ImageModelBadge = ({
   return (
     <Badge variant="secondary" className="text-xs">
       {formatImageModels(allModels)}
-    </Badge>
-  );
-};
-
-export const MusicModelBadge = ({ model }: { model?: string }) => {
-  if (!model) {
-    return <Skeleton className="w-[100px] h-[20px]" />;
-  }
-
-  const modelConfig = isValidAudioModel(model)
-    ? AUDIO_MODELS[model]
-    : undefined;
-  return (
-    <Badge variant="secondary" className="text-xs">
-      {modelConfig?.name || model}
     </Badge>
   );
 };

--- a/src/components/model/music-model-selector.tsx
+++ b/src/components/model/music-model-selector.tsx
@@ -1,4 +1,7 @@
-import { BaseModelSelector } from './base-model-selector';
+import {
+  BaseModelSelector,
+  type ModelGenerationStatus,
+} from './base-model-selector';
 import {
   AUDIO_MODELS,
   isValidAudioModel,
@@ -35,14 +38,25 @@ type MusicModelSelectorProps = {
   selectedModel: AudioModel;
   onModelChange: (model: AudioModel) => void;
   disabled?: boolean;
+  /** Per-model generation status (#546); renders ⊙/✓/⟳/! in the list. */
+  generatedStatuses?: Map<string, ModelGenerationStatus>;
 };
 
 export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
   selectedModel,
   onModelChange,
   disabled = false,
+  generatedStatuses,
 }) => {
-  const models = useMusicModels();
+  const baseModels = useMusicModels();
+  const models = useMemo(
+    () =>
+      baseModels.map((m) => ({
+        ...m,
+        generationStatus: generatedStatuses?.get(m.id),
+      })),
+    [baseModels, generatedStatuses]
+  );
 
   return (
     <BaseModelSelector

--- a/src/components/model/music-model-selector.tsx
+++ b/src/components/model/music-model-selector.tsx
@@ -8,18 +8,9 @@ import { useMemo } from 'react';
 
 const GROUP_ORDER = ['all'] as const;
 
-type MusicModelSelectorProps = {
-  selectedModel: AudioModel;
-  onModelChange: (model: AudioModel) => void;
-  disabled?: boolean;
-};
-
-export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
-  selectedModel,
-  onModelChange,
-  disabled = false,
-}) => {
-  const models = useMemo(
+// Shared option list — only music models (not SFX), sorted by quality.
+function useMusicModels() {
+  return useMemo(
     () =>
       Object.entries(AUDIO_MODELS)
         .filter(([key, m]) => {
@@ -38,6 +29,20 @@ export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
         })),
     []
   );
+}
+
+type MusicModelSelectorProps = {
+  selectedModel: AudioModel;
+  onModelChange: (model: AudioModel) => void;
+  disabled?: boolean;
+};
+
+export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
+  selectedModel,
+  onModelChange,
+  disabled = false,
+}) => {
+  const models = useMusicModels();
 
   return (
     <BaseModelSelector
@@ -53,6 +58,35 @@ export const MusicModelSelector: React.FC<MusicModelSelectorProps> = ({
       }}
       disabled={disabled}
       multiSelect={false}
+    />
+  );
+};
+
+type MusicModelMultiSelectorProps = {
+  selectedModels: AudioModel[];
+  onModelsChange: (models: AudioModel[]) => void;
+  disabled?: boolean;
+};
+
+export const MusicModelMultiSelector: React.FC<
+  MusicModelMultiSelectorProps
+> = ({ selectedModels, onModelsChange, disabled = false }) => {
+  const models = useMusicModels();
+
+  return (
+    <BaseModelSelector
+      label="Music Models"
+      models={models}
+      groupOrder={GROUP_ORDER}
+      selectedIds={selectedModels}
+      onSelectionChange={(ids) => {
+        const validIds = ids.filter(isValidAudioModel);
+        if (validIds.length > 0) {
+          onModelsChange(validIds);
+        }
+      }}
+      disabled={disabled}
+      multiSelect={true}
     />
   );
 };

--- a/src/components/model/sequence-audio-model-selector.tsx
+++ b/src/components/model/sequence-audio-model-selector.tsx
@@ -10,19 +10,20 @@ import {
 import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
 import { useSequenceAudioModels } from '@/hooks/use-sequences';
 import { AUDIO_MODELS, isValidAudioModel } from '@/lib/ai/models';
-import { ChevronDown } from 'lucide-react';
+import { Check, ChevronDown, CircleCheck } from 'lucide-react';
 
 function audioModelName(model: string): string {
   return isValidAudioModel(model) ? AUDIO_MODELS[model].name : model;
 }
 
 /**
- * Top-level audio-model switcher for the sequence header (#546). Replaces the
- * old read-only music chip once any music variants exist: lists the distinct
- * models that have generated a track for this sequence (derived from
- * sequence_music_variants) and lets the viewer pick which model's track plays.
- * Viewer-local (localStorage via useActiveAudioModel). "Mixed" is shown when
- * more than one model has output and no specific one is pinned.
+ * Top-level audio-model switcher for the sequence header (#546). Audio is
+ * per-sequence — one track plays at a time — so there is no "Mixed" state
+ * (that's a video-only, per-scene concept). The dropdown just chooses which
+ * model's track this viewer hears (localStorage via useActiveAudioModel): the
+ * live primary is marked ⊙ `set`, other models that have generated a track are
+ * marked ✓ and can be previewed here, then promoted ("Set Music") from the
+ * music tab. When nothing is pinned, the primary plays.
  */
 export const SequenceAudioModelSelector = ({
   sequenceId,
@@ -44,19 +45,17 @@ export const SequenceAudioModelSelector = ({
     );
   }
 
-  const firstModel = models[0];
-  const label = activeAudioModel
-    ? audioModelName(activeAudioModel)
-    : models.length === 1 && firstModel
-      ? audioModelName(firstModel)
-      : 'Mixed';
+  // The live primary track's model (what plays when nothing is pinned).
+  const primaryModel = sequenceMusicModel ?? models[0] ?? null;
+  // What this viewer currently hears: the pinned model, else the primary.
+  const effectiveModel = activeAudioModel ?? primaryModel;
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button type="button" aria-label="Select audio model">
           <Badge variant="secondary" className="text-xs cursor-pointer gap-1">
-            {label}
+            {effectiveModel ? audioModelName(effectiveModel) : 'Audio model'}
             <ChevronDown className="size-3" />
           </Badge>
         </button>
@@ -64,27 +63,35 @@ export const SequenceAudioModelSelector = ({
       <DropdownMenuContent align="start" className="w-[200px]">
         <DropdownMenuLabel className="text-xs">Audio model</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        {models.length > 1 && (
-          <DropdownMenuCheckboxItem
-            checked={activeAudioModel === null}
-            onCheckedChange={() => selectAudioModel(null)}
-            onSelect={(e) => e.preventDefault()}
-            className="cursor-pointer"
-          >
-            Mixed (primary)
-          </DropdownMenuCheckboxItem>
-        )}
-        {models.filter(isValidAudioModel).map((model) => (
-          <DropdownMenuCheckboxItem
-            key={model}
-            checked={activeAudioModel === model}
-            onCheckedChange={() => selectAudioModel(model)}
-            onSelect={(e) => e.preventDefault()}
-            className="cursor-pointer"
-          >
-            {audioModelName(model)}
-          </DropdownMenuCheckboxItem>
-        ))}
+        {models.filter(isValidAudioModel).map((model) => {
+          const isPrimary = model === primaryModel;
+          return (
+            <DropdownMenuCheckboxItem
+              key={model}
+              checked={effectiveModel === model}
+              // Pinning the primary is equivalent to no pick — store null so
+              // this viewer keeps following the primary if it later changes.
+              onCheckedChange={() => selectAudioModel(isPrimary ? null : model)}
+              onSelect={(e) => e.preventDefault()}
+              className="cursor-pointer"
+            >
+              <span className="flex items-center gap-2">
+                {isPrimary ? (
+                  <CircleCheck
+                    className="size-3.5 shrink-0 text-emerald-500"
+                    aria-label="Currently set"
+                  />
+                ) : (
+                  <Check
+                    className="size-3.5 shrink-0 text-muted-foreground"
+                    aria-label="Generated"
+                  />
+                )}
+                {audioModelName(model)}
+              </span>
+            </DropdownMenuCheckboxItem>
+          );
+        })}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/model/sequence-audio-model-selector.tsx
+++ b/src/components/model/sequence-audio-model-selector.tsx
@@ -1,0 +1,91 @@
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
+import { useSequenceAudioModels } from '@/hooks/use-sequences';
+import { AUDIO_MODELS, isValidAudioModel } from '@/lib/ai/models';
+import { ChevronDown } from 'lucide-react';
+
+function audioModelName(model: string): string {
+  return isValidAudioModel(model) ? AUDIO_MODELS[model].name : model;
+}
+
+/**
+ * Top-level audio-model switcher for the sequence header (#546). Replaces the
+ * old read-only music chip once any music variants exist: lists the distinct
+ * models that have generated a track for this sequence (derived from
+ * sequence_music_variants) and lets the viewer pick which model's track plays.
+ * Viewer-local (localStorage via useActiveAudioModel). "Mixed" is shown when
+ * more than one model has output and no specific one is pinned.
+ */
+export const SequenceAudioModelSelector = ({
+  sequenceId,
+  sequenceMusicModel,
+}: {
+  sequenceId: string;
+  sequenceMusicModel?: string | null;
+}) => {
+  const { data: models } = useSequenceAudioModels(sequenceId);
+  const { activeAudioModel, selectAudioModel } =
+    useActiveAudioModel(sequenceId);
+
+  if (!models || models.length === 0) {
+    if (!sequenceMusicModel) return null;
+    return (
+      <Badge variant="secondary" className="text-xs">
+        {audioModelName(sequenceMusicModel)}
+      </Badge>
+    );
+  }
+
+  const firstModel = models[0];
+  const label = activeAudioModel
+    ? audioModelName(activeAudioModel)
+    : models.length === 1 && firstModel
+      ? audioModelName(firstModel)
+      : 'Mixed';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button type="button" aria-label="Select audio model">
+          <Badge variant="secondary" className="text-xs cursor-pointer gap-1">
+            {label}
+            <ChevronDown className="size-3" />
+          </Badge>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-[200px]">
+        <DropdownMenuLabel className="text-xs">Audio model</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {models.length > 1 && (
+          <DropdownMenuCheckboxItem
+            checked={activeAudioModel === null}
+            onCheckedChange={() => selectAudioModel(null)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            Mixed (primary)
+          </DropdownMenuCheckboxItem>
+        )}
+        {models.filter(isValidAudioModel).map((model) => (
+          <DropdownMenuCheckboxItem
+            key={model}
+            checked={activeAudioModel === model}
+            onCheckedChange={() => selectAudioModel(model)}
+            onSelect={(e) => e.preventDefault()}
+            className="cursor-pointer"
+          >
+            {audioModelName(model)}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/src/components/music/music-view.tsx
+++ b/src/components/music/music-view.tsx
@@ -1,3 +1,4 @@
+import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
 import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { PromptHistorySheet } from '@/components/prompts/prompt-history-sheet';
 import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
@@ -35,6 +36,16 @@ type MusicViewProps = {
   videoDuration?: number;
   onGenerateMusic: (args?: GenerateMusicArgs) => void;
   isGeneratingMusic: boolean;
+  /**
+   * Per-model generation status for this sequence (#546), mirroring the
+   * video/image scene-detail selector: ⊙ `set` (the live primary track) /
+   * ✓ `completed` (a generated alternate) / ⟳ `generating` / ! `failed`.
+   * Drives the model markers and the Set/Regenerate/Generate action button.
+   */
+  audioModelStatuses?: Map<string, ModelGenerationStatus>;
+  /** Promote the selected model's track to the sequence primary ("Set Music"). */
+  onSetModel: (model: AudioModel) => void;
+  isSettingModel?: boolean;
   /** Banner rendered above the audio player while `musicStatus === 'completed'`. */
   divergentBanner?: React.ReactNode;
   isMusicPromptStale?: boolean;
@@ -133,6 +144,9 @@ export const MusicView: React.FC<MusicViewProps> = ({
   videoDuration,
   onGenerateMusic,
   isGeneratingMusic,
+  audioModelStatuses,
+  onSetModel,
+  isSettingModel = false,
   divergentBanner,
   isMusicPromptStale,
   onRegenerateMusicPrompt,
@@ -220,6 +234,33 @@ export const MusicView: React.FC<MusicViewProps> = ({
     });
   }
 
+  // Action for the selected model, mirroring the video/image scene-detail
+  // button: a completed alternate promotes ("Set Music"); the live primary
+  // regenerates; anything without a track generates for the first time.
+  const selectedStatus = audioModelStatuses?.get(editModel);
+  const selectedIsSet = selectedStatus === 'set';
+  const selectedIsCompletedAlternate = selectedStatus === 'completed';
+
+  const actionButton = selectedIsCompletedAlternate ? (
+    <LoadingButton
+      onClick={() => onSetModel(editModel)}
+      isLoading={isSettingModel}
+      loadingText="Setting…"
+    >
+      Set Music
+    </LoadingButton>
+  ) : (
+    <LoadingButton
+      variant={selectedIsSet ? 'outline' : 'default'}
+      onClick={handleGenerate}
+      disabled={!editPrompt}
+      isLoading={isGeneratingMusic}
+      loadingText={selectedIsSet ? 'Regenerating…' : 'Generating…'}
+    >
+      {selectedIsSet ? 'Regenerate Music' : 'Generate Music'}
+    </LoadingButton>
+  );
+
   if (musicStatus === 'completed' && musicUrl) {
     return (
       <StatusPanel
@@ -240,6 +281,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
           <MusicModelSelector
             selectedModel={editModel}
             onModelChange={setEditModel}
+            generatedStatuses={audioModelStatuses}
           />
         </FormField>
 
@@ -248,14 +290,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
 
         <div className="flex justify-center gap-3">
           {historyButton}
-          <LoadingButton
-            variant="outline"
-            onClick={handleGenerate}
-            isLoading={isGeneratingMusic}
-            loadingText="Regenerating…"
-          >
-            Regenerate Music
-          </LoadingButton>
+          {actionButton}
         </div>
         {historySheet}
       </StatusPanel>
@@ -290,17 +325,11 @@ export const MusicView: React.FC<MusicViewProps> = ({
           <MusicModelSelector
             selectedModel={editModel}
             onModelChange={setEditModel}
+            generatedStatuses={audioModelStatuses}
           />
         </FormField>
 
-        <LoadingButton
-          className="self-center"
-          onClick={handleGenerate}
-          isLoading={isGeneratingMusic}
-          loadingText="Retrying…"
-        >
-          Retry
-        </LoadingButton>
+        <div className="flex justify-center">{actionButton}</div>
       </StatusPanel>
     );
   }
@@ -340,6 +369,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
         <MusicModelSelector
           selectedModel={editModel}
           onModelChange={setEditModel}
+          generatedStatuses={audioModelStatuses}
         />
       </FormField>
 
@@ -363,14 +393,7 @@ export const MusicView: React.FC<MusicViewProps> = ({
 
       <div className="flex justify-center gap-3">
         {historyButton}
-        <LoadingButton
-          onClick={handleGenerate}
-          disabled={!editPrompt}
-          isLoading={isGeneratingMusic}
-          loadingText="Generating…"
-        >
-          Generate Music
-        </LoadingButton>
+        {actionButton}
       </div>
       {historySheet}
     </StatusPanel>

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -138,7 +138,7 @@ export const ScriptView: FC<{
     imageModels: TextToImageModel[];
     videoModels: ImageToVideoModel[];
     autoGenerateMotion: boolean;
-    musicModel: AudioModel;
+    audioModels: AudioModel[];
     autoGenerateMusic: boolean;
   }>(() => ({
     analysisModels: sequenceAnalysisModels,
@@ -152,10 +152,10 @@ export const ScriptView: FC<{
         ? [safeImageToVideoModel(sequence.videoModel, DEFAULT_VIDEO_MODEL)]
         : savedSettings.videoModels,
     autoGenerateMotion: isEditing ? false : savedSettings.autoGenerateMotion,
-    musicModel:
+    audioModels:
       isEditing && sequence.musicModel
-        ? safeAudioModel(sequence.musicModel, DEFAULT_MUSIC_MODEL)
-        : savedSettings.musicModel,
+        ? [safeAudioModel(sequence.musicModel, DEFAULT_MUSIC_MODEL)]
+        : savedSettings.audioModels,
     autoGenerateMusic: isEditing ? false : savedSettings.autoGenerateMusic,
   }));
   const {
@@ -164,7 +164,7 @@ export const ScriptView: FC<{
     imageModels,
     videoModels,
     autoGenerateMotion,
-    musicModel,
+    audioModels,
     autoGenerateMusic,
   } = genSettings;
   const updateGen = <K extends keyof typeof genSettings>(
@@ -302,7 +302,7 @@ export const ScriptView: FC<{
         imageModels: savedSettings.imageModels,
         videoModels: savedSettings.videoModels,
         autoGenerateMotion: savedSettings.autoGenerateMotion,
-        musicModel: savedSettings.musicModel,
+        audioModels: savedSettings.audioModels,
         autoGenerateMusic: savedSettings.autoGenerateMusic,
       });
       hasSyncedRef.current = true;
@@ -497,6 +497,7 @@ export const ScriptView: FC<{
       aspect_ratio: aspectRatio,
       image_models: imageModels,
       video_models: videoModels,
+      audio_models: audioModels,
       auto_generate_motion: autoGenerateMotion,
       auto_generate_music: autoGenerateMusic,
       analysis_model_count: analysisModels.length,
@@ -515,7 +516,8 @@ export const ScriptView: FC<{
         videoModel: videoModels[0] ?? DEFAULT_VIDEO_MODEL,
         autoGenerateMotion,
         autoGenerateMusic,
-        musicModel,
+        musicModel: audioModels[0] ?? DEFAULT_MUSIC_MODEL,
+        audioModels,
         suggestedTalentIds:
           selectedTalentIds.length > 0 ? selectedTalentIds : undefined,
         suggestedLocationIds:
@@ -697,7 +699,7 @@ export const ScriptView: FC<{
             imageModels={imageModels}
             videoModels={videoModels}
             autoGenerateMotion={autoGenerateMotion}
-            musicModel={musicModel}
+            audioModels={audioModels}
             autoGenerateMusic={autoGenerateMusic}
             onAspectRatioChange={(v) => updateGen('aspectRatio', v)}
             onAnalysisModelsChange={(v) => updateGen('analysisModels', v)}
@@ -706,7 +708,7 @@ export const ScriptView: FC<{
             onAutoGenerateMotionChange={(v) =>
               updateGen('autoGenerateMotion', v)
             }
-            onMusicModelChange={(v) => updateGen('musicModel', v)}
+            onAudioModelsChange={(v) => updateGen('audioModels', v)}
             onAutoGenerateMusicChange={(v) => updateGen('autoGenerateMusic', v)}
             disabled={loading}
             styleCategory={styleCategory}

--- a/src/components/settings/generation-settings.tsx
+++ b/src/components/settings/generation-settings.tsx
@@ -7,7 +7,10 @@ import {
   MotionModelMultiSelector,
   MotionModelSelector,
 } from '@/components/model/motion-model-selector';
-import { MusicModelSelector } from '@/components/model/music-model-selector';
+import {
+  MusicModelMultiSelector,
+  MusicModelSelector,
+} from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import {
@@ -18,6 +21,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import {
   DEFAULT_IMAGE_MODEL,
+  DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
   type AudioModel,
   type ImageToVideoModel,
@@ -65,14 +69,14 @@ type GenerationSettingsProps = {
   imageModels: TextToImageModel[];
   videoModels: ImageToVideoModel[];
   autoGenerateMotion?: boolean;
-  musicModel?: AudioModel;
+  audioModels?: AudioModel[];
   autoGenerateMusic?: boolean;
   onAspectRatioChange: (value: AspectRatio) => void;
   onAnalysisModelsChange: (value: AnalysisModelId[]) => void;
   onImageModelsChange: (value: TextToImageModel[]) => void;
   onVideoModelsChange: (value: ImageToVideoModel[]) => void;
   onAutoGenerateMotionChange?: (value: boolean) => void;
-  onMusicModelChange?: (value: AudioModel) => void;
+  onAudioModelsChange?: (value: AudioModel[]) => void;
   onAutoGenerateMusicChange?: (value: boolean) => void;
   disabled?: boolean;
   singleSelectAnalysis?: boolean;
@@ -80,6 +84,8 @@ type GenerationSettingsProps = {
   singleSelectImage?: boolean;
   /** Use single-select for motion model (e.g. in regeneration context) */
   singleSelectMotion?: boolean;
+  /** Use single-select for music model (e.g. in regeneration context) */
+  singleSelectMusic?: boolean;
   /** Current style category, used to show/hide style-restricted motion models */
   styleCategory?: string;
   /** Current style name, used in recommendation tooltips */
@@ -105,19 +111,20 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
   imageModels,
   videoModels,
   autoGenerateMotion = false,
-  musicModel,
+  audioModels,
   autoGenerateMusic = false,
   onAspectRatioChange,
   onAnalysisModelsChange,
   onImageModelsChange,
   onVideoModelsChange,
   onAutoGenerateMotionChange,
-  onMusicModelChange,
+  onAudioModelsChange,
   onAutoGenerateMusicChange,
   disabled = false,
   singleSelectAnalysis = false,
   singleSelectImage = false,
   singleSelectMotion = false,
+  singleSelectMusic = false,
   styleCategory,
   styleName,
   recommendedImageModel,
@@ -252,13 +259,15 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
             )}
           </section>
 
-          {onAutoGenerateMusicChange && onMusicModelChange && musicModel && (
+          {onAutoGenerateMusicChange && onAudioModelsChange && audioModels && (
             <>
               <Separator />
 
               {/* Music Model Section */}
               <section className="flex flex-col gap-2">
-                <h3 className="text-sm font-medium text-foreground">Music</h3>
+                <h3 className="text-sm font-medium text-foreground">
+                  Music Model{!singleSelectMusic && 's'}
+                </h3>
                 <AutoToggle
                   id="auto-generate-music"
                   label="Auto-generate music"
@@ -266,11 +275,19 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
                   onChange={onAutoGenerateMusicChange}
                   disabled={disabled}
                 />
-                <MusicModelSelector
-                  selectedModel={musicModel}
-                  onModelChange={onMusicModelChange}
-                  disabled={disabled || !autoGenerateMusic}
-                />
+                {singleSelectMusic ? (
+                  <MusicModelSelector
+                    selectedModel={audioModels[0] ?? DEFAULT_MUSIC_MODEL}
+                    onModelChange={(model) => onAudioModelsChange([model])}
+                    disabled={disabled || !autoGenerateMusic}
+                  />
+                ) : (
+                  <MusicModelMultiSelector
+                    selectedModels={audioModels}
+                    onModelsChange={onAudioModelsChange}
+                    disabled={disabled || !autoGenerateMusic}
+                  />
+                )}
               </section>
             </>
           )}

--- a/src/functions/sequence-variants.ts
+++ b/src/functions/sequence-variants.ts
@@ -115,6 +115,63 @@ export const promoteSequenceMusicVariantFn = createServerFn({ method: 'POST' })
     return { sequence: updatedSequence, variantId: variant.id };
   });
 
+// ── Set music model (non-destructive) ────────────────────────────────────────
+
+const setMusicFromVariantInputSchema = z.object({
+  sequenceId: ulidSchema,
+  model: z.string().min(1),
+});
+
+/**
+ * Switch the sequence's live primary music to the selected model's track
+ * ("Set Music"), the per-sequence analog of `setVideoFromVariantFn`. Resolves
+ * the model to its own live (non-divergent, non-discarded) completed variant
+ * and copies it onto `sequences.music*` without discarding the row, so the
+ * model stays available to switch back to. Emits a terminal `audio:progress`
+ * so existing listeners refetch the sequence.
+ */
+export const setMusicFromVariantFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(zodValidator(setMusicFromVariantInputSchema))
+  .handler(async ({ data, context }) => {
+    const { sequence, scopedDb } = context;
+    const variants = await scopedDb.sequenceVariants.listMusicBySequence(
+      sequence.id
+    );
+    const variant = variants.find(
+      (v) =>
+        v.model === data.model &&
+        v.status === 'completed' &&
+        v.divergedAt === null &&
+        v.discardedAt === null &&
+        v.url
+    );
+    if (!variant) {
+      throw new Error('No completed track found for this model');
+    }
+
+    const updatedSequence = await scopedDb.sequenceVariants.setMusicFromVariant(
+      variant.id
+    );
+
+    try {
+      await getGenerationChannel(sequence.id).emit(
+        'generation.audio:progress',
+        {
+          status: 'completed',
+          model: variant.model,
+          ...(updatedSequence.musicUrl
+            ? { audioUrl: updatedSequence.musicUrl }
+            : {}),
+        }
+      );
+    } catch (error) {
+      logger.error('realtime emit failed', { err: error });
+    }
+
+    return { sequence: updatedSequence, model: variant.model };
+  });
+
 // ── Discard / Undiscard ─────────────────────────────────────────────────────
 
 export const discardSequenceMusicVariantFn = createServerFn({ method: 'POST' })

--- a/src/functions/sequence-variants.ts
+++ b/src/functions/sequence-variants.ts
@@ -102,6 +102,7 @@ export const promoteSequenceMusicVariantFn = createServerFn({ method: 'POST' })
         'generation.audio:progress',
         {
           status: 'completed',
+          model: variant.model,
           ...(updatedSequence.musicUrl
             ? { audioUrl: updatedSequence.musicUrl }
             : {}),

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -156,8 +156,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         // Music only actually generates when motion is also on (it spawns from
         // inside motion-batch), so don't charge for music tracks that won't run.
         autoGenerateMusic: autoGenerateMotion && autoGenerateMusic,
-        audioModel: primaryAudioModel,
-        audioModelCount: audioModels.length,
+        audioModels,
       }),
       {
         providers: ['fal', 'openrouter'],
@@ -456,10 +455,6 @@ export function buildSceneSummaries(frames: Frame[]): MusicSceneSummary[] {
 }
 
 /**
- * Trigger sequence-level music generation.
- * Uses pre-generated prompt/tags when available, otherwise builds from frame audio specs.
- */
-/**
  * Distinct audio models that have generated a track for this sequence (#546).
  * Drives the header audio-model dropdown.
  */
@@ -480,6 +475,10 @@ export const getSequenceAudioVariantsFn = createServerFn({ method: 'GET' })
     );
   });
 
+/**
+ * Trigger sequence-level music generation.
+ * Uses pre-generated prompt/tags when available, otherwise builds from frame audio specs.
+ */
 export const generateMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
   .inputValidator(

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MUSIC_MODEL,
   DEFAULT_VIDEO_MODEL,
   isValidAudioModel,
+  safeAudioModel,
   safeImageToVideoModel,
   safeTextToImageModel,
 } from '@/lib/ai/models';
@@ -10,6 +11,7 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
+import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import { requireTeamMemberAccess } from '@/lib/auth/action-utils';
@@ -75,6 +77,7 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
       autoGenerateMotion = false,
       autoGenerateMusic = true,
       musicModel,
+      audioModels: audioModelsInput,
       suggestedTalentIds,
       suggestedLocationIds,
       elementUploads,
@@ -121,6 +124,23 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
       );
     }
 
+    // Validate and resolve audio models (sequence-level, mirrors the pattern).
+    const validatedAudioModels = audioModelsInput?.map((m) =>
+      safeAudioModel(m, DEFAULT_MUSIC_MODEL)
+    );
+    const audioModels = resolveAudioModels(
+      validatedAudioModels,
+      musicModel && isValidAudioModel(musicModel)
+        ? safeAudioModel(musicModel, DEFAULT_MUSIC_MODEL)
+        : undefined
+    );
+    const [primaryAudioModel] = audioModels;
+    if (!primaryAudioModel) {
+      throw new Error(
+        'Expected resolveAudioModels to return at least one model'
+      );
+    }
+
     if (!styleId || !aspectRatio) {
       throw new Error('Style ID and aspect ratio are required');
     }
@@ -133,6 +153,11 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         aspectRatio,
         autoGenerateMotion,
         videoModels,
+        // Music only actually generates when motion is also on (it spawns from
+        // inside motion-batch), so don't charge for music tracks that won't run.
+        autoGenerateMusic: autoGenerateMotion && autoGenerateMusic,
+        audioModel: primaryAudioModel,
+        audioModelCount: audioModels.length,
       }),
       {
         providers: ['fal', 'openrouter'],
@@ -146,12 +171,9 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
         // into auto-generation. Otherwise the sequence ends up with a "ghost"
         // model preference the user never picked, which surfaces stale values
         // in the header chip and batch footer. Tracked in #714.
-        const persistedMusicModel =
-          autoGenerateMusic && musicModel && isValidAudioModel(musicModel)
-            ? musicModel
-            : autoGenerateMusic
-              ? DEFAULT_MUSIC_MODEL
-              : undefined;
+        const persistedMusicModel = autoGenerateMusic
+          ? primaryAudioModel
+          : undefined;
 
         const sequence = await context.scopedDb.sequences.create({
           title: data.title || 'Untitled Sequence',
@@ -215,10 +237,8 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
           },
           autoGenerateMotion,
           autoGenerateMusic,
-          musicModel:
-            musicModel && isValidAudioModel(musicModel)
-              ? musicModel
-              : undefined,
+          musicModel: autoGenerateMusic ? primaryAudioModel : undefined,
+          audioModels: autoGenerateMusic ? audioModels : undefined,
           suggestedTalentIds,
           suggestedLocationIds,
         };
@@ -439,6 +459,27 @@ export function buildSceneSummaries(frames: Frame[]): MusicSceneSummary[] {
  * Trigger sequence-level music generation.
  * Uses pre-generated prompt/tags when available, otherwise builds from frame audio specs.
  */
+/**
+ * Distinct audio models that have generated a track for this sequence (#546).
+ * Drives the header audio-model dropdown.
+ */
+export const getSequenceAudioModelsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.sequenceVariants.listMusicModels(
+      context.sequence.id
+    );
+  });
+
+/** All music variant rows for a sequence (#546). */
+export const getSequenceAudioVariantsFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }) => {
+    return context.scopedDb.sequenceVariants.listMusicBySequence(
+      context.sequence.id
+    );
+  });
+
 export const generateMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
   .inputValidator(

--- a/src/hooks/use-active-audio-model.ts
+++ b/src/hooks/use-active-audio-model.ts
@@ -1,0 +1,108 @@
+import { isValidAudioModel, type AudioModel } from '@/lib/ai/models';
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'ui', 'use-active-audio-model']);
+
+/**
+ * Viewer-local "active audio model" selection for a sequence (#546).
+ *
+ * Audio is generated per-sequence (one track per model in
+ * `sequence_music_variants`); which model's track the music tab plays is a
+ * per-viewer preference, stored in localStorage keyed by sequence. Same
+ * module-store + `useSyncExternalStore` pattern as {@link useActiveVideoModel}
+ * so the header dropdown and the music tab stay in sync within the tab and
+ * across tabs. `null` means "no explicit pick" — fall back to the live
+ * `sequences.music*` primary.
+ */
+
+const KEY_PREFIX = 'openstory:active-audio-model:';
+const storageKey = (sequenceId: string) => `${KEY_PREFIX}${sequenceId}`;
+
+const store = new Map<string, AudioModel | null | undefined>();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+let storageListenerAttached = false;
+function ensureStorageListener() {
+  if (storageListenerAttached || typeof window === 'undefined') return;
+  storageListenerAttached = true;
+  window.addEventListener('storage', (event) => {
+    if (!event.key || !event.key.startsWith(KEY_PREFIX)) return;
+    const sequenceId = event.key.slice(KEY_PREFIX.length);
+    const next =
+      event.newValue && isValidAudioModel(event.newValue)
+        ? event.newValue
+        : null;
+    store.set(sequenceId, next);
+    emit();
+  });
+}
+
+function subscribe(listener: () => void) {
+  ensureStorageListener();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function hydrate(sequenceId: string): AudioModel | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(storageKey(sequenceId));
+    if (raw && isValidAudioModel(raw)) return raw;
+  } catch (error) {
+    logger.warn('Failed to read active audio model from localStorage', {
+      err: error,
+    });
+  }
+  return null;
+}
+
+function read(sequenceId: string): AudioModel | null {
+  const cached = store.get(sequenceId);
+  if (cached !== undefined) return cached;
+  const hydrated = hydrate(sequenceId);
+  store.set(sequenceId, hydrated);
+  return hydrated;
+}
+
+function write(sequenceId: string, model: AudioModel | null) {
+  store.set(sequenceId, model);
+  if (typeof window !== 'undefined') {
+    try {
+      if (model) {
+        localStorage.setItem(storageKey(sequenceId), model);
+      } else {
+        localStorage.removeItem(storageKey(sequenceId));
+      }
+    } catch (error) {
+      logger.warn('Failed to persist active audio model to localStorage', {
+        err: error,
+      });
+    }
+  }
+  emit();
+}
+
+export function useActiveAudioModel(sequenceId: string) {
+  const activeAudioModel = useSyncExternalStore(
+    subscribe,
+    () => read(sequenceId),
+    () => null
+  );
+
+  const selectAudioModel = useCallback(
+    (model: AudioModel | null) => {
+      write(sequenceId, model);
+    },
+    [sequenceId]
+  );
+
+  return { activeAudioModel, selectAudioModel };
+}

--- a/src/hooks/use-generation-settings.ts
+++ b/src/hooks/use-generation-settings.ts
@@ -36,6 +36,7 @@ type GenerationSettings = {
   videoModels: ImageToVideoModel[];
   autoGenerateMotion: boolean;
   musicModel: AudioModel;
+  audioModels: AudioModel[];
   autoGenerateMusic: boolean;
 };
 
@@ -48,6 +49,7 @@ const DEFAULT_SETTINGS: GenerationSettings = {
   videoModels: [DEFAULT_VIDEO_MODEL],
   autoGenerateMotion: false,
   musicModel: DEFAULT_MUSIC_MODEL,
+  audioModels: [DEFAULT_MUSIC_MODEL],
   autoGenerateMusic: false,
 };
 
@@ -158,6 +160,15 @@ function loadSettings(): GenerationSettings {
         ? parsed.musicModel
         : DEFAULT_MUSIC_MODEL;
 
+    // Load audioModels array, falling back to [musicModel] for backward compat.
+    const audioModels =
+      'audioModels' in parsed &&
+      Array.isArray(parsed.audioModels) &&
+      parsed.audioModels.length > 0 &&
+      parsed.audioModels.every(isValidAudioModel)
+        ? parsed.audioModels
+        : [musicModel];
+
     const autoGenerateMusic =
       'autoGenerateMusic' in parsed &&
       typeof parsed.autoGenerateMusic === 'boolean'
@@ -173,6 +184,7 @@ function loadSettings(): GenerationSettings {
       videoModels,
       autoGenerateMotion,
       musicModel,
+      audioModels,
       autoGenerateMusic,
     };
   } catch (error) {

--- a/src/hooks/use-sequence-variants.ts
+++ b/src/hooks/use-sequence-variants.ts
@@ -4,6 +4,7 @@ import {
   getDivergentSequenceMusicVariantsFn,
   getTeamDivergentSequenceVariantsFn,
   promoteSequenceMusicVariantFn,
+  setMusicFromVariantFn,
   undiscardSequenceMusicVariantFn,
 } from '@/functions/sequence-variants';
 import { sequenceKeys } from '@/hooks/use-sequences';
@@ -79,6 +80,35 @@ export function usePromoteSequenceMusicVariant() {
         }),
         queryClient.invalidateQueries({
           queryKey: sequenceVariantKeys.divergentByTeam(),
+        }),
+      ]);
+    },
+  });
+}
+
+/**
+ * "Set Music": switch the sequence's live primary track to a chosen model
+ * (#546). Non-destructive — the per-sequence analog of `useSetVideoFromVariant`.
+ */
+export function useSetMusicFromVariant() {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { sequence: Sequence; model: string },
+    Error,
+    { sequenceId: string; model: string }
+  >({
+    mutationFn: async (input) => setMusicFromVariantFn({ data: input }),
+    onSuccess: async ({ sequence }, { sequenceId }) => {
+      queryClient.setQueryData(sequenceKeys.detail(sequenceId), sequence);
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: sequenceKeys.detail(sequenceId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['sequence-audio-models', sequenceId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ['sequence-audio-variants', sequenceId],
         }),
       ]);
     },

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -1,11 +1,14 @@
 import {
   archiveSequenceFn,
   createSequenceFn,
+  getSequenceAudioModelsFn,
+  getSequenceAudioVariantsFn,
   getSequenceFn,
   getSequencesFn,
   updateSequenceFn,
 } from '@/functions/sequences';
 import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
+import type { SequenceMusicVariant } from '@/lib/db/schema';
 import {
   type CreateSequenceInput,
   type UpdateSequenceInput,
@@ -25,6 +28,35 @@ export const sequenceKeys = {
   details: () => [...sequenceKeys.all, 'detail'] as const,
   detail: (id?: string) => [...sequenceKeys.details(), id] as const,
 };
+
+// Distinct audio models that have generated a track for this sequence (#546).
+// Drives the header audio-model dropdown. The realtime audio:progress handler
+// invalidates `['sequence-audio-models', sequenceId]`, matching this key.
+export function useSequenceAudioModels(sequenceId?: string) {
+  return useQuery<string[]>({
+    queryKey: ['sequence-audio-models', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceAudioModelsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
+
+// All music variant rows for a sequence (#546). Used by the music tab to
+// resolve playback through the active model's track.
+export function useSequenceAudioVariants(sequenceId?: string) {
+  return useQuery<SequenceMusicVariant[]>({
+    queryKey: ['sequence-audio-variants', sequenceId ?? ''],
+    queryFn: async () => {
+      if (!sequenceId) throw new Error('sequenceId is required');
+      return getSequenceAudioVariantsFn({ data: { sequenceId } });
+    },
+    enabled: !!sequenceId,
+    staleTime: 30_000,
+  });
+}
 
 // Hook for listing sequences
 export function useSequences(teamId?: string) {
@@ -84,9 +116,14 @@ export function useCreateSequence() {
           aspectRatio: input.aspectRatio,
           imageModels: input.imageModels,
           videoModel: input.videoModel,
+          // Forward the multi-model arrays — without these the server only ever
+          // sees the singular primary and resolveVideoModels/resolveAudioModels
+          // collapse the user's selection to one model (#545/#546).
+          videoModels: input.videoModels,
           autoGenerateMotion: input.autoGenerateMotion,
           autoGenerateMusic: input.autoGenerateMusic,
           musicModel: input.musicModel,
+          audioModels: input.audioModels,
           suggestedTalentIds: input.suggestedTalentIds,
           suggestedLocationIds: input.suggestedLocationIds,
           elementUploads: input.elementUploads,

--- a/src/lib/ai/resolve-audio-models.test.ts
+++ b/src/lib/ai/resolve-audio-models.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from './models';
+import { resolveAudioModels } from './resolve-audio-models';
+
+describe('resolveAudioModels', () => {
+  it('returns the audioModels array when non-empty', () => {
+    const models: AudioModel[] = [DEFAULT_MUSIC_MODEL];
+    expect(resolveAudioModels(models, undefined)).toEqual(models);
+  });
+
+  it('falls back to the legacy singular musicModel when array is empty/undefined', () => {
+    expect(resolveAudioModels(undefined, DEFAULT_MUSIC_MODEL)).toEqual([
+      DEFAULT_MUSIC_MODEL,
+    ]);
+    expect(resolveAudioModels([], DEFAULT_MUSIC_MODEL)).toEqual([
+      DEFAULT_MUSIC_MODEL,
+    ]);
+  });
+
+  it('falls back to the default model when neither is provided', () => {
+    expect(resolveAudioModels(undefined, undefined)).toEqual([
+      DEFAULT_MUSIC_MODEL,
+    ]);
+  });
+
+  it('dedupes repeated models, preserving first-seen order', () => {
+    expect(
+      resolveAudioModels([DEFAULT_MUSIC_MODEL, DEFAULT_MUSIC_MODEL], undefined)
+    ).toEqual([DEFAULT_MUSIC_MODEL]);
+  });
+});

--- a/src/lib/ai/resolve-audio-models.ts
+++ b/src/lib/ai/resolve-audio-models.ts
@@ -1,0 +1,24 @@
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from './models';
+
+/**
+ * Resolve an audio models array from the dual-field pattern
+ * (optional `audioModels[]` + optional legacy `musicModel`).
+ *
+ * Guarantees a non-empty, deduplicated result. Mirrors
+ * {@link resolveImageModels} / {@link resolveVideoModels}. Audio is generated
+ * per-sequence (one track per model in `sequence_music_variants`), so the
+ * first element is the primary whose track also lands on the live
+ * `sequences.music*` columns; the rest are alternates.
+ */
+export function resolveAudioModels(
+  audioModels: AudioModel[] | undefined,
+  musicModel: AudioModel | undefined
+): AudioModel[] {
+  const models =
+    audioModels && audioModels.length > 0
+      ? audioModels
+      : musicModel
+        ? [musicModel]
+        : [DEFAULT_MUSIC_MODEL];
+  return [...new Set(models)];
+}

--- a/src/lib/billing/cost-estimation.test.ts
+++ b/src/lib/billing/cost-estimation.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  DEFAULT_MUSIC_MODEL,
   type AudioModel,
   type ImageToVideoModel,
   type TextToImageModel,
@@ -14,7 +13,11 @@ import {
 const IMAGE_MODEL: TextToImageModel = 'nano_banana_2';
 const VIDEO_A: ImageToVideoModel = 'kling_v3_pro';
 const VIDEO_B: ImageToVideoModel = 'veo3_1';
-const AUDIO_MODEL: AudioModel = DEFAULT_MUSIC_MODEL;
+// Two audio models with genuinely different pricing (ElevenLabs is billed
+// per-minute, ACE-Step per-second) so a mixed selection can't be a flat
+// multiple of either.
+const AUDIO_A: AudioModel = 'elevenlabs_music';
+const AUDIO_B: AudioModel = 'ace_step_1_5';
 const SCENE_COUNT = 8;
 const DURATION = 5;
 
@@ -27,6 +30,16 @@ const base = {
 /** Per-frame motion cost a model contributes across the whole storyboard. */
 const motionContribution = (model: ImageToVideoModel) =>
   Number(estimateVideoCost(model, DURATION)) * SCENE_COUNT;
+
+/** Per-sequence music cost a single audio model adds to the storyboard. */
+const audioContribution = (model: AudioModel) =>
+  Number(
+    estimateStoryboardCost({
+      ...base,
+      autoGenerateMusic: true,
+      audioModels: [model],
+    })
+  ) - Number(estimateStoryboardCost({ ...base, autoGenerateMusic: false }));
 
 describe('estimateStoryboardCost', () => {
   it('adds exactly one extra per-frame image pass per image model', () => {
@@ -88,7 +101,7 @@ describe('estimateStoryboardCost', () => {
     expect(mixed - noMotion).not.toBe(flatMultiplierEstimate);
   });
 
-  it('multiplies the per-sequence music cost by audioModelCount', () => {
+  it('sums each selected audio model’s own per-sequence music cost', () => {
     const noMusic = Number(
       estimateStoryboardCost({ ...base, autoGenerateMusic: false })
     );
@@ -96,21 +109,63 @@ describe('estimateStoryboardCost', () => {
       estimateStoryboardCost({
         ...base,
         autoGenerateMusic: true,
-        audioModel: AUDIO_MODEL,
-        audioModelCount: 1,
+        audioModels: [AUDIO_A],
       })
     );
     const twoModels = Number(
       estimateStoryboardCost({
         ...base,
         autoGenerateMusic: true,
-        audioModel: AUDIO_MODEL,
-        audioModelCount: 2,
+        audioModels: [AUDIO_A, AUDIO_B],
       })
     );
-    const perModelMusicCost = oneModel - noMusic;
-    expect(twoModels - oneModel).toBe(perModelMusicCost);
-    expect(twoModels).toBeGreaterThanOrEqual(oneModel);
+
+    expect(oneModel - noMusic).toBe(audioContribution(AUDIO_A));
+    expect(twoModels - noMusic).toBe(
+      audioContribution(AUDIO_A) + audioContribution(AUDIO_B)
+    );
+  });
+
+  it('prices a mixed audio selection per model, not as a flat multiple of the primary', () => {
+    // Guards the regression where every audio model was priced at the primary's
+    // rate × count. These two models have different pricing, so the true sum
+    // diverges from the flat-multiplier estimate.
+    expect(audioContribution(AUDIO_A)).not.toBe(audioContribution(AUDIO_B));
+
+    const noMusic = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMusic: false })
+    );
+    const mixed = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMusic: true,
+        audioModels: [AUDIO_A, AUDIO_B],
+      })
+    );
+
+    const trueSum = audioContribution(AUDIO_A) + audioContribution(AUDIO_B);
+    const flatMultiplierEstimate = audioContribution(AUDIO_A) * 2;
+    expect(mixed - noMusic).toBe(trueSum);
+    expect(mixed - noMusic).not.toBe(flatMultiplierEstimate);
+  });
+
+  it('adds no music cost when music is off or no models are selected', () => {
+    const noMusic = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMusic: false })
+    );
+    // autoGenerateMusic true but no models / empty list → nothing to bill.
+    expect(
+      Number(estimateStoryboardCost({ ...base, autoGenerateMusic: true }))
+    ).toBe(noMusic);
+    expect(
+      Number(
+        estimateStoryboardCost({
+          ...base,
+          autoGenerateMusic: true,
+          audioModels: [],
+        })
+      )
+    ).toBe(noMusic);
   });
 
   it('adds no motion cost when motion is off or no models are selected', () => {

--- a/src/lib/billing/cost-estimation.test.ts
+++ b/src/lib/billing/cost-estimation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import type { TextToImageModel, ImageToVideoModel } from '@/lib/ai/models';
+import {
+  DEFAULT_MUSIC_MODEL,
+  type AudioModel,
+  type ImageToVideoModel,
+  type TextToImageModel,
+} from '@/lib/ai/models';
 import {
   estimateImageCost,
   estimateStoryboardCost,
@@ -9,6 +14,7 @@ import {
 const IMAGE_MODEL: TextToImageModel = 'nano_banana_2';
 const VIDEO_A: ImageToVideoModel = 'kling_v3_pro';
 const VIDEO_B: ImageToVideoModel = 'veo3_1';
+const AUDIO_MODEL: AudioModel = DEFAULT_MUSIC_MODEL;
 const SCENE_COUNT = 8;
 const DURATION = 5;
 
@@ -80,6 +86,31 @@ describe('estimateStoryboardCost', () => {
     const flatMultiplierEstimate = motionContribution(VIDEO_A) * 2;
     expect(mixed - noMotion).toBe(trueSum);
     expect(mixed - noMotion).not.toBe(flatMultiplierEstimate);
+  });
+
+  it('multiplies the per-sequence music cost by audioModelCount', () => {
+    const noMusic = Number(
+      estimateStoryboardCost({ ...base, autoGenerateMusic: false })
+    );
+    const oneModel = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMusic: true,
+        audioModel: AUDIO_MODEL,
+        audioModelCount: 1,
+      })
+    );
+    const twoModels = Number(
+      estimateStoryboardCost({
+        ...base,
+        autoGenerateMusic: true,
+        audioModel: AUDIO_MODEL,
+        audioModelCount: 2,
+      })
+    );
+    const perModelMusicCost = oneModel - noMusic;
+    expect(twoModels - oneModel).toBe(perModelMusicCost);
+    expect(twoModels).toBeGreaterThanOrEqual(oneModel);
   });
 
   it('adds no motion cost when motion is off or no models are selected', () => {

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -119,15 +119,19 @@ export function estimateStoryboardCost(opts: {
   videoModels?: ImageToVideoModel[];
   videoDurationSeconds?: number;
   autoGenerateMusic?: boolean;
-  audioModel?: AudioModel;
-  /** Number of audio models selected (multiplies per-sequence music cost) */
-  audioModelCount?: number;
+  /**
+   * Audio models selected for the per-sequence music track (#546). Each model
+   * is priced individually from its own parameters — audio models have
+   * genuinely different rates (e.g. ElevenLabs per-minute vs ACE-Step
+   * per-second), so a uniform multiplier would mis-estimate a mixed selection.
+   * First is primary; one track per model spans the sequence.
+   */
+  audioModels?: AudioModel[];
   /** Total sequence duration in seconds (one music track spans the sequence) */
   audioDurationSeconds?: number;
 }): Microdollars {
   const sceneCount = opts.estimatedSceneCount ?? DEFAULT_ESTIMATED_SCENE_COUNT;
   const imageModelCount = opts.imageModelCount ?? 1;
-  const audioModelCount = opts.audioModelCount ?? 1;
 
   // LLM calls: script analysis + character bible + location bible (~3 calls)
   const llmCost = estimateLLMCost(3);
@@ -164,14 +168,15 @@ export function estimateStoryboardCost(opts: {
     }
   }
 
-  // Optional music generation — one track per sequence per audio model.
-  if (opts.autoGenerateMusic && opts.audioModel) {
+  // Optional music generation — one track per sequence per audio model. Sum
+  // each selected model's own cost (priced from its parameters) rather than
+  // scaling the primary's rate by a count — a mixed selection has genuinely
+  // different per-model costs (mirrors the per-model video costing above).
+  if (opts.autoGenerateMusic && opts.audioModels?.length) {
     const audioDuration = opts.audioDurationSeconds ?? sceneCount * 5;
-    const perTrackMusic = estimateAudioCost(opts.audioModel, audioDuration);
-    totalCost = addMicros(
-      totalCost,
-      multiplyMicros(perTrackMusic, audioModelCount)
-    );
+    for (const model of opts.audioModels) {
+      totalCost = addMicros(totalCost, estimateAudioCost(model, audioDuration));
+    }
   }
 
   return totalCost;

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -4,10 +4,16 @@
  * All functions return Microdollars for exact arithmetic.
  */
 
-import { calculateImageCost, calculateVideoCost } from '@/lib/ai/fal-cost';
 import {
+  calculateAudioCost,
+  calculateImageCost,
+  calculateVideoCost,
+} from '@/lib/ai/fal-cost';
+import {
+  AUDIO_MODELS,
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
+  type AudioModel,
   type ImageToVideoModel,
   type TextToImageModel,
   videoModelSupportsAudio,
@@ -65,6 +71,20 @@ export function estimateVideoCost(
 }
 
 /**
+ * Estimate the raw cost (before markup) of generating one music track.
+ * Internal — used by `estimateStoryboardCost`'s music component.
+ */
+function estimateAudioCost(
+  model: AudioModel,
+  durationSeconds: number
+): Microdollars {
+  return calculateAudioCost({
+    endpointId: AUDIO_MODELS[model].id,
+    durationSeconds,
+  });
+}
+
+/**
  * Rough estimate of LLM cost per call for pre-flight credit checks.
  * Based on average token usage for script analysis calls.
  * Only used for client-side gate affordability checks, not actual deduction.
@@ -98,9 +118,16 @@ export function estimateStoryboardCost(opts: {
    */
   videoModels?: ImageToVideoModel[];
   videoDurationSeconds?: number;
+  autoGenerateMusic?: boolean;
+  audioModel?: AudioModel;
+  /** Number of audio models selected (multiplies per-sequence music cost) */
+  audioModelCount?: number;
+  /** Total sequence duration in seconds (one music track spans the sequence) */
+  audioDurationSeconds?: number;
 }): Microdollars {
   const sceneCount = opts.estimatedSceneCount ?? DEFAULT_ESTIMATED_SCENE_COUNT;
   const imageModelCount = opts.imageModelCount ?? 1;
+  const audioModelCount = opts.audioModelCount ?? 1;
 
   // LLM calls: script analysis + character bible + location bible (~3 calls)
   const llmCost = estimateLLMCost(3);
@@ -135,6 +162,16 @@ export function estimateStoryboardCost(opts: {
         multiplyMicros(perFrameMotion, sceneCount)
       );
     }
+  }
+
+  // Optional music generation — one track per sequence per audio model.
+  if (opts.autoGenerateMusic && opts.audioModel) {
+    const audioDuration = opts.audioDurationSeconds ?? sceneCount * 5;
+    const perTrackMusic = estimateAudioCost(opts.audioModel, audioDuration);
+    totalCost = addMicros(
+      totalCost,
+      multiplyMicros(perTrackMusic, audioModelCount)
+    );
   }
 
   return totalCost;

--- a/src/lib/db/scoped/sequence-variants.ts
+++ b/src/lib/db/scoped/sequence-variants.ts
@@ -108,6 +108,23 @@ export function createSequenceVariantsMethods(db: Database) {
         .where(eq(sequenceMusicVariants.sequenceId, sequenceId));
     },
 
+    /**
+     * Distinct audio models that have a primary (non-divergent) variant for
+     * this sequence (#546). Drives the header audio-model dropdown.
+     */
+    listMusicModels: async (sequenceId: string): Promise<string[]> => {
+      const result = await db
+        .selectDistinct({ model: sequenceMusicVariants.model })
+        .from(sequenceMusicVariants)
+        .where(
+          and(
+            eq(sequenceMusicVariants.sequenceId, sequenceId),
+            sql`${sequenceMusicVariants.divergedAt} IS NULL`
+          )
+        );
+      return result.map((r) => r.model);
+    },
+
     getMusicPrimary,
     upsertMusicPrimary,
     insertDivergentMusic,

--- a/src/lib/db/scoped/sequence-variants.ts
+++ b/src/lib/db/scoped/sequence-variants.ts
@@ -299,5 +299,45 @@ export function createSequenceVariantsMethods(db: Database) {
       }
       return { sequence: promotedSequence, discardedAt: now };
     },
+
+    /**
+     * Copy a model's completed variant onto the sequence's live primary
+     * (`sequences.music*`) WITHOUT discarding the variant row — the
+     * non-destructive "Set Music" used to switch which model's track is the
+     * sequence primary (#546). Mirrors `setVideoFromVariant`. Contrast
+     * `promoteMusicVariant`, which consumes a divergent alternate.
+     */
+    setMusicFromVariant: async (variantId: string): Promise<Sequence> => {
+      const variantRows = await db
+        .select()
+        .from(sequenceMusicVariants)
+        .where(eq(sequenceMusicVariants.id, variantId));
+      const variant = variantRows.at(0);
+      if (!variant) {
+        throw new Error(`SequenceMusicVariant ${variantId} not found`);
+      }
+      const now = new Date();
+      const [updated] = await db
+        .update(sequences)
+        .set({
+          musicUrl: variant.url,
+          musicPath: variant.storagePath,
+          musicPrompt: variant.prompt,
+          musicTags: variant.tags,
+          musicModel: variant.model,
+          musicStatus: 'completed',
+          musicGeneratedAt: variant.generatedAt ?? now,
+          musicError: null,
+          updatedAt: now,
+        })
+        .where(eq(sequences.id, variant.sequenceId))
+        .returning();
+      if (!updated) {
+        throw new Error(
+          `Sequence ${variant.sequenceId} disappeared during set-music`
+        );
+      }
+      return updated;
+    },
   };
 }

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -144,6 +144,10 @@ export const realtimeSchema = {
       frameId: z.string().optional(),
       status: z.enum(['pending', 'generating', 'completed', 'failed']),
       audioUrl: z.string().optional(),
+      // Which audio model produced this update. Optional for backward compat
+      // with emitters that predate multi-model audio (#546); the model-aware
+      // cache invalidation and the music-view track switcher key off it.
+      model: z.string().optional(),
     }),
 
     // Character sheet generation progress (during recasting)

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -145,8 +145,10 @@ export const realtimeSchema = {
       status: z.enum(['pending', 'generating', 'completed', 'failed']),
       audioUrl: z.string().optional(),
       // Which audio model produced this update. Optional for backward compat
-      // with emitters that predate multi-model audio (#546); the model-aware
-      // cache invalidation and the music-view track switcher key off it.
+      // with emitters that predate multi-model audio (#546). The cache updater
+      // uses it to scope live `sequences.music*` writes to the primary model
+      // (so a secondary model can't clobber the primary) and to refresh the
+      // per-model audio queries.
       model: z.string().optional(),
     }),
 

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -218,17 +218,29 @@ export function updateQueryCacheFromEvent(
     case 'generation.audio:progress': {
       const status = data.status;
       const audioUrl = getOptionalString(data, 'audioUrl');
+      const model = getOptionalString(data, 'model');
       if (isValidMusicStatus(status)) {
         queryClient.setQueryData<Sequence>(
           sequenceKeys.detail(sequenceId),
-          (old) =>
-            old
-              ? {
-                  ...old,
-                  musicStatus: status,
-                  ...(audioUrl ? { musicUrl: audioUrl } : {}),
-                }
-              : old
+          (old) => {
+            if (!old) return old;
+            // Only the primary model owns the live `sequences.music*` columns.
+            // In a multi-model fan-out (#546) secondary models emit model-scoped
+            // events purely to refresh the per-model queries below — applying
+            // their status/url here would clobber the primary (last-writer-wins,
+            // and a secondary failure would mask a working primary track). The
+            // primary's `set-generating-status` writes `musicModel` first, so
+            // match against it; a missing `model` (single-model / legacy
+            // emitters) is treated as the primary.
+            if (model && old.musicModel && model !== old.musicModel) {
+              return old;
+            }
+            return {
+              ...old,
+              musicStatus: status,
+              ...(audioUrl ? { musicUrl: audioUrl } : {}),
+            };
+          }
         );
       }
       // Refresh per-model audio data so the header model dropdown and the

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -231,6 +231,22 @@ export function updateQueryCacheFromEvent(
               : old
         );
       }
+      // Refresh per-model audio data so the header model dropdown and the
+      // music-tab track switcher stay current (#546). Audio is sequence-level
+      // (sequence_music_variants), so these are separate queries from the frame
+      // image/video variant ones.
+      if (status === 'completed' || status === 'failed') {
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-audio-variants', sequenceId],
+          `audio-variants:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-audio-models', sequenceId],
+          `audio-models:${sequenceId}`
+        );
+      }
       break;
     }
 

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -106,12 +106,22 @@ export const createSequenceSchema = createInsertSchema(sequences, {
     autoGenerateMotion: z.boolean().default(false).optional(),
     // Auto-generate music flag (UI-only, not stored in DB)
     autoGenerateMusic: z.boolean().default(false).optional(),
-    // Music model selection (model key, not full ID)
+    // Music model selection (model key, not full ID) — primary / first of audioModels
     musicModel: z
       .string()
       .refine((val) => validAudioModelKeys.includes(val), {
         message: 'Invalid music model',
       })
+      .optional(),
+    // Multiple audio models for variant generation (first is primary). Optional
+    // (music is opt-in via autoGenerateMusic); when present must be non-empty.
+    audioModels: z
+      .array(
+        z.string().refine((val) => validAudioModelKeys.includes(val), {
+          message: 'Invalid audio model',
+        })
+      )
+      .min(1, 'At least one audio model must be selected')
       .optional(),
     // Suggested talent IDs for AI-assisted casting during generation
     suggestedTalentIds: z.array(z.string()).optional(),

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -128,6 +128,8 @@ export interface StoryboardWorkflowInput extends SequenceWorkflowContext {
   autoGenerateMotion?: boolean;
   autoGenerateMusic?: boolean;
   musicModel?: keyof typeof AUDIO_MODELS;
+  /** Multiple audio models for variant generation (first is primary) */
+  audioModels?: (keyof typeof AUDIO_MODELS)[];
   /** Talent IDs suggested by user for AI-assisted casting */
   suggestedTalentIds?: string[];
   /** Location IDs suggested by user for visual consistency */
@@ -152,6 +154,8 @@ export interface AnalyzeScriptWorkflowInput extends SequenceWorkflowContext {
   autoGenerateMotion?: boolean;
   autoGenerateMusic?: boolean;
   musicModel?: keyof typeof AUDIO_MODELS;
+  /** Multiple audio models for variant generation (first is primary) */
+  audioModels?: (keyof typeof AUDIO_MODELS)[];
   /** Talent IDs suggested by user for AI-assisted casting */
   suggestedTalentIds?: string[];
   /** Location IDs suggested by user for visual consistency */
@@ -758,6 +762,14 @@ export interface BatchMotionMusicWorkflowInput extends SequenceWorkflowContext {
     duration: number;
     model?: keyof typeof AUDIO_MODELS;
   };
+  /**
+   * Audio models to generate for the sequence (#546). First is primary (its
+   * track also lands on the live `sequences.music*` columns); the rest are
+   * alternates stored as separate primary rows in `sequence_music_variants`
+   * keyed by (sequenceId, model). When absent, falls back to `music.model`
+   * (single-model behaviour). Each model reuses `music.prompt/tags/duration`.
+   */
+  audioModels?: (keyof typeof AUDIO_MODELS)[];
 }
 
 /**

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -706,6 +706,14 @@ export interface MusicWorkflowInput extends SequenceWorkflowContext {
   duration: number;
   /** Audio model to use */
   model?: keyof typeof AUDIO_MODELS;
+  /**
+   * Whether this model owns the live `sequences.music*` columns (#546). In a
+   * multi-model fan-out only the primary (audioModels[0]) writes the shared
+   * sequence row + drives `musicStatus`; secondary models persist only their
+   * own `sequence_music_variants` row and emit model-scoped events. Defaults
+   * to true for single-model / legacy callers that don't set it.
+   */
+  isPrimary?: boolean;
 }
 
 export interface MusicWorkflowResult {

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -25,6 +25,7 @@
  * `motion-batch` (Phase 5 motion + music + merge tree). */
 
 import { sanitizeScriptContent } from '@/lib/ai/prompt-validation';
+import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
@@ -98,12 +99,14 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
       autoGenerateMotion = false,
       autoGenerateMusic = false,
       musicModel,
+      audioModels: audioModelsInput,
       suggestedTalentIds,
       suggestedLocationIds,
     } = input;
 
     const imageModels = resolveImageModels(imageModelsInput, imageModel);
     const videoModels = resolveVideoModels(videoModelsInput, videoModel);
+    const audioModels = resolveAudioModels(audioModelsInput, musicModel);
     // First selected model is primary: it drives the legacy `frames.video*`
     // columns and the model-aware duration snapping; the rest are alternates.
     const primaryVideoModel = videoModels[0] ?? videoModel;
@@ -645,6 +648,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
           includeMusic: shouldGenerateMusic,
           frames: batchFrames,
           videoModels,
+          audioModels: shouldGenerateMusic ? audioModels : undefined,
           music: shouldGenerateMusic
             ? {
                 prompt: musicPrompt,

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -139,8 +139,10 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
 
     // Multi-model audio (#546): one MUSIC_WORKFLOW child per selected model,
     // each reusing the same prompt/tags/duration and writing its own primary
-    // row in sequence_music_variants (keyed by (sequenceId, model)). Falls back
-    // to the single `music.model` when no audioModels were threaded through.
+    // row in sequence_music_variants (keyed by (sequenceId, model)). Only the
+    // first model is primary — it alone writes the live `sequences.music*`
+    // columns; the rest persist only their variant row (see `isPrimary` below).
+    // Falls back to the single `music.model` when no audioModels were threaded.
     const audioModels =
       includeMusic && input.music
         ? resolveAudioModels(input.audioModels, input.music.model)
@@ -170,6 +172,9 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
           tags: music.tags,
           duration: music.duration,
           model,
+          // audioModels[0] is primary (resolveAudioModels preserves order +
+          // dedupes); only it writes the live `sequences.music*` columns.
+          isPrimary: index === 0,
         },
         spawnStepName: `spawn-music-${index}-${model}`,
         awaitStepName: `await-music-${index}-${model}`,

--- a/src/lib/workflows/motion-batch-workflow.ts
+++ b/src/lib/workflows/motion-batch-workflow.ts
@@ -21,6 +21,7 @@
  *     rather than a silently-skipped child), `Promise.allSettled` on await
  *     so a single bad frame doesn't kill the rest of the batch. */
 
+import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
@@ -136,31 +137,49 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
       );
     });
 
-    const musicAwait =
+    // Multi-model audio (#546): one MUSIC_WORKFLOW child per selected model,
+    // each reusing the same prompt/tags/duration and writing its own primary
+    // row in sequence_music_variants (keyed by (sequenceId, model)). Falls back
+    // to the single `music.model` when no audioModels were threaded through.
+    const audioModels =
+      includeMusic && input.music
+        ? resolveAudioModels(input.audioModels, input.music.model)
+        : [];
+
+    const musicJobs =
       includeMusic && input.music && musicBinding
-        ? spawnAndAwaitChild<MusicWorkflowInput, MusicWorkflowResult>(step, {
-            binding: musicBinding,
-            parentBindingName: 'MOTION_BATCH_WORKFLOW',
-            parentInstanceId,
-            childId: `music:${sequenceId}`,
-            childPayload: {
-              userId: input.userId,
-              teamId: input.teamId,
-              sequenceId,
-              prompt: input.music.prompt,
-              tags: input.music.tags,
-              duration: input.music.duration,
-              model: input.music.model,
-            },
-            spawnStepName: 'spawn-music',
-            awaitStepName: 'await-music',
-            timeout: '30 minutes',
-          })
-        : null;
+        ? audioModels.map((model) => ({ model }))
+        : [];
+
+    const musicAwaits = musicJobs.map(({ model }, index) => {
+      // input.music is narrowed truthy by musicJobs construction above.
+      const music = input.music;
+      if (!music || !musicBinding) {
+        throw new WorkflowValidationError('music config missing for batch');
+      }
+      return spawnAndAwaitChild<MusicWorkflowInput, MusicWorkflowResult>(step, {
+        binding: musicBinding,
+        parentBindingName: 'MOTION_BATCH_WORKFLOW',
+        parentInstanceId,
+        childId: `music:${sequenceId}:${model}`,
+        childPayload: {
+          userId: input.userId,
+          teamId: input.teamId,
+          sequenceId,
+          prompt: music.prompt,
+          tags: music.tags,
+          duration: music.duration,
+          model,
+        },
+        spawnStepName: `spawn-music-${index}-${model}`,
+        awaitStepName: `await-music-${index}-${model}`,
+        timeout: '30 minutes',
+      });
+    });
 
     const motionResults = await Promise.allSettled(motionAwaits);
-    const musicResult = musicAwait
-      ? await Promise.allSettled([musicAwait])
+    const musicResults = musicAwaits.length
+      ? await Promise.allSettled(musicAwaits)
       : null;
 
     // Log per-frame motion failures for visibility; we don't throw here — the
@@ -180,15 +199,17 @@ export class MotionBatchWorkflow extends OpenStoryWorkflowEntrypoint<BatchMotion
         );
       }
     }
-    if (musicResult) {
-      const [m] = musicResult;
-      if (m.status === 'rejected') {
-        logger.warn(
-          `[MotionBatchWorkflow:cf] Music generation failed for sequence ${sequenceId}:`,
-          {
-            err: m.reason,
-          }
-        );
+    if (musicResults) {
+      for (let i = 0; i < musicResults.length; i++) {
+        const m = musicResults[i];
+        if (m?.status === 'rejected') {
+          logger.warn(
+            `[MotionBatchWorkflow:cf] Music generation failed for sequence ${sequenceId} model ${musicJobs[i]?.model ?? '(unknown)'}:`,
+            {
+              err: m.reason,
+            }
+          );
+        }
       }
     }
 

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -59,6 +59,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
           'generation.audio:progress',
           {
             status: 'generating',
+            model,
           }
         );
       });
@@ -178,6 +179,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
           const channel = getGenerationChannel(sequenceId);
           await channel.emit('generation.audio:progress', {
             status: 'completed',
+            model,
             ...(status?.musicUrl ? { audioUrl: status.musicUrl } : {}),
           });
           await channel.emit('generation.stale:detected', {
@@ -206,6 +208,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
             {
               status: 'completed',
               audioUrl: audioUrl,
+              model,
             }
           );
         });
@@ -227,6 +230,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
     scopedDb: ScopedDb;
   }): Promise<void> {
     const input = event.payload;
+    const model = input.model || DEFAULT_MUSIC_MODEL;
     if (input.sequenceId) {
       const failSeq = scopedDb.sequence(input.sequenceId);
 
@@ -238,7 +242,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
       try {
         await getGenerationChannel(input.sequenceId).emit(
           'generation.audio:progress',
-          { status: 'failed' }
+          { status: 'failed', model }
         );
       } catch (emitError) {
         logger.error(

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -46,8 +46,13 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
 
     const { sequenceId, teamId } = input;
     const model = input.model || DEFAULT_MUSIC_MODEL;
+    // Only the primary model owns the live `sequences.music*` columns. In a
+    // multi-model fan-out (#546) secondary models persist only their own
+    // variant row and emit model-scoped events; writing the shared sequence row
+    // would make `musicStatus`/`musicUrl` last-writer-wins across siblings.
+    const isPrimary = input.isPrimary ?? true;
 
-    if (sequenceId) {
+    if (sequenceId && isPrimary) {
       await step.do('set-generating-status', async () => {
         await scopedDb.sequence(sequenceId).updateMusicFields({
           musicStatus: 'generating',
@@ -163,24 +168,29 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
 
       if (writeResult.divergent) {
         // Divergent run: prior primary on `sequences.music*` stays
-        // authoritative. Reset musicStatus from 'generating' (set above) back
-        // to 'completed' and emit a terminal event so the UI doesn't hang on
-        // a spinner. The alternate is preserved in `sequence_music_variants`
-        // for future surfacing.
+        // authoritative. For the primary model, reset musicStatus from
+        // 'generating' (set above) back to 'completed'; secondary models never
+        // touched the shared row. Either way emit a terminal event so the UI
+        // doesn't hang on a spinner. The alternate is preserved in
+        // `sequence_music_variants` for future surfacing.
         const divergedVariantId = writeResult.variant.id;
         await step.do('update-sequence-music-divergent', async () => {
           const seq = scopedDb.sequence(sequenceId);
-          const status = await seq.getMusicStatus();
-          await seq.updateMusicFields({
-            musicStatus: 'completed',
-            musicError: null,
-          });
+          let liveMusicUrl: string | undefined;
+          if (isPrimary) {
+            const status = await seq.getMusicStatus();
+            await seq.updateMusicFields({
+              musicStatus: 'completed',
+              musicError: null,
+            });
+            liveMusicUrl = status?.musicUrl ?? undefined;
+          }
 
           const channel = getGenerationChannel(sequenceId);
           await channel.emit('generation.audio:progress', {
             status: 'completed',
             model,
-            ...(status?.musicUrl ? { audioUrl: status.musicUrl } : {}),
+            ...(liveMusicUrl ? { audioUrl: liveMusicUrl } : {}),
           });
           await channel.emit('generation.stale:detected', {
             entityType: 'sequence',
@@ -195,13 +205,18 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
         );
       } else {
         await step.do('update-sequence-music', async () => {
-          await scopedDb.sequence(sequenceId).updateMusicFields({
-            musicUrl: audioUrl,
-            musicPath: storageResult.path,
-            musicStatus: 'completed',
-            musicGeneratedAt: new Date(),
-            musicError: null,
-          });
+          // Primary owns the live columns; secondary models only emit a
+          // model-scoped event so the per-model audio queries refresh without
+          // clobbering the primary's `sequences.music*`.
+          if (isPrimary) {
+            await scopedDb.sequence(sequenceId).updateMusicFields({
+              musicUrl: audioUrl,
+              musicPath: storageResult.path,
+              musicStatus: 'completed',
+              musicGeneratedAt: new Date(),
+              musicError: null,
+            });
+          }
 
           await getGenerationChannel(sequenceId).emit(
             'generation.audio:progress',
@@ -231,13 +246,17 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
   }): Promise<void> {
     const input = event.payload;
     const model = input.model || DEFAULT_MUSIC_MODEL;
+    const isPrimary = input.isPrimary ?? true;
     if (input.sequenceId) {
-      const failSeq = scopedDb.sequence(input.sequenceId);
-
-      await failSeq.updateMusicFields({
-        musicStatus: 'failed',
-        musicError: error,
-      });
+      // Only the primary model owns the live music status — a secondary model's
+      // failure must not clobber a successful primary track (#546). Secondary
+      // failures still emit a model-scoped event so per-model queries refresh.
+      if (isPrimary) {
+        await scopedDb.sequence(input.sequenceId).updateMusicFields({
+          musicStatus: 'failed',
+          musicError: error,
+        });
+      }
 
       try {
         await getGenerationChannel(input.sequenceId).emit(

--- a/src/lib/workflows/storyboard-workflow.ts
+++ b/src/lib/workflows/storyboard-workflow.ts
@@ -196,6 +196,7 @@ export class StoryboardWorkflow extends OpenStoryWorkflowEntrypoint<StoryboardWo
         autoGenerateMotion: input.autoGenerateMotion ?? false,
         autoGenerateMusic: input.autoGenerateMusic ?? false,
         musicModel: input.musicModel,
+        audioModels: input.audioModels,
         suggestedTalentIds: input.suggestedTalentIds,
         suggestedLocationIds: input.suggestedLocationIds,
       },

--- a/src/routes/_protected/sequences/$id/music.tsx
+++ b/src/routes/_protected/sequences/$id/music.tsx
@@ -5,8 +5,13 @@ import {
   regenerateMusicPromptFn,
 } from '@/functions/prompt-variants';
 import { generateMusicFn } from '@/functions/sequences';
+import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
 import { useFramesBySequence } from '@/hooks/use-frames';
-import { useSequence, sequenceKeys } from '@/hooks/use-sequences';
+import {
+  useSequence,
+  useSequenceAudioVariants,
+  sequenceKeys,
+} from '@/hooks/use-sequences';
 import {
   useDiscardSequenceMusicVariant,
   usePromoteSequenceMusicVariant,
@@ -35,6 +40,31 @@ function MusicPage() {
   const { data: frames } = useFramesBySequence(sequenceId, {
     refetchInterval: false,
   });
+  // Resolve the music tab through the viewer's active audio model (#546). When
+  // a model is pinned in the header, play that model's primary track instead
+  // of the live `sequences.music*` primary; "Mixed" (null) keeps the primary.
+  const { activeAudioModel } = useActiveAudioModel(sequenceId);
+  const { data: audioVariants } = useSequenceAudioVariants(sequenceId);
+  const resolvedSequence = useMemo<Sequence | undefined>(() => {
+    if (!sequence || !activeAudioModel || !audioVariants) return sequence;
+    // Player-only remap (mirrors scenes-view's playerFrames): swap ONLY the
+    // playback URL to the pinned model's completed track. Status / error /
+    // prompt / tags stay sourced from the live sequence so a regeneration of
+    // the pinned model still surfaces the generating spinner + failure UI and
+    // never clobbers an in-progress prompt edit. Only swap while the live track
+    // is completed — never mask a live generating/failed state.
+    if (sequence.musicStatus !== 'completed') return sequence;
+    const variant = audioVariants.find(
+      (v) =>
+        v.model === activeAudioModel &&
+        v.divergedAt === null &&
+        v.discardedAt === null &&
+        v.status === 'completed' &&
+        v.url
+    );
+    if (!variant?.url) return sequence;
+    return { ...sequence, musicUrl: variant.url };
+  }, [sequence, activeAudioModel, audioVariants]);
   const queryClient = useQueryClient();
   const posthog = usePostHog();
 
@@ -204,7 +234,7 @@ function MusicPage() {
     <div className="flex-1 overflow-auto p-4">
       <div className="max-w-4xl mx-auto">
         <MusicView
-          sequence={sequence}
+          sequence={resolvedSequence ?? sequence}
           videoDuration={videoDuration}
           onGenerateMusic={(args) => generateMusic.mutate(args)}
           isGeneratingMusic={generateMusic.isPending}

--- a/src/routes/_protected/sequences/$id/music.tsx
+++ b/src/routes/_protected/sequences/$id/music.tsx
@@ -16,8 +16,11 @@ import {
   useDiscardSequenceMusicVariant,
   usePromoteSequenceMusicVariant,
   useSequenceDivergentMusicVariants,
+  useSetMusicFromVariant,
   useUndiscardSequenceMusicVariant,
 } from '@/hooks/use-sequence-variants';
+import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
+import { type AudioModel } from '@/lib/ai/models';
 import type { SequenceMusicVariant } from '@/lib/db/schema';
 import { useGenerationStream } from '@/lib/realtime/use-generation-stream';
 import { useSequenceStaleDetected } from '@/lib/realtime/use-sequence-stale-detected';
@@ -41,8 +44,8 @@ function MusicPage() {
     refetchInterval: false,
   });
   // Resolve the music tab through the viewer's active audio model (#546). When
-  // a model is pinned in the header, play that model's primary track instead
-  // of the live `sequences.music*` primary; "Mixed" (null) keeps the primary.
+  // a model is pinned in the header, play that model's track instead of the
+  // live `sequences.music*` primary; unpinned (null) follows the primary.
   const { activeAudioModel } = useActiveAudioModel(sequenceId);
   const { data: audioVariants } = useSequenceAudioVariants(sequenceId);
   const resolvedSequence = useMemo<Sequence | undefined>(() => {
@@ -65,6 +68,39 @@ function MusicPage() {
     if (!variant?.url) return sequence;
     return { ...sequence, musicUrl: variant.url };
   }, [sequence, activeAudioModel, audioVariants]);
+
+  // Per-model status for the music model selector + action button (#546),
+  // mirroring scenes-view's videoModelStatuses. The "set" model is the one
+  // whose track is the sequence's live primary (url match, else the recorded
+  // musicModel); a completed alternate is selectable, then promoted via "Set
+  // Music". Music variant rows have no 'generating' state, so the live
+  // generating status is overlaid onto the model currently being generated.
+  const audioModelStatuses = useMemo(() => {
+    const map = new Map<string, ModelGenerationStatus>();
+    const variants = (audioVariants ?? []).filter(
+      (v) => v.divergedAt === null && v.discardedAt === null
+    );
+    const primaryUrl = sequence?.musicUrl ?? null;
+    const setModel = primaryUrl
+      ? (variants.find((v) => v.url === primaryUrl)?.model ??
+        sequence?.musicModel ??
+        null)
+      : null;
+    for (const v of variants) {
+      map.set(v.model, v.model === setModel ? 'set' : v.status);
+    }
+    if (setModel && !map.has(setModel)) map.set(setModel, 'set');
+    if (sequence?.musicStatus === 'generating' && sequence.musicModel) {
+      map.set(sequence.musicModel, 'generating');
+    }
+    return map;
+  }, [
+    audioVariants,
+    sequence?.musicUrl,
+    sequence?.musicModel,
+    sequence?.musicStatus,
+  ]);
+
   const queryClient = useQueryClient();
   const posthog = usePostHog();
 
@@ -93,6 +129,7 @@ function MusicPage() {
   const promoteVariant = usePromoteSequenceMusicVariant();
   const discardVariant = useDiscardSequenceMusicVariant();
   const undiscardVariant = useUndiscardSequenceMusicVariant();
+  const setMusicModel = useSetMusicFromVariant();
 
   const handleDiscardWithUndo = useCallback(
     (variant: SequenceMusicVariant) => {
@@ -147,6 +184,29 @@ function MusicPage() {
       );
     },
     [sequenceId, promoteVariant]
+  );
+
+  // "Set Music": switch the sequence's live primary to the selected model's
+  // track (mirrors the video tab's "Set Video"). Non-destructive — the server
+  // resolves the model to its live completed variant and keeps the row.
+  const handleSetModel = useCallback(
+    (model: AudioModel) => {
+      setMusicModel.mutate(
+        { sequenceId, model },
+        {
+          onSuccess: () => {
+            toast.success('Music model set');
+          },
+          onError: (error) => {
+            toast.error('Failed to set music model', {
+              description:
+                error instanceof Error ? error.message : 'Unknown error',
+            });
+          },
+        }
+      );
+    },
+    [sequenceId, setMusicModel]
   );
 
   const generateMusic = useMutation({
@@ -236,6 +296,9 @@ function MusicPage() {
         <MusicView
           sequence={resolvedSequence ?? sequence}
           videoDuration={videoDuration}
+          audioModelStatuses={audioModelStatuses}
+          onSetModel={handleSetModel}
+          isSettingModel={setMusicModel.isPending}
           onGenerateMusic={(args) => generateMusic.mutate(args)}
           isGeneratingMusic={generateMusic.isPending}
           divergentBanner={divergentBanner}

--- a/src/routes/_protected/sequences/$id/route.tsx
+++ b/src/routes/_protected/sequences/$id/route.tsx
@@ -1,9 +1,6 @@
 import { RouteErrorFallback } from '@/components/error/route-error-fallback';
-import {
-  ImageModelBadge,
-  ModelBadge,
-  MusicModelBadge,
-} from '@/components/model/model-badge';
+import { ImageModelBadge, ModelBadge } from '@/components/model/model-badge';
+import { SequenceAudioModelSelector } from '@/components/model/sequence-audio-model-selector';
 import { SequenceVideoModelSelector } from '@/components/model/sequence-video-model-selector';
 import { getSequenceImageModelsFn } from '@/functions/frames';
 import { frameKeys } from '@/hooks/use-frames';
@@ -98,7 +95,10 @@ function SequenceLayout() {
               sequenceId={sequenceId}
               sequenceVideoModel={sequence?.videoModel}
             />
-            <MusicModelBadge model={sequence?.musicModel ?? undefined} />
+            <SequenceAudioModelSelector
+              sequenceId={sequenceId}
+              sequenceMusicModel={sequence?.musicModel}
+            />
           </div>
         </PageHeader>
         <SequenceTabs sequenceId={sequenceId} />


### PR DESCRIPTION
Closes #546

Phase 3 of the multi-model variant system. Now targets `main` directly (the #545 video parent merged in #781).

> Supersedes #782, which GitHub auto-closed when its base branch (`545-multi-select-video-models`) was deleted on merge and could not be reopened. The adversarial-review thread lives there; this is the same commit rebased cleanly onto `main`.

Audio/music is **per-sequence**, so multi-model audio extends the existing `sequence_music_variants` table (already keyed `(sequenceId, model)`) rather than `frame_variants` — the correct architecture vs the issue's per-frame premise.

## Workflows
- `motion-batch` fans out one `MUSIC_WORKFLOW` child per audio model (each writes its own primary row); `music-workflow` + the music-promote fn emit `audio:progress` with `model`; `audioModels[]` threads through the chain.

## Creation / viewing / realtime
- `MusicModelMultiSelector`; audio cost added to the estimate (gated on motion, since music only spawns via motion-batch).
- `useActiveAudioModel` + header `SequenceAudioModelSelector` dropdown ("Mixed"); music tab resolves playback through the active model's track (player-only remap — live status/error/prompt stay authoritative).
- `audio:progress` carries `model`; model-aware cache invalidation.

Also fixes a latent bug from #545: the create mutation dropped `videoModels[]`/`audioModels[]` before the server call, collapsing multi-select to one model on creation.

## Rebase note
Rebased onto `main` after #545 merged; resolved 4 conflicts from main's motion-cost refactor (`videoModelCount` multiplier → per-model `videoModels[]` pricing) — kept main's per-model video costing, layered the audio `audioModelCount` multiplier on top, dropped the obsolete `videoModelCount` test, and trimmed a now-dead video-model import in `motion-batch-workflow.ts`. `bun typecheck` clean · `bun lint` 0 errors · 49 affected unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
