### PR TITLE
fix(workflows): propagate sequence image model to location sheets and recasts

### DIFF
--- a/src/functions/sequence-characters.ts
+++ b/src/functions/sequence-characters.ts
@@ -7,6 +7,7 @@ import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 
+import { safeTextToImageModel } from '@/lib/ai/models';
 import { StyleConfigSchema } from '@/lib/db/schema';
 import { buildCastingAttributes } from '@/lib/prompts/character-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
@@ -165,6 +166,7 @@ export const recastCharacterFn = createServerFn({ method: 'POST' })
       talentMetadata: defaultSheet?.metadata ?? undefined,
       talentDescription:
         `This character must look exactly like ${talentWithSheets.name}. ${talentWithSheets.description ?? ''}`.trim(),
+      imageModel: safeTextToImageModel(sequence.imageModel),
       affectedFrameIds,
       styleConfig,
     };

--- a/src/functions/sequence-locations.ts
+++ b/src/functions/sequence-locations.ts
@@ -1,3 +1,4 @@
+import { safeTextToImageModel } from '@/lib/ai/models';
 import { type SequenceLocation, StyleConfigSchema } from '@/lib/db/schema';
 import { getGenerationChannel } from '@/lib/realtime';
 import { triggerWorkflow } from '@/lib/workflow/client';
@@ -132,6 +133,7 @@ export const recastLocationFn = createServerFn({ method: 'POST' })
         userId: context.user.id,
         referenceImageUrl: data.referenceImageUrl,
         libraryLocationDescription: data.description,
+        imageModel: safeTextToImageModel(sequence.imageModel),
         affectedFrameIds,
         styleConfig,
       } satisfies RecastLocationWorkflowInput,

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -380,6 +380,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
             teamId: input.teamId,
             locationBible,
             libraryLocationMatches,
+            imageModel,
             styleConfig,
           },
           spawnStepName: 'spawn-location-bible',


### PR DESCRIPTION
## Problem

Selecting an image model on a sequence (e.g. Flux 2 Max) was not honoured by location sheets or recasts — they always generated with `DEFAULT_IMAGE_MODEL` (`nano_banana_2`). Surfaced when the fal queue for `fal-ai/nano-banana-2` was ~8,800 jobs deep: location-sheet workflows looped 10-minute step timeouts indefinitely regardless of the selected model, while frame images (which do respect the selection) completed fine.

## Root cause

Three trigger sites omitted `imageModel` from the workflow payload, so the workflows fell back to `input.imageModel ?? DEFAULT_IMAGE_MODEL`:

1. **`analyze-script-workflow.ts`** — the character-bible child payload included `imageModel`, but the location-bible payload did not (asymmetric fan-out)
2. **`recastLocationFn`** (`sequence-locations.ts`) — loaded the sequence for `styleConfig` but didn't pass `sequence.imageModel`
3. **`recastCharacterFn`** (`sequence-characters.ts`) — same omission

The downstream chain needed no changes: `LocationBibleWorkflow` already forwards `input.imageModel` to each location-sheet child, and both recast workflows forward it to their sheet children — the value just never arrived.

## Fix

- Add `imageModel` (already in scope) to the location-bible `childPayload`
- Pass `safeTextToImageModel(sequence.imageModel)` in both recast functions (validated cast with fallback to default for null/invalid DB values)

Audited the remaining sheet-trigger sites: the library-sheet paths (`/library-location-sheet`, `/library-talent-sheet`) are team-library scoped with no sequence model to honour — correctly out of scope.

## Verification

- `bun run test` — 1084 passed · `bun typecheck` clean · `bun lint` 0 errors
- Local: create a sequence with a non-default model (or recast a location) — the location-sheet instance's `build-prompt` step output in the workflow explorer now shows the selected model instead of `nano_banana_2`

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)