### PR TITLE
feat(api-v1): public streaming enhance-script endpoint (#856)

### DIFF
--- a/src/lib/api-v1/discovery.test.ts
+++ b/src/lib/api-v1/discovery.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildRootDocument, createSequenceLink } from './discovery';
+import {
+  buildRootDocument,
+  createSequenceLink,
+  enhanceScriptLink,
+} from './discovery';
+import { apiEnhanceScriptSchema } from './enhance-input-schema';
 import { apiCreateSequenceSchema } from './input-schema';
 
 describe('buildRootDocument', () => {
@@ -28,6 +33,16 @@ describe('buildRootDocument', () => {
     expect(create?.method).toBe('POST');
     expect(create?.contentType).toBe('application/json');
     expect(create?.examples).toHaveLength(1);
+
+    const enhance = _links['enhance-script'];
+    expect(enhance?.method).toBe('POST');
+    expect(enhance?.href).toBe('/api/v1/scripts/enhance');
+  });
+
+  it('documents the streaming enhance endpoint in the narrative', () => {
+    const { instructions } = buildRootDocument();
+    expect(instructions).toMatch(/POST \/api\/v1\/scripts\/enhance/);
+    expect(instructions).toMatch(/Server-Sent Events/);
   });
 });
 
@@ -36,5 +51,12 @@ describe('createSequenceLink', () => {
     const [example] = createSequenceLink().examples ?? [];
     // The advertised example must actually be a valid request.
     expect(() => apiCreateSequenceSchema.parse(example)).not.toThrow();
+  });
+});
+
+describe('enhanceScriptLink', () => {
+  it('carries an example body that satisfies the enhance schema', () => {
+    const [example] = enhanceScriptLink().examples ?? [];
+    expect(() => apiEnhanceScriptSchema.parse(example)).not.toThrow();
   });
 });

--- a/src/lib/api-v1/discovery.ts
+++ b/src/lib/api-v1/discovery.ts
@@ -30,8 +30,10 @@ Enhance only (no sequence):
   video. Takes the enhancement-relevant inputs (style, aspectRatio, targetSeconds,
   elements) and STREAMS the result back as Server-Sent Events: unnamed 'data:'
   frames each carry { "delta": "..." }; a final 'event: done' frame carries the
-  full { "enhancedScript": "..." }. Errors after streaming starts arrive as an
-  'event: error' frame.
+  full { "enhancedScript": "..." } plus a '_links' catalog whose
+  'create-sequence' affordance embeds a ready-to-POST example body using the
+  enhanced script (with enhance: "off"). Errors after streaming starts arrive
+  as an 'event: error' frame.
 
 Authentication:
   Every endpoint except this root requires an API key. Create one in the

--- a/src/lib/api-v1/discovery.ts
+++ b/src/lib/api-v1/discovery.ts
@@ -10,6 +10,7 @@
  * caller has wired up a key, so the narrative can tell them how to get one.
  */
 
+import { apiEnhanceScriptSchema } from './enhance-input-schema';
 import { API_V1_BASE, type HalLink, type HalResource } from './hal';
 import { apiCreateSequenceSchema } from './input-schema';
 import { z } from 'zod';
@@ -23,6 +24,14 @@ Workflow:
   2. GET the statusUrl to watch progress: overall status, per-frame image/video
      status + URLs, music, poster, and ready counts. Status is derived from the
      database, so it is always correct even if you reconnect later.
+
+Enhance only (no sequence):
+  POST /api/v1/scripts/enhance to expand/polish a script without generating a
+  video. Takes the enhancement-relevant inputs (style, aspectRatio, targetSeconds,
+  elements) and STREAMS the result back as Server-Sent Events: unnamed 'data:'
+  frames each carry { "delta": "..." }; a final 'event: done' frame carries the
+  full { "enhancedScript": "..." }. Errors after streaming starts arrive as an
+  'event: error' frame.
 
 Authentication:
   Every endpoint except this root requires an API key. Create one in the
@@ -75,6 +84,27 @@ export function createSequenceLink(): HalLink {
   };
 }
 
