### PR TITLE
feat(models): daily model-version-check skill + routine

### DIFF
--- a/.claude/skills/update-model-versions/SKILL.md
+++ b/.claude/skills/update-model-versions/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: update-model-versions
+description: >
+  Check whether newer versions of the AI models we already use (fal.ai image,
+  video/motion, audio; OpenRouter text) or our @tanstack/ai* packages have
+  shipped, and open a PR bumping any genuine successor. Use when asked to
+  "check for model updates", "are our models current", "bump models", or when
+  run by the daily model-freshness routine. Only bumps EXISTING models to a
+  newer version of the same model — it does not add net-new models.
+---
+
+# Update model versions
+
+Our model registries are the single source of truth:
+
+| Class                   | File                          | Export                   |
+| ----------------------- | ----------------------------- | ------------------------ |
+| Text (OpenRouter)       | `src/lib/ai/models.config.ts` | `SCRIPT_ANALYSIS_MODELS` |
+| Image (fal.ai)          | `src/lib/ai/models.ts`        | `IMAGE_MODELS`           |
+| Video / motion (fal.ai) | `src/lib/ai/models.ts`        | `IMAGE_TO_VIDEO_MODELS`  |
+| Audio (fal.ai)          | `src/lib/ai/models.ts`        | `AUDIO_MODELS`           |
+| AI SDK packages         | `package.json`                | `@tanstack/ai*`          |
+
+The goal each run: detect newer versions → verify each is a real successor →
+open a focused PR that bumps it → leave everything green.
+
+## 1. Detect candidates
+
+```bash
+bun models:check          # human-readable report
+bun models:check --json   # { hasUpdates, models[], packages[] } for scripting
+```
+
+`scripts/check-model-updates.ts` reads the registries and queries public,
+unauthenticated catalogs (fal.ai `/api/models`, OpenRouter `/api/v1/models`, npm
+registry). It is HTTP-only so it runs anywhere — no `FAL_KEY` or MCP needed.
+
+Candidates are **heuristic** (same brand, higher version number, same modality,
+not already adopted). Treat them as leads to verify, not facts. If
+`hasUpdates` is `false`, stop — nothing to do.
+
+## 2. Verify each candidate is a genuine successor
+
+Do not bump on the heuristic alone. For each flagged candidate decide: _is this
+the same model, one version newer — or a different product line / tier?_
+
+**fal models — prefer the fal tooling (richest signal):**
+
+- **genmedia CLI** (what the fal community skills use; works headless):
+  ```bash
+  curl https://genmedia.sh/install -fsS | bash   # once, if missing
+  genmedia setup --non-interactive --api-key "$FAL_KEY"
+  genmedia models --endpoint_id <candidate-id> --json   # confirm it exists
+  genmedia schema  <candidate-id> --json                # compare input params
+  genmedia pricing <candidate-id> --json                # cost delta
+  ```
+- **fal-ai MCP** if available in this session: `search_models`,
+  `get_model_schema`, `get_pricing` give the same data.
+- **Fallback (zero-auth):** the OpenAPI spec — a 200 means the endpoint is real:
+  `curl -s -o /dev/null -w "%{http_code}" "https://fal.ai/api/openapi/queue/openapi.json?endpoint_id=<id>"`,
+  and `https://fal.ai/models/<path>/llms.txt` for param specs (see CLAUDE.md).
+
+**text models:** confirm the candidate id resolves on
+`https://openrouter.ai/api/v1/models` and keeps the same tier (don't turn a
+`-mini` into a non-mini, or a `pro` into `flash`).
+
+**Reject a candidate when** it is a different tier/variant (fast/lite/standard
+vs pro, lora/trainer/edit gear), a different modality, a preview/experimental
+build replacing a stable one, or its schema/pricing changed so much it needs
+product judgement. When unsure, skip it and note it in the PR body rather than
+guessing.
+
+## 3. Apply the bump (one PR per upgrade)
+
+Work one upgrade at a time so each PR is reviewable and revertible.
+
+**Idempotency — check first:** `gh pr list --state open --search "in:title model"`.
+If an open PR or branch already covers this exact bump, skip it. Branch name:
+`auto/model-update-<registry-key>-<new-version>` (e.g.
+`auto/model-update-minimax_hailuo_02-2.3`).
+
+**Golden rule: change the `id` (and metadata), never the registry KEY.** Keys
+are persisted in the DB (a team's selected model) and referenced across selectors
+and schemas — renaming one is a breaking migration, out of scope here.
+
+Per class, edit and follow through:
+
+- **Text** (`models.config.ts`): update `id`, `name`, `description`,
+  `contextWindow`. If you bump `DEFAULT_ANALYSIS_MODEL`'s model, the constant
+  references a key, so it's unaffected.
+- **Image** (`models.ts` `IMAGE_MODELS`): update `id`, `name`, `description`,
+  `maxPromptLength`. If the model has an `EDIT_ENDPOINTS` entry, update that
+  endpoint id too. Confirm the new endpoint still supports the edit/reference
+  flow if it had one.
+- **Video / motion** (`models.ts` `IMAGE_TO_VIDEO_MODELS`): update `id` + meta,
+  then regenerate the schemas — **`bun motion:codegen`** (writes
+  `src/lib/motion/generated/**` and `endpoint-map.ts`). Never hand-write motion
+  schemas. Re-check `maxPromptLength` against the new schema.
+- **Audio** (`models.ts` `AUDIO_MODELS`): update `id` + `capabilities`
+  (durations, formats) from the new schema.
+- **fal pricing:** model ids are pricing keys in `src/lib/ai/fal-pricing-data.ts`
+  (auto-generated). After any fal id change run **`bun scripts/update-fal-pricing.ts`**
+  (needs `FAL_KEY`). If it can't run, add the new id's pricing manually via the
+  override path documented in that script and flag it in the PR.
+- **Packages:** bump the `@tanstack/ai*` range in `package.json`, then
+  `bun install`. Skip major bumps (breaking) — open an issue for those instead.
+
+## 4. Quality gates (must pass before opening the PR)
+
+```bash
+bun typecheck
+bun lint
+bun run test src/lib/ai src/lib/motion   # registry + motion suites
+bun run test src/lib/billing             # pricing/cost if fal pricing changed
+```
+
+Fix anything that breaks. If a bump cascades into non-trivial changes (schema
+shape changed, pricing model differs, tests need rework), stop and open an
+**issue** describing it instead of forcing a half-working PR.
+
+## 5. Open the PR
+
+```bash
+git checkout -b auto/model-update-<key>-<version>
+git commit -am "chore(models): bump <name> <old> → <new>"
+gh pr create --title "chore(models): bump <name> <old> → <new>" --body "<body>"
+```
+
+PR body must include, per change: registry key, old id → new id, why it's a
+genuine successor, links (fal model page / OpenRouter / npm), pricing delta, and
+which generated files / pricing were regenerated. End with: "🤖 Opened by the
+daily model-freshness routine (#792). Verify pricing & quality before merge."
+
+Leave PRs as **draft** only if a quality gate is amber (e.g. pricing couldn't be
+auto-fetched); otherwise ready-for-review. Do not merge — a human reviews.

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "motion:codegen": "bun scripts/pull-motion-schemas.ts",
+    "models:check": "bun scripts/check-model-updates.ts",
     "doppler:setup": "doppler setup -p openstory -c dev",
     "doppler:pull:dev": "doppler secrets download -p openstory --config=dev --format=env --no-file > .env.local",
     "doppler:pull:dev_test": "doppler secrets download -p openstory --config=dev_test --format=env --no-file > .env.local",

--- a/scripts/check-model-updates.ts
+++ b/scripts/check-model-updates.ts
@@ -1,0 +1,497 @@
+/**
+ * Detect newer versions of the AI models (and AI SDK packages) we already use.
+ *
+ * Reads our four model registries plus the @tanstack/ai* deps in package.json,
+ * then queries public, unauthenticated endpoints to find newer sibling versions:
+ *   - fal.ai catalog      → https://fal.ai/api/models?keywords=…&category=…
+ *   - OpenRouter catalog  → https://openrouter.ai/api/v1/models
+ *   - npm registry        → https://registry.npmjs.org/<pkg>
+ *
+ * This is the deterministic backbone of the `update-model-versions` skill and
+ * the daily "model freshness" routine. It only REPORTS candidates — deciding
+ * whether a candidate is a genuine successor (vs a different product line) and
+ * applying the bump is the skill's job. HTTP-only by design so it runs anywhere
+ * (local, CI, or a headless cron agent) without genmedia/fal-MCP/FAL_KEY.
+ *
+ * Usage:
+ *   bun scripts/check-model-updates.ts            # human-readable report
+ *   bun scripts/check-model-updates.ts --json     # machine-readable JSON
+ *
+ * Exit code is 0 even when updates are found (it is a report, not a gate);
+ * use the JSON `hasUpdates` field to branch in automation.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  AUDIO_MODELS,
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+} from '@/lib/ai/models';
+import { SCRIPT_ANALYSIS_MODELS } from '@/lib/ai/models.config';
+
+const jsonOutput = process.argv.includes('--json');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type Candidate = {
+  id: string;
+  title?: string;
+  version: string | null;
+};
+
+type ModelReport = {
+  source: 'fal-image' | 'fal-video' | 'fal-audio' | 'openrouter';
+  key: string;
+  currentId: string;
+  currentVersion: string | null;
+  /** Siblings in the same family that look NEWER than what we use. */
+  newer: Candidate[];
+  /** All same-family siblings, for context (may include older/variants). */
+  family: Candidate[];
+  error?: string;
+};
+
+type PackageReport = {
+  source: 'npm';
+  name: string;
+  currentRange: string;
+  currentResolved: string;
+  latest: string | null;
+  isOutdated: boolean;
+  error?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Version helpers
+// ---------------------------------------------------------------------------
+
+const ORG_PREFIXES = new Set([
+  'fal-ai',
+  'xai',
+  'x-ai',
+  'openai',
+  'google',
+  'anthropic',
+  'bytedance',
+  'bytedance-seed',
+  'z-ai',
+  'deepseek',
+  'mistralai',
+  'meta-llama',
+  'qwen',
+  'minimax',
+]);
+
+/** Modality suffixes that are not part of the version/brand. */
+const MODALITY_SUFFIXES =
+  /\/(image-to-video|text-to-video|text-to-image|image-to-image|text-to-music|text-to-audio|text-to-speech|speech-to-text|reference-to-video|edit|pro|standard|lite|turbo|master|fast)$/;
+
+/**
+ * Leaf path segments that identify a model's modality/role. A candidate is only
+ * treated as a successor if it shares the current model's leaf (apples-to-apples:
+ * an image-to-video successor, not the same brand's text-to-video or TTS sibling).
+ */
+const MODALITY_LEAVES = new Set([
+  'image-to-video',
+  'text-to-video',
+  'text-to-image',
+  'image-to-image',
+  'text-to-music',
+  'music',
+  'prompt-to-audio',
+  'edit',
+]);
+
+/** Endpoint flavours that are not the primary base model (LoRA gear, trainers, etc.). */
+const VARIANT_DENYLIST = [
+  'lora',
+  'trainer',
+  'distilled',
+  'gallery',
+  'controlnet',
+  'multiple-angles',
+  'lighting',
+  'remove-element',
+  'face-to',
+  'integrate-product',
+  'add-background',
+  'inpaint',
+  'outpaint',
+  'redux',
+];
+
+/** Endpoint ids we already use across every registry — never flag these as "new". */
+const ADOPTED_IDS = new Set<string>([
+  ...Object.values(IMAGE_MODELS).map((m) => m.id),
+  ...Object.values(IMAGE_TO_VIDEO_MODELS).map((m) => m.id),
+  ...Object.values(AUDIO_MODELS).map((m) => m.id),
+]);
+
+/** The modality leaf of an endpoint id (last path segment), or null if none. */
+function modalityLeaf(id: string): string | null {
+  const last = id.split('/').pop() ?? '';
+  return MODALITY_LEAVES.has(last) ? last : null;
+}
+
+/** Pull the first numeric version run (e.g. "3", "2.5", "4.6") from a string. */
+function extractVersion(id: string): string | null {
+  const stripped = id.replace(MODALITY_SUFFIXES, '');
+  const match = stripped.match(/v?(\d+(?:\.\d+)*)/i);
+  return match?.[1] ?? null;
+}
+
+/** Compare dotted numeric versions. Returns >0 if a is newer than b. */
+function compareVersions(a: string | null, b: string | null): number {
+  const pa = (a ?? '0').split('.').map(Number);
+  const pb = (b ?? '0').split('.').map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+/**
+ * Derive a free-text search keyword (brand) from an endpoint id.
+ * e.g. "fal-ai/kling-video/v3/pro/image-to-video" → "kling video"
+ *      "fal-ai/nano-banana-2"                      → "nano banana"
+ *      "fal-ai/bytedance/seedance/v1.5/pro/…"      → "seedance"
+ */
+function brandKeyword(id: string): string {
+  const parts = id.split('/');
+  let i = 0;
+  while (i < parts.length - 1 && ORG_PREFIXES.has(parts[i] ?? '')) i++;
+  const seg = parts[i] ?? parts[0] ?? id;
+  return seg
+    .replace(/-?v?\d+(?:\.\d+)*/gi, '') // drop version tokens
+    .replace(/-+/g, ' ')
+    .trim();
+}
+
+/** First alpha token of the brand, used to filter noisy search results. */
+function brandStem(id: string): string {
+  return brandKeyword(id).split(' ')[0] ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// Network helpers
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(url: string, timeoutMs = 20_000): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { 'user-agent': 'openstory-model-update-checker' },
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
+    const data: T = await res.json();
+    return data;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+type FalCatalogResponse = {
+  items?: { id: string; title?: string; category?: string }[];
+};
+
+async function falCatalog(
+  keyword: string,
+  category: string
+): Promise<Candidate[]> {
+  const url = `https://fal.ai/api/models?keywords=${encodeURIComponent(
+    keyword
+  )}&category=${encodeURIComponent(category)}&page=1`;
+  const data = await fetchJson<FalCatalogResponse>(url);
+  return (data.items ?? []).map((i) => ({
+    id: i.id,
+    title: i.title,
+    version: extractVersion(i.id),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// fal model checks
+// ---------------------------------------------------------------------------
+
+async function checkFalModel(
+  source: ModelReport['source'],
+  key: string,
+  currentId: string,
+  category: string
+): Promise<ModelReport> {
+  const currentVersion = extractVersion(currentId);
+  const stem = brandStem(currentId);
+  try {
+    const results = await falCatalog(brandKeyword(currentId), category);
+    // Keep same-brand siblings only (avoid unrelated search noise).
+    const family = results
+      .filter((c) => brandStem(c.id) === stem && c.id !== currentId)
+      .sort((a, b) => compareVersions(b.version, a.version));
+
+    const currentLeaf = modalityLeaf(currentId);
+    const newer = family.filter((c) => {
+      if (compareVersions(c.version, currentVersion) <= 0) return false;
+      if (ADOPTED_IDS.has(c.id)) return false; // already used under another key
+      if (VARIANT_DENYLIST.some((token) => c.id.includes(token))) return false;
+      // Apples-to-apples: a same-role successor, not a cross-modality sibling.
+      if (currentLeaf && modalityLeaf(c.id) !== currentLeaf) return false;
+      return true;
+    });
+    return { source, key, currentId, currentVersion, newer, family };
+  } catch (error) {
+    return {
+      source,
+      key,
+      currentId,
+      currentVersion,
+      newer: [],
+      family: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OpenRouter text-model checks
+// ---------------------------------------------------------------------------
+
+type OpenRouterResponse = { data?: { id: string; name?: string }[] };
+
+/** Family key = prefix-before-version + suffix-after-version (keeps mini/pro/nano distinct). */
+function openRouterFamily(id: string): {
+  family: string;
+  version: string | null;
+} {
+  const match = id.match(/^(.*?)(\d+(?:\.\d+)*)(.*)$/);
+  if (!match) return { family: id, version: null };
+  const prefix = match[1] ?? '';
+  const version = match[2] ?? null;
+  const suffix = match[3] ?? '';
+  return { family: `${prefix}|${suffix}`, version };
+}
+
+async function checkTextModels(): Promise<ModelReport[]> {
+  let catalog: OpenRouterResponse['data'] = [];
+  let fetchError: string | undefined;
+  try {
+    catalog =
+      (
+        await fetchJson<OpenRouterResponse>(
+          'https://openrouter.ai/api/v1/models'
+        )
+      ).data ?? [];
+  } catch (error) {
+    fetchError = error instanceof Error ? error.message : String(error);
+  }
+
+  return SCRIPT_ANALYSIS_MODELS.map((model) => {
+    const currentVersion = extractVersion(model.id);
+    if (fetchError) {
+      return {
+        source: 'openrouter' as const,
+        key: model.name,
+        currentId: model.id,
+        currentVersion,
+        newer: [],
+        family: [],
+        error: fetchError,
+      };
+    }
+    const { family: ourFamily } = openRouterFamily(model.id);
+    const adoptedTextIds = new Set<string>(
+      SCRIPT_ANALYSIS_MODELS.map((m) => m.id)
+    );
+    const siblings = catalog
+      .filter((m) => !m.id.startsWith('~')) // skip "latest" aliases
+      .filter((m) => !adoptedTextIds.has(m.id)) // already in our registry
+      .filter(
+        (m) => openRouterFamily(m.id).family === ourFamily && m.id !== model.id
+      )
+      .map((m) => ({
+        id: m.id,
+        title: m.name,
+        version: openRouterFamily(m.id).version,
+      }))
+      .sort((a, b) => compareVersions(b.version, a.version));
+    const newer = siblings.filter(
+      (c) => compareVersions(c.version, currentVersion) > 0
+    );
+    return {
+      source: 'openrouter' as const,
+      key: model.name,
+      currentId: model.id,
+      currentVersion,
+      newer,
+      family: siblings,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// npm package checks (@tanstack/ai*)
+// ---------------------------------------------------------------------------
+
+async function checkPackages(): Promise<PackageReport[]> {
+  const pkgPath = join(process.cwd(), 'package.json');
+  const pkg: {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  } = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  const allDeps: Record<string, string> = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+  };
+  const targets = Object.keys(allDeps).filter((name) =>
+    name.startsWith('@tanstack/ai')
+  );
+
+  return Promise.all(
+    targets.map(async (name): Promise<PackageReport> => {
+      const range = allDeps[name] ?? '';
+      const resolved = range.replace(/^[\^~>=<\s]+/, '');
+      try {
+        const data = await fetchJson<{ 'dist-tags'?: { latest?: string } }>(
+          `https://registry.npmjs.org/${name}`
+        );
+        const latest = data['dist-tags']?.latest ?? null;
+        return {
+          source: 'npm',
+          name,
+          currentRange: range,
+          currentResolved: resolved,
+          latest,
+          isOutdated: latest != null && compareVersions(latest, resolved) > 0,
+        };
+      } catch (error) {
+        return {
+          source: 'npm',
+          name,
+          currentRange: range,
+          currentResolved: resolved,
+          latest: null,
+          isOutdated: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const falChecks: Promise<ModelReport>[] = [
+    ...Object.entries(IMAGE_MODELS).map(([key, m]) =>
+      checkFalModel('fal-image', key, m.id, 'text-to-image')
+    ),
+    ...Object.entries(IMAGE_TO_VIDEO_MODELS).map(([key, m]) =>
+      checkFalModel('fal-video', key, m.id, 'image-to-video')
+    ),
+    ...Object.entries(AUDIO_MODELS).map(([key, m]) =>
+      checkFalModel('fal-audio', key, m.id, 'text-to-music')
+    ),
+  ];
+
+  const [falReports, textReports, packageReports] = await Promise.all([
+    Promise.all(falChecks),
+    checkTextModels(),
+    checkPackages(),
+  ]);
+
+  const modelReports = [...falReports, ...textReports];
+  const modelsWithUpdates = modelReports.filter((r) => r.newer.length > 0);
+  const packagesWithUpdates = packageReports.filter((r) => r.isOutdated);
+  const hasUpdates =
+    modelsWithUpdates.length > 0 || packagesWithUpdates.length > 0;
+
+  if (jsonOutput) {
+    console.log(
+      JSON.stringify(
+        { hasUpdates, models: modelReports, packages: packageReports },
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  printReport(modelReports, packageReports, hasUpdates);
+}
+
+function printReport(
+  modelReports: ModelReport[],
+  packageReports: PackageReport[],
+  hasUpdates: boolean
+) {
+  const SOURCE_LABEL: Record<ModelReport['source'], string> = {
+    'fal-image': 'Image (fal.ai)',
+    'fal-video': 'Video / motion (fal.ai)',
+    'fal-audio': 'Audio (fal.ai)',
+    openrouter: 'Text (OpenRouter)',
+  };
+
+  console.log('\n=== Model freshness report ===\n');
+
+  for (const source of [
+    'fal-image',
+    'fal-video',
+    'fal-audio',
+    'openrouter',
+  ] as const) {
+    const group = modelReports.filter((r) => r.source === source);
+    console.log(`## ${SOURCE_LABEL[source]}`);
+    for (const r of group) {
+      if (r.error) {
+        console.log(
+          `  ⚠️  ${r.key} (${r.currentId}) — lookup failed: ${r.error}`
+        );
+      } else if (r.newer.length > 0) {
+        console.log(
+          `  🆕 ${r.key} (${r.currentId}, v${r.currentVersion ?? '?'}) → candidates:`
+        );
+        for (const c of r.newer) {
+          console.log(
+            `        ${c.id} (v${c.version ?? '?'})${c.title ? ` — ${c.title}` : ''}`
+          );
+        }
+      } else {
+        console.log(`  ✅ ${r.key} (${r.currentId}) — current`);
+      }
+    }
+    console.log('');
+  }
+
+  console.log('## Packages (npm)');
+  for (const r of packageReports) {
+    if (r.error) {
+      console.log(`  ⚠️  ${r.name} — lookup failed: ${r.error}`);
+    } else if (r.isOutdated) {
+      console.log(`  🆕 ${r.name}: ${r.currentResolved} → ${r.latest}`);
+    } else {
+      console.log(`  ✅ ${r.name}: ${r.currentResolved} (latest ${r.latest})`);
+    }
+  }
+
+  console.log(
+    `\n=== ${hasUpdates ? 'UPDATES AVAILABLE — review candidates above' : 'Everything is up to date'} ===\n`
+  );
+  console.log(
+    'Candidates are heuristic (same brand, higher version number). Verify each\n' +
+      'is a genuine successor before bumping — see the update-model-versions skill.\n'
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Keeps our AI model registries current by automatically detecting newer versions of models we **already** support and opening PRs to bump them. Built for #792.

### 1. Detector — `scripts/check-model-updates.ts` (`bun models:check [--json]`)
HTTP-only (no `FAL_KEY`/MCP/secrets), so it runs locally, in CI, or in a headless cloud routine. Reads all four registries + `@tanstack/ai*` deps and queries public catalogs:
- fal.ai `/api/models` — image / video / audio
- OpenRouter `/api/v1/models` — text
- npm registry — packages

Filters out noise (cross-modality siblings, lora/trainer/edit variants, params misread as versions, ids we already use). `--json` emits `{ hasUpdates, models[], packages[] }` for scripting.

### 2. Skill — `.claude/skills/update-model-versions/SKILL.md`
Detect → **verify each candidate is a real same-tier successor** (genmedia CLI primary; fal-ai MCP if present; zero-auth fal HTTP fallback) → apply a per-class edit checklist → quality gates → one focused PR per upgrade. Key guardrail: change the model `id` + metadata, **never the registry key** (keys are persisted in the DB). Wires in `bun motion:codegen` for video and `bun scripts/update-fal-pricing.ts` for fal pricing.

### 3. Routine — `daily-model-version-check` (remote, daily 08:17 Australia/Sydney)
`trig_01G1EmXsFezC3MuDoEUxL7KG` — runs the detector + skill against `main`, opens one PR per verified upgrade (never merges). Created via the scheduling system; lives outside the repo.

## Sample run (today)
35 models + 4 packages checked → flagged: hailuo-02→2.3, grok-imagine-video→v1.5, claude-opus-4.6→4.8, glm-5→5.1, gpt-5.4→5.5, and three `@tanstack/ai*` patch bumps. Everything else current.

## Note
The routine checks out `main`, so it only becomes functional once this PR merges.

Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)