### PR TITLE
fix(images): route previews through Cloudflare Image Transformations via AppImage

### DIFF
--- a/src/components/eval/eval-cell-dialog.tsx
+++ b/src/components/eval/eval-cell-dialog.tsx
@@ -19,7 +19,7 @@ import type { Frame } from '@/types/database';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { stripMarkdown } from '@/lib/utils/markdown-plain';
 import { Clapperboard, FileTextIcon, ImageIcon, TextIcon } from 'lucide-react';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import type React from 'react';
 import { useEffect, useState } from 'react';
 import {
@@ -243,7 +243,7 @@ export const EvalCellDialog: React.FC<EvalCellDialogProps> = ({
               </div>
             ) : (
               <div className="flex justify-center items-center h-full">
-                <Image
+                <AppImage
                   src={frame.thumbnailUrl}
                   alt={`Scene ${sceneNumber}`}
                   className="max-w-full max-h-full object-contain rounded-lg"
@@ -259,7 +259,7 @@ export const EvalCellDialog: React.FC<EvalCellDialogProps> = ({
               frame.thumbnailUrl ? (
                 <div className="flex justify-center items-center h-full w-full">
                   <div className="relative w-full max-w-4xl">
-                    <Image
+                    <AppImage
                       src={frame.thumbnailUrl}
                       alt={`Scene ${sceneNumber} preview`}
                       className="w-full h-auto object-contain rounded-lg opacity-60"

--- a/src/components/eval/eval-scene-cell.tsx
+++ b/src/components/eval/eval-scene-cell.tsx
@@ -3,7 +3,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import type { Frame } from '@/types/database';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { stripMarkdown } from '@/lib/utils/markdown-plain';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import type React from 'react';
 import { EvalCellDialog, type DialogTab } from './eval-cell-dialog';
 import type { ViewMode } from './eval-view';
@@ -121,13 +121,13 @@ export const EvalSceneCell: React.FC<EvalSceneCellProps> = ({
           onClick={handleClick}
         >
           <div className="flex-1 flex items-center justify-center min-h-0">
-            <Image
+            <AppImage
               src={frame.thumbnailUrl}
               alt={`Scene ${sceneNumber}`}
               className="max-w-full max-h-full object-contain rounded-md"
               loading="lazy"
-              width={1000}
-              height={1000}
+              width={400}
+              height={400}
             />
           </div>
         </button>
@@ -202,13 +202,13 @@ export const EvalSceneCell: React.FC<EvalSceneCellProps> = ({
               onClick={handleClick}
             >
               <div className="relative flex-1 flex items-center justify-center min-h-0">
-                <Image
+                <AppImage
                   src={frame.thumbnailUrl}
                   alt={`Scene ${sceneNumber} preview`}
                   className="max-w-full max-h-full object-contain rounded-md opacity-60"
                   loading="lazy"
-                  width={1000}
-                  height={1000}
+                  width={400}
+                  height={400}
                 />
                 <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                   <span className="text-xs font-medium text-foreground bg-background/80 backdrop-blur-sm px-2 py-1 rounded-md border">

--- a/src/components/eval/eval-sequence-row.tsx
+++ b/src/components/eval/eval-sequence-row.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import { EvalSequenceMetadata } from './eval-sequence-metadata';
 import { EvalSceneCell } from './eval-scene-cell';
 import type { DialogTab } from './eval-cell-dialog';
@@ -67,13 +67,13 @@ export const EvalSequenceRow: React.FC<EvalSequenceRowProps> = ({
             aria-label={`Play ${sequence.title || 'sequence'} in theatre`}
             className="w-full h-full flex items-center justify-center cursor-pointer appearance-none bg-transparent border-0 p-0"
           >
-            <Image
+            <AppImage
               src={previewUrl}
               alt={`${sequence.title || 'Sequence'} preview`}
               className="max-w-full max-h-full object-contain rounded-md"
               loading="lazy"
-              width={1000}
-              height={1000}
+              width={400}
+              height={400}
             />
           </button>
         ) : (

--- a/src/components/eval/eval-sequences-mobile.tsx
+++ b/src/components/eval/eval-sequences-mobile.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { useMemo, useState } from 'react';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { EvalSceneCell } from './eval-scene-cell';
@@ -294,13 +294,13 @@ const SequencePosterCell: React.FC<SequencePosterCellProps> = ({
   if (previewUrl) {
     return (
       <Link {...linkProps} className={baseClass} style={style}>
-        <Image
+        <AppImage
           src={previewUrl}
           alt={`${sequence.title || 'Sequence'} poster`}
           className="w-full h-full object-cover"
           loading="lazy"
-          width={1000}
-          height={1000}
+          width={400}
+          height={400}
         />
         {modelBadge}
       </Link>

--- a/src/components/marketing/site-footer.tsx
+++ b/src/components/marketing/site-footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import { Button } from '@/components/ui/button';
 import { OpenStoryLogo } from '@/components/icons/openstory-logo';
 import { XIcon } from '@/components/icons/x-icon';
@@ -50,7 +50,7 @@ export function SiteFooter() {
           style={{ animation: 'marquee 45s linear infinite' }}
         >
           {duplicatedFilmstrip.map(({ src, id }) => (
-            <Image
+            <AppImage
               key={id}
               src={src}
               alt=""

--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/lib/constants/aspect-ratios';
 import { cn } from '@/lib/utils';
 import type { Frame } from '@/types/database';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import {
   AlertCircle,
   Download,
@@ -179,7 +179,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
           >
             {posterUrl ? (
               <>
-                <Image
+                <AppImage
                   src={posterUrl}
                   alt=""
                   width={imageDimensions.width}
@@ -216,7 +216,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
               getAspectRatioClassName(aspectRatio)
             )}
           >
-            <Image
+            <AppImage
               src={posterUrl}
               alt=""
               width={imageDimensions.width}
@@ -305,7 +305,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
               rel="noopener noreferrer"
               className="block w-full h-full"
             >
-              <Image
+              <AppImage
                 src={displayImage}
                 alt={title || 'Scene thumbnail'}
                 className="w-full h-full object-cover"

--- a/src/components/scenes/scene-thumbnail.tsx
+++ b/src/components/scenes/scene-thumbnail.tsx
@@ -6,7 +6,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import { AlertCircle } from 'lucide-react';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import { memo } from 'react';
 
 type SceneThumbnailProps = {
@@ -53,7 +53,7 @@ const SceneThumbnailComponent: React.FC<SceneThumbnailProps> = ({
       )}
 
       {displayUrl && (
-        <Image
+        <AppImage
           src={displayUrl}
           alt={alt}
           className="h-full w-full object-cover"

--- a/src/components/style/style-grid.tsx
+++ b/src/components/style/style-grid.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 import type { Style } from '@/types/database';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import type { FC, KeyboardEvent } from 'react';
 import { useCallback, useRef, useEffect, useState } from 'react';
 import { getStyleGradient } from './style-gradient';
@@ -86,7 +86,7 @@ const StyleCard: FC<StyleCardProps> = ({
       <CardContent className="p-0">
         <div className="relative aspect-square overflow-hidden rounded-t-lg bg-muted">
           {style.previewUrl && !imgError ? (
-            <Image
+            <AppImage
               src={style.previewUrl}
               alt={`${style.name} style preview`}
               layout="fullWidth"

--- a/src/components/style/style-selector-button.tsx
+++ b/src/components/style/style-selector-button.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@/components/ui/button';
 import type { Style } from '@/types/database';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import { ChevronDown } from 'lucide-react';
 import { useState, type FC } from 'react';
 import { getStyleGradient } from './style-gradient';
@@ -56,7 +56,7 @@ export const StyleSelectorButton: FC<StyleSelectorButtonProps> = ({
       {selectedStyle && (
         <>
           {showImage ? (
-            <Image
+            <AppImage
               key={selectedStyle.id}
               src={previewUrl}
               layout="fullWidth"

--- a/src/components/style/style-selector.tsx
+++ b/src/components/style/style-selector.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from '@/components/ui/skeleton';
 import type { Style } from '@/lib/db/schema/libraries';
 import { cn } from '@/lib/utils';
-import { Image } from '@unpic/react';
+import { AppImage } from '@/components/ui/app-image';
 import { MoreHorizontal } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getStyleGradient } from './style-gradient';
@@ -11,7 +11,7 @@ const StyleTileBackground: React.FC<{ style: Style }> = ({ style }) => {
   const [imgError, setImgError] = useState(false);
 
   return style.previewUrl && !imgError ? (
-    <Image
+    <AppImage
       key={style.id}
       src={style.previewUrl}
       layout="fullWidth"

--- a/src/components/ui/app-image.test.tsx
+++ b/src/components/ui/app-image.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { AppImage, isTransformableUrl } from './app-image';
+
+const REMOTE_SRC = 'https://assets.openstory.so/sequences/abc/frame-1.png';
+
+function renderImg(src: string) {
+  return renderToStaticMarkup(
+    <AppImage src={src} alt="" width={400} height={400} />
+  );
+}
+
+describe('isTransformableUrl', () => {
+  it('accepts same-zone https URLs', () => {
+    expect(isTransformableUrl(REMOTE_SRC)).toBe(true);
+    expect(isTransformableUrl('https://openstory.so/logo.png')).toBe(true);
+  });
+
+  it('rejects cross-origin sources — zone has any-origin resizing OFF (403)', () => {
+    expect(isTransformableUrl('https://fal.media/files/abc/out.jpeg')).toBe(
+      false
+    );
+    // suffix must be a label boundary, not a substring match
+    expect(isTransformableUrl('https://evilopenstory.so/img.png')).toBe(false);
+  });
+
+  it('rejects local dev/e2e hosts', () => {
+    expect(isTransformableUrl('http://localhost:4011/fixtures/img.png')).toBe(
+      false
+    );
+    expect(isTransformableUrl('http://127.0.0.1:3000/img.png')).toBe(false);
+  });
+
+  it('rejects relative paths and non-http schemes', () => {
+    expect(isTransformableUrl('/images/marketing/og.jpg')).toBe(false);
+    expect(isTransformableUrl('data:image/png;base64,AAAA')).toBe(false);
+    expect(isTransformableUrl('blob:https://openstory.so/some-id')).toBe(false);
+  });
+});
+
+describe('AppImage', () => {
+  it('routes remote images through Cloudflare Image Transformations', () => {
+    const html = renderImg(REMOTE_SRC);
+
+    // Transform URL shape: https://<zone-host>/cdn-cgi/image/<ops>/<source>
+    expect(html).toContain('/cdn-cgi/image/');
+    expect(html).toContain(REMOTE_SRC);
+    // Graceful fallback to the original if the transform fails
+    expect(html).toContain('onerror=redirect');
+    // Bound inside the box without cropping — preserves source aspect ratio
+    // (the provider default fit=cover would crop to a 400×400 square)
+    expect(html).toContain('fit=scale-down');
+    expect(html).not.toContain('fit=cover');
+    // Responsive srcset so the browser downloads sized, not original, bytes
+    expect(html).toMatch(/srcset=/i);
+    expect(html).toContain('width=400');
+    // unstyled: no injected inline styles — Tailwind classes at the call
+    // sites control layout (object-contain/cover, max-w/h), as they did
+    // before the CDN wrapper existed
+    expect(html).not.toContain('style=');
+  });
+
+  it('leaves fal.media originals untransformed (any-origin resizing is off)', () => {
+    const src = 'https://fal.media/files/abc/out.jpeg';
+    const html = renderImg(src);
+    expect(html).toContain(`src="${src}"`);
+    expect(html).not.toContain('/cdn-cgi/image/');
+  });
+
+  it('falls back to a plain img for local URLs', () => {
+    const src = 'http://localhost:4011/fixtures/img.png';
+    const html = renderImg(src);
+    expect(html).toContain(`src="${src}"`);
+    expect(html).not.toContain('/cdn-cgi/image/');
+  });
+
+  it('falls back to a plain img for data URIs', () => {
+    const src = 'data:image/png;base64,AAAA';
+    const html = renderImg(src);
+    expect(html).toContain('src="data:image/png;base64,AAAA"');
+    expect(html).not.toContain('/cdn-cgi/image/');
+  });
+});

--- a/src/components/ui/app-image.tsx
+++ b/src/components/ui/app-image.tsx
@@ -1,0 +1,89 @@
+import { Image, type ImageProps } from '@unpic/react';
+
+/**
+ * Cloudflare zone hostname used for URL-based image transformations
+ * (`https://<domain>/cdn-cgi/image/<ops>/<source-url>`). Any hostname on the
+ * openstory.so zone works; the assets domain is the one `bun setup` reminds
+ * you to enable Image Transformations for, and it resolves in every
+ * environment (dev, PR previews, prod).
+ */
+const TRANSFORM_DOMAIN =
+  import.meta.env.VITE_R2_PUBLIC_ASSETS_DOMAIN || 'assets.openstory.so';
+
+/**
+ * The Cloudflare zone (registrable domain) the transform endpoint lives on,
+ * derived from the assets domain (`assets.openstory.so` → `openstory.so`).
+ *
+ * The zone's "Resize images from any origin" option is OFF: transforming a
+ * source outside the zone returns a hard 403 — `onerror=redirect` does NOT
+ * rescue that case — so only same-zone sources may be transformed. If the
+ * option is ever enabled, this guard can be relaxed to any remote URL
+ * (e.g. fal.media originals).
+ */
+const TRANSFORM_ZONE = TRANSFORM_DOMAIN.split('.').slice(-2).join('.');
+
+/**
+ * True when `src` is an image Cloudflare's edge is allowed to fetch and
+ * transform — i.e. an absolute URL on the transform zone. Relative paths,
+ * `data:`/`blob:` URIs, local dev/e2e hosts, and cross-origin sources
+ * (fal.media) fall back to a plain `<img>`.
+ */
+export function isTransformableUrl(src: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(src);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return false;
+  }
+  return (
+    url.hostname === TRANSFORM_ZONE ||
+    url.hostname.endsWith(`.${TRANSFORM_ZONE}`)
+  );
+}
+
+/**
+ * Drop-in replacement for `@unpic/react`'s `<Image>` that routes same-zone
+ * remote images through Cloudflare Image Transformations, so the browser
+ * downloads resized, format-negotiated bytes (with a responsive `srcset`)
+ * instead of the full-resolution original. `onerror=redirect` makes
+ * Cloudflare serve the original URL if a transform fails (e.g. the source
+ * 404s or can't be decoded).
+ *
+ * Use this instead of importing `Image` from `@unpic/react` directly.
+ */
+export const AppImage: React.FC<ImageProps> = (props) => {
+  if (typeof props.src !== 'string' || !isTransformableUrl(props.src)) {
+    return <Image {...props} />;
+  }
+
+  return (
+    <Image
+      // Without `cdn`, unpic passes props straight through (no inline styles),
+      // so call sites size images with Tailwind classes. Keep it that way:
+      // unpic's injected styles (object-fit:cover, aspect-ratio, width:100%)
+      // would override those classes.
+      unstyled
+      {...props}
+      cdn="cloudflare"
+      options={{
+        ...props.options,
+        cloudflare: { domain: TRANSFORM_DOMAIN, ...props.options?.cloudflare },
+      }}
+      operations={{
+        ...props.operations,
+        cloudflare: {
+          // unpic's provider default is fit=cover, which would crop the
+          // source to the width×height box. scale-down bounds it inside the
+          // box instead, preserving the source aspect ratio and never
+          // upscaling.
+          fit: 'scale-down',
+          onerror: 'redirect',
+          ...props.operations?.cloudflare,
+        },
+      }}
+    />
+  );
+};


### PR DESCRIPTION
## Problem

Every `<Image>` usage imported from `@unpic/react` without a `cdn` prop. unpic short-circuits in that case (`if (!cdn) return props`), so the browser fetched full-resolution originals — 6 MB+ for thumbnails rendered at 200–400 px (issue #810).

## Fix

New `AppImage` wrapper (`src/components/ui/app-image.tsx`) — a drop-in replacement for unpic's `<Image>` that routes same-zone images through Cloudflare Image Transformations:

```
https://assets.openstory.so/cdn-cgi/image/fit=scale-down,onerror=redirect,width=400,height=400,f=auto/<source-url>
```

- **`cdn="cloudflare"`** with `VITE_R2_PUBLIC_ASSETS_DOMAIN` (fallback `assets.openstory.so`) as the transform zone — absolute URLs, so transforms work identically in dev, PR previews, and prod
- **`fit=scale-down`** — the provider default `fit=cover` cropped sources to the width×height box, squashing 9:16 previews into squares
- **`onerror=redirect`** — graceful fallback to the original if a transform fails. Note: this is *not* an unpic provider default (the issue assumed it was); it's passed explicitly
- **`unstyled`** — without `cdn`, unpic injected no inline styles, so all call sites size images with Tailwind classes. unpic's injected styles (`object-fit:cover`, `aspect-ratio`, `width:100%`) silently overrode those classes and broke the eval matrix layout
- **Same-zone guard** — "Resize images from any origin" is **off** on the zone: cross-origin sources return a hard 403 that `onerror=redirect` does **not** rescue. Only `*.openstory.so` sources are transformed; fal.media originals fall back to a plain `<img>` (guard documented inline for when the toggle is enabled)

All 10 `<Image>` call sites now use `AppImage`, and the `width={1000}` hints on 200–400 px thumbnails are now `width={400}` (srcset tops out at 800w instead of 2000w).

## Verification

- Live edge probes: 107 KB original → **1.2 KB** at width=100; `f=auto` negotiates WebP; `scale-down` preserves aspect (400×210 vs 400×400 crop); missing source → 307 redirect to original
- New tests (`app-image.test.tsx`, 8 cases) render to static markup and assert the transform URL shape, `fit=scale-down`, `onerror=redirect`, no injected inline styles, and all fallback paths (fal.media, localhost, `data:`, relative)
- `bun run test` 1038 passed · `bun typecheck` clean · `bun lint` 0 errors
- Verified visually in the eval matrix (desktop + mobile) — aspect ratios and layout match pre-change rendering

Closes #810

🤖 Generated with [Claude Code](https://claude.com/claude-code)