### PR TITLE
fix(style): make visual style preview images fill their tiles

### DIFF
--- a/src/components/style/style-grid.tsx
+++ b/src/components/style/style-grid.tsx
@@ -90,7 +90,7 @@ const StyleCard: FC<StyleCardProps> = ({
               src={style.previewUrl}
               alt={`${style.name} style preview`}
               layout="fullWidth"
-              className="object-cover"
+              className="h-full w-full object-cover"
               onError={() => setImgError(true)}
             />
           ) : (
@@ -118,7 +118,7 @@ const StyleCard: FC<StyleCardProps> = ({
 const StyleCardSkeleton = () => (
   <Card>
     <CardContent className="p-0">
-      <Skeleton className="aspect-[4/3] rounded-t-lg" />
+      <Skeleton className="aspect-square rounded-t-lg" />
       <div className="p-3">
         <Skeleton className="mx-auto h-3 w-3/4" />
       </div>


### PR DESCRIPTION
Fixes #837

## Problem

In the Visual Style picker, style preview images rendered at intrinsic size inside their square tiles instead of filling them, leaving empty bars on the sides.

## Cause

`AppImage` renders `unstyled` for transformable URLs (so unpic doesn't inject inline styles that would override Tailwind), which means call sites must size images with classes. The style grid only passed `object-cover` — no `h-full w-full` — so the image got no dimensions. The bug only shows with transformable (prod/remote) asset URLs; locally, preview URLs are non-transformable and unpic styles the image itself, which is why it looked fine in dev.

## Fix

- Add `h-full w-full` to the grid's `AppImage`, matching the sibling call sites (`style-selector.tsx`, `style-selector-button.tsx`, `scene-thumbnail.tsx`) that already render correctly.
- Align the loading skeleton with the real tile (`aspect-[4/3]` → `aspect-square`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)