+/** A representative `POST /api/v1/scripts/enhance` body. */
+function exampleEnhanceBody(): unknown {
+  return apiEnhanceScriptSchema.parse({
+    script: 'A lighthouse keeper befriends a stranded whale.',
+    style: 'Cinematic Noir',
+    targetSeconds: 30,
+  });
+}
+
+/** The `enhance-script` affordance, advertised in the root document. */
+export function enhanceScriptLink(): HalLink {
+  return {
+    href: `${API_V1_BASE}/scripts/enhance`,
+    method: 'POST',
+    title:
+      'Enhance a script without creating a sequence. Streams the result as Server-Sent Events.',
+    contentType: 'application/json',
+    examples: [exampleEnhanceBody()],
+  };
+}
+
 export type RootDocument = HalResource<{
   name: string;
   version: string;
@@ -97,6 +127,7 @@ export function buildRootDocument(): RootDocument {
         title: 'API root / instructions',
       },
       'create-sequence': createSequenceLink(),
+      'enhance-script': enhanceScriptLink(),
       'sequence-status': {
         href: `${API_V1_BASE}/sequences/{id}{?wait}`,
         method: 'GET',

--- a/src/lib/api-v1/enhance-input-schema.ts
+++ b/src/lib/api-v1/enhance-input-schema.ts
@@ -46,11 +46,11 @@ export const apiEnhanceScriptSchema = z
     targetSeconds: z
       .int()
       .min(5)
-      .max(300)
+      .max(180)
       .optional()
       .meta({
         description:
-          'Target video length in seconds (max 5 minutes); guides scene count and length of the enhanced script.',
+          'Target video length in seconds (max 3 minutes); guides scene count and length of the enhanced script.',
         examples: [30],
       }),
 

--- a/src/lib/api-v1/enhance-input-schema.ts
+++ b/src/lib/api-v1/enhance-input-schema.ts
@@ -1,0 +1,95 @@
+/**
+ * Public input schema for `POST /api/v1/scripts/enhance`. Like
+ * {@link apiCreateSequenceSchema} this is deliberately ergonomic — callers pass
+ * a style by id/name/slug and reference elements by hosted URL — and carries
+ * `.meta({...})` on every field so `z.toJSONSchema()` yields a fully-described
+ * OpenAPI component.
+ *
+ * Scope is intentionally limited to the inputs that actually influence the
+ * enhancement output today: style (→ its StyleConfig), aspect ratio, target
+ * duration, and reference elements. Cast/locations don't feed the enhance prompt
+ * yet, so they're not accepted here (vs. the create endpoint, which uses them for
+ * generation).
+ *
+ * This module is client-safe (zod only) so the discovery/OpenAPI documents can
+ * import it without pulling in the server-only AI stack from `enhance.ts`.
+ */
+
+import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
+import { z } from 'zod';
+
+export const apiEnhanceScriptSchema = z
+  .object({
+    script: z
+      .string()
+      .min(10)
+      .max(50000)
+      .meta({
+        description:
+          'Raw script or a one-liner / brief to expand into a full visual script.',
+        examples: ['A lighthouse keeper befriends a stranded whale.'],
+      }),
+
+    style: z
+      .string()
+      .min(1)
+      .optional()
+      .meta({
+        description:
+          "Style by id, name, or slugified name. When given, the style's aesthetics (mood, lighting, palette, camera work, reference films) guide the enhancement. Omit for a neutral enhancement.",
+        examples: ['Cinematic Noir'],
+      }),
+    aspectRatio: aspectRatioSchema.optional().meta({
+      description:
+        "Aspect ratio framing hint. Defaults to the resolved style's recommendation when omitted.",
+    }),
+    targetSeconds: z
+      .int()
+      .min(5)
+      .max(300)
+      .optional()
+      .meta({
+        description:
+          'Target video length in seconds (max 5 minutes); guides scene count and length of the enhanced script.',
+        examples: [30],
+      }),
+
+    elements: z
+      .array(
+        z
+          .object({
+            url: z.url().meta({
+              description:
+                'Hosted image URL for the element; sent to the model so it can see the reference.',
+            }),
+            token: z
+              .string()
+              .min(1)
+              .max(100)
+              .meta({
+                description:
+                  'UPPERCASE token used to reference this element in the enhanced script.',
+                examples: ['LOGO'],
+              }),
+            description: z
+              .string()
+              .max(2000)
+              .optional()
+              .meta({ description: 'Optional description of the element.' }),
+          })
+          .meta({ id: 'EnhanceElementInput' })
+      )
+      .optional()
+      .meta({
+        description:
+          'Reference elements (logos, products) to weave into the script by token.',
+      }),
+  })
+  .meta({
+    id: 'EnhanceScriptRequest',
+    title: 'Enhance Script Request',
+    description:
+      'Input for POST /api/v1/scripts/enhance — enhance a script without creating a sequence. Streams the enhanced script back as Server-Sent Events.',
+  });
+
+export type ApiEnhanceScriptInput = z.infer<typeof apiEnhanceScriptSchema>;

--- a/src/lib/api-v1/enhance.test.ts
+++ b/src/lib/api-v1/enhance.test.ts
@@ -32,10 +32,28 @@ describe('enhanceSseResponse', () => {
     const body = await readSse(res);
     expect(body).toContain('data: {"delta":"INT. "}\n\n');
     expect(body).toContain('data: {"delta":"LIGHTHOUSE"}\n\n');
-    // The done frame carries the trimmed, concatenated script.
-    expect(body).toContain(
-      'event: done\ndata: {"enhancedScript":"INT. LIGHTHOUSE - NIGHT"}\n\n'
+
+    // The done frame carries the trimmed, concatenated script plus the HAL
+    // affordance catalog every v1 response exposes.
+    const doneFrame = body
+      .split('\n\n')
+      .find((frame) => frame.startsWith('event: done'));
+    expect(doneFrame).toBeDefined();
+    const donePayload = JSON.parse(
+      (doneFrame ?? '').replace('event: done\ndata: ', '')
     );
+    expect(donePayload.enhancedScript).toBe('INT. LIGHTHOUSE - NIGHT');
+    expect(donePayload._links.self.href).toBe('/api/v1/scripts/enhance');
+    expect(donePayload._links.root.href).toBe('/api/v1');
+    const createLink = donePayload._links['create-sequence'];
+    expect(createLink.href).toBe('/api/v1/sequences');
+    expect(createLink.method).toBe('POST');
+    expect(createLink.contentType).toBe('application/json');
+    // The create affordance is ready-to-POST: it embeds the enhanced script
+    // with enhancement disabled (the script is already enhanced).
+    expect(createLink.examples).toEqual([
+      { script: 'INT. LIGHTHOUSE - NIGHT', enhance: 'off' },
+    ]);
   });
 
   it('emits an error frame when the generator fails mid-stream', async () => {

--- a/src/lib/api-v1/enhance.test.ts
+++ b/src/lib/api-v1/enhance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { enhanceSseResponse } from './enhance';
+
+/** Drain an SSE Response body to its decoded text. */
+async function readSse(res: Response): Promise<string> {
+  return new Response(res.body).text();
+}
+
+/** A generator that yields the given deltas, then optionally throws. */
+async function* deltas(
+  values: string[],
+  throwAt?: number
+): AsyncGenerator<{ delta: string }> {
+  let i = 0;
+  for (const delta of values) {
+    if (throwAt === i++) throw new Error('mid-stream boom');
+    yield { delta };
+  }
+}
+
+describe('enhanceSseResponse', () => {
+  it('streams delta frames then a terminal done frame with the full script', async () => {
+    const gen = deltas(['INT. ', 'LIGHTHOUSE', ' - NIGHT  ']);
+    const first = await gen.next();
+    const res = enhanceSseResponse(first, gen);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe(
+      'text/event-stream; charset=utf-8'
+    );
+
+    const body = await readSse(res);
+    expect(body).toContain('data: {"delta":"INT. "}\n\n');
+    expect(body).toContain('data: {"delta":"LIGHTHOUSE"}\n\n');
+    // The done frame carries the trimmed, concatenated script.
+    expect(body).toContain(
+      'event: done\ndata: {"enhancedScript":"INT. LIGHTHOUSE - NIGHT"}\n\n'
+    );
+  });
+
+  it('emits an error frame when the generator fails mid-stream', async () => {
+    const gen = deltas(['partial ', 'never'], 1); // yields one delta, then throws
+    const first = await gen.next();
+    const body = await readSse(enhanceSseResponse(first, gen));
+
+    expect(body).toContain('data: {"delta":"partial "}\n\n');
+    expect(body).toContain('event: error');
+    expect(body).not.toContain('event: done');
+  });
+});

--- a/src/lib/api-v1/enhance.ts
+++ b/src/lib/api-v1/enhance.ts
@@ -20,7 +20,9 @@ import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { handleApiError } from '@/lib/errors';
 import { getLogger, toErrorPayload } from '@/lib/observability/logger';
+import { createSequenceLink, enhanceScriptLink } from './discovery';
 import type { ApiEnhanceScriptInput } from './enhance-input-schema';
+import { API_V1_BASE, type HalLinks, getLink } from './hal';
 import { resolveStyle } from './resolve';
 
 const logger = getLogger(['openstory', 'api-v1']);
@@ -76,6 +78,26 @@ export async function buildEnhanceGenerator(
   });
 }
 
+/**
+ * The HAL affordance catalog for the terminal `done` frame — the SSE analogue
+ * of the `_links` every JSON response carries. The natural next action is
+ * creating a sequence from the just-enhanced script, so `create-sequence`
+ * embeds a ready-to-POST example body (with `enhance: 'off'`, since the script
+ * is already enhanced).
+ */
+function doneLinks(enhancedScript: string): HalLinks {
+  return {
+    self: enhanceScriptLink(),
+    'create-sequence': {
+      ...createSequenceLink(),
+      title:
+        'Create a video sequence from this enhanced script (use enhance: "off" — it is already enhanced)',
+      examples: [{ script: enhancedScript, enhance: 'off' }],
+    },
+    root: getLink(API_V1_BASE, 'API root / instructions'),
+  };
+}
+
 const SSE_HEADERS = {
   'Content-Type': 'text/event-stream; charset=utf-8',
   'Cache-Control': 'no-cache, no-transform',
@@ -92,8 +114,10 @@ const SSE_HEADERS = {
  *
  * Wire format (matches the OpenAPI doc): each delta is an unnamed `data:` frame
  * `{ "delta": "…" }`; a terminal `event: done` frame carries the full
- * `{ "enhancedScript": "…" }`. A mid-stream failure (headers already sent)
- * becomes an `event: error` frame `{ code, message }`.
+ * `{ "enhancedScript": "…", "_links": {…} }` — the `_links` catalog of next
+ * actions every other v1 response carries, attached to the one frame that
+ * represents the completed resource. A mid-stream failure (headers already
+ * sent) becomes an `event: error` frame `{ code, message }`.
  */
 export function enhanceSseResponse(
   first: IteratorResult<{ delta: string }>,
@@ -122,7 +146,8 @@ export function enhanceSseResponse(
       try {
         if (!first.done) push(first.value.delta);
         for await (const chunk of rest) push(chunk.delta);
-        event('done', { enhancedScript: full.trim() });
+        const enhancedScript = full.trim();
+        event('done', { enhancedScript, _links: doneLinks(enhancedScript) });
       } catch (err) {
         const handled = handleApiError(err);
         // Headers are already committed, so this can't become a JSON 500 — but

--- a/src/lib/api-v1/enhance.ts
+++ b/src/lib/api-v1/enhance.ts
@@ -19,8 +19,11 @@ import { toEnhanceInputs } from '@/lib/ai/enhance-inputs';
 import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { handleApiError } from '@/lib/errors';
+import { getLogger, toErrorPayload } from '@/lib/observability/logger';
 import type { ApiEnhanceScriptInput } from './enhance-input-schema';
 import { resolveStyle } from './resolve';
+
+const logger = getLogger(['openstory', 'api-v1']);
 
 export type EnhanceContext = {
   scopedDb: ScopedDb;
@@ -122,6 +125,20 @@ export function enhanceSseResponse(
         event('done', { enhancedScript: full.trim() });
       } catch (err) {
         const handled = handleApiError(err);
+        // Headers are already committed, so this can't become a JSON 500 — but
+        // it must still be traceable. Mirror runApiV1Handler: log server-class
+        // failures (incl. a post-success `deduct` throw, which lands here) with
+        // the original stack/cause; the client only ever sees code/message.
+        if (handled.statusCode >= 500) {
+          logger.error(
+            'api/v1 enhance stream failed mid-stream: {code} {message}',
+            {
+              code: handled.code,
+              message: handled.message,
+              err: toErrorPayload(err),
+            }
+          );
+        }
         event('error', { code: handled.code, message: handled.message });
       } finally {
         controller.close();
@@ -129,8 +146,16 @@ export function enhanceSseResponse(
     },
     async cancel() {
       // Client disconnected — let the generator unwind (skips the final
-      // billing deduction, matching the dashboard stream's behaviour).
-      await rest.return(undefined);
+      // billing deduction, matching the dashboard stream's behaviour). A
+      // cleanup failure while unwinding would otherwise surface as an unhandled
+      // rejection, so log and swallow it.
+      try {
+        await rest.return(undefined);
+      } catch (err) {
+        logger.warn('api/v1 enhance stream cancel: generator cleanup failed', {
+          err: toErrorPayload(err),
+        });
+      }
     },
   });
 

--- a/src/lib/api-v1/enhance.ts
+++ b/src/lib/api-v1/enhance.ts
@@ -1,0 +1,138 @@
+/**
+ * Orchestrator for `POST /api/v1/scripts/enhance`. Resolves the public,
+ * human-friendly input (style by ref, elements by URL) into the shared
+ * {@link streamScriptEnhancement} generator, then frames its deltas as
+ * Server-Sent Events.
+ *
+ *   resolve style → build EnhanceScriptInput → stream deltas as SSE
+ *
+ * Server-only (imports the AI stack via `@/functions/ai`); kept separate from
+ * `enhance-input-schema.ts` so discovery/OpenAPI can import the schema without
+ * pulling this in.
+ */
+
+import {
+  type EnhanceScriptInput,
+  streamScriptEnhancement,
+} from '@/functions/ai';
+import { toEnhanceInputs } from '@/lib/ai/enhance-inputs';
+import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
+import type { ScopedDb } from '@/lib/db/scoped';
+import { handleApiError } from '@/lib/errors';
+import type { ApiEnhanceScriptInput } from './enhance-input-schema';
+import { resolveStyle } from './resolve';
+
+export type EnhanceContext = {
+  scopedDb: ScopedDb;
+  user: { id: string };
+  teamId: string;
+};
+
+/**
+ * Turn the public enhance input into the shared enhancement generator. When a
+ * style reference is given, it's resolved read-only (no library writes) so its
+ * aesthetic recipe + identity (name/category/tags) and recommended aspect ratio
+ * steer the rewrite — fed via the same `toEnhanceInputs` the UI and create flow
+ * use, so all three enhance identically. Throws (→ JSON error) on an
+ * unresolvable style reference; the returned generator defers billing and the
+ * LLM call to its first `.next()`.
+ */
+export async function buildEnhanceGenerator(
+  input: ApiEnhanceScriptInput,
+  ctx: EnhanceContext
+): Promise<AsyncGenerator<{ delta: string }>> {
+  const style = input.style
+    ? await resolveStyle(ctx.scopedDb, input.style)
+    : undefined;
+
+  const data: EnhanceScriptInput = {
+    script: input.script,
+    targetDuration: input.targetSeconds,
+    aspectRatio:
+      input.aspectRatio ??
+      (style
+        ? aspectRatioSchema.safeParse(style.defaultAspectRatio).data
+        : undefined),
+    // Caller-hosted element URLs go straight to the model (no ingest needed —
+    // there's no sequence to persist them into); map url → the tempPublicUrl
+    // field `toEnhanceInputs` reads.
+    ...toEnhanceInputs({
+      style,
+      elements: input.elements?.map((el) => ({
+        token: el.token,
+        tempPublicUrl: el.url,
+        description: el.description,
+      })),
+    }),
+  };
+
+  return streamScriptEnhancement(data, {
+    scopedDb: ctx.scopedDb,
+    userId: ctx.user.id,
+    teamId: ctx.teamId,
+  });
+}
+
+const SSE_HEADERS = {
+  'Content-Type': 'text/event-stream; charset=utf-8',
+  'Cache-Control': 'no-cache, no-transform',
+  Connection: 'keep-alive',
+  // Disable proxy buffering so deltas flush as they're produced.
+  'X-Accel-Buffering': 'no',
+} as const;
+
+/**
+ * Frame an already-started enhancement generator as an SSE stream. `first` is
+ * the result of the caller's initial `gen.next()` — pulled before this is called
+ * so pre-stream failures (billing, an unresolvable model) surface as a JSON
+ * error with the right status, rather than a 200 stream that immediately errors.
+ *
+ * Wire format (matches the OpenAPI doc): each delta is an unnamed `data:` frame
+ * `{ "delta": "…" }`; a terminal `event: done` frame carries the full
+ * `{ "enhancedScript": "…" }`. A mid-stream failure (headers already sent)
+ * becomes an `event: error` frame `{ code, message }`.
+ */
+export function enhanceSseResponse(
+  first: IteratorResult<{ delta: string }>,
+  rest: AsyncGenerator<{ delta: string }>
+): Response {
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const data = (payload: unknown) =>
+        controller.enqueue(
+          encoder.encode(`data: ${JSON.stringify(payload)}\n\n`)
+        );
+      const event = (name: string, payload: unknown) =>
+        controller.enqueue(
+          encoder.encode(`event: ${name}\ndata: ${JSON.stringify(payload)}\n\n`)
+        );
+
+      let full = '';
+      const push = (delta: string) => {
+        if (!delta) return;
+        full += delta;
+        data({ delta });
+      };
+
+      try {
+        if (!first.done) push(first.value.delta);
+        for await (const chunk of rest) push(chunk.delta);
+        event('done', { enhancedScript: full.trim() });
+      } catch (err) {
+        const handled = handleApiError(err);
+        event('error', { code: handled.code, message: handled.message });
+      } finally {
+        controller.close();
+      }
+    },
+    async cancel() {
+      // Client disconnected — let the generator unwind (skips the final
+      // billing deduction, matching the dashboard stream's behaviour).
+      await rest.return(undefined);
+    },
+  });
+
+  return new Response(stream, { status: 200, headers: SSE_HEADERS });
+}

--- a/src/lib/api-v1/openapi.test.ts
+++ b/src/lib/api-v1/openapi.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { apiEnhanceScriptSchema } from './enhance-input-schema';
 import { apiCreateSequenceSchema } from './input-schema';
 import { buildOpenApiDocument } from './openapi';
 
@@ -24,11 +25,20 @@ describe('buildOpenApiDocument', () => {
     expect(Array.isArray(doc.servers)).toBe(true);
   });
 
-  it('documents the three operations', () => {
+  it('documents the operations', () => {
     expect(doc.paths['/api/v1'].get).toBeDefined();
     expect(doc.paths['/api/v1/sequences'].post).toBeDefined();
     expect(doc.paths['/api/v1/sequences/{id}'].get).toBeDefined();
     expect(doc.paths['/api/v1/openapi.json'].get).toBeDefined();
+    expect(doc.paths['/api/v1/scripts/enhance'].post).toBeDefined();
+  });
+
+  it('documents the enhance endpoint as an SSE stream with a valid example', () => {
+    const op = doc.paths['/api/v1/scripts/enhance'].post;
+    expect(op.responses['200'].content).toHaveProperty('text/event-stream');
+    expect(doc.components.schemas).toHaveProperty('EnhanceScriptRequest');
+    const example = op.requestBody.content['application/json'].example;
+    expect(() => apiEnhanceScriptSchema.parse(example)).not.toThrow();
   });
 
   it('every $ref resolves to a defined component schema (no dangling refs)', () => {

--- a/src/lib/api-v1/openapi.ts
+++ b/src/lib/api-v1/openapi.ts
@@ -232,7 +232,7 @@ export function buildOpenApiDocument(): JsonObject {
           tags: ['scripts'],
           summary: 'Enhance a script (streaming)',
           description:
-            'Enhance/expand a script WITHOUT creating a sequence, using the enhancement-relevant inputs (style, aspect ratio, target duration, elements). Streams the result as Server-Sent Events: unnamed `data:` frames each carry `{ "delta": "..." }`; a terminal `event: done` frame carries the full `{ "enhancedScript": "..." }`. A failure after streaming starts arrives as an `event: error` frame `{ code, message }`. Pre-stream failures (invalid body, unresolvable style, billing) return the JSON error envelope instead.',
+            'Enhance/expand a script WITHOUT creating a sequence, using the enhancement-relevant inputs (style, aspect ratio, target duration, elements). Streams the result as Server-Sent Events: unnamed `data:` frames each carry `{ "delta": "..." }`; a terminal `event: done` frame carries the full `{ "enhancedScript": "...", "_links": {...} }` — a HAL catalog whose `create-sequence` affordance embeds a ready-to-POST example body using the enhanced script. A failure after streaming starts arrives as an `event: error` frame `{ code, message }`. Pre-stream failures (invalid body, unresolvable style, billing) return the JSON error envelope instead.',
           requestBody: {
             required: true,
             content: {
@@ -245,12 +245,12 @@ export function buildOpenApiDocument(): JsonObject {
           responses: {
             '200': {
               description:
-                'An SSE stream of the enhanced script. Delta frames, then a terminal `done` frame with the full text.',
+                'An SSE stream of the enhanced script. Delta frames, then a terminal `done` frame with the full text and a HAL `_links` catalog of next actions.',
               content: {
                 'text/event-stream': {
                   schema: { type: 'string' },
                   example:
-                    'data: {"delta":"INT. "}\n\ndata: {"delta":"LIGHTHOUSE"}\n\nevent: done\ndata: {"enhancedScript":"INT. LIGHTHOUSE - NIGHT\\n..."}\n\n',
+                    'data: {"delta":"INT. "}\n\ndata: {"delta":"LIGHTHOUSE"}\n\nevent: done\ndata: {"enhancedScript":"INT. LIGHTHOUSE - NIGHT\\n...","_links":{"create-sequence":{"href":"/api/v1/sequences","method":"POST"}}}\n\n',
                 },
               },
             },

--- a/src/lib/api-v1/openapi.ts
+++ b/src/lib/api-v1/openapi.ts
@@ -13,9 +13,10 @@
  */
 
 import { FRAME_GENERATION_STATUSES } from '@/lib/db/schema/frames';
+import { apiEnhanceScriptSchema } from './enhance-input-schema';
 import { API_V1_BASE } from './hal';
 import { apiCreateSequenceSchema } from './input-schema';
-import { z } from 'zod';
+import { z, type ZodType } from 'zod';
 
 type JsonValue =
   | string
@@ -55,16 +56,19 @@ function rewriteRefsInObject(obj: JsonObject): JsonObject {
 }
 
 /**
- * Split the generated create-request schema into an OpenAPI root component plus
- * its lifted `$defs` (CharacterRef, CreateCharacter, …), all refs repointed at
+ * Split a generated request schema into an OpenAPI root component plus its lifted
+ * `$defs` (CharacterRef, CreateCharacter, …), all refs repointed at
  * `#/components/schemas`. Zod emits a self-contained draft-2020-12 schema whose
  * internal `#/$defs` refs don't resolve once embedded in an OpenAPI document, so
  * we hoist them to siblings under `components.schemas`.
  */
-function createRequestSchemas(): { root: JsonObject; defs: JsonObject } {
+function requestSchemas(schema: ZodType): {
+  root: JsonObject;
+  defs: JsonObject;
+} {
   // Round-trip through JSON to get a plain, mutable JSON tree (no Zod classes).
   const generated: JsonObject = JSON.parse(
-    JSON.stringify(z.toJSONSchema(apiCreateSequenceSchema))
+    JSON.stringify(z.toJSONSchema(schema))
   );
   const { $defs, $schema: _schema, ...root } = generated;
   const defs =
@@ -85,6 +89,13 @@ const EXAMPLE_CREATE_BODY: JsonObject = {
   music: true,
   characters: ['Old Tom the keeper', { name: 'The whale', isHuman: false }],
   locations: ['Stormy lighthouse'],
+};
+
+/** A representative enhance body, embedded as the request example. */
+const EXAMPLE_ENHANCE_BODY: JsonObject = {
+  script: 'A lighthouse keeper befriends a stranded whale.',
+  style: 'Cinematic Noir',
+  targetSeconds: 30,
 };
 
 const statusEnum = (values: JsonValue[]): JsonObject => ({
@@ -110,7 +121,10 @@ function errorResponse(description: string): JsonObject {
 
 /** Build the full OpenAPI 3.1 document for `/api/v1`. */
 export function buildOpenApiDocument(): JsonObject {
-  const { root: createRequest, defs } = createRequestSchemas();
+  const { root: createRequest, defs } = requestSchemas(apiCreateSequenceSchema);
+  const { root: enhanceRequest, defs: enhanceDefs } = requestSchemas(
+    apiEnhanceScriptSchema
+  );
 
   const waitParam: JsonObject = {
     name: 'wait',
@@ -140,6 +154,7 @@ export function buildOpenApiDocument(): JsonObject {
     tags: [
       { name: 'discovery', description: 'Unauthenticated self-description.' },
       { name: 'sequences', description: 'Create and watch video sequences.' },
+      { name: 'scripts', description: 'Enhance scripts without generating.' },
     ],
     paths: {
       [API_V1_BASE]: {
@@ -212,6 +227,41 @@ export function buildOpenApiDocument(): JsonObject {
           },
         },
       },
+      [`${API_V1_BASE}/scripts/enhance`]: {
+        post: {
+          tags: ['scripts'],
+          summary: 'Enhance a script (streaming)',
+          description:
+            'Enhance/expand a script WITHOUT creating a sequence, using the enhancement-relevant inputs (style, aspect ratio, target duration, elements). Streams the result as Server-Sent Events: unnamed `data:` frames each carry `{ "delta": "..." }`; a terminal `event: done` frame carries the full `{ "enhancedScript": "..." }`. A failure after streaming starts arrives as an `event: error` frame `{ code, message }`. Pre-stream failures (invalid body, unresolvable style, billing) return the JSON error envelope instead.',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: { $ref: '#/components/schemas/EnhanceScriptRequest' },
+                example: EXAMPLE_ENHANCE_BODY,
+              },
+            },
+          },
+          responses: {
+            '200': {
+              description:
+                'An SSE stream of the enhanced script. Delta frames, then a terminal `done` frame with the full text.',
+              content: {
+                'text/event-stream': {
+                  schema: { type: 'string' },
+                  example:
+                    'data: {"delta":"INT. "}\n\ndata: {"delta":"LIGHTHOUSE"}\n\nevent: done\ndata: {"enhancedScript":"INT. LIGHTHOUSE - NIGHT\\n..."}\n\n',
+                },
+              },
+            },
+            '400': errorResponse('Invalid JSON or request body.'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '403': errorResponse('No team associated with the key.'),
+            '404': errorResponse('No style found matching the reference.'),
+            '429': errorResponse('Per-key rate limit exceeded (10 req/s).'),
+          },
+        },
+      },
       [`${API_V1_BASE}/sequences/{id}`]: {
         get: {
           tags: ['sequences'],
@@ -269,6 +319,8 @@ export function buildOpenApiDocument(): JsonObject {
       schemas: {
         CreateSequenceRequest: createRequest,
         ...defs,
+        EnhanceScriptRequest: enhanceRequest,
+        ...enhanceDefs,
         HalLink: {
           type: 'object',
           required: ['href'],

--- a/src/lib/marketing/llms.ts
+++ b/src/lib/marketing/llms.ts
@@ -56,7 +56,7 @@ export function buildLlmsTxt(): string {
   lines.push('## API');
   lines.push('');
   lines.push(
-    `${SITE_CONFIG.name} has a public HTTP API for agents and scripts: create an AI video sequence from a script in one call, then poll its status. Both endpoints below are self-describing and need no separate docs.`
+    `${SITE_CONFIG.name} has a public HTTP API for agents and scripts: create an AI video sequence from a script in one call then poll its status, or enhance a script on its own (streamed back). The endpoints below are self-describing and need no separate docs.`
   );
   lines.push('');
   lines.push(
@@ -67,7 +67,7 @@ export function buildLlmsTxt(): string {
   );
   lines.push('');
   lines.push(
-    'Authenticate with an API key (create one under Settings → Developer) sent as "Authorization: Bearer <key>" or "x-api-key". POST /api/v1/sequences to create; GET the returned status URL (append ?wait=60s to long-poll) to watch progress.'
+    'Authenticate with an API key (create one under Settings → Developer) sent as "Authorization: Bearer <key>" or "x-api-key". POST /api/v1/sequences to create; GET the returned status URL (append ?wait=60s to long-poll) to watch progress. POST /api/v1/scripts/enhance to enhance a script without creating a sequence — the enhanced script streams back as Server-Sent Events.'
   );
   lines.push('');
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -1539,3 +1539,13 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -67,6 +67,7 @@ import { Route as AppLocationsLocationIdRouteImport } from './routes/_app/locati
 import { Route as AppAdminUsageRouteImport } from './routes/_app/admin/usage'
 import { Route as AppSequencesIdRouteRouteImport } from './routes/_app/sequences/$id/route'
 import { Route as ApiV1SequencesIdRouteImport } from './routes/api/v1/sequences.$id'
+import { Route as ApiV1ScriptsEnhanceRouteImport } from './routes/api/v1/scripts.enhance'
 import { Route as AppSequencesIdTheatreRouteImport } from './routes/_app/sequences/$id/theatre'
 import { Route as AppSequencesIdScriptRouteImport } from './routes/_app/sequences/$id/script'
 import { Route as AppSequencesIdScenesRouteImport } from './routes/_app/sequences/$id/scenes'
@@ -364,6 +365,11 @@ const ApiV1SequencesIdRoute = ApiV1SequencesIdRouteImport.update({
   path: '/$id',
   getParentRoute: () => ApiV1SequencesRoute,
 } as any)
+const ApiV1ScriptsEnhanceRoute = ApiV1ScriptsEnhanceRouteImport.update({
+  id: '/api/v1/scripts/enhance',
+  path: '/api/v1/scripts/enhance',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppSequencesIdTheatreRoute = AppSequencesIdTheatreRouteImport.update({
   id: '/theatre',
   path: '/theatre',
@@ -473,6 +479,7 @@ export interface FileRoutesByFullPath {
   '/sequences/$id/scenes': typeof AppSequencesIdScenesRoute
   '/sequences/$id/script': typeof AppSequencesIdScriptRoute
   '/sequences/$id/theatre': typeof AppSequencesIdTheatreRoute
+  '/api/v1/scripts/enhance': typeof ApiV1ScriptsEnhanceRoute
   '/api/v1/sequences/$id': typeof ApiV1SequencesIdRoute
   '/sequences/$id/cast/$characterId': typeof AppSequencesIdCastCharacterIdRoute
   '/sequences/$id/locations/$locationId': typeof AppSequencesIdLocationsLocationIdRoute
@@ -537,6 +544,7 @@ export interface FileRoutesByTo {
   '/sequences/$id/scenes': typeof AppSequencesIdScenesRoute
   '/sequences/$id/script': typeof AppSequencesIdScriptRoute
   '/sequences/$id/theatre': typeof AppSequencesIdTheatreRoute
+  '/api/v1/scripts/enhance': typeof ApiV1ScriptsEnhanceRoute
   '/api/v1/sequences/$id': typeof ApiV1SequencesIdRoute
   '/sequences/$id/cast/$characterId': typeof AppSequencesIdCastCharacterIdRoute
   '/sequences/$id/locations/$locationId': typeof AppSequencesIdLocationsLocationIdRoute
@@ -607,6 +615,7 @@ export interface FileRoutesById {
   '/_app/sequences/$id/scenes': typeof AppSequencesIdScenesRoute
   '/_app/sequences/$id/script': typeof AppSequencesIdScriptRoute
   '/_app/sequences/$id/theatre': typeof AppSequencesIdTheatreRoute
+  '/api/v1/scripts/enhance': typeof ApiV1ScriptsEnhanceRoute
   '/api/v1/sequences/$id': typeof ApiV1SequencesIdRoute
   '/_app/sequences/$id/cast/$characterId': typeof AppSequencesIdCastCharacterIdRoute
   '/_app/sequences/$id/locations/$locationId': typeof AppSequencesIdLocationsLocationIdRoute
@@ -675,6 +684,7 @@ export interface FileRouteTypes {
     | '/sequences/$id/scenes'
     | '/sequences/$id/script'
     | '/sequences/$id/theatre'
+    | '/api/v1/scripts/enhance'
     | '/api/v1/sequences/$id'
     | '/sequences/$id/cast/$characterId'
     | '/sequences/$id/locations/$locationId'
@@ -739,6 +749,7 @@ export interface FileRouteTypes {
     | '/sequences/$id/scenes'
     | '/sequences/$id/script'
     | '/sequences/$id/theatre'
+    | '/api/v1/scripts/enhance'
     | '/api/v1/sequences/$id'
     | '/sequences/$id/cast/$characterId'
     | '/sequences/$id/locations/$locationId'
@@ -808,6 +819,7 @@ export interface FileRouteTypes {
     | '/_app/sequences/$id/scenes'
     | '/_app/sequences/$id/script'
     | '/_app/sequences/$id/theatre'
+    | '/api/v1/scripts/enhance'
     | '/api/v1/sequences/$id'
     | '/_app/sequences/$id/cast/$characterId'
     | '/_app/sequences/$id/locations/$locationId'
@@ -839,6 +851,7 @@ export interface RootRouteChildren {
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1SequencesRoute: typeof ApiV1SequencesRouteWithChildren
   ApiV1IndexRoute: typeof ApiV1IndexRoute
+  ApiV1ScriptsEnhanceRoute: typeof ApiV1ScriptsEnhanceRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1249,6 +1262,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiV1SequencesIdRouteImport
       parentRoute: typeof ApiV1SequencesRoute
     }
+    '/api/v1/scripts/enhance': {
+      id: '/api/v1/scripts/enhance'
+      path: '/api/v1/scripts/enhance'
+      fullPath: '/api/v1/scripts/enhance'
+      preLoaderRoute: typeof ApiV1ScriptsEnhanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_app/sequences/$id/theatre': {
       id: '/_app/sequences/$id/theatre'
       path: '/theatre'
@@ -1514,17 +1534,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1SequencesRoute: ApiV1SequencesRouteWithChildren,
   ApiV1IndexRoute: ApiV1IndexRoute,
+  ApiV1ScriptsEnhanceRoute: ApiV1ScriptsEnhanceRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
-  }
-}

--- a/src/routes/api/v1/scripts.enhance.ts
+++ b/src/routes/api/v1/scripts.enhance.ts
@@ -4,7 +4,9 @@
  * Enhances a script WITHOUT creating a sequence: takes the enhancement-relevant
  * inputs (style, aspect ratio, target duration, reference elements) and streams
  * the enhanced script back as Server-Sent Events (unnamed `data:` delta frames,
- * then a terminal `event: done` carrying the full text).
+ * then a terminal `event: done` carrying the full text plus the HAL `_links`
+ * catalog of next actions — notably `create-sequence` pre-filled with the
+ * enhanced script).
  *
  * Authenticated via `authWithTeamRequestMiddleware` (API key or dashboard
  * session), billed per request like the dashboard enhance. Pre-stream failures

--- a/src/routes/api/v1/scripts.enhance.ts
+++ b/src/routes/api/v1/scripts.enhance.ts
@@ -1,0 +1,56 @@
+/**
+ * POST /api/v1/scripts/enhance — public, streaming script enhancement.
+ *
+ * Enhances a script WITHOUT creating a sequence: takes the enhancement-relevant
+ * inputs (style, aspect ratio, target duration, reference elements) and streams
+ * the enhanced script back as Server-Sent Events (unnamed `data:` delta frames,
+ * then a terminal `event: done` carrying the full text).
+ *
+ * Authenticated via `authWithTeamRequestMiddleware` (API key or dashboard
+ * session), billed per request like the dashboard enhance. Pre-stream failures
+ * (bad body, unresolvable style, billing) return the standard JSON error
+ * envelope; failures after streaming has begun arrive as an `event: error` frame.
+ */
+
+import { authWithTeamRequestMiddleware } from '@/functions/middleware';
+import {
+  buildEnhanceGenerator,
+  enhanceSseResponse,
+} from '@/lib/api-v1/enhance';
+import { apiEnhanceScriptSchema } from '@/lib/api-v1/enhance-input-schema';
+import { apiJsonError, runApiV1Handler } from '@/lib/api-v1/errors';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/api/v1/scripts/enhance')({
+  server: {
+    middleware: [authWithTeamRequestMiddleware],
+    handlers: {
+      POST: async ({ request, context }) =>
+        runApiV1Handler(async () => {
+          let body: unknown;
+          try {
+            body = await request.json();
+          } catch {
+            return apiJsonError(
+              400,
+              'INVALID_JSON',
+              'Request body must be valid JSON.'
+            );
+          }
+
+          const input = apiEnhanceScriptSchema.parse(body);
+          const gen = await buildEnhanceGenerator(input, {
+            scopedDb: context.scopedDb,
+            user: context.user,
+            teamId: context.teamId,
+          });
+
+          // Pull the first chunk here (inside runApiV1Handler) so setup failures
+          // — billing, the LLM call — surface as a JSON error with the right
+          // status before any SSE headers are committed.
+          const first = await gen.next();
+          return enhanceSseResponse(first, gen);
+        }),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Adds `POST /api/v1/scripts/enhance` — a public API endpoint that **enhances a script without creating a sequence** and **streams the enhanced script back as Server-Sent Events**. Closes #856.

The repo already had a mature `/api/v1` (API-key auth, HAL discovery, OpenAPI), so this slots in alongside the one-shot create endpoint and reuses the battle-tested enhancement core.

### Wire format
- Unnamed `data:` frames each carry `{ "delta": "..." }`
- A terminal `event: done` frame carries the full `{ "enhancedScript": "..." }`
- A mid-stream failure (headers already sent) arrives as `event: error` `{ code, message }`
- Pre-stream failures (invalid body, unresolvable style, billing) return the standard JSON error envelope **before** any SSE headers go out

### Inputs (the ones that influence enhancement)
`script`, `style` (id/name/slug), `aspectRatio`, `targetSeconds`, `elements[]` (`{url, token, description?}`). Talent/locations are intentionally excluded since they don't feed the enhance prompt today.

## Implementation
- **`enhance-input-schema.ts`** — lenient, client-safe public schema (zod only) so discovery/OpenAPI can import it without pulling in the AI stack.
- **`enhance.ts`** — `buildEnhanceGenerator` resolves the style ref read-only (no library writes) and feeds the shared `streamScriptEnhancement` core via `toEnhanceInputs`, so the API enhances **identically** to the UI and create flow. `enhanceSseResponse` frames the generator's deltas as SSE.
- **`scripts.enhance.ts`** route — behind `authWithTeamRequestMiddleware` (API key or session); pulls the first chunk inside `runApiV1Handler` so setup failures map to JSON errors with the right status.
- Caller-hosted element URLs go straight to the model (no ingest — there's no sequence to persist them into).
- Wired into discovery (HAL `enhance-script` link + narrative), OpenAPI (`text/event-stream` path + `EnhanceScriptRequest` component), and marketing `llms.txt`.

## Design notes
- Style only applies when a ref is given (neutral enhancement otherwise) — predictable for a standalone enhance endpoint, vs. create which auto-picks a popular style.
- Per-key rate limiting (10 req/s via the apiKey plugin) covers it, consistent with the other v1 endpoints.

## Testing
- `bun run test src/lib/api-v1/` ✅ 77 passed (new SSE happy-path + error-frame tests; discovery/OpenAPI assertions for the new endpoint).
- `bun tsgo --noEmit` ✅ · `bun lint` ✅ · `bun format` ✅ · `bun dead-code` ✅
- Not yet smoke-tested live (the running dev server is a different worktree); the SSE framing, generator wiring, and schema are unit-tested and the enhancement core is already exercised by the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)