### PR TITLE
fix(workflows): harden step idempotency — 5 root causes from rules-of-workflows audit

### DIFF
--- a/drizzle/migrations/20260607072118_dashing_epoch/migration.sql
+++ b/drizzle/migrations/20260607072118_dashing_epoch/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `transactions` ADD `idempotency_key` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_transactions_team_idempotency_key` ON `transactions` (`team_id`,`idempotency_key`) WHERE "transactions"."idempotency_key" IS NOT NULL;

--- a/drizzle/migrations/20260607072118_dashing_epoch/snapshot.json
+++ b/drizzle/migrations/20260607072118_dashing_epoch/snapshot.json
@@ -1,0 +1,7312 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "2f022cbf-9e66-4dcb-96b5-924c27573bc9",
+  "prevIds": ["d371edb5-4608-4052-a121-8b18dccbf8ac"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "apikey",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frames",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_exports",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_interval",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_amount",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_refill_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "rate_limit_enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_time_window",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_max",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "request_count",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_request",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permissions",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_thumbnail_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "variant_image_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "thumbnail_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_frames_hash",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_music_variant_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "loudness_gain_db",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sample_videos",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_image_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_video_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_aspect_ratio",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "use_cases",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frame_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frame_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "frames_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_sequence_exports_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "apikey_pk",
+      "table": "apikey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_prompt_variants_pk",
+      "table": "frame_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_variants_pk",
+      "table": "frame_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frames_pk",
+      "table": "frames",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_exports_pk",
+      "table": "sequence_exports",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_variants_pk",
+      "table": "sequence_music_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_referenceId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_key_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_configId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_prompt_variants_frame_type_created",
+      "entityType": "indexes",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_prompt_variants\".\"input_hash\" IS NOT NULL AND \"frame_prompt_variants\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_frame_prompt_variants_frame_type_hash_ai",
+      "entityType": "indexes",
+      "table": "frame_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_frame_type",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "frame_variants_primary_key",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "frame_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_order",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_sequence_id",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "frames_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_sequence",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_created_at",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_prompt_variants\".\"input_hash\" IS NOT NULL AND \"sequence_music_prompt_variants\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_sequence_music_prompt_variants_sequence_hash_ai",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"transactions\".\"idempotency_key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "idx_transactions_team_idempotency_key",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": []
+}

--- a/src/lib/billing/workflow-deduction.test.ts
+++ b/src/lib/billing/workflow-deduction.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `deductWorkflowCredits` — in particular that the (now required)
+ * `idempotencyKey` is forwarded to `scopedDb.billing.deductCredits`, since
+ * that key is what makes a workflow-step replay charge-once (issue #846 RC1).
+ */
+
+import type { ScopedDb } from '@/lib/db/scoped';
+import { describe, expect, it, vi } from 'vitest';
+import { micros, ZERO_MICROS } from './money';
+import { deductWorkflowCredits } from './workflow-deduction';
+
+function makeScopedDb({ canAfford = true } = {}) {
+  const deductCredits = vi.fn().mockResolvedValue({
+    newBalance: micros(0),
+    chargedAmount: micros(0),
+    transactionId: 'tx1',
+  });
+  const hasEnoughCredits = vi.fn().mockResolvedValue(canAfford);
+  const checkAutoTopUp = vi.fn().mockResolvedValue(undefined);
+  const scopedDbStub = {
+    billing: { deductCredits, hasEnoughCredits, checkAutoTopUp },
+  };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal ScopedDb stub exposing only the billing methods under test
+  const scopedDb = scopedDbStub as unknown as ScopedDb;
+  return { scopedDb, deductCredits, hasEnoughCredits, checkAutoTopUp };
+}
+
+describe('deductWorkflowCredits', () => {
+  it('forwards the idempotencyKey to deductCredits', async () => {
+    const { scopedDb, deductCredits } = makeScopedDb();
+
+    await deductWorkflowCredits({
+      scopedDb,
+      costMicros: micros(2_000_000),
+      usedOwnKey: false,
+      description: 'Image generation (test-model)',
+      idempotencyKey: 'env_image_abc123:image',
+      metadata: { frameId: 'f1' },
+    });
+
+    expect(deductCredits).toHaveBeenCalledTimes(1);
+    expect(deductCredits).toHaveBeenCalledWith(micros(2_000_000), {
+      description: 'Image generation (test-model)',
+      metadata: { frameId: 'f1' },
+      idempotencyKey: 'env_image_abc123:image',
+    });
+  });
+
+  it('skips when the team used its own key', async () => {
+    const { scopedDb, deductCredits } = makeScopedDb();
+
+    await deductWorkflowCredits({
+      scopedDb,
+      costMicros: micros(2_000_000),
+      usedOwnKey: true,
+      description: 'Image generation (test-model)',
+      idempotencyKey: 'env_image_abc123:image',
+    });
+
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  it('skips for a zero cost', async () => {
+    const { scopedDb, deductCredits } = makeScopedDb();
+
+    await deductWorkflowCredits({
+      scopedDb,
+      costMicros: ZERO_MICROS,
+      usedOwnKey: false,
+      description: 'LLM analysis (model)',
+      idempotencyKey: 'env_wf_abc123:llm-step',
+    });
+
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  it('skips without a scopedDb (anonymous workflow)', async () => {
+    const { deductCredits } = makeScopedDb();
+
+    await deductWorkflowCredits({
+      scopedDb: undefined,
+      costMicros: micros(2_000_000),
+      usedOwnKey: false,
+      description: 'Image generation (test-model)',
+      idempotencyKey: 'env_image_abc123:image',
+    });
+
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  it('warns and skips (but still kicks auto-top-up) when credits are insufficient', async () => {
+    const { scopedDb, deductCredits, checkAutoTopUp } = makeScopedDb({
+      canAfford: false,
+    });
+
+    await deductWorkflowCredits({
+      scopedDb,
+      costMicros: micros(2_000_000),
+      usedOwnKey: false,
+      description: 'Image generation (test-model)',
+      idempotencyKey: 'env_image_abc123:image',
+      workflowName: 'ImageWorkflow',
+    });
+
+    expect(deductCredits).not.toHaveBeenCalled();
+    expect(checkAutoTopUp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/billing/workflow-deduction.ts
+++ b/src/lib/billing/workflow-deduction.ts
@@ -22,6 +22,13 @@ type WorkflowDeductionOpts = {
   /** Set to true if the team used their own API key for this generation */
   usedOwnKey: boolean;
   description: string;
+  /**
+   * Stable key making this deduction idempotent across `step.do` retries.
+   * Convention: `${event.instanceId}:<charge-name>` — the workflow instance
+   * id is replay-stable, so a retried step recovers the original transaction
+   * instead of double-charging the team.
+   */
+  idempotencyKey: string;
   metadata?: Record<string, unknown>;
   /** Workflow name for the logger.warn prefix (e.g., "VariantWorkflow") */
   workflowName?: string;
@@ -57,6 +64,7 @@ export async function deductWorkflowCredits(
   await scopedDb.billing.deductCredits(opts.costMicros, {
     description: opts.description,
     metadata: opts.metadata,
+    idempotencyKey: opts.idempotencyKey,
   });
 }
 

--- a/src/lib/db/schema/credits.ts
+++ b/src/lib/db/schema/credits.ts
@@ -54,6 +54,12 @@ export const transactions = snakeCase.table(
     metadata: text({ mode: 'json' }).$defaultFn(() => ({})),
     stripeSessionId: text(),
     description: text(),
+    /**
+     * Stable key making a deduction idempotent across workflow step retries
+     * (convention: `${workflowInstanceId}:<charge-name>`). Null for charges
+     * with no retry path (e.g. HTTP single-shot LLM calls).
+     */
+    idempotencyKey: text(),
     createdAt: integer({ mode: 'timestamp' })
       .$defaultFn(() => new Date())
       .notNull(),
@@ -64,6 +70,9 @@ export const transactions = snakeCase.table(
     index('idx_transactions_team_id').on(table.teamId),
     index('idx_transactions_user_id').on(table.userId),
     uniqueIndex('idx_transactions_stripe_session_id').on(table.stripeSessionId),
+    uniqueIndex('idx_transactions_team_idempotency_key')
+      .on(table.teamId, table.idempotencyKey)
+      .where(sql`${table.idempotencyKey} IS NOT NULL`),
   ]
 );
 

--- a/src/lib/db/scoped/billing.test.ts
+++ b/src/lib/db/scoped/billing.test.ts
@@ -130,6 +130,17 @@ describe('deductCredits with an idempotencyKey', () => {
       .where(eq(transactions.teamId, teamId));
     expect(rows).toHaveLength(2);
 
+    // Each ledger row must persist the balance as of ITS charge — a stale
+    // read in the balanceAfter subquery would surface on the second row.
+    const imageRow = rows.find(
+      (r) => r.idempotencyKey === 'wf-instance-1:image'
+    );
+    const motionRow = rows.find(
+      (r) => r.idempotencyKey === 'wf-instance-1:motion'
+    );
+    expect(imageRow?.balanceAfter).toBe(STARTING_BALANCE - charged);
+    expect(motionRow?.balanceAfter).toBe(STARTING_BALANCE - 2 * charged);
+
     const [credit] = await db
       .select({ balance: credits.balance })
       .from(credits)

--- a/src/lib/db/scoped/billing.test.ts
+++ b/src/lib/db/scoped/billing.test.ts
@@ -1,0 +1,203 @@
+/**
+ * In-memory DB tests for `deductCredits` idempotency (issue #846 RC1).
+ *
+ * A workflow `step.do` that throws partway (or is killed by an engine abort)
+ * re-runs its closure from the top, so `deductCredits` must be safe to replay:
+ * with an `idempotencyKey`, the balance UPDATE and the transaction INSERT run
+ * in one atomic `db.batch` guarded by the partial unique index on
+ * `(team_id, idempotency_key)` — a replay is a no-op that recovers the
+ * original transaction id instead of double-debiting the team.
+ */
+
+import { applyMarkup } from '@/lib/billing/constants';
+import { micros, negateMicros } from '@/lib/billing/money';
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import { credits, teams, transactions, user } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createBillingMethods } from './billing';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let userId = '';
+
+const STARTING_BALANCE = 100_000_000; // $100
+
+async function seed() {
+  await db.delete(transactions);
+  await db.delete(credits);
+  await db.delete(teams);
+  await db.delete(user);
+
+  teamId = generateId();
+  userId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  await db
+    .insert(user)
+    .values({ id: userId, name: 'U', email: `${userId}@example.com` });
+  await db.insert(credits).values({ teamId, balance: STARTING_BALANCE });
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('deductCredits with an idempotencyKey', () => {
+  const rawCost = micros(1_000_000); // $1 raw
+
+  it('debits once and writes a single ledger row', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    const charged = applyMarkup(rawCost);
+
+    const result = await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-instance-1:image',
+    });
+
+    expect(result.chargedAmount).toBe(charged);
+    expect(result.newBalance).toBe(STARTING_BALANCE - charged);
+    expect(result.transactionId).not.toBe('');
+
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.teamId, teamId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.amount).toBe(negateMicros(charged));
+    // The balanceAfter subquery must see the post-UPDATE balance (the batch
+    // statements run sequentially inside one transaction).
+    expect(rows[0]?.balanceAfter).toBe(STARTING_BALANCE - charged);
+    expect(rows[0]?.idempotencyKey).toBe('wf-instance-1:image');
+  });
+
+  it('replay with the same key is a no-op that returns the original transaction id', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    const charged = applyMarkup(rawCost);
+
+    const first = await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-instance-1:image',
+    });
+    const replay = await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-instance-1:image',
+    });
+
+    // Must not throw, must not double-debit, must recover the original id.
+    expect(replay.transactionId).toBe(first.transactionId);
+    expect(replay.newBalance).toBe(STARTING_BALANCE - charged);
+
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.teamId, teamId));
+    expect(rows).toHaveLength(1);
+
+    const [credit] = await db
+      .select({ balance: credits.balance })
+      .from(credits)
+      .where(eq(credits.teamId, teamId));
+    expect(credit?.balance).toBe(STARTING_BALANCE - charged);
+  });
+
+  it('distinct keys are distinct charges', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    const charged = applyMarkup(rawCost);
+
+    await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-instance-1:image',
+    });
+    await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-instance-1:motion',
+    });
+
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.teamId, teamId));
+    expect(rows).toHaveLength(2);
+
+    const [credit] = await db
+      .select({ balance: credits.balance })
+      .from(credits)
+      .where(eq(credits.teamId, teamId));
+    expect(credit?.balance).toBe(STARTING_BALANCE - 2 * charged);
+  });
+
+  it('the same key under a different team charges both teams (key is team-scoped)', async () => {
+    const otherTeamId = generateId();
+    await db.insert(teams).values({ id: otherTeamId, name: 'T2', slug: 't2' });
+    await db
+      .insert(credits)
+      .values({ teamId: otherTeamId, balance: STARTING_BALANCE });
+
+    const billingA = createBillingMethods(db, teamId, userId);
+    const billingB = createBillingMethods(db, otherTeamId, userId);
+
+    const a = await billingA.deductCredits(rawCost, {
+      idempotencyKey: 'shared-key',
+    });
+    const b = await billingB.deductCredits(rawCost, {
+      idempotencyKey: 'shared-key',
+    });
+
+    expect(a.transactionId).not.toBe(b.transactionId);
+    const charged = applyMarkup(rawCost);
+    expect(a.newBalance).toBe(STARTING_BALANCE - charged);
+    expect(b.newBalance).toBe(STARTING_BALANCE - charged);
+  });
+});
+
+describe('deductCredits without an idempotencyKey (keyless path)', () => {
+  const rawCost = micros(1_000_000);
+
+  it('charges on every call (HTTP single-shot semantics preserved)', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    const charged = applyMarkup(rawCost);
+
+    const r1 = await billing.deductCredits(rawCost, {
+      description: 'one',
+    });
+    const r2 = await billing.deductCredits(rawCost, {
+      description: 'two',
+    });
+
+    expect(r1.transactionId).not.toBe(r2.transactionId);
+    expect(r2.newBalance).toBe(STARTING_BALANCE - 2 * charged);
+
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.teamId, teamId));
+    expect(rows).toHaveLength(2);
+    expect(rows.every((row) => row.idempotencyKey === null)).toBe(true);
+  });
+
+  it('returns early without writing anything for a non-positive cost', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+
+    const result = await billing.deductCredits(micros(0));
+
+    expect(result.newBalance).toBe(STARTING_BALANCE);
+    expect(result.transactionId).toBe('');
+
+    const rows = await db
+      .select()
+      .from(transactions)
+      .where(eq(transactions.teamId, teamId));
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -285,7 +285,9 @@ export function createBillingMethods(
    * transaction INSERT run in one atomic `db.batch`; the UPDATE is guarded on
    * "no transaction with this key exists yet" and the INSERT dedupes via the
    * partial unique index on `(team_id, idempotency_key)`. A replay is a no-op
-   * that returns the original transaction id.
+   * that returns the original transaction id — note that on a replay the
+   * returned `chargedAmount` is what the ORIGINAL attempt charged; nothing
+   * was debited by this call (don't emit "charged $X" side effects from it).
    */
   async function deductCredits(
     rawCostMicros: Microdollars,
@@ -367,6 +369,12 @@ export function createBillingMethods(
       .onConflictDoNothing()
       .returning({ id: transactions.id });
 
+    // Third statement: re-read the balance to return to the caller. Distinct
+    // from the `balanceAfter` ledger column above (that one is persisted into
+    // the transaction row; this one is the authoritative read-back, correct
+    // even on a replay where the UPDATE no-ops) — both rely on running after
+    // `updateBalance` inside the same batch transaction, so don't "optimize"
+    // either away in favor of the other.
     const readBackBalance = db
       .select({ balance: credits.balance })
       .from(credits)

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -34,7 +34,7 @@ import type {
   TransactionType,
 } from '@/lib/db/schema/credits';
 import { ValidationError } from '@/lib/errors';
-import { and, count, desc, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, notExists, sql } from 'drizzle-orm';
 import { generateId } from '../id';
 import { giftTokenRedemptions, giftTokens } from '../schema';
 
@@ -274,12 +274,25 @@ export function createBillingMethods(
       });
   }
 
-  /** Applies markup automatically. Triggers auto-top-up if balance drops below threshold. */
+  /**
+   * Applies markup automatically. Triggers auto-top-up if balance drops below
+   * threshold.
+   *
+   * Pass `opts.idempotencyKey` (convention: `${workflowInstanceId}:<charge-name>`)
+   * from any retryable context — a workflow `step.do` that throws partway
+   * re-runs its closure, and without the key every replay double-debits the
+   * team and writes a duplicate ledger row. The balance UPDATE and the
+   * transaction INSERT run in one atomic `db.batch`; the UPDATE is guarded on
+   * "no transaction with this key exists yet" and the INSERT dedupes via the
+   * partial unique index on `(team_id, idempotency_key)`. A replay is a no-op
+   * that returns the original transaction id.
+   */
   async function deductCredits(
     rawCostMicros: Microdollars,
     opts: {
       description?: string;
       metadata?: Record<string, unknown>;
+      idempotencyKey?: string;
     } = {}
   ): Promise<{
     newBalance: Microdollars;
@@ -294,39 +307,53 @@ export function createBillingMethods(
       };
 
     const chargedAmount = applyMarkup(rawCostMicros);
+    const { idempotencyKey } = opts;
 
-    // TODO: TB Mar 26 2026: I really don't like this. SQLite is a pain for doing credits... this should be a transaction.
     await db
       .insert(credits)
       .values({ teamId, balance: 0 })
       .onConflictDoNothing();
 
-    const [updated] = await db
+    const rawUsd = microsToUsd(rawCostMicros);
+    const chargedUsd = microsToUsd(chargedAmount);
+
+    const updateBalance = db
       .update(credits)
       .set({
         balance: sql`${credits.balance} - ${chargedAmount}`,
         updatedAt: new Date(),
       })
-      .where(eq(credits.teamId, teamId))
-      .returning({ balance: credits.balance });
-
-    if (!updated) {
-      throw new Error(
-        `deductCredits: update returned no row for team ${teamId}`
+      .where(
+        idempotencyKey
+          ? and(
+              eq(credits.teamId, teamId),
+              notExists(
+                db
+                  .select({ id: transactions.id })
+                  .from(transactions)
+                  .where(
+                    and(
+                      eq(transactions.teamId, teamId),
+                      eq(transactions.idempotencyKey, idempotencyKey)
+                    )
+                  )
+              )
+            )
+          : eq(credits.teamId, teamId)
       );
-    }
 
-    const rawUsd = microsToUsd(rawCostMicros);
-    const chargedUsd = microsToUsd(chargedAmount);
-
-    const [tx] = await db
+    // balanceAfter reads the post-UPDATE balance via subquery — the batch
+    // statements run sequentially inside one transaction, so this sees the
+    // decremented value. On a replay the INSERT no-ops, so the (stale) value
+    // is never written.
+    const insertTransaction = db
       .insert(transactions)
       .values({
         teamId,
         userId,
         type: 'credit_usage' as TransactionType,
         amount: negateMicros(chargedAmount),
-        balanceAfter: updated.balance,
+        balanceAfter: sql`(select ${credits.balance} from ${credits} where ${credits.teamId} = ${teamId})`,
         description:
           opts.description ??
           `Usage: $${chargedUsd.toFixed(4)} (raw: $${rawUsd.toFixed(4)})`,
@@ -335,23 +362,65 @@ export function createBillingMethods(
           chargedAmountMicros: chargedAmount,
           ...opts.metadata,
         },
+        idempotencyKey: idempotencyKey ?? null,
       })
+      .onConflictDoNothing()
       .returning({ id: transactions.id });
 
-    if (!tx) {
+    const readBackBalance = db
+      .select({ balance: credits.balance })
+      .from(credits)
+      .where(eq(credits.teamId, teamId));
+
+    const [, insertedRows, balanceRows] = await db.batch([
+      updateBalance,
+      insertTransaction,
+      readBackBalance,
+    ]);
+
+    const balanceRow = balanceRows[0];
+    if (!balanceRow) {
       throw new Error(
-        `deductCredits: transaction insert returned no row for team ${teamId}`
+        `deductCredits: credits row missing for team ${teamId} after batch`
       );
     }
+    const newBalance = micros(balanceRow.balance);
 
-    void maybeAutoTopUp(micros(updated.balance)).catch((err) => {
+    let transactionId = insertedRows[0]?.id;
+    if (!transactionId) {
+      if (!idempotencyKey) {
+        throw new Error(
+          `deductCredits: transaction insert returned no row for team ${teamId}`
+        );
+      }
+      // Replay of an already-applied deduction — recover the original
+      // transaction id. Must not throw: the charge landed on a prior attempt.
+      const [existing] = await db
+        .select({ id: transactions.id })
+        .from(transactions)
+        .where(
+          and(
+            eq(transactions.teamId, teamId),
+            eq(transactions.idempotencyKey, idempotencyKey)
+          )
+        )
+        .limit(1);
+      if (!existing) {
+        throw new Error(
+          `deductCredits: no transaction row for team ${teamId} key ${idempotencyKey} after conflict no-op`
+        );
+      }
+      transactionId = existing.id;
+    }
+
+    void maybeAutoTopUp(newBalance).catch((err) => {
       logger.error('Failed:', { err });
     });
 
     return {
-      newBalance: micros(updated.balance),
+      newBalance,
       chargedAmount,
-      transactionId: tx.id,
+      transactionId,
     };
   }
 

--- a/src/lib/db/scoped/sequence-elements.test.ts
+++ b/src/lib/db/scoped/sequence-elements.test.ts
@@ -1,15 +1,21 @@
 /**
- * In-memory DB tests for getFrameCountsByElement.
+ * In-memory DB tests for the sequence-elements scoped module.
  *
- * Pins the two invariants the elements grid relies on:
+ * getFrameCountsByElement — pins the two invariants the elements grid relies on:
  *   - Elements with zero matching frames appear in the result map with `0`
  *     (otherwise the badge reads `undefined`).
  *   - A frame that references N elements increments every matched element's
  *     count (no first-match short-circuit).
+ *
+ * ensureUniqueToken / cascadeRename — pins the workflow-retry idempotency of
+ * the ElementVisionWorkflow auto-rename (issue #846 RC5): the element's own
+ * row must not count as a collision, and the cascade must be atomic so a
+ * replay yields zero deltas instead of split-brained `TOKEN_2` references.
  */
 
 import { type Client, createClient } from '@libsql/client';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 import type { Database } from '@/lib/db/client';
@@ -189,5 +195,120 @@ describe('getFrameCountsByElement', () => {
     expect(result[logo.id]?.frameCount).toBe(2);
     expect(result[bottle.id]?.frameCount).toBe(1);
     expect(result[orphan.id]?.frameCount).toBe(0);
+  });
+});
+
+async function insertElement(token: string) {
+  const [element] = await db
+    .insert(sequenceElements)
+    .values({
+      sequenceId,
+      uploadedFilename: `${token.toLowerCase()}.png`,
+      token,
+      imageUrl: `https://r2/${token.toLowerCase()}.png`,
+      imagePath: `elements/x/${token.toLowerCase()}.png`,
+    })
+    .returning();
+  if (!element) throw new Error('test setup: element insert returned nothing');
+  return element;
+}
+
+describe('ensureUniqueToken', () => {
+  it('does not count the excluded element’s own row as a collision', async () => {
+    const methods = createSequenceElementsMethods(db);
+    const element = await insertElement('PROP');
+
+    // Without exclusion the element's own row collides → suffix (the
+    // pre-#846 retry bug). With exclusion the token comes back unchanged.
+    await expect(methods.ensureUniqueToken(sequenceId, 'PROP')).resolves.toBe(
+      'PROP_2'
+    );
+    await expect(
+      methods.ensureUniqueToken(sequenceId, 'PROP', element.id)
+    ).resolves.toBe('PROP');
+  });
+
+  it('still suffixes when a different element holds the token', async () => {
+    const methods = createSequenceElementsMethods(db);
+    await insertElement('PROP');
+    const other = await insertElement('OTHER');
+
+    await expect(
+      methods.ensureUniqueToken(sequenceId, 'PROP', other.id)
+    ).resolves.toBe('PROP_2');
+  });
+});
+
+describe('cascadeRename', () => {
+  it('rewrites element + script + frames, and a replay yields zero deltas', async () => {
+    const methods = createSequenceElementsMethods(db);
+    const element = await insertElement('LOGO');
+
+    await db
+      .update(sequences)
+      .set({ script: 'The LOGO appears. Pan across the LOGO.' })
+      .where(eq(sequences.id, sequenceId));
+
+    await db.insert(frames).values({
+      sequenceId,
+      orderIndex: 0,
+      metadata: frameMetadata({
+        sceneId: 's1',
+        elementTags: ['LOGO'],
+        extract: 'The LOGO appears on screen.',
+      }),
+    });
+    await db.insert(frames).values({
+      sequenceId,
+      orderIndex: 1,
+      metadata: frameMetadata({
+        sceneId: 's2',
+        elementTags: [],
+        extract: 'No element here.',
+      }),
+    });
+
+    const first = await methods.cascadeRename({
+      sequenceId,
+      elementId: element.id,
+      oldToken: 'LOGO',
+      newToken: 'BRAND',
+    });
+    expect(first.element.token).toBe('BRAND');
+    expect(first.scriptUpdated).toBe(true);
+    expect(first.framesUpdated).toBe(1);
+
+    const [seq] = await db
+      .select({ script: sequences.script })
+      .from(sequences)
+      .where(eq(sequences.id, sequenceId));
+    expect(seq?.script).toBe('The BRAND appears. Pan across the BRAND.');
+
+    // Workflow-step replay: the cached pre-rename token is the oldToken.
+    // Everything already carries BRAND, so the cascade must be a no-op.
+    const replay = await methods.cascadeRename({
+      sequenceId,
+      elementId: element.id,
+      oldToken: 'LOGO',
+      newToken: 'BRAND',
+    });
+    expect(replay.element.token).toBe('BRAND');
+    expect(replay.scriptUpdated).toBe(false);
+    expect(replay.framesUpdated).toBe(0);
+  });
+
+  it('short-circuits when oldToken === newToken', async () => {
+    const methods = createSequenceElementsMethods(db);
+    const element = await insertElement('LOGO');
+
+    const result = await methods.cascadeRename({
+      sequenceId,
+      elementId: element.id,
+      oldToken: 'LOGO',
+      newToken: 'LOGO',
+    });
+    expect(result.element.token).toBe('LOGO');
+    expect(result.framesUpdated).toBe(0);
+    expect(result.scriptUpdated).toBe(false);
   });
 });

