### PR TITLE
fix: namespace PR-preview Cloudflare Workflows per-PR

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -169,6 +169,19 @@ jobs:
               { bucket_name: 'openstory-public-assets', binding: 'R2_PUBLIC_ASSETS_BUCKET', remote: true },
               { binding: 'R2_STORAGE_BUCKET', bucket_name: 'openstory-storage-stg' }
             ];
+            // Cloudflare Workflows are account-global resources keyed by 'name'
+            // — NOT scoped per worker. Without this, a preview's workflow
+            // entries reuse production's names (image-workflow, …), so
+            // triggerWorkflow() -> binding.create() resolves to the shared,
+            // production-owned workflow (prod code + prod D1 + prod realtime
+            // DO) and a preview deploy can last-writer-wins re-point ownership
+            // onto the preview worker, breaking prod. Namespace the name per-PR
+            // (keep binding + class_name so TRIGGER_TO_BINDING still resolves)
+            // so each preview owns an isolated set. See issue #805.
+            obj.workflows = (obj.workflows || []).map((w) => ({
+              ...w,
+              name: \`\${w.name}-pr-${PR_NUMBER}\`,
+            }));
             // Tail-consume preview logs into the staging log forwarder
             // (workers/posthog-log-forwarder), which transforms our LogTape
             // JSON into proper OTLP log records and POSTs to PostHog. The
@@ -296,6 +309,47 @@ jobs:
             -H "Authorization: Bearer $CF_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workers/scripts/$WORKER_NAME")
           echo "Delete worker $WORKER_NAME response: $status"
+
+      - name: Delete preview workflows
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Workflows are account-global resources (see issue #805), so the
+          # preview's namespaced set (`<name>-pr-<n>`) survives the worker
+          # delete above. Sweep them by exact `-pr-<n>` suffix so the account
+          # doesn't accumulate orphaned `*-pr-<n>` workflow definitions.
+          SUFFIX="-pr-${PR_NUMBER}"
+          page=1
+          deleted=0
+          while :; do
+            resp=$(curl -sf \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workflows?per_page=100&page=$page") || {
+                echo "::warning::Failed to list workflows (page $page) — skipping workflow cleanup"
+                break
+              }
+
+            names=$(echo "$resp" | jq -r --arg sfx "$SUFFIX" '.result[]?.name | select(endswith($sfx))')
+
+            for name in $names; do
+              status=$(curl -sw '%{http_code}' -o /dev/null \
+                -X DELETE \
+                -H "Authorization: Bearer $CF_API_TOKEN" \
+                "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/workflows/$name")
+              echo "Delete workflow $name response: $status"
+              deleted=$((deleted + 1))
+            done
+
+            count=$(echo "$resp" | jq -r '.result | length')
+            total_pages=$(echo "$resp" | jq -r '.result_info.total_pages // 1')
+            if [ "$count" -eq 0 ] || [ "$page" -ge "$total_pages" ]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+          echo "Deleted $deleted preview workflow(s) with suffix $SUFFIX"
 
       - name: Delete D1 database
         env:


### PR DESCRIPTION
## Problem

Cloudflare Workflows are **account-global resources keyed by `name`** — not scoped per worker. The PR-preview deploy namespaces the worker (`pr-<n>`), D1 (`openstory-pr-<n>`), and R2, but left `workflows[].name` identical to production (`image-workflow`, …). The patch script never touched `obj.workflows`.

Consequences:
1. **Preview generations can't run the pipeline.** `triggerWorkflow()` → `binding.create()` resolved to the shared, production-owned workflow, executing prod code + prod bindings (prod D1, prod realtime DO) — so the preview page saw no progress.
2. **Latent prod risk.** Previews declared `class_name` for prod-owned names without a `script_name`, so a preview deploy could (last-writer-wins) re-point workflow ownership onto the preview worker and break production.

## Fix

In `.github/workflows/deploy-cloudflare.yml`:

- **Namespace workflow names per-PR** in the "Patch wrangler config for preview" step — rewrite each entry's `name` to `<name>-pr-<n>`, keeping `binding` + `class_name` unchanged so the code's `TRIGGER_TO_BINDING` mapping (keyed on binding, not name) still resolves. Each preview now owns an isolated set (`image-workflow-pr-123`, …).
- **Clean up on PR close** — new "Delete preview workflows" step in `cleanup-preview` lists account workflows (paginated) and `DELETE`s every name ending in the exact `-pr-<n>` suffix, so closed PRs don't leave orphaned `*-pr-<n>` definitions accumulating. Best-effort: a list failure warns rather than failing the job; the exact-suffix match avoids touching other PRs (`-pr-12` ≠ `-pr-123`).

## Acceptance criteria

- [x] Preview workflow names namespaced per-PR; bindings + `class_name` unchanged so `triggerWorkflow()` still resolves.
- [x] Production workflows stay owned by `openstory` — previews declare uniquely-named workflows, so no re-pointing of prod names.
- [x] `cleanup-preview` deletes the per-PR workflows on close.
- [ ] Verify a preview generation runs end-to-end against the preview's own D1 and streams progress — only exercisable once this branch deploys a preview; watch the first preview deploy's logs (also unblocks validating #802 realtime on previews).
- [ ] Sanity-check Workflows account limits: each open PR adds ~30 workflow definitions. Cleanup prevents cross-PR accumulation, but confirm the account limit covers ~30 × max concurrent open PRs.

## Validation

- Verified the inline `node -e` template-literal shell-escaping produces correct output (`image-workflow-pr-123`, etc.) with bindings/class_names preserved.
- Confirmed the Cloudflare REST endpoints used (`GET`/`DELETE /accounts/{id}/workflows[/{name}]`).
- YAML parses cleanly; no `pull_request_target` introduced. `PR_NUMBER` is a GitHub-controlled integer passed via `env:`.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)