### PR TITLE
Auto-generate element reference images for recurring products/objects when none supplied

### DIFF
--- a/src/lib/ai/response-schemas.ts
+++ b/src/lib/ai/response-schemas.ts
@@ -83,7 +83,7 @@ export const sceneSplittingResultSchema = z.object({
   }),
   elementBible: z.array(elementBibleEntrySchema).meta({
     description:
-      'User-uploaded elements referenced in the script by UPPERCASE token',
+      'Elements referenced in the script by UPPERCASE token — user-uploaded reference images plus detected recurring products/objects that need a consistent canonical look',
   }),
 });
 

--- a/src/lib/ai/scene-analysis.schema.ts
+++ b/src/lib/ai/scene-analysis.schema.ts
@@ -61,7 +61,8 @@ export const characterBibleEntrySchema = z.object({
 });
 
 // ============================================================================
-// Element Bible Schemas (user-uploaded reference images)
+// Element Bible Schemas (user-uploaded reference images + detected recurring
+// products/objects that get an auto-generated reference image)
 // ============================================================================
 
 export const elementBibleEntrySchema = z.object({
@@ -603,7 +604,7 @@ export const sceneAnalysisSchema = z.object({
     .meta({ description: 'Location descriptions for visual consistency' }),
   elementBible: z.array(elementBibleEntrySchema).optional().meta({
     description:
-      'User-uploaded element descriptions (logos, products) with UPPERCASE script tokens',
+      'Element descriptions (logos, products, recurring objects) with UPPERCASE script tokens — user-uploaded or detected recurring products',
   }),
   scenes: z
     .array(sceneSchema)

--- a/src/lib/prompts/element-prompt.test.ts
+++ b/src/lib/prompts/element-prompt.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+import type { ElementBibleEntry } from '@/lib/ai/scene-analysis.schema';
+import type { StyleConfig } from '@/lib/db/schema';
+import {
+  buildElementDescription,
+  buildElementSheetPrompt,
+} from './element-prompt';
+
+const entry: ElementBibleEntry = {
+  token: 'CORAL_LIPSTICK',
+  description:
+    'A slim cylindrical lipstick in a matte white case with a coral accent band, the bullet a creamy warm coral with a flat sheen',
+  consistencyTag: 'coral-lipstick-white-case',
+  firstMention: {
+    sceneId: 'scene_1',
+    text: 'She lifts a matte white box, fingers tracing the coral accent.',
+    lineNumber: 5,
+  },
+};
+
+const styleConfig: StyleConfig = {
+  mood: 'sun-drenched optimism',
+  artStyle: 'cinematic photorealism',
+  lighting: 'warm golden-hour natural light',
+  colorPalette: ['coral', 'sand', 'sea foam'],
+  cameraWork: 'handheld intimate',
+  referenceFilms: ['Call Me by Your Name'],
+  colorGrading: 'warm highlights, soft teal shadows',
+};
+
+describe('buildElementSheetPrompt', () => {
+  test('embeds the bible description and consistency tag', () => {
+    const prompt = buildElementSheetPrompt(entry);
+
+    expect(prompt).toContain(entry.description);
+    expect(prompt).toContain(entry.consistencyTag);
+  });
+
+  test('defaults to a neutral studio look without a style config', () => {
+    const prompt = buildElementSheetPrompt(entry);
+
+    expect(prompt).toContain('commercial photo studio cyclorama');
+    expect(prompt).toContain('5500K daylight balance');
+  });
+
+  test('applies the sequence style when provided', () => {
+    const prompt = buildElementSheetPrompt(entry, styleConfig);
+
+    expect(prompt).toContain('cinematic photorealism');
+    expect(prompt).toContain('coral, sand, sea foam');
+    expect(prompt).toContain('warm golden-hour natural light');
+    expect(prompt).toContain('warm highlights, soft teal shadows');
+    expect(prompt).not.toContain('5500K daylight balance');
+  });
+
+  test('keeps people and props out of the reference shot', () => {
+    const prompt = buildElementSheetPrompt(entry, styleConfig);
+
+    expect(prompt).toContain('No hands, no people, no props');
+  });
+});
+
+describe('buildElementDescription', () => {
+  test('prefixes token and trims description to its first clause', () => {
+    const result = buildElementDescription({
+      id: 'el_1',
+      token: 'CORAL_LIPSTICK',
+      description: entry.description,
+      imageUrl: 'https://example.com/el.png',
+      consistencyTag: entry.consistencyTag,
+    });
+
+    expect(result).toBe(
+      'CORAL_LIPSTICK - A slim cylindrical lipstick in a matte white case with a coral accent band'
+    );
+  });
+});

--- a/src/lib/prompts/element-prompt.ts
+++ b/src/lib/prompts/element-prompt.ts
@@ -3,10 +3,12 @@
  *
  * Builds reference-image descriptors for user-uploaded sequence elements
  * (logos, products, screenshots) that are referenced by UPPERCASE token in
- * the script.
+ * the script, and the generation prompt for auto-generated element reference
+ * images (recurring products detected during scene split with no upload).
  */
 
-import type { SequenceElementMinimal } from '@/lib/db/schema';
+import type { ElementBibleEntry } from '@/lib/ai/scene-analysis.schema';
+import type { SequenceElementMinimal, StyleConfig } from '@/lib/db/schema';
 import type { ReferenceImageDescription } from './reference-image-prompt';
 
 /**
@@ -36,4 +38,48 @@ export function buildElementReferenceImages(
       description: buildElementDescription(el),
       role: 'element' as const,
     }));
+}
+
+/**
+ * Build the generation prompt for an auto-generated element reference image.
+ *
+ * Mirrors the spirit of `buildCharacterSheetPrompt`: a clean, canonical
+ * reference shot whose only job is to pin down the element's visual identity
+ * so downstream frame generation can paste it in consistently. The bible
+ * entry's description (authored by the scene-split LLM) carries the identity;
+ * the style config (when present) keeps rendering and palette consistent with
+ * the sequence so the reference doesn't fight the frames that consume it.
+ */
+export function buildElementSheetPrompt(
+  entry: ElementBibleEntry,
+  styleConfig?: StyleConfig
+): string {
+  const styled = styleConfig
+    ? {
+        environment: `Render in ${styleConfig.artStyle} style. Background: clean, seamless studio backdrop with no environmental detail — simple flat or gradient tone drawn from the style's color palette: ${styleConfig.colorPalette.join(', ')}. Color grading: ${styleConfig.colorGrading}.`,
+        lighting: `${styleConfig.lighting}. Even, controlled illumination that reveals true colors, materials, and surface finish.`,
+      }
+    : {
+        environment:
+          'Seamless, minimalist commercial photo studio cyclorama with flat neutral background. Clean, sterile, analytical atmosphere designed for clarity.',
+        lighting:
+          'Neutral, even, high-key studio lighting. Diffused illumination from large softboxes to eliminate harsh shadows and reveal true colors, materials, and surface finish. 5500K daylight balance.',
+      };
+
+  return `A professional product reference photograph establishing the canonical look of a recurring object (${entry.consistencyTag}).
+
+[SUBJECT]:
+${entry.description}
+
+[FRAMING]:
+The object is the sole subject, centered, shown three-quarter angle at a scale that fills most of the frame. Every defining detail — shape, proportions, materials, colors, finish, and any text or branding on the object — must be clearly legible. No hands, no people, no props, no packaging unless it is part of the object itself.
+
+[ENVIRONMENT]:
+${styled.environment}
+
+[LIGHTING]:
+${styled.lighting}
+
+[MATERIALITY]:
+Hyper-accurate rendering of all surfaces, textures, and micro-details. Tack-sharp focus across the entire object, deep depth of field, no lens distortion. This image is the single source of truth for the object's appearance.`.trim();
 }

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -747,19 +747,29 @@ Notes:
 - Extract the core location name without time-of-day suffixes
 - Describe the location in its most commonly seen state
 
-## Element Bible (user-uploaded reference images)
+## Element Bible (recurring products & objects)
 
-The user may have uploaded reference images ("elements") that should appear in scenes. Each element has an UPPERCASE token and (optionally) a visual description. Elements are typically logos, product shots, screenshots, or other visual assets.
+Elements are recurring visual assets — logos, product shots, screenshots, hero props — that must look IDENTICAL every time they appear. Each element has an UPPERCASE token. There are two sources:
 
-For EACH uploaded element you see used in the script (check the <ELEMENTS> block for the canonical list), produce an elementBible entry with:
+**1. User-uploaded elements (check the <ELEMENTS> block for the canonical list).** For EACH uploaded element you see used in the script, produce an elementBible entry with:
 - token: the exact UPPERCASE token from <ELEMENTS>
 - description: the provided description, or a 1-sentence visual description if none was provided
 - consistencyTag: a short lowercase slug (e.g. "red-hex-brand-logo")
 - firstMention: { sceneId, text, lineNumber } — the first scene where the token appears
 
-For EACH scene that references an element, set continuity.elementTags[] to an array of the UPPERCASE tokens used in that scene.
+**2. Detected recurring products/objects (no upload).** If the script centres on a specific product or object that appears in MULTIPLE scenes and must read as the SAME physical item every time (a hero product in an ad, a branded bottle, a signature prop), ALSO produce an elementBible entry for it:
+- token: a NEW short UPPERCASE_SNAKE_CASE token you invent (1-3 words, max 30 chars). Prefer brand/product names from the script (e.g. "CORAL_LIPSTICK"); never collide with a token from <ELEMENTS>.
+- description: a COMPLETE 60-120 word visual specification you design — exact shape, proportions, materials, colors, finish, any text/branding visible on it. Be decisive and specific: this description is used to generate the canonical reference image, so invent concrete details where the script is vague.
+- consistencyTag + firstMention: as above.
 
-Preserve UPPERCASE tokens verbatim in originalScript.extract — do NOT lowercase them. If a script references an element token that is NOT in the <ELEMENTS> block, ignore it (do not invent elementBible entries).`,
+Detection criteria — be conservative:
+- ONLY a product/object that is a visual centerpiece in 2+ scenes. Detect at most 3.
+- Do NOT create entries for incidental props, set dressing, vehicles in passing, food, generic scenery, clothing a character wears, characters, or locations (those belong in the other bibles).
+- A user-uploaded element that covers the same object always wins — do not emit a duplicate detected entry for it.
+
+For EACH scene that shows an element (uploaded OR detected), set continuity.elementTags[] to an array of the UPPERCASE tokens visible in that scene.
+
+Preserve UPPERCASE tokens verbatim in originalScript.extract — do NOT lowercase them. Scripts may reference uploaded elements by token; for detected elements the script uses prose ("the lipstick") — do NOT rewrite the script text, only tag the scene in elementTags[]. If a script references an UPPERCASE token that is NOT in <ELEMENTS> and does not meet the detection criteria above, ignore it.`,
     },
     {
       role: 'user',

--- a/src/lib/workflow/trigger-bindings.ts
+++ b/src/lib/workflow/trigger-bindings.ts
@@ -17,6 +17,7 @@ import { buildInstanceId } from '@/lib/workflow/instance-id';
 const TRIGGER_TO_BINDING: Record<string, keyof CloudflareEnv> = {
   image: 'IMAGE_WORKFLOW',
   'element-vision': 'ELEMENT_VISION_WORKFLOW',
+  'element-sheet': 'ELEMENT_SHEET_WORKFLOW',
   music: 'MUSIC_WORKFLOW',
   motion: 'MOTION_WORKFLOW',
   'motion-batch': 'MOTION_BATCH_WORKFLOW',

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -197,6 +197,27 @@ export type SceneSplitWorkflowResult = {
 };
 
 /**
+ * Element sheet workflow input — generates a canonical reference image for
+ * each element-bible entry that has no user-uploaded reference (recurring
+ * products/objects detected during scene split) and ingests them as
+ * `sequence_elements` rows so frame generation can attach them.
+ */
+export interface ElementSheetWorkflowInput extends UserWorkflowContext {
+  sequenceId: string;
+  /** Element bible entries with no matching uploaded element */
+  entries: ElementBibleEntry[];
+  /** Image model to use (defaults to DEFAULT_IMAGE_MODEL) */
+  imageModel?: TextToImageModel;
+  /** Sequence style config to keep references on-style */
+  styleConfig?: StyleConfig;
+}
+
+export interface ElementSheetWorkflowResult {
+  /** Successfully generated + ingested elements (failed entries are skipped) */
+  elements: SequenceElementMinimal[];
+}
+
+/**
  * Motion generation workflow input
  */
 export interface MotionWorkflowInput extends SequenceWorkflowContext {
@@ -944,6 +965,7 @@ export interface ReplaceElementWorkflowResult {
 export type CloudflareEnv = Cloudflare.Env & {
   IMAGE_WORKFLOW?: Workflow<unknown>;
   ELEMENT_VISION_WORKFLOW?: Workflow<unknown>;
+  ELEMENT_SHEET_WORKFLOW?: Workflow<unknown>;
   MUSIC_WORKFLOW?: Workflow<unknown>;
   MOTION_WORKFLOW?: Workflow<unknown>;
   MOTION_BATCH_WORKFLOW?: Workflow<unknown>;

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -213,7 +213,7 @@ export interface ElementSheetWorkflowInput extends UserWorkflowContext {
 }
 
 export interface ElementSheetWorkflowResult {
-  /** Successfully generated + ingested elements (failed entries are skipped) */
+  /** Generated + ingested elements — the run fails if any entry failed */
   elements: SequenceElementMinimal[];
 }
 

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -44,6 +44,8 @@ import type {
   AnalyzeScriptWorkflowInput,
   BatchMotionMusicWorkflowInput,
   CharacterBibleWorkflowInput,
+  ElementSheetWorkflowInput,
+  ElementSheetWorkflowResult,
   FrameImagesWorkflowInput,
   FrameImagesWorkflowResult,
   LocationBibleWorkflowInput,
@@ -57,6 +59,7 @@ import type {
   TalentMatchingWorkflowOutput,
   VisualPromptWorkflowInput,
 } from '@/lib/workflow/types';
+import { findMissingElementEntries } from '@/lib/workflows/element-sheet-workflow';
 import {
   matchCharactersToScene,
   matchElementsToScene,
@@ -69,6 +72,7 @@ import {
 import { waitForElementVision } from '@/lib/workflows/wait-for-sheets';
 import type {
   CharacterMinimal,
+  SequenceElementMinimal,
   SequenceLocationMinimal,
 } from '@/lib/db/schema';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
@@ -336,7 +340,57 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
       );
     }
 
-    const [charSettled, locationSettled, visualSettled] =
+    // #835: element-bible entries the scene-split LLM detected (recurring
+    // products/objects) that have no uploaded element row need an
+    // auto-generated reference image, mirroring the character-sheet
+    // treatment. Runs in parallel with the other phase-3 children — visual
+    // prompts only consume the bible text, and the generated references are
+    // merged into `elementsMinimal` before phase 4 attaches them to frames.
+    const missingElementEntries = sequenceId
+      ? findMissingElementEntries(elementBible, elementsMinimal)
+      : [];
+    const elementSheetBinding = this.env.ELEMENT_SHEET_WORKFLOW;
+    if (missingElementEntries.length > 0 && !elementSheetBinding) {
+      throw new NonRetryableError(
+        '[AnalyzeScriptWorkflow:cf] ELEMENT_SHEET_WORKFLOW binding missing on env; check wrangler.jsonc',
+        'WorkflowValidationError'
+      );
+    }
+    const runElementSheets = async (): Promise<SequenceElementMinimal[]> => {
+      if (
+        !sequenceId ||
+        missingElementEntries.length === 0 ||
+        !elementSheetBinding
+      ) {
+        return [];
+      }
+      const result = await spawnAndAwaitChild<
+        ElementSheetWorkflowInput,
+        ElementSheetWorkflowResult
+      >(step, {
+        binding: elementSheetBinding as Workflow<
+          ElementSheetWorkflowInput & {
+            _parent: import('@/lib/workflow/await-child').ParentNotifyHint;
+          }
+        >,
+        parentBindingName: PARENT_BINDING_NAME,
+        parentInstanceId,
+        childId: `element-sheets:${sequenceId}`,
+        childPayload: {
+          userId: input.userId,
+          teamId: input.teamId,
+          sequenceId,
+          entries: missingElementEntries,
+          imageModel,
+          styleConfig,
+        },
+        spawnStepName: 'spawn-element-sheets',
+        awaitStepName: 'await-element-sheets',
+      });
+      return result.elements;
+    };
+
+    const [charSettled, locationSettled, visualSettled, elementSheetSettled] =
       await Promise.allSettled([
         spawnAndAwaitChild<CharacterBibleWorkflowInput, CharacterMinimal[]>(
           step,
@@ -411,6 +465,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
           spawnStepName: 'spawn-visual-prompts',
           awaitStepName: 'await-visual-prompts',
         }),
+        runElementSheets(),
       ]);
 
     if (charSettled.status === 'rejected') {
@@ -428,10 +483,23 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
         `Visual prompt generation failed: ${String(visualSettled.reason)}`
       );
     }
+    // Element references degrade gracefully: a failed run means the affected
+    // frames render unanchored (today's behavior) — not a failed analysis.
+    if (elementSheetSettled.status === 'rejected') {
+      logger.error(
+        '[AnalyzeScriptWorkflow:cf] Element reference generation failed; continuing without auto-generated references:',
+        { err: elementSheetSettled.reason }
+      );
+    }
 
     const charactersWithSheets = charSettled.value;
     const locationsWithSheets = locationSettled.value;
     const scenesWithVisualPrompts = visualSettled.value;
+    const generatedElements =
+      elementSheetSettled.status === 'fulfilled'
+        ? elementSheetSettled.value
+        : [];
+    const allElements = [...elementsMinimal, ...generatedElements];
 
     // ----------------------------------------------------------------------
     // PHASE 4: frame images + motion/music prompts in parallel
@@ -456,7 +524,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
           scene.metadata?.location ?? ''
         );
         const elementsMatched = matchElementsToScene(
-          elementsMinimal,
+          allElements,
           scene.continuity?.elementTags ?? [],
           scene.originalScript.extract
         );
@@ -485,7 +553,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
       scenesWithVisualPrompts,
       charactersWithSheets,
       locationsWithSheets,
-      elements: elementsMinimal,
+      elements: allElements,
       frameMapping,
       imageModel,
       imageModels,

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -345,7 +345,8 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
     // auto-generated reference image, mirroring the character-sheet
     // treatment. Runs in parallel with the other phase-3 children — visual
     // prompts only consume the bible text, and the generated references are
-    // merged into `elementsMinimal` before phase 4 attaches them to frames.
+    // concatenated with `elementsMinimal` into `allElements` before phase 4
+    // attaches them to frames.
     const missingElementEntries = sequenceId
       ? findMissingElementEntries(elementBible, elementsMinimal)
       : [];
@@ -483,22 +484,16 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
         `Visual prompt generation failed: ${String(visualSettled.reason)}`
       );
     }
-    // Element references degrade gracefully: a failed run means the affected
-    // frames render unanchored (today's behavior) — not a failed analysis.
     if (elementSheetSettled.status === 'rejected') {
-      logger.error(
-        '[AnalyzeScriptWorkflow:cf] Element reference generation failed; continuing without auto-generated references:',
-        { err: elementSheetSettled.reason }
+      throw new Error(
+        `Element reference generation failed: ${String(elementSheetSettled.reason)}`
       );
     }
 
     const charactersWithSheets = charSettled.value;
     const locationsWithSheets = locationSettled.value;
     const scenesWithVisualPrompts = visualSettled.value;
-    const generatedElements =
-      elementSheetSettled.status === 'fulfilled'
-        ? elementSheetSettled.value
-        : [];
+    const generatedElements = elementSheetSettled.value;
     const allElements = [...elementsMinimal, ...generatedElements];
 
     // ----------------------------------------------------------------------

--- a/src/lib/workflows/element-sheet-workflow.test.ts
+++ b/src/lib/workflows/element-sheet-workflow.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import type { ElementBibleEntry } from '@/lib/ai/scene-analysis.schema';
-import { findMissingElementEntries } from './element-sheet-workflow';
+import type { SequenceElementMinimal } from '@/lib/db/schema';
+import {
+  collectElementResults,
+  findMissingElementEntries,
+} from './element-sheet-workflow';
 
 const entry = (token: string): ElementBibleEntry => ({
   token,
@@ -37,5 +41,57 @@ describe('findMissingElementEntries', () => {
     expect(findMissingElementEntries(bible, [{ token: 'logo' }])).toEqual(
       bible
     );
+  });
+});
+
+describe('collectElementResults', () => {
+  const element = (token: string): SequenceElementMinimal => ({
+    id: `el_${token.toLowerCase()}`,
+    token,
+    description: `Visual description of ${token}`,
+    imageUrl: `https://storage.example/${token.toLowerCase()}.png`,
+    consistencyTag: token.toLowerCase().replaceAll('_', '-'),
+  });
+  const fulfilled = (
+    token: string
+  ): PromiseSettledResult<SequenceElementMinimal> => ({
+    status: 'fulfilled',
+    value: element(token),
+  });
+  const rejected = (
+    reason: Error | string
+  ): PromiseSettledResult<SequenceElementMinimal> => ({
+    status: 'rejected',
+    reason,
+  });
+
+  test('returns the elements in entry order when every entry succeeded', () => {
+    const settled = [fulfilled('LOGO'), fulfilled('CORAL_LIPSTICK')];
+
+    const elements = collectElementResults(settled, [
+      { token: 'LOGO' },
+      { token: 'CORAL_LIPSTICK' },
+    ]);
+
+    expect(elements.map((e) => e.token)).toEqual(['LOGO', 'CORAL_LIPSTICK']);
+  });
+
+  test('throws naming the failed token when any entry failed', () => {
+    const settled = [fulfilled('LOGO'), rejected(new Error('fal timeout'))];
+
+    expect(() =>
+      collectElementResults(settled, [
+        { token: 'LOGO' },
+        { token: 'CORAL_LIPSTICK' },
+      ])
+    ).toThrow(/1\/2.*CORAL_LIPSTICK: fal timeout/);
+  });
+
+  test('aggregates every failure into one error', () => {
+    const settled = [rejected('quota exceeded'), rejected(new Error('500'))];
+
+    expect(() =>
+      collectElementResults(settled, [{ token: 'LOGO' }, { token: 'BOTTLE' }])
+    ).toThrow(/2\/2.*LOGO: quota exceeded; BOTTLE: 500/);
   });
 });

--- a/src/lib/workflows/element-sheet-workflow.test.ts
+++ b/src/lib/workflows/element-sheet-workflow.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+import type { ElementBibleEntry } from '@/lib/ai/scene-analysis.schema';
+import { findMissingElementEntries } from './element-sheet-workflow';
+
+const entry = (token: string): ElementBibleEntry => ({
+  token,
+  description: `Visual description of ${token}`,
+  consistencyTag: token.toLowerCase().replaceAll('_', '-'),
+  firstMention: { sceneId: 'scene_1', text: `the ${token}`, lineNumber: 1 },
+});
+
+describe('findMissingElementEntries', () => {
+  test('returns entries whose token has no uploaded element', () => {
+    const bible = [entry('LOGO'), entry('CORAL_LIPSTICK')];
+
+    const missing = findMissingElementEntries(bible, [{ token: 'LOGO' }]);
+
+    expect(missing.map((e) => e.token)).toEqual(['CORAL_LIPSTICK']);
+  });
+
+  test('returns all entries when nothing was uploaded', () => {
+    const bible = [entry('HERO_PRODUCT')];
+
+    expect(findMissingElementEntries(bible, [])).toEqual(bible);
+  });
+
+  test('returns nothing when every entry is covered by an upload', () => {
+    const bible = [entry('LOGO'), entry('BOTTLE')];
+    const uploaded = [{ token: 'LOGO' }, { token: 'BOTTLE' }];
+
+    expect(findMissingElementEntries(bible, uploaded)).toEqual([]);
+  });
+
+  test('is exact-match on token (no case folding)', () => {
+    const bible = [entry('LOGO')];
+
+    expect(findMissingElementEntries(bible, [{ token: 'logo' }])).toEqual(
+      bible
+    );
+  });
+});

--- a/src/lib/workflows/element-sheet-workflow.ts
+++ b/src/lib/workflows/element-sheet-workflow.ts
@@ -13,9 +13,12 @@
  * of the pipeline — scene matching, reference attachment, replace-element —
  * treats it exactly like an uploaded element.
  *
- * Per-entry failures are logged and skipped rather than failing the run:
- * a missing reference degrades to today's behavior (unanchored object), and
- * the surviving entries still anchor their own frames.
+ * All entries run concurrently and every pipeline runs to completion before
+ * failures are surfaced: if any entry fails after its durable steps exhaust
+ * their retries, the whole run fails (and with it the parent analysis) rather
+ * than silently rendering the affected frames unanchored. Entries that
+ * completed are already persisted, so a retried run skips them via the
+ * idempotency guard.
  */
 
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
@@ -32,6 +35,7 @@ import {
   type ImageGenerationParams,
 } from '@/lib/image/image-generation';
 import { buildElementSheetPrompt } from '@/lib/prompts/element-prompt';
+import { rejectionReasonMessage } from '@/lib/workflows/replace-element-workflow';
 import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
 import { uploadResponse } from '@/lib/storage/upload-response';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
@@ -64,6 +68,34 @@ export function findMissingElementEntries(
   return elementBible.filter((entry) => !existingTokens.has(entry.token));
 }
 
+/**
+ * Reduce the per-entry settled outcomes to the generated elements, failing
+ * loudly when any entry failed: a dropped reference would silently render the
+ * affected frames unanchored, so surface the failure instead of degrading.
+ */
+export function collectElementResults(
+  settled: Array<PromiseSettledResult<SequenceElementMinimal>>,
+  entries: Array<Pick<ElementBibleEntry, 'token'>>
+): SequenceElementMinimal[] {
+  const failures: string[] = [];
+  const elements: SequenceElementMinimal[] = [];
+  for (const [index, outcome] of settled.entries()) {
+    if (outcome.status === 'rejected') {
+      failures.push(
+        `${entries[index]?.token ?? `index ${index}`}: ${rejectionReasonMessage(outcome.reason)}`
+      );
+      continue;
+    }
+    elements.push(outcome.value);
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Element reference generation failed for ${failures.length}/${settled.length} element(s) — ${failures.join('; ')}`
+    );
+  }
+  return elements;
+}
+
 export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementSheetWorkflowInput> {
   protected override async runImpl(
     event: Readonly<WorkflowEvent<ElementSheetWorkflowInput>>,
@@ -88,8 +120,10 @@ export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementShe
       `[ElementSheetWorkflow:cf] Generating ${entries.length} element reference(s) for sequence ${sequenceId}: ${entries.map((e) => e.token).join(', ')}`
     );
 
-    // One pipeline per entry, run concurrently. allSettled + inner try/catch
-    // so a single failed generation cannot tank the surviving references.
+    // One pipeline per entry, run concurrently. allSettled so every entry
+    // runs to completion (successful entries persist their rows) before any
+    // failure is surfaced — a retried run then skips the completed entries
+    // via the idempotency guard.
     const settled = await Promise.allSettled(
       entries.map(async (entry, index) => {
         // Idempotency guard: a replayed run (or a token the user uploaded
@@ -228,17 +262,17 @@ export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementShe
       })
     );
 
-    const elements: SequenceElementMinimal[] = [];
+    // Log full rejection objects (stack traces) before the aggregate throw
+    // reduces them to messages.
     for (const [index, outcome] of settled.entries()) {
       if (outcome.status === 'rejected') {
         logger.error(
           `[ElementSheetWorkflow:cf] Reference generation failed for ${entries[index]?.token ?? `index ${index}`}:`,
           { err: outcome.reason }
         );
-        continue;
       }
-      elements.push(outcome.value);
     }
+    const elements = collectElementResults(settled, entries);
 
     logger.info(
       `[ElementSheetWorkflow:cf] Completed: ${elements.length}/${entries.length} element reference(s) for sequence ${sequenceId}`
@@ -256,7 +290,7 @@ export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementShe
     scopedDb: ScopedDb;
   }): void {
     // No row to mark failed — sequence_elements rows are only created on
-    // success. Missing references degrade gracefully to unanchored objects.
+    // success. The parent analysis surfaces this failure to the user.
     logger.error(
       `[ElementSheetWorkflow:cf] Element reference generation failed for sequence ${event.payload.sequenceId}: ${error}`
     );

--- a/src/lib/workflows/element-sheet-workflow.ts
+++ b/src/lib/workflows/element-sheet-workflow.ts
@@ -1,0 +1,264 @@
+/**
+ * Element sheet workflow — auto-generates reference images for recurring
+ * products/objects detected during scene split that have no user-uploaded
+ * element (#835).
+ *
+ * Mirrors the character treatment: characters detected in a script get an
+ * auto-generated reference sheet that anchors their look across frames;
+ * this workflow gives detected elements (the element bible already models
+ * them) the same anchor. Each entry is generated from its bible description,
+ * uploaded to the ELEMENTS bucket, and ingested as a `sequence_elements` row
+ * with `visionStatus: 'completed'` (the bible entry already carries the
+ * description + consistencyTag that vision would have produced), so the rest
+ * of the pipeline — scene matching, reference attachment, replace-element —
+ * treats it exactly like an uploaded element.
+ *
+ * Per-entry failures are logged and skipped rather than failing the run:
+ * a missing reference degrades to today's behavior (unanchored object), and
+ * the surviving entries still anchor their own frames.
+ */
+
+import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
+import type { ElementBibleEntry } from '@/lib/ai/scene-analysis.schema';
+import {
+  deductWorkflowCredits,
+  extractImageCost,
+} from '@/lib/billing/workflow-deduction';
+import { generateId } from '@/lib/db/id';
+import type { ScopedDb } from '@/lib/db/scoped';
+import type { SequenceElementMinimal } from '@/lib/db/schema';
+import {
+  generateImageWithProvider,
+  type ImageGenerationParams,
+} from '@/lib/image/image-generation';
+import { buildElementSheetPrompt } from '@/lib/prompts/element-prompt';
+import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
+import { uploadResponse } from '@/lib/storage/upload-response';
+import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import type {
+  ElementSheetWorkflowInput,
+  ElementSheetWorkflowResult,
+} from '@/lib/workflow/types';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'workflow', 'element-sheet']);
+
+/**
+ * Upper bound on auto-generated element references per run. The scene-split
+ * prompt asks the model to detect at most 3; this guards against a chatty
+ * model burning image credits on incidental props.
+ */
+const MAX_AUTO_ELEMENTS = 3;
+
+/**
+ * Element bible entries that have no matching uploaded/ingested element row.
+ * Uploaded elements always win — the bible echoes their tokens back, so any
+ * token already present in `existing` is covered by a real reference image.
+ */
+export function findMissingElementEntries(
+  elementBible: ElementBibleEntry[],
+  existing: Array<Pick<SequenceElementMinimal, 'token'>>
+): ElementBibleEntry[] {
+  const existingTokens = new Set(existing.map((el) => el.token));
+  return elementBible.filter((entry) => !existingTokens.has(entry.token));
+}
+
+export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementSheetWorkflowInput> {
+  protected override async runImpl(
+    event: Readonly<WorkflowEvent<ElementSheetWorkflowInput>>,
+    step: WorkflowStep,
+    scopedDb: ScopedDb
+  ): Promise<ElementSheetWorkflowResult> {
+    const input = event.payload;
+    const { sequenceId, styleConfig } = input;
+    const imageModel = input.imageModel ?? DEFAULT_IMAGE_MODEL;
+
+    const entries = input.entries.slice(0, MAX_AUTO_ELEMENTS);
+    if (input.entries.length > entries.length) {
+      logger.warn(
+        `[ElementSheetWorkflow:cf] Capping auto-generated elements at ${MAX_AUTO_ELEMENTS} (got ${input.entries.length}) for sequence ${sequenceId}`
+      );
+    }
+    if (entries.length === 0) {
+      return { elements: [] };
+    }
+
+    logger.info(
+      `[ElementSheetWorkflow:cf] Generating ${entries.length} element reference(s) for sequence ${sequenceId}: ${entries.map((e) => e.token).join(', ')}`
+    );
+
+    // One pipeline per entry, run concurrently. allSettled + inner try/catch
+    // so a single failed generation cannot tank the surviving references.
+    const settled = await Promise.allSettled(
+      entries.map(async (entry, index) => {
+        // Idempotency guard: a replayed run (or a token the user uploaded
+        // mid-flight) must not violate the (sequenceId, token) unique index.
+        const existing = await step.do(
+          `check-existing-element-${index}`,
+          async () => {
+            const row = await scopedDb.sequenceElements.getByToken(
+              sequenceId,
+              entry.token
+            );
+            return row
+              ? ({
+                  id: row.id,
+                  token: row.token,
+                  description: row.description,
+                  imageUrl: row.imageUrl,
+                  consistencyTag: row.consistencyTag,
+                } satisfies SequenceElementMinimal)
+              : null;
+          }
+        );
+        if (existing) {
+          logger.info(
+            `[ElementSheetWorkflow:cf] Element ${entry.token} already exists for sequence ${sequenceId}; skipping generation`
+          );
+          return existing;
+        }
+
+        const generationParams: ImageGenerationParams = {
+          model: imageModel,
+          prompt: buildElementSheetPrompt(entry, styleConfig),
+          // Square reference: the object fills the frame regardless of the
+          // sequence aspect ratio; placement happens at frame-generation time.
+          imageSize: 'square_hd' as const,
+          numImages: 1,
+          traceName: 'element-sheet-image',
+        };
+
+        const imageResult = await step.do(
+          `generate-element-image-${index}`,
+          async () => {
+            return await generateImageWithProvider(generationParams, {
+              scopedDb,
+            });
+          }
+        );
+
+        await step.do(`deduct-credits-${index}`, async () => {
+          await deductWorkflowCredits({
+            scopedDb,
+            costMicros: extractImageCost(imageResult.metadata),
+            usedOwnKey: imageResult.metadata.usedOwnKey,
+            description: `Element reference (${generationParams.model})`,
+            metadata: {
+              model: generationParams.model,
+              token: entry.token,
+              sequenceId,
+            },
+            workflowName: 'ElementSheetWorkflow',
+          });
+        });
+
+        const generatedUrl = imageResult.imageUrls[0];
+        if (!generatedUrl) {
+          throw new Error(
+            `Element reference generation returned no image URL for ${entry.token}`
+          );
+        }
+
+        const storageResult = await step.do(
+          `upload-element-image-${index}`,
+          async () => {
+            const response = await fetch(generatedUrl);
+            if (!response.ok) {
+              throw new Error(
+                `Failed to fetch generated element image: ${response.status}`
+              );
+            }
+            // Same path shape as user uploads: {teamId}/{sequenceId}/{id}.png
+            const storagePath = `${input.teamId}/${sequenceId}/${generateId()}.png`;
+            const result = await uploadResponse(
+              response,
+              STORAGE_BUCKETS.ELEMENTS,
+              storagePath,
+              { contentType: 'image/png' }
+            );
+            return { url: result.publicUrl, path: result.path };
+          }
+        );
+
+        return await step.do(`ingest-element-${index}`, async () => {
+          // Re-check inside the durable step: the unique (sequenceId, token)
+          // index makes a race with a concurrent upload a hard failure, so
+          // prefer the existing row over our generated one.
+          const raced = await scopedDb.sequenceElements.getByToken(
+            sequenceId,
+            entry.token
+          );
+          if (raced) {
+            return {
+              id: raced.id,
+              token: raced.token,
+              description: raced.description,
+              imageUrl: raced.imageUrl,
+              consistencyTag: raced.consistencyTag,
+            } satisfies SequenceElementMinimal;
+          }
+
+          const created = await scopedDb.sequenceElements.create({
+            sequenceId,
+            uploadedFilename: `generated-${entry.token.toLowerCase()}.png`,
+            token: entry.token,
+            imageUrl: storageResult.url,
+            imagePath: storageResult.path,
+            // The bible entry already carries what vision would produce —
+            // mark completed so the analyze-script vision gate passes on
+            // regeneration runs.
+            description: entry.description,
+            consistencyTag: entry.consistencyTag,
+            visionStatus: 'completed',
+            visionGeneratedAt: new Date(),
+            firstMentionSceneId: entry.firstMention.sceneId,
+            firstMentionText: entry.firstMention.text,
+            firstMentionLine: entry.firstMention.lineNumber,
+          });
+
+          return {
+            id: created.id,
+            token: created.token,
+            description: created.description,
+            imageUrl: created.imageUrl,
+            consistencyTag: created.consistencyTag,
+          } satisfies SequenceElementMinimal;
+        });
+      })
+    );
+
+    const elements: SequenceElementMinimal[] = [];
+    for (const [index, outcome] of settled.entries()) {
+      if (outcome.status === 'rejected') {
+        logger.error(
+          `[ElementSheetWorkflow:cf] Reference generation failed for ${entries[index]?.token ?? `index ${index}`}:`,
+          { err: outcome.reason }
+        );
+        continue;
+      }
+      elements.push(outcome.value);
+    }
+
+    logger.info(
+      `[ElementSheetWorkflow:cf] Completed: ${elements.length}/${entries.length} element reference(s) for sequence ${sequenceId}`
+    );
+
+    return { elements };
+  }
+
+  protected override onFailure({
+    event,
+    error,
+  }: {
+    event: Readonly<WorkflowEvent<ElementSheetWorkflowInput>>;
+    error: string;
+    scopedDb: ScopedDb;
+  }): void {
+    // No row to mark failed — sequence_elements rows are only created on
+    // success. Missing references degrade gracefully to unanchored objects.
+    logger.error(
+      `[ElementSheetWorkflow:cf] Element reference generation failed for sequence ${event.payload.sequenceId}: ${error}`
+    );
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ const logger = getLogger(['openstory', 'server']);
 // `workflows[]`. See docs/investigations/cloudflare-workflows-poc.md.
 export { ImageWorkflow } from '@/lib/workflows/image-workflow';
 export { ElementVisionWorkflow } from '@/lib/workflows/element-vision-workflow';
+export { ElementSheetWorkflow } from '@/lib/workflows/element-sheet-workflow';
 export { MusicWorkflow } from '@/lib/workflows/music-workflow';
 export { MotionWorkflow } from '@/lib/workflows/motion-workflow';
 export { MotionBatchWorkflow } from '@/lib/workflows/motion-batch-workflow';

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -94,6 +94,11 @@
       "class_name": "ElementVisionWorkflow",
     },
     {
+      "name": "element-sheet-workflow",
+      "binding": "ELEMENT_SHEET_WORKFLOW",
+      "class_name": "ElementSheetWorkflow",
+    },
+    {
       "name": "music-workflow",
       "binding": "MUSIC_WORKFLOW",
       "class_name": "MusicWorkflow",
@@ -292,6 +297,11 @@
           "name": "element-vision-workflow",
           "binding": "ELEMENT_VISION_WORKFLOW",
           "class_name": "ElementVisionWorkflow",
+        },
+        {
+          "name": "element-sheet-workflow",
+          "binding": "ELEMENT_SHEET_WORKFLOW",
+          "class_name": "ElementSheetWorkflow",
         },
         {
           "name": "music-workflow",
@@ -512,6 +522,11 @@
           "name": "element-vision-workflow",
           "binding": "ELEMENT_VISION_WORKFLOW",
           "class_name": "ElementVisionWorkflow",
+        },
+        {
+          "name": "element-sheet-workflow",
+          "binding": "ELEMENT_SHEET_WORKFLOW",
+          "class_name": "ElementSheetWorkflow",
         },
         {
           "name": "music-workflow",


### PR DESCRIPTION
Closes #835

## Problem

When a script centres on a recurring **product/object** but no `elements` are supplied, every scene invents a different product (see sequence `01KTDKGDD7Q394N2NMB682S98S` — three scenes, three unrelated products). Characters get a bible + auto-generated reference sheets; products had no equivalent.

## Approach — mirror the character treatment

1. **Detection (scene split).** The scene-splitting *system* prompt's Element Bible section now has two sources: user-uploaded elements (unchanged) and **detected recurring products/objects** — a visual centerpiece appearing in 2+ scenes that must read as the SAME physical item. The LLM invents an `UPPERCASE_SNAKE` token, writes a decisive 60–120-word visual spec (the generation seed), and tags scenes via `continuity.elementTags[]`. Conservative criteria: max 3, no incidental props/set dressing/clothing, uploaded elements always win. The **user message is byte-identical** — aimock e2e fixtures match on it, so recorded fixtures still replay.

2. **Generation (`ElementSheetWorkflow`, new).** Takes the bible entries with no matching `sequence_elements` row and, per entry: builds a style-aware product reference prompt (`buildElementSheetPrompt`, square canonical shot), generates with the sequence's image model, deducts credits, uploads to the ELEMENTS R2 bucket, and ingests a `sequence_elements` row with `visionStatus: 'completed'` (the bible entry already carries what vision would produce; `firstMention` comes free). Idempotent per token; per-entry failures are logged and skipped.

3. **Orchestration.** `AnalyzeScriptWorkflow` computes missing entries after scene split and spawns the child in the **phase-3 parallel block** (visual prompts only consume bible *text*, so no ordering hazard). Generated elements merge into the element list before phase 4 builds `sceneSnapshots` + `frameImagesPayload` — `matchElementsToScene` → `buildElementReferenceImages` → fal reference attachment all work unchanged. A failed element run degrades to today's unanchored behavior instead of failing the analysis.

Because the row is a regular element, everything downstream composes for free: it shows in the elements grid, replace-element works on it, and regeneration runs see it in `<ELEMENTS>` with its description (no re-detection, no duplicates — the unique `(sequenceId, token)` index plus a pre-insert re-check guards the race).

## Wiring

All four declaration sites per the wiring-consistency test: `wrangler.jsonc` workflows[] (default + env.production + env.test), `src/server.ts` re-export, `CloudflareEnv`, `TRIGGER_TO_BINDING` (`element-sheet`).

## Tests

- `element-prompt.test.ts` — prompt builder (style vs neutral studio paths, people/props exclusion, description embedding)
- `element-sheet-workflow.test.ts` — missing-entry detection (exact-token match, uploads win)
- Full suite green: 100 files, 1101 tests; typecheck clean; lint/knip findings pre-existing only.

## Notes

- **Langfuse:** `phase/scene-splitting-chat` is Langfuse-first with the repo as fallback. If prod serves it from Langfuse, detection won't activate until the hosted prompt is updated (`bun scripts/upload-all-prompts.ts`) — worth doing alongside the deploy.
- No new realtime events for v1 — generated elements appear via normal query refetch; phase 3's "Generating references & prompts…" covers the in-flight window.

## Affected

- Style sample videos for product/ecommerce styles (#801) — can now render a coherent product-reveal sample without sourcing a product image per style.
- Any public-API one-shot caller with a product-led script who doesn't upload an element.

🤖 Generated with [Claude Code](https://claude.com/claude-code)