--- a/src/lib/db/scoped/sequence-elements.ts
+++ b/src/lib/db/scoped/sequence-elements.ts
@@ -89,24 +89,33 @@ export function createSequenceElementsMethods(db: Database) {
       return rows.length > 0;
     },
 
+    /**
+     * Pass `excludeElementId` when the token is being assigned to an existing
+     * element (e.g. the vision auto-rename) — otherwise the element's own row
+     * counts as a collision and a workflow-step retry after a successful
+     * rename suffixes the token to `TOKEN_2`.
+     */
     ensureUniqueToken: async (
       sequenceId: string,
-      token: string
+      token: string,
+      excludeElementId?: string
     ): Promise<string> => {
       // Escape LIKE wildcards (%, _, \) so `foo_bar` doesn't match `foo1bar`.
       const escaped = token.replace(/[\\%_]/g, (c) => `\\${c}`);
+      const whereClauses = [
+        eq(sequenceElements.sequenceId, sequenceId),
+        or(
+          eq(sequenceElements.token, token),
+          like(sequenceElements.token, sql`${`${escaped}\\_%`} ESCAPE '\\'`)
+        ),
+      ];
+      if (excludeElementId) {
+        whereClauses.push(ne(sequenceElements.id, excludeElementId));
+      }
       const rows = await db
         .select({ token: sequenceElements.token })
         .from(sequenceElements)
-        .where(
-          and(
-            eq(sequenceElements.sequenceId, sequenceId),
-            or(
-              eq(sequenceElements.token, token),
-              like(sequenceElements.token, sql`${`${escaped}\\_%`} ESCAPE '\\'`)
-            )
-          )
-        );
+        .where(and(...whereClauses));
 
       const taken = new Set(rows.map((r) => r.token));
       if (!taken.has(token)) return token;
@@ -197,6 +206,11 @@ export function createSequenceElementsMethods(db: Database) {
      * tags, originalScript extract, prompt strings) and the user-edit
      * `imagePrompt`/`motionPrompt` overrides on `frames`.
      *
+     * All writes (element row, script, frame deltas) run in a single
+     * `db.batch()` — one transaction — so a mid-cascade failure can't leave
+     * mixed token references (and a workflow-step retry then renaming the
+     * remainder to `TOKEN_2`, splitting element/script/frames).
+     *
      * Returns the affected counts so callers can surface a meaningful toast
      * ("Renamed LOGO → BRAND across 5 frames + script"). The caller is
      * expected to have already validated uniqueness of `newToken` within the
@@ -213,17 +227,24 @@ export function createSequenceElementsMethods(db: Database) {
       scriptUpdated: boolean;
     }> => {
       const { sequenceId, elementId, oldToken, newToken } = args;
-      const element = await update(elementId, { token: newToken });
 
       if (oldToken === newToken) {
+        const element = await update(elementId, { token: newToken });
         return { element, framesUpdated: 0, scriptUpdated: false };
       }
 
-      let scriptUpdated = false;
+      const now = new Date();
+      const elementUpdate = db
+        .update(sequenceElements)
+        .set({ token: newToken, updatedAt: now })
+        .where(eq(sequenceElements.id, elementId))
+        .returning();
+
       const [sequenceRow] = await db
         .select({ script: sequences.script })
         .from(sequences)
         .where(eq(sequences.id, sequenceId));
+      let rewrittenScript: string | null = null;
       if (sequenceRow?.script) {
         const rewritten = replaceTokenInText(
           sequenceRow.script,
@@ -231,27 +252,43 @@ export function createSequenceElementsMethods(db: Database) {
           newToken
         );
         if (rewritten !== sequenceRow.script) {
-          await db
-            .update(sequences)
-            .set({ script: rewritten, updatedAt: new Date() })
-            .where(eq(sequences.id, sequenceId));
-          scriptUpdated = true;
+          rewrittenScript = rewritten;
         }
       }
+      const scriptUpdated = rewrittenScript !== null;
+      const scriptStatements =
+        rewrittenScript === null
+          ? []
+          : [
+              db
+                .update(sequences)
+                .set({ script: rewrittenScript, updatedAt: now })
+                .where(eq(sequences.id, sequenceId)),
+            ];
 
       const allFrames = (await db
         .select()
         .from(frames)
         .where(eq(frames.sequenceId, sequenceId))) as Frame[];
       const deltas = buildFrameRenameDeltas(allFrames, oldToken, newToken);
-      for (const delta of deltas) {
-        const set: Record<string, unknown> = { updatedAt: new Date() };
+      const frameStatements = deltas.map((delta) => {
+        const set: Record<string, unknown> = { updatedAt: now };
         if (delta.metadata !== undefined) set.metadata = delta.metadata;
         if (delta.imagePrompt !== undefined)
           set.imagePrompt = delta.imagePrompt;
         if (delta.motionPrompt !== undefined)
           set.motionPrompt = delta.motionPrompt;
-        await db.update(frames).set(set).where(eq(frames.id, delta.frameId));
+        return db.update(frames).set(set).where(eq(frames.id, delta.frameId));
+      });
+
+      const [elementRows] = await db.batch([
+        elementUpdate,
+        ...scriptStatements,
+        ...frameStatements,
+      ]);
+      const element = elementRows[0];
+      if (!element) {
+        throw new Error(`SequenceElement ${elementId} not found`);
       }
 
       return { element, framesUpdated: deltas.length, scriptUpdated };

--- a/src/lib/db/scoped/sequence-locations-create-bulk.test.ts
+++ b/src/lib/db/scoped/sequence-locations-create-bulk.test.ts
@@ -1,0 +1,152 @@
+/**
+ * In-memory DB tests for `sequenceLocations.createBulk` upsert semantics
+ * (issue #846 RC4).
+ *
+ * LocationBibleWorkflow's `create-location-records` step inserts in batches
+ * of 3; a retry after a partial batch commit used to hit a UNIQUE violation
+ * on `(sequence_id, location_id)` on every replay — exhausting the retry
+ * budget and stranding locations in `referenceStatus='generating'`. The
+ * upsert keeps replays converging: existing rows keep their `id` (and their
+ * reference-image columns, owned by the child LocationSheetWorkflow) while
+ * bible fields refresh from the incoming row.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import type { NewSequenceLocation } from '@/lib/db/schema';
+import { sequenceLocations, sequences, styles, teams } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createSequenceLocationsMethods } from './sequence-locations';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let sequenceId = '';
+
+async function seed() {
+  await db.delete(sequenceLocations);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+
+  teamId = generateId();
+  sequenceId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db.insert(sequences).values({
+    id: sequenceId,
+    teamId,
+    title: 'S',
+    styleId: style.id,
+  });
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+function locationInsert(locationId: string): NewSequenceLocation {
+  return {
+    id: generateId(),
+    sequenceId,
+    locationId,
+    name: `Location ${locationId}`,
+    description: `Description for ${locationId}`,
+    referenceStatus: 'generating',
+  };
+}
+
+describe('createBulk', () => {
+  it('a full replay converges instead of throwing UNIQUE violations', async () => {
+    const methods = createSequenceLocationsMethods(db);
+    // 4 rows > BATCH_SIZE (3) so the replay crosses a batch boundary.
+    const inserts = ['loc_001', 'loc_002', 'loc_003', 'loc_004'].map(
+      locationInsert
+    );
+
+    const first = await methods.createBulk(inserts);
+    expect(first).toHaveLength(4);
+
+    // Workflow-step retry replays the whole closure with fresh ULIDs but the
+    // same (sequenceId, locationId) pairs.
+    const replayInserts = ['loc_001', 'loc_002', 'loc_003', 'loc_004'].map(
+      locationInsert
+    );
+    const replay = await methods.createBulk(replayInserts);
+
+    // Same row count (the workflow's `created.length` guard keeps working)
+    // and the original ids survive — the replay updates, it doesn't insert.
+    expect(replay).toHaveLength(4);
+    const firstIds = new Set(first.map((row) => row.id));
+    expect(replay.every((row) => firstIds.has(row.id))).toBe(true);
+
+    const all = await db
+      .select()
+      .from(sequenceLocations)
+      .where(eq(sequenceLocations.sequenceId, sequenceId));
+    expect(all).toHaveLength(4);
+  });
+
+  it('refreshes bible fields but leaves reference-image columns untouched', async () => {
+    const methods = createSequenceLocationsMethods(db);
+    const [created] = await methods.createBulk([locationInsert('loc_001')]);
+    if (!created) throw new Error('test setup: createBulk returned nothing');
+
+    // Child LocationSheetWorkflow completes the reference in the meantime.
+    await db
+      .update(sequenceLocations)
+      .set({
+        referenceStatus: 'completed',
+        referenceImageUrl: 'https://r2/loc_001.png',
+        referenceImagePath: 'locations/loc_001.png',
+      })
+      .where(eq(sequenceLocations.id, created.id));
+
+    const [upserted] = await methods.createBulk([
+      { ...locationInsert('loc_001'), description: 'fresher description' },
+    ]);
+
+    expect(upserted?.id).toBe(created.id);
+    expect(upserted?.description).toBe('fresher description');
+    // Owned by the child workflow — must not be clobbered by a parent replay.
+    expect(upserted?.referenceStatus).toBe('completed');
+    expect(upserted?.referenceImageUrl).toBe('https://r2/loc_001.png');
+    expect(upserted?.referenceImagePath).toBe('locations/loc_001.png');
+  });
+
+  it('returns [] for an empty input', async () => {
+    const methods = createSequenceLocationsMethods(db);
+    await expect(methods.createBulk([])).resolves.toEqual([]);
+  });
+});

--- a/src/lib/db/scoped/sequence-locations.ts
+++ b/src/lib/db/scoped/sequence-locations.ts
@@ -3,7 +3,7 @@
  * Location CRUD, reference images, and frame-location matching.
  */
 
-import { and, eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { Database } from '@/lib/db/client';
 import type {
   Frame,
@@ -175,6 +175,15 @@ export function createSequenceLocationsMethods(db: Database) {
       return location;
     },
 
+    /**
+     * Bulk insert, upserting on the `(sequenceId, locationId)` unique index
+     * so a workflow-step retry after a partial batch commit converges
+     * instead of failing every replay on a UNIQUE violation (and stranding
+     * locations in `referenceStatus='generating'`). Bible fields are
+     * refreshed from the incoming row; `id`/keys/`createdAt` and the
+     * reference-image columns (owned by the child LocationSheetWorkflow)
+     * are left untouched.
+     */
     createBulk: async (
       data: NewSequenceLocation[]
     ): Promise<SequenceLocation[]> => {
@@ -187,6 +196,29 @@ export function createSequenceLocationsMethods(db: Database) {
         const batchResults = await db
           .insert(sequenceLocations)
           .values(batch)
+          .onConflictDoUpdate({
+            target: [
+              sequenceLocations.sequenceId,
+              sequenceLocations.locationId,
+            ],
+            set: {
+              name: sql.raw(`excluded."name"`),
+              libraryLocationId: sql.raw(`excluded."library_location_id"`),
+              type: sql.raw(`excluded."type"`),
+              timeOfDay: sql.raw(`excluded."time_of_day"`),
+              description: sql.raw(`excluded."description"`),
+              architecturalStyle: sql.raw(`excluded."architectural_style"`),
+              keyFeatures: sql.raw(`excluded."key_features"`),
+              colorPalette: sql.raw(`excluded."color_palette"`),
+              lightingSetup: sql.raw(`excluded."lighting_setup"`),
+              ambiance: sql.raw(`excluded."ambiance"`),
+              consistencyTag: sql.raw(`excluded."consistency_tag"`),
+              firstMentionSceneId: sql.raw(`excluded."first_mention_scene_id"`),
+              firstMentionText: sql.raw(`excluded."first_mention_text"`),
+              firstMentionLine: sql.raw(`excluded."first_mention_line"`),
+              updatedAt: new Date(),
+            },
+          })
           .returning();
         results.push(...batchResults);
       }

--- a/src/lib/workflow/await-child.ts
+++ b/src/lib/workflow/await-child.ts
@@ -30,7 +30,10 @@
 
 import { simpleHash } from '@/lib/utils/hash';
 import { getLogger } from '@/lib/observability/logger';
-import { isRecipientInFiniteStateError } from '@/lib/workflow/errors';
+import {
+  isInstanceAlreadyExistsError,
+  isRecipientInFiniteStateError,
+} from '@/lib/workflow/errors';
 import type { CloudflareEnv } from '@/lib/workflow/types';
 import type { WorkflowSleepDuration, WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
@@ -92,22 +95,6 @@ export function buildChildInstanceId(
   const digest = simpleHash(`${parentInstanceId}${semanticChildId}`);
   const head = semantic.slice(0, MAX_INSTANCE_ID_LENGTH - digest.length - 2);
   return `${head}__${digest}`;
-}
-
-/**
- * CF surfaces a reused instance id as `(instance.already_exists) Instance
- * already exists`. Match on the message defensively (the thrown value's class
- * isn't part of the public API) so an in-run durable retry — where `create()`
- * succeeded but the step's result wasn't persisted before a crash — is treated
- * as success instead of a hard failure.
- */
-function isInstanceAlreadyExistsError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  const message =
-    'message' in error && typeof error.message === 'string'
-      ? error.message
-      : '';
-  return /already.?exists/i.test(message);
 }
 
 /**

--- a/src/lib/workflow/dedup-ids.test.ts
+++ b/src/lib/workflow/dedup-ids.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Pins the two invariants of the child-spawn deduplication ids (issue #846
+ * RC2): replay-stability (a retried `step.do` reuses the existing child
+ * instead of spawning a second paid job) and hash-first ordering (the
+ * run-scoping hash must survive `buildInstanceId`'s end-of-suffix truncation,
+ * or two different runs would silently collapse onto one stale instance).
+ */
+
+import { describe, expect, test } from 'vitest';
+import { previewImageDedupId, shotVariantDedupId } from './dedup-ids';
+import { buildInstanceId } from './instance-id';
+
+const RUN_A = 'openstory-so_scene-split_01JX3YZABCDEFGHJKMNPQRSTVW';
+const RUN_B = 'openstory-so_scene-split_01JX3YZABCDEFGHJKMNPQRSTVX';
+const FRAME_ID = '01JX4FRAMEABCDEFGHJKMNPQRS';
+const OTHER_FRAME_ID = '01JX4FRAMEABCDEFGHJKMNPQRT';
+
+// Realistic worst-case namespacing: PR-preview env slugs are the longest.
+const previewEnv = { VITE_APP_URL: 'https://pr-1234.openstory.dev' };
+
+describe('previewImageDedupId', () => {
+  test('is stable across calls with the same inputs (replay-safe)', () => {
+    expect(previewImageDedupId(RUN_A, FRAME_ID)).toBe(
+      previewImageDedupId(RUN_A, FRAME_ID)
+    );
+  });
+
+  test('distinct frames get distinct ids within one run', () => {
+    expect(previewImageDedupId(RUN_A, FRAME_ID)).not.toBe(
+      previewImageDedupId(RUN_A, OTHER_FRAME_ID)
+    );
+  });
+
+  test('distinct runs get distinct ids for the same frame (re-split spawns fresh previews)', () => {
+    expect(previewImageDedupId(RUN_A, FRAME_ID)).not.toBe(
+      previewImageDedupId(RUN_B, FRAME_ID)
+    );
+  });
+
+  test('survives buildInstanceId untruncated for realistic inputs', () => {
+    const suffix = previewImageDedupId(RUN_A, FRAME_ID);
+    const id = buildInstanceId({
+      env: previewEnv,
+      workflowName: 'image',
+      suffix,
+    });
+    expect(id.endsWith(suffix)).toBe(true);
+    expect(id.length).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('shotVariantDedupId', () => {
+  test('is stable across calls with the same inputs (replay-safe)', () => {
+    expect(shotVariantDedupId(RUN_A, FRAME_ID, 'nano_banana_2')).toBe(
+      shotVariantDedupId(RUN_A, FRAME_ID, 'nano_banana_2')
+    );
+  });
+
+  test('distinct frames and models get distinct ids within one run', () => {
+    const base = shotVariantDedupId(RUN_A, FRAME_ID, 'nano_banana_2');
+    expect(base).not.toBe(
+      shotVariantDedupId(RUN_A, OTHER_FRAME_ID, 'nano_banana_2')
+    );
+    expect(base).not.toBe(shotVariantDedupId(RUN_A, FRAME_ID, 'seedream'));
+  });
+
+  test('survives buildInstanceId untruncated for realistic inputs', () => {
+    const suffix = shotVariantDedupId(RUN_A, FRAME_ID, 'nano_banana_2');
+    const id = buildInstanceId({
+      env: previewEnv,
+      workflowName: 'variant-image',
+      suffix,
+    });
+    expect(id.endsWith(suffix)).toBe(true);
+    expect(id.length).toBeLessThanOrEqual(100);
+  });
+
+  test('run-scoping hash survives truncation even with absurdly long discriminators', () => {
+    // Force buildInstanceId to truncate the suffix. Because the hash leads,
+    // truncation shears the tail (frame/model), never the run discriminator —
+    // two different runs must NEVER collapse onto the same instance id, or
+    // the second run would silently reuse the first run's (possibly stale or
+    // failed) child instance.
+    const longModel = 'x'.repeat(120);
+    const idA = buildInstanceId({
+      env: previewEnv,
+      workflowName: 'variant-image',
+      suffix: shotVariantDedupId(RUN_A, FRAME_ID, longModel),
+    });
+    const idB = buildInstanceId({
+      env: previewEnv,
+      workflowName: 'variant-image',
+      suffix: shotVariantDedupId(RUN_B, FRAME_ID, longModel),
+    });
+    expect(idA.length).toBe(100); // truncation actually occurred
+    expect(idB.length).toBe(100);
+    expect(idA).not.toBe(idB); // ...and the run hash survived it
+  });
+});

--- a/src/lib/workflow/dedup-ids.ts
+++ b/src/lib/workflow/dedup-ids.ts
@@ -5,11 +5,12 @@
  *
  * 1. Replay-stable: a retried step must produce the identical id so the
  *    existing child instance is reused instead of spawning a second paid job.
- * 2. Run-scoping hash FIRST: `buildInstanceId` keeps only `100 − prefix`
- *    chars of the suffix, truncating from the END, so the hash that separates
- *    two different runs must lead. Truncation may shear the human-readable
- *    tail, never the part that prevents a new run from colliding with (and
- *    silently reusing) a previous run's instance.
+ * 2. Run-scoping hash FIRST: `buildInstanceId` (instance-id.ts) keeps only
+ *    `100 − prefix` chars of the suffix, truncating from the END, so the hash
+ *    that separates two different runs must lead. Truncation may shear the
+ *    human-readable tail, never the part that prevents a new run from
+ *    colliding with (and silently reusing) a previous run's instance. If
+ *    instance-id.ts ever changes its truncation strategy, revisit this.
  */
 
 import { simpleHash } from '@/lib/utils/hash';
@@ -28,7 +29,8 @@ export function previewImageDedupId(
 }
 
 /**
- * Shot-variant grid spawned by FrameImagesWorkflow, one per (frame, model).
+ * Shot-variant grid spawned by FrameImagesWorkflow, one per (frame, model) —
+ * keyed on the scene id instead when no frame matched the scene.
  */
 export function shotVariantDedupId(
   parentInstanceId: string,

--- a/src/lib/workflow/dedup-ids.ts
+++ b/src/lib/workflow/dedup-ids.ts
@@ -1,0 +1,39 @@
+/**
+ * Deterministic `deduplicationId` builders for child workflows triggered from
+ * inside `step.do` closures (issue #846 RC2). Two invariants, both pinned by
+ * dedup-ids.test.ts:
+ *
+ * 1. Replay-stable: a retried step must produce the identical id so the
+ *    existing child instance is reused instead of spawning a second paid job.
+ * 2. Run-scoping hash FIRST: `buildInstanceId` keeps only `100 − prefix`
+ *    chars of the suffix, truncating from the END, so the hash that separates
+ *    two different runs must lead. Truncation may shear the human-readable
+ *    tail, never the part that prevents a new run from colliding with (and
+ *    silently reusing) a previous run's instance.
+ */
+
+import { simpleHash } from '@/lib/utils/hash';
+
+/**
+ * Preview image spawned by SceneSplitWorkflow for a freshly upserted frame.
+ * `frameId` is replay-stable (frames upsert on `(sequenceId, orderIndex)`);
+ * the parent-instance hash scopes per run so a re-split still gets fresh
+ * previews while a step retry can't re-spawn paid image jobs.
+ */
+export function previewImageDedupId(
+  parentInstanceId: string,
+  frameId: string
+): string {
+  return `preview-${simpleHash(parentInstanceId)}-${frameId}`;
+}
+
+/**
+ * Shot-variant grid spawned by FrameImagesWorkflow, one per (frame, model).
+ */
+export function shotVariantDedupId(
+  parentInstanceId: string,
+  frameOrSceneId: string,
+  model: string
+): string {
+  return `variant-${simpleHash(parentInstanceId)}-${frameOrSceneId}-${model}`;
+}

--- a/src/lib/workflow/errors.test.ts
+++ b/src/lib/workflow/errors.test.ts
@@ -35,6 +35,18 @@ describe('isEngineAbortError', () => {
     );
   });
 
+  test('does not match unrelated errors that mention a grace period', () => {
+    // A true positive skips onFailure and parent notification, so a bare
+    // "grace period" token from another layer must never classify as an
+    // engine abort.
+    expect(
+      isEngineAbortError(new Error('subscription grace period expired'))
+    ).toBe(false);
+    expect(
+      isEngineAbortError(new Error('grace period: 30 days remaining'))
+    ).toBe(false);
+  });
+
   test('does not match ordinary failures', () => {
     expect(isEngineAbortError(new Error('fal request failed: 500'))).toBe(
       false

--- a/src/lib/workflow/errors.test.ts
+++ b/src/lib/workflow/errors.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { describe, expect, test } from 'vitest';
-import { isEngineAbortError, isRecipientInFiniteStateError } from './errors';
+import {
+  isEngineAbortError,
+  isInstanceAlreadyExistsError,
+  isRecipientInFiniteStateError,
+} from './errors';
 
 describe('isEngineAbortError', () => {
   test('matches the exact prod engine-abort message', () => {
@@ -43,6 +47,54 @@ describe('isEngineAbortError', () => {
     expect(isEngineAbortError(null)).toBe(false);
     expect(isEngineAbortError(undefined)).toBe(false);
     expect(isEngineAbortError(42)).toBe(false);
+  });
+});
+
+describe('isInstanceAlreadyExistsError', () => {
+  test('matches the exact prod already_exists message', () => {
+    expect(
+      isInstanceAlreadyExistsError(
+        new Error('(instance.already_exists) Instance already exists')
+      )
+    ).toBe(true);
+  });
+
+  test('matches when wrapped in a child-failure message', () => {
+    expect(
+      isInstanceAlreadyExistsError(
+        new Error(
+          'Child workflow image:01SEQ failed: (instance.already_exists) Instance already exists'
+        )
+      )
+    ).toBe(true);
+  });
+
+  test('matches plain strings', () => {
+    expect(isInstanceAlreadyExistsError('Instance already exists')).toBe(true);
+  });
+
+  test('does not match unrelated "already exists" errors from other layers', () => {
+    // Swallowing one of these as a successful trigger would mask a real
+    // failure — the matcher is anchored on the `instance` token.
+    expect(isInstanceAlreadyExistsError(new Error('user already exists'))).toBe(
+      false
+    );
+    expect(
+      isInstanceAlreadyExistsError(new Error('bucket already exists'))
+    ).toBe(false);
+    expect(
+      isInstanceAlreadyExistsError(new Error('table frames already exists'))
+    ).toBe(false);
+  });
+
+  test('does not match ordinary failures', () => {
+    expect(isInstanceAlreadyExistsError(new Error('network down'))).toBe(false);
+    expect(isInstanceAlreadyExistsError(new Error('instance not found'))).toBe(
+      false
+    );
+    expect(isInstanceAlreadyExistsError(null)).toBe(false);
+    expect(isInstanceAlreadyExistsError(undefined)).toBe(false);
+    expect(isInstanceAlreadyExistsError(42)).toBe(false);
   });
 });
 

--- a/src/lib/workflow/errors.ts
+++ b/src/lib/workflow/errors.ts
@@ -40,7 +40,10 @@ function errorMessage(error: unknown): string {
  * of the public API. See issue #839 (2026-06-06 mass-abort cascade).
  */
 export function isEngineAbortError(error: unknown): boolean {
-  return /aborting engine|grace period/i.test(errorMessage(error));
+  // Matched on the full phrase, not a bare "grace period" token — a true
+  // positive here skips onFailure AND parent notification, so an app error
+  // that merely mentions a grace period must never be classified as one.
+  return /aborting engine|grace period complete/i.test(errorMessage(error));
 }
 
 /**

--- a/src/lib/workflow/errors.ts
+++ b/src/lib/workflow/errors.ts
@@ -60,8 +60,12 @@ export function isRecipientInFiniteStateError(error: unknown): boolean {
  * already exists`. Match on the message defensively (the thrown value's class
  * isn't part of the public API) so an in-run durable retry — where `create()`
  * succeeded but the step's result wasn't persisted before a crash — is treated
- * as success instead of a hard failure.
+ * as success instead of a hard failure. Anchored on the `instance` token so an
+ * unrelated "already exists" error (user, bucket, table…) from another layer
+ * is never misclassified as a duplicate workflow instance.
  */
 export function isInstanceAlreadyExistsError(error: unknown): boolean {
-  return /already.?exists/i.test(errorMessage(error));
+  return /instance\.already_exists|instance already exists/i.test(
+    errorMessage(error)
+  );
 }

--- a/src/lib/workflow/errors.ts
+++ b/src/lib/workflow/errors.ts
@@ -54,3 +54,14 @@ export function isEngineAbortError(error: unknown): boolean {
 export function isRecipientInFiniteStateError(error: unknown): boolean {
   return /in_finite_state|finite state/i.test(errorMessage(error));
 }
+
+/**
+ * CF surfaces a reused instance id as `(instance.already_exists) Instance
+ * already exists`. Match on the message defensively (the thrown value's class
+ * isn't part of the public API) so an in-run durable retry — where `create()`
+ * succeeded but the step's result wasn't persisted before a crash — is treated
+ * as success instead of a hard failure.
+ */
+export function isInstanceAlreadyExistsError(error: unknown): boolean {
+  return /already.?exists/i.test(errorMessage(error));
+}

--- a/src/lib/workflow/trigger-bindings.test.ts
+++ b/src/lib/workflow/trigger-bindings.test.ts
@@ -3,11 +3,15 @@
  *
  * Mirror-image of the `spawnAndAwaitChild` swallow (await-child.test.ts): when
  * the caller passed a deterministic `deduplicationId` and CF rejects the
- * create with `already_exists`, the existing instance belongs to this same
- * logical trigger (a `step.do` replay re-running its closure), so the trigger
- * must succeed and return the deterministic id — otherwise a multi-create
- * step can never complete once one sibling fails (issue #846 RC3). The
- * random-suffix path can't collide legitimately, so it keeps throwing.
+ * create with `already_exists`, the existing instance usually belongs to this
+ * same logical trigger (a `step.do` replay re-running its closure), so the
+ * trigger must succeed and return the deterministic id — otherwise a
+ * multi-create step can never complete once one sibling fails (issue #846
+ * RC3). But dedup ids are not always run-scoped (`framePromptDedupId` is
+ * stable across user requests), so the swallow is gated on the existing
+ * instance's status: alive-or-complete reuses it; errored/terminated/unknown/
+ * unverifiable rethrows so a dead instance can't masquerade as "enqueued".
+ * The random-suffix path can't collide legitimately, so it keeps throwing.
  */
 
 import { describe, expect, test, vi } from 'vitest';
@@ -22,16 +26,29 @@ const env = {
 const body = { userId: 'u1', teamId: 't1' };
 
 function harness(
-  createImpl: (opts: { id: string; params: unknown }) => Promise<unknown>
+  createImpl: (opts: { id: string; params: unknown }) => Promise<unknown>,
+  existingInstanceStatus?: InstanceStatus['status'] | 'lookup-fails'
 ) {
   const create =
     vi.fn<(opts: { id: string; params: unknown }) => Promise<unknown>>(
       createImpl
     );
-  const bindingStub = { create };
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Workflow binding stub exposing only create
+  const get = vi.fn(async (id: string) => {
+    if (
+      existingInstanceStatus === undefined ||
+      existingInstanceStatus === 'lookup-fails'
+    ) {
+      throw new Error('instance not found');
+    }
+    return {
+      id,
+      status: () => Promise.resolve({ status: existingInstanceStatus }),
+    };
+  });
+  const bindingStub = { create, get };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Workflow binding stub exposing only create + get
   const binding = bindingStub as unknown as Workflow<typeof body>;
-  return { binding, create };
+  return { binding, create, get };
 }
 
 const alreadyExists = () =>
@@ -84,8 +101,8 @@ describe('triggerCfWorkflow', () => {
     expect(a.workflowRunId).toBe(b.workflowRunId);
   });
 
-  test('swallows already_exists and returns the deterministic id when deduplicationId was provided', async () => {
-    const { binding, create } = harness(alreadyExists);
+  test('swallows already_exists and returns the deterministic id when the existing instance is running', async () => {
+    const { binding, create, get } = harness(alreadyExists, 'running');
 
     const result = await triggerCfWorkflow({
       binding,
@@ -98,6 +115,67 @@ describe('triggerCfWorkflow', () => {
     const attempted = create.mock.calls[0]?.[0];
     if (!attempted) throw new Error('binding.create was not called');
     expect(result.workflowRunId).toBe(attempted.id);
+    expect(get).toHaveBeenCalledWith(attempted.id);
+  });
+
+  // `complete` matters most: a step replay after the child already finished
+  // must still succeed. The queued/paused/waiting states are alive instances
+  // that will do the work.
+  test.each([
+    'queued',
+    'paused',
+    'waiting',
+    'waitingForPause',
+    'complete',
+  ] as const)(
+    'swallows already_exists when the existing instance is %s',
+    async (status) => {
+      const { binding, create } = harness(alreadyExists, status);
+
+      const result = await triggerCfWorkflow({
+        binding,
+        triggerPath: '/variant-image',
+        body,
+        env,
+        deduplicationId: 'variant-f1-m1-abc',
+      });
+
+      expect(result.workflowRunId).toBe(create.mock.calls[0]?.[0]?.id);
+    }
+  );
+
+  // A request-stable dedup id (e.g. framePromptDedupId) colliding with a
+  // FAILED prior instance must stay loud: returning the dead instance's id
+  // would clear staleness banners while no workflow ever runs (#846 review).
+  test.each(['errored', 'terminated', 'unknown'] as const)(
+    'rethrows already_exists when the existing instance is %s',
+    async (status) => {
+      const { binding } = harness(alreadyExists, status);
+
+      await expect(
+        triggerCfWorkflow({
+          binding,
+          triggerPath: '/visual-prompt-scene',
+          body,
+          env,
+          deduplicationId: 'prompt-visual-f1-h4sh',
+        })
+      ).rejects.toThrow(/already exists/i);
+    }
+  );
+
+  test('rethrows the original already_exists error when the status lookup itself fails', async () => {
+    const { binding } = harness(alreadyExists, 'lookup-fails');
+
+    await expect(
+      triggerCfWorkflow({
+        binding,
+        triggerPath: '/variant-image',
+        body,
+        env,
+        deduplicationId: 'variant-f1-m1-abc',
+      })
+    ).rejects.toThrow(/already exists/i);
   });
 
   test('rethrows already_exists when no deduplicationId was provided (random-suffix path)', async () => {

--- a/src/lib/workflow/trigger-bindings.test.ts
+++ b/src/lib/workflow/trigger-bindings.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for `triggerCfWorkflow`'s `instance.already_exists` tolerance.
+ *
+ * Mirror-image of the `spawnAndAwaitChild` swallow (await-child.test.ts): when
+ * the caller passed a deterministic `deduplicationId` and CF rejects the
+ * create with `already_exists`, the existing instance belongs to this same
+ * logical trigger (a `step.do` replay re-running its closure), so the trigger
+ * must succeed and return the deterministic id — otherwise a multi-create
+ * step can never complete once one sibling fails (issue #846 RC3). The
+ * random-suffix path can't collide legitimately, so it keeps throwing.
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import { triggerCfWorkflow } from './trigger-bindings';
+import type { CloudflareEnv } from '@/lib/workflow/types';
+
+// oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal env stub: triggerCfWorkflow only reads VITE_APP_URL (via buildInstanceId)
+const env = {
+  VITE_APP_URL: 'https://openstory.so',
+} as unknown as CloudflareEnv;
+
+const body = { userId: 'u1', teamId: 't1' };
+
+function harness(
+  createImpl: (opts: { id: string; params: unknown }) => Promise<unknown>
+) {
+  const create =
+    vi.fn<(opts: { id: string; params: unknown }) => Promise<unknown>>(
+      createImpl
+    );
+  const bindingStub = { create };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Workflow binding stub exposing only create
+  const binding = bindingStub as unknown as Workflow<typeof body>;
+  return { binding, create };
+}
+
+const alreadyExists = () =>
+  Promise.reject(
+    new Error('(instance.already_exists) Instance already exists')
+  );
+
+describe('triggerCfWorkflow', () => {
+  test('returns the created instance id on success', async () => {
+    const { binding, create } = harness((opts) =>
+      Promise.resolve({ id: opts.id })
+    );
+
+    const result = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/variant-image',
+      body,
+      env,
+      deduplicationId: 'variant-f1-m1-abc',
+    });
+
+    const attempted = create.mock.calls[0]?.[0];
+    if (!attempted) throw new Error('binding.create was not called');
+    expect(result.workflowRunId).toBe(attempted.id);
+    expect(attempted.id).toContain('variant-f1-m1-abc');
+    expect(attempted.params).toEqual(body);
+  });
+
+  test('deterministic deduplicationId is stable across calls (replay-safe)', async () => {
+    const { binding, create } = harness((opts) =>
+      Promise.resolve({ id: opts.id })
+    );
+
+    const a = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/image',
+      body,
+      env,
+      deduplicationId: 'preview-frame1-h4sh',
+    });
+    const b = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/image',
+      body,
+      env,
+      deduplicationId: 'preview-frame1-h4sh',
+    });
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(a.workflowRunId).toBe(b.workflowRunId);
+  });
+
+  test('swallows already_exists and returns the deterministic id when deduplicationId was provided', async () => {
+    const { binding, create } = harness(alreadyExists);
+
+    const result = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/variant-image',
+      body,
+      env,
+      deduplicationId: 'variant-f1-m1-abc',
+    });
+
+    const attempted = create.mock.calls[0]?.[0];
+    if (!attempted) throw new Error('binding.create was not called');
+    expect(result.workflowRunId).toBe(attempted.id);
+  });
+
+  test('rethrows already_exists when no deduplicationId was provided (random-suffix path)', async () => {
+    const { binding } = harness(alreadyExists);
+
+    await expect(
+      triggerCfWorkflow({ binding, triggerPath: '/image', body, env })
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  test('rethrows unrelated create errors even with a deduplicationId', async () => {
+    const { binding } = harness(() =>
+      Promise.reject(new Error('network down'))
+    );
+
+    await expect(
+      triggerCfWorkflow({
+        binding,
+        triggerPath: '/image',
+        body,
+        env,
+        deduplicationId: 'preview-frame1-h4sh',
+      })
+    ).rejects.toThrow('network down');
+  });
+});

--- a/src/lib/workflow/trigger-bindings.ts
+++ b/src/lib/workflow/trigger-bindings.ts
@@ -12,7 +12,11 @@
  */
 
 import type { CloudflareEnv } from '@/lib/workflow/types';
+import { isInstanceAlreadyExistsError } from '@/lib/workflow/errors';
 import { buildInstanceId } from '@/lib/workflow/instance-id';
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'workflow', 'trigger-bindings']);
 
 const TRIGGER_TO_BINDING: Record<string, keyof CloudflareEnv> = {
   image: 'IMAGE_WORKFLOW',
@@ -128,6 +132,22 @@ export async function triggerCfWorkflow<T extends Rpc.Serializable<T>>({
     suffix: deduplicationId ?? `${Date.now()}-${crypto.randomUUID()}`,
   });
 
-  const instance = await binding.create({ id, params: body });
-  return { workflowRunId: instance.id };
+  try {
+    const instance = await binding.create({ id, params: body });
+    return { workflowRunId: instance.id };
+  } catch (error) {
+    // A deterministic id (caller passed `deduplicationId`) hitting
+    // `instance.already_exists` means a prior attempt of this same logical
+    // trigger — typically a `step.do` replay — already created the instance.
+    // Treat it as success so the retrying step can complete instead of
+    // burning its budget on a permanent error. The random-suffix path can't
+    // collide legitimately, so it keeps throwing.
+    if (deduplicationId && isInstanceAlreadyExistsError(error)) {
+      logger.info(
+        `[triggerCfWorkflow] ${id} already exists; reusing existing instance for '${workflowName}'`
+      );
+      return { workflowRunId: id };
+    }
+    throw error;
+  }
 }

--- a/src/lib/workflow/trigger-bindings.ts
+++ b/src/lib/workflow/trigger-bindings.ts
@@ -110,6 +110,44 @@ export function getCfBindingForRunId(
 }
 
 /**
+ * Instance states an `already_exists` rejection may legitimately stand in
+ * for: the prior instance is still making progress, or already finished its
+ * work, so reusing its id is success. `errored`/`terminated` are excluded —
+ * that instance will never do the work, and pretending it was enqueued turns
+ * a loud failure into a silent no-op. This matters because deduplication ids
+ * are not always run-scoped: `framePromptDedupId`/`musicPromptDedupId` are
+ * stable across user requests, so a failed instance would otherwise pin every
+ * retry to a dead id for CF's 30-day retention window. `unknown` is excluded
+ * too — rethrow rather than trust an id we can't verify.
+ */
+const REUSABLE_INSTANCE_STATUSES: ReadonlySet<InstanceStatus['status']> =
+  new Set([
+    'queued',
+    'running',
+    'paused',
+    'waiting',
+    'waitingForPause',
+    'complete',
+  ]);
+
+/**
+ * Status of an existing instance, or null when the lookup itself fails — the
+ * caller treats null as "not reusable" and rethrows its original error, so a
+ * transient lookup failure stays loud rather than minting a fake success.
+ */
+async function getInstanceStatus<T>(
+  binding: Workflow<T>,
+  id: string
+): Promise<InstanceStatus['status'] | null> {
+  try {
+    const instance = await binding.get(id);
+    return (await instance.status()).status;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Trigger a workflow.
  */
 export async function triggerCfWorkflow<T extends Rpc.Serializable<T>>({
@@ -137,16 +175,25 @@ export async function triggerCfWorkflow<T extends Rpc.Serializable<T>>({
     return { workflowRunId: instance.id };
   } catch (error) {
     // A deterministic id (caller passed `deduplicationId`) hitting
-    // `instance.already_exists` means a prior attempt of this same logical
-    // trigger — typically a `step.do` replay — already created the instance.
-    // Treat it as success so the retrying step can complete instead of
-    // burning its budget on a permanent error. The random-suffix path can't
-    // collide legitimately, so it keeps throwing.
+    // `instance.already_exists` usually means a prior attempt of this same
+    // logical trigger — typically a `step.do` replay — already created the
+    // instance, so the trigger should succeed instead of burning the step's
+    // retry budget on a permanent error. But only when the existing instance
+    // is verifiably alive or complete (see REUSABLE_INSTANCE_STATUSES):
+    // reusing an errored/terminated instance would silently report "enqueued"
+    // for work that will never happen. The random-suffix path can't collide
+    // legitimately, so it always rethrows.
     if (deduplicationId && isInstanceAlreadyExistsError(error)) {
-      logger.info(
-        `[triggerCfWorkflow] ${id} already exists; reusing existing instance for '${workflowName}'`
+      const status = await getInstanceStatus(binding, id);
+      if (status !== null && REUSABLE_INSTANCE_STATUSES.has(status)) {
+        logger.info(
+          `[triggerCfWorkflow] ${id} already exists (${status}); reusing existing instance for '${workflowName}'`
+        );
+        return { workflowRunId: id };
+      }
+      logger.warn(
+        `[triggerCfWorkflow] ${id} already exists but is not reusable (status: ${status ?? 'unavailable'}); rethrowing for '${workflowName}'`
       );
-      return { workflowRunId: id };
     }
     throw error;
   }

--- a/src/lib/workflows/character-sheet-workflow.ts
+++ b/src/lib/workflows/character-sheet-workflow.ts
@@ -145,6 +145,7 @@ export class CharacterSheetWorkflow extends OpenStoryWorkflowEntrypoint<Characte
         costMicros: extractImageCost(imageResult.metadata),
         usedOwnKey: imageResult.metadata.usedOwnKey,
         description: `Character sheet (${generationParams.model})`,
+        idempotencyKey: `${event.instanceId}:sheet`,
         metadata: {
           model: generationParams.model,
           characterName: input.characterName,

--- a/src/lib/workflows/element-sheet-workflow.ts
+++ b/src/lib/workflows/element-sheet-workflow.ts
@@ -178,6 +178,7 @@ export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementShe
             costMicros: extractImageCost(imageResult.metadata),
             usedOwnKey: imageResult.metadata.usedOwnKey,
             description: `Element reference (${generationParams.model})`,
+            idempotencyKey: `${event.instanceId}:element-ref-${index}`,
             metadata: {
               model: generationParams.model,
               token: entry.token,

--- a/src/lib/workflows/element-vision-workflow.ts
+++ b/src/lib/workflows/element-vision-workflow.ts
@@ -76,9 +76,10 @@ export class ElementVisionWorkflow extends OpenStoryWorkflowEntrypoint<ElementVi
     // ensureUniqueToken (suffixes `_2` on collision) because the system is
     // choosing the name — failing the workflow on collision would strand the
     // element with no usable name. Excluding the element's own row keeps a
-    // step retry idempotent: after a successful rename the replay sees the
-    // suggested token on this element only, gets it back un-suffixed, and
-    // the (atomic) cascade re-run yields zero deltas.
+    // step retry idempotent: after a successful rename the replay gets the
+    // suggested token back un-suffixed, and — since the in-memory
+    // `element.token` still holds the pre-rename name, so neither early
+    // return fires — the cascade re-runs, atomically yielding zero deltas.
     const finalToken = await step.do('auto-rename', async () => {
       if (suggestedToken === element.token) return element.token;
       const unique = await scopedDb.sequenceElements.ensureUniqueToken(

--- a/src/lib/workflows/element-vision-workflow.ts
+++ b/src/lib/workflows/element-vision-workflow.ts
@@ -75,12 +75,16 @@ export class ElementVisionWorkflow extends OpenStoryWorkflowEntrypoint<ElementVi
     // Step 5: auto-rename to vision-suggested token if different. Uses
     // ensureUniqueToken (suffixes `_2` on collision) because the system is
     // choosing the name — failing the workflow on collision would strand the
-    // element with no usable name.
+    // element with no usable name. Excluding the element's own row keeps a
+    // step retry idempotent: after a successful rename the replay sees the
+    // suggested token on this element only, gets it back un-suffixed, and
+    // the (atomic) cascade re-run yields zero deltas.
     const finalToken = await step.do('auto-rename', async () => {
       if (suggestedToken === element.token) return element.token;
       const unique = await scopedDb.sequenceElements.ensureUniqueToken(
         element.sequenceId,
-        suggestedToken
+        suggestedToken,
+        elementId
       );
       if (unique === element.token) return element.token;
       const result = await scopedDb.sequenceElements.cascadeRename({

--- a/src/lib/workflows/frame-images-workflow.ts
+++ b/src/lib/workflows/frame-images-workflow.ts
@@ -28,7 +28,7 @@ import type { ScopedDb } from '@/lib/db/scoped';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
 import { buildElementReferenceImages } from '@/lib/prompts/element-prompt';
 import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
-import { simpleHash } from '@/lib/utils/hash';
+import { shotVariantDedupId } from '@/lib/workflow/dedup-ids';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { triggerWorkflow } from '@/lib/workflow/client';
@@ -313,9 +313,12 @@ export class FrameImagesWorkflow extends OpenStoryWorkflowEntrypoint<FrameImages
                     retryDelay: 'pow(2, retried) * 1000',
                     // Replay-stable: a retry of this step.do must reuse the
                     // existing variant instance instead of spawning a second
-                    // paid job. Discriminators first — buildInstanceId
-                    // truncates the suffix at 100 chars.
-                    deduplicationId: `variant-${matchedFrame?.frameId ?? scene.sceneId}-${model}-${simpleHash(parentInstanceId)}`,
+                    // paid job (see dedup-ids.ts).
+                    deduplicationId: shotVariantDedupId(
+                      parentInstanceId,
+                      matchedFrame?.frameId ?? scene.sceneId,
+                      model
+                    ),
                   }
                 );
               }

--- a/src/lib/workflows/frame-images-workflow.ts
+++ b/src/lib/workflows/frame-images-workflow.ts
@@ -28,6 +28,7 @@ import type { ScopedDb } from '@/lib/db/scoped';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
 import { buildElementReferenceImages } from '@/lib/prompts/element-prompt';
 import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
+import { simpleHash } from '@/lib/utils/hash';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { triggerWorkflow } from '@/lib/workflow/client';
@@ -310,6 +311,11 @@ export class FrameImagesWorkflow extends OpenStoryWorkflowEntrypoint<FrameImages
                     label,
                     retries: 3,
                     retryDelay: 'pow(2, retried) * 1000',
+                    // Replay-stable: a retry of this step.do must reuse the
+                    // existing variant instance instead of spawning a second
+                    // paid job. Discriminators first — buildInstanceId
+                    // truncates the suffix at 100 chars.
+                    deduplicationId: `variant-${matchedFrame?.frameId ?? scene.sceneId}-${model}-${simpleHash(parentInstanceId)}`,
                   }
                 );
               }

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -234,6 +234,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
         }
         await scopedDb.billing.deductCredits(imageCostMicros, {
           description: `Image generation (${generationParams.model})`,
+          idempotencyKey: `${event.instanceId}:image`,
           metadata: {
             model: generationParams.model,
             frameId: input.frameId,

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -17,7 +17,8 @@
 import { computeVisualPromptInputHash } from '@/lib/ai/input-hash';
 import { DEFAULT_IMAGE_MODEL, IMAGE_MODELS } from '@/lib/ai/models';
 import { loadNarrowFramePromptContext } from '@/lib/ai/prompt-context';
-import { ZERO_MICROS, microsToUsd } from '@/lib/billing/money';
+import { ZERO_MICROS } from '@/lib/billing/money';
+import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import { DEFAULT_IMAGE_SIZE } from '@/lib/constants/aspect-ratios';
 import type { ScopedDb } from '@/lib/db/scoped';
 import {
@@ -226,13 +227,10 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
     const { teamId, frameId, sequenceId } = input;
     if (imageCostMicros > 0 && teamId && !imageResult.metadata.usedOwnKey) {
       await step.do('deduct-credits', async () => {
-        if (!(await scopedDb.billing.hasEnoughCredits(imageCostMicros))) {
-          logger.warn(
-            `[ImageWorkflow:cf] Insufficient credits for team ${teamId} (cost: $${microsToUsd(imageCostMicros).toFixed(4)}), skipping deduction`
-          );
-          return;
-        }
-        await scopedDb.billing.deductCredits(imageCostMicros, {
+        await deductWorkflowCredits({
+          scopedDb,
+          costMicros: imageCostMicros,
+          usedOwnKey: imageResult.metadata.usedOwnKey,
           description: `Image generation (${generationParams.model})`,
           idempotencyKey: `${event.instanceId}:image`,
           metadata: {
@@ -240,6 +238,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
             frameId: input.frameId,
             sequenceId: input.sequenceId,
           },
+          workflowName: 'ImageWorkflow:cf',
         });
       });
     }

--- a/src/lib/workflows/library-location-sheet-workflow.ts
+++ b/src/lib/workflows/library-location-sheet-workflow.ts
@@ -103,6 +103,7 @@ export class LibraryLocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<Li
         costMicros: extractImageCost(imageResult.metadata),
         usedOwnKey: imageResult.metadata.usedOwnKey,
         description: `Library location sheet (${generationParams.model})`,
+        idempotencyKey: `${event.instanceId}:sheet`,
         metadata: {
           model: generationParams.model,
           locationName: input.locationName,
@@ -197,6 +198,7 @@ export class LibraryLocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<Li
         costMicros: extractImageCost(previewResult.metadata),
         usedOwnKey: previewResult.metadata.usedOwnKey,
         description: `Location preview (${input.imageModel ?? DEFAULT_IMAGE_MODEL})`,
+        idempotencyKey: `${event.instanceId}:preview`,
         metadata: { locationDbId: input.locationDbId, type: 'preview' },
         workflowName: 'LibraryLocationSheetWorkflow',
       });

--- a/src/lib/workflows/library-talent-sheet-workflow.ts
+++ b/src/lib/workflows/library-talent-sheet-workflow.ts
@@ -139,6 +139,7 @@ export class LibraryTalentSheetWorkflow extends OpenStoryWorkflowEntrypoint<Libr
         costMicros: extractImageCost(imageResult.metadata),
         usedOwnKey: imageResult.metadata.usedOwnKey,
         description: `Talent sheet (${input.imageModel ?? DEFAULT_IMAGE_MODEL})`,
+        idempotencyKey: `${event.instanceId}:sheet`,
         metadata: { talentId: input.talentId, type: 'sheet' },
         workflowName: 'LibraryTalentSheetWorkflow',
       });
@@ -336,6 +337,7 @@ export class LibraryTalentSheetWorkflow extends OpenStoryWorkflowEntrypoint<Libr
         costMicros: extractImageCost(headshotResult.metadata),
         usedOwnKey: headshotResult.metadata.usedOwnKey,
         description: `Talent headshot (${input.imageModel ?? DEFAULT_IMAGE_MODEL})`,
+        idempotencyKey: `${event.instanceId}:headshot`,
         metadata: { talentId: input.talentId, type: 'headshot' },
         workflowName: 'LibraryTalentSheetWorkflow',
       });

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -40,6 +40,12 @@ export type DurableLLMCallConfig<TSchema extends z.ZodType> = {
 export type DurableLLMCallContext = {
   sequenceId?: string;
   userId?: string;
+  /**
+   * The workflow's `event.instanceId` — replay-stable, used as the
+   * idempotency-key prefix for the credit-deduction step so a step retry
+   * can't double-charge.
+   */
+  workflowRunId: string;
   /** Override OpenRouter API key (e.g. user-provided). Falls back to platform env key. */
   openRouterApiKey?: string;
   /** Scoped DB context for resolving team API keys + deducting credits. */
@@ -176,6 +182,7 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
         costMicros: ZERO_MICROS,
         usedOwnKey: !!callContext.openRouterApiKey,
         description: `LLM analysis (${modelId})`,
+        idempotencyKey: `${callContext.workflowRunId}:llm-${name}`,
         metadata: {
           model: modelId,
           phase: phase.number,
@@ -352,6 +359,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
         costMicros: ZERO_MICROS,
         usedOwnKey: !!callContext.openRouterApiKey,
         description: `LLM analysis (${modelId})`,
+        idempotencyKey: `${callContext.workflowRunId}:llm-${name}`,
         metadata: {
           model: modelId,
           phase: phase.number,

--- a/src/lib/workflows/location-matching-workflow.ts
+++ b/src/lib/workflows/location-matching-workflow.ts
@@ -110,6 +110,7 @@ export class LocationMatchingWorkflow extends OpenStoryWorkflowEntrypoint<Locati
             {
               sequenceId,
               userId: input.userId,
+              workflowRunId: event.instanceId,
               scopedDb,
             }
           )

--- a/src/lib/workflows/location-sheet-workflow.ts
+++ b/src/lib/workflows/location-sheet-workflow.ts
@@ -144,6 +144,7 @@ export class LocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<LocationS
         costMicros: extractImageCost(imageResult.metadata),
         usedOwnKey: imageResult.metadata.usedOwnKey,
         description: `Location sheet (${generationParams.model})`,
+        idempotencyKey: `${event.instanceId}:sheet`,
         metadata: {
           model: generationParams.model,
           locationName: input.locationName,

--- a/src/lib/workflows/motion-prompt-scene-workflow.ts
+++ b/src/lib/workflows/motion-prompt-scene-workflow.ts
@@ -89,6 +89,7 @@ export class MotionPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Motio
       },
       {
         sequenceId,
+        workflowRunId: event.instanceId,
         scopedDb,
         framePromptStream:
           input.emitStreaming && frameId

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -20,6 +20,7 @@ import { computeMotionPromptInputHash } from '@/lib/ai/input-hash';
 import { DEFAULT_VIDEO_MODEL, IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
 import { loadNarrowFramePromptContext } from '@/lib/ai/prompt-context';
 import { microsToUsd, type Microdollars } from '@/lib/billing/money';
+import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { ensureImageUnderLimit } from '@/lib/image/image-compress';
 import {
@@ -409,10 +410,16 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
       });
     });
 
-    // Deduct credits (skip if team used own fal key)
+    // Deduct credits (skip if team used own fal key). Routed through
+    // deductWorkflowCredits so insufficient balances warn-and-skip (with an
+    // auto-top-up attempt) like every other workflow, instead of debiting
+    // the balance negative.
     if (cost > 0 && input.teamId && !job.usedOwnKey) {
       await step.do('deduct-credits', async () => {
-        await scopedDb.billing.deductCredits(cost, {
+        await deductWorkflowCredits({
+          scopedDb,
+          costMicros: cost,
+          usedOwnKey: job.usedOwnKey,
           description: `Motion generation (${model})`,
           idempotencyKey: `${event.instanceId}:motion`,
           metadata: {
@@ -421,6 +428,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
             sequenceId: input.sequenceId,
             duration: duration,
           },
+          workflowName: 'MotionWorkflow:cf',
         });
       });
     }

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -414,6 +414,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
       await step.do('deduct-credits', async () => {
         await scopedDb.billing.deductCredits(cost, {
           description: `Motion generation (${model})`,
+          idempotencyKey: `${event.instanceId}:motion`,
           metadata: {
             model,
             frameId: input.frameId,

--- a/src/lib/workflows/music-prompt-workflow.ts
+++ b/src/lib/workflows/music-prompt-workflow.ts
@@ -58,6 +58,7 @@ export class MusicPromptWorkflow extends OpenStoryWorkflowEntrypoint<MusicPrompt
       {
         sequenceId,
         userId: input.userId,
+        workflowRunId: event.instanceId,
         scopedDb,
       }
     );

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -15,7 +15,8 @@ import { computeSequenceMusicInputHash } from '@/lib/ai/input-hash';
 import { DEFAULT_MUSIC_MODEL } from '@/lib/ai/models';
 import { uploadAudioToStorage } from '@/lib/audio/audio-storage';
 import { generateMusic } from '@/lib/audio/music-generation';
-import { ZERO_MICROS, microsToUsd } from '@/lib/billing/money';
+import { ZERO_MICROS } from '@/lib/billing/money';
+import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { getGenerationChannel } from '@/lib/realtime';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
@@ -100,15 +101,10 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
     const musicCostMicros = audioResult.metadata?.cost ?? ZERO_MICROS;
     if (musicCostMicros > 0 && !audioResult.metadata.usedOwnKey) {
       await step.do('deduct-credits', async () => {
-        const canAfford =
-          await scopedDb.billing.hasEnoughCredits(musicCostMicros);
-        if (!canAfford) {
-          logger.warn(
-            `[MusicWorkflow:cf] Insufficient credits for team ${teamId} (cost: $${microsToUsd(musicCostMicros).toFixed(4)}), skipping deduction`
-          );
-          return;
-        }
-        await scopedDb.billing.deductCredits(musicCostMicros, {
+        await deductWorkflowCredits({
+          scopedDb,
+          costMicros: musicCostMicros,
+          usedOwnKey: audioResult.metadata.usedOwnKey,
           description: `Music generation (${model})`,
           idempotencyKey: `${event.instanceId}:music`,
           metadata: {
@@ -117,6 +113,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
             // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
             duration: audioResult.metadata?.duration,
           },
+          workflowName: 'MusicWorkflow:cf',
         });
       });
     }

--- a/src/lib/workflows/music-workflow.ts
+++ b/src/lib/workflows/music-workflow.ts
@@ -110,6 +110,7 @@ export class MusicWorkflow extends OpenStoryWorkflowEntrypoint<MusicWorkflowInpu
         }
         await scopedDb.billing.deductCredits(musicCostMicros, {
           description: `Music generation (${model})`,
+          idempotencyKey: `${event.instanceId}:music`,
           metadata: {
             model,
             sequenceId,

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -40,7 +40,7 @@ import type { ScopedDb } from '@/lib/db/scoped';
 import { getChatPrompt } from '@/lib/prompts';
 import { buildPreviewPrompt } from '@/lib/prompts/poster-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
-import { simpleHash } from '@/lib/utils/hash';
+import { previewImageDedupId } from '@/lib/workflow/dedup-ids';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
@@ -308,11 +308,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                   // scene. Routed through `triggerWorkflow` so the engine
                   // registry picks whichever engine is configured for
                   // `/image` at runtime. The deduplicationId makes a replay
-                  // of this mega-step idempotent: frameId is replay-stable
-                  // (frames upsert on (sequenceId, orderIndex)) and the
-                  // instance-id hash scopes per run, so a re-split still
-                  // gets fresh previews while a step retry can't re-spawn
-                  // paid image jobs for already-processed scenes.
+                  // of this mega-step idempotent (see dedup-ids.ts).
                   await triggerWorkflow(
                     '/image',
                     {
@@ -328,7 +324,10 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                     } satisfies ImageWorkflowInput,
                     {
                       label: buildWorkflowLabel(sequenceId),
-                      deduplicationId: `preview-${prevFrameId}-${simpleHash(event.instanceId)}`,
+                      deduplicationId: previewImageDedupId(
+                        event.instanceId,
+                        prevFrameId
+                      ),
                     }
                   );
                 }
@@ -365,7 +364,10 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
             } satisfies ImageWorkflowInput,
             {
               label: buildWorkflowLabel(sequenceId),
-              deduplicationId: `preview-${prevFrameId}-${simpleHash(event.instanceId)}`,
+              deduplicationId: previewImageDedupId(
+                event.instanceId,
+                prevFrameId
+              ),
             }
           );
         }

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -40,6 +40,7 @@ import type { ScopedDb } from '@/lib/db/scoped';
 import { getChatPrompt } from '@/lib/prompts';
 import { buildPreviewPrompt } from '@/lib/prompts/poster-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
+import { simpleHash } from '@/lib/utils/hash';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
@@ -306,7 +307,12 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                   // Fire-and-forget preview-image trigger for the previous
                   // scene. Routed through `triggerWorkflow` so the engine
                   // registry picks whichever engine is configured for
-                  // `/image` at runtime.
+                  // `/image` at runtime. The deduplicationId makes a replay
+                  // of this mega-step idempotent: frameId is replay-stable
+                  // (frames upsert on (sequenceId, orderIndex)) and the
+                  // instance-id hash scopes per run, so a re-split still
+                  // gets fresh previews while a step retry can't re-spawn
+                  // paid image jobs for already-processed scenes.
                   await triggerWorkflow(
                     '/image',
                     {
@@ -322,6 +328,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                     } satisfies ImageWorkflowInput,
                     {
                       label: buildWorkflowLabel(sequenceId),
+                      deduplicationId: `preview-${prevFrameId}-${simpleHash(event.instanceId)}`,
                     }
                   );
                 }
@@ -358,6 +365,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
             } satisfies ImageWorkflowInput,
             {
               label: buildWorkflowLabel(sequenceId),
+              deduplicationId: `preview-${prevFrameId}-${simpleHash(event.instanceId)}`,
             }
           );
         }
@@ -523,6 +531,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         costMicros: ZERO_MICROS,
         usedOwnKey: openRouterKeyInfo.source === 'team',
         description: `LLM analysis (${modelId})`,
+        idempotencyKey: `${event.instanceId}:llm-${STEP_NAME}`,
         metadata: {
           model: modelId,
           phase: PHASE.number,

--- a/src/lib/workflows/shot-variant-workflow.ts
+++ b/src/lib/workflows/shot-variant-workflow.ts
@@ -178,6 +178,7 @@ export class ShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<ShotVariant
         costMicros: extractImageCost(imageResult.metadata),
         usedOwnKey: imageResult.metadata.usedOwnKey,
         description: `Variant image generation (${generationParams.model})`,
+        idempotencyKey: `${event.instanceId}:variant-image`,
         metadata: {
           model: generationParams.model,
           frameId: input.frameId,

--- a/src/lib/workflows/talent-matching-workflow.ts
+++ b/src/lib/workflows/talent-matching-workflow.ts
@@ -104,6 +104,7 @@ export class TalentMatchingWorkflow extends OpenStoryWorkflowEntrypoint<TalentMa
             {
               sequenceId,
               userId: input.userId,
+              workflowRunId: event.instanceId,
               scopedDb,
             }
           )

--- a/src/lib/workflows/upscale-shot-variant-workflow.ts
+++ b/src/lib/workflows/upscale-shot-variant-workflow.ts
@@ -153,6 +153,7 @@ export class UpscaleShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<Upsc
         costMicros: upscaleResult.cost,
         usedOwnKey: upscaleResult.usedOwnKey,
         description: 'Variant upscale (nano_banana_2)',
+        idempotencyKey: `${event.instanceId}:upscale`,
         metadata: { frameId: input.frameId, sequenceId: input.sequenceId },
         workflowName: 'UpscaleShotVariantWorkflow',
       });

--- a/src/lib/workflows/visual-prompt-scene-workflow.ts
+++ b/src/lib/workflows/visual-prompt-scene-workflow.ts
@@ -272,6 +272,7 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
         costMicros: ZERO_MICROS,
         usedOwnKey: false,
         description: `LLM analysis (${analysisModelId})`,
+        idempotencyKey: `${event.instanceId}:llm-${STEP_NAME}`,
         metadata: {
           model: analysisModelId,
           phase: PHASE.number,


### PR DESCRIPTION
Closes #846

A 29-workflow audit (193 steps) against [Cloudflare's rules of workflows](https://developers.cloudflare.com/workflows/build/rules-of-workflows/) found 14 high-severity findings collapsing into 5 root causes — all retry hazards where a `step.do` that throws partway (or is killed by an engine abort, as in the #839 mass-abort cascade) re-runs its closure from the top.

## RC1 — `deductCredits` double-charges on step retry

- New nullable `transactions.idempotency_key` + partial unique index on `(team_id, idempotency_key) WHERE idempotency_key IS NOT NULL`.
- `deductCredits` now runs three statements in one atomic `db.batch`: balance UPDATE guarded by `notExists(key)`, transaction INSERT with `onConflictDoNothing` (with `balanceAfter` as a post-UPDATE subquery), and an authoritative balance read-back. A replay is a no-op that recovers the original `transactionId` via SELECT-by-key — never throws.
- `deductWorkflowCredits` now **requires** `idempotencyKey` (convention `${event.instanceId}:<charge-name>`); all 11 call sites updated; `workflowRunId` threaded through `DurableLLMCallContext` for the (currently $0) LLM sites. `functions/ai.ts` HTTP single-shot stays keyless.
- **Review hardening:** the `image`/`music`/`motion` workflows now also route through `deductWorkflowCredits` instead of calling `scopedDb.billing.deductCredits` directly, so the compile-time-required key covers every workflow charge. Side effect: motion previously deducted with no affordability check (could debit a balance negative); it now warn-and-skips with an auto-top-up attempt like every other workflow.

## RC2 — child spawns without `deduplicationId` inside steps

- Scene-split's two preview-image triggers and frame-images' `/variant-image` trigger now use shared builders in `src/lib/workflow/dedup-ids.ts`: `preview-<runHash>-<frameId>` and `variant-<runHash>-<frameId|sceneId>-<model>`. frameId is replay-stable via the frames upsert on `(sequenceId, orderIndex)`; the parent-instance hash scopes per run so a re-split still gets fresh previews.
- **Review hardening:** the run-scoping hash now LEADS the id — `buildInstanceId` truncates the suffix from the end (room is `100 − prefix`, not a flat 100), so truncation can shear the human-readable tail but never the hash that separates two runs. New `dedup-ids.test.ts` pins stability, distinctness, and truncation survival.

## RC3 — `triggerCfWorkflow` doesn't tolerate `instance.already_exists`

- `isInstanceAlreadyExistsError` moved to `src/lib/workflow/errors.ts` (shared with `spawnAndAwaitChild`) and anchored on the `instance` token so unrelated "already exists" errors from other layers are never misclassified as a duplicate workflow instance.
- `triggerCfWorkflow` swallows `already_exists` **only when `deduplicationId` was provided**, and — review hardening — only after verifying the existing instance via `binding.get(id).status()`: alive-or-complete is reused (returning the deterministic id); `errored`/`terminated`/`unknown`/unverifiable rethrows with a `logger.warn`. Without the status gate, request-stable dedup ids (`framePromptDedupId`/`musicPromptDedupId`) colliding with a FAILED prior instance would silently report "enqueued" forever while no workflow runs. The random-suffix path keeps throwing. This unwedges `regenerate-frames-workflow`'s multi-create step.

## RC4 — `sequenceLocations.createBulk` bricks LocationBibleWorkflow on partial-batch retry

- `onConflictDoUpdate` on `(sequenceId, locationId)` following the `frames.ts` `bulkUpsert` precedent: bible fields refresh via `excluded.*`, while `id`/keys/`createdAt` and the reference-image columns (owned by the child LocationSheetWorkflow) stay untouched. The workflow's `created.length` guard keeps working.

## RC5 — `ElementVisionWorkflow.auto-rename` split-brains tokens on retry

- `ensureUniqueToken` gains optional `excludeElementId` so the element's own row no longer counts as a collision (the pre-fix retry suffixed to `TOKEN_2`).
- `cascadeRename` is now a single atomic `db.batch` (element row + script + N frame deltas) — other callers (`replace-element-workflow`, `functions/sequence-elements`) get atomicity for free; signature unchanged. A replay after full success yields zero deltas.

## Tests & verification

- New: `trigger-bindings.test.ts` (already_exists swallow/rethrow matrix across all 9 instance statuses + lookup-failure), `dedup-ids.test.ts` (RC2 id invariants), `isInstanceAlreadyExistsError` classifier block in `errors.test.ts`, `billing.test.ts` (atomic batch, replay recovers original transactionId without throwing, team-scoped keys, keyless path), `workflow-deduction.test.ts` (key forwarding), `sequence-locations-create-bulk.test.ts` (cross-batch replay convergence, reference-column preservation), `ensureUniqueToken` exclusion + `cascadeRename` replay idempotency.
- `bun typecheck` ✅ · `bun lint` 0 errors ✅ · `bun run test` 1192 passed ✅ · knip identical to clean tree ✅
- `bun test:e2e`: 33 passed; 9 failures are pre-existing on the clean branch base (verified by stash + re-run) and already tracked in #827.
- Post-review verification pass: silent-failure-hunter + test-analyzer re-ran on the review fixes — all findings verified fixed, no new silent failures.

## Deploy note

Migration `20260607072118_dashing_epoch` is additive (`ALTER TABLE ADD` + partial index — no table rebuild, safe for the d1-http migrator). Apply to prod D1 (`bun db:migrate:d1`) before/with deploy; old code ignores the new column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
