### PR TITLE
fix(api-keys): memoize team key lookup per scope + log D1 error cause #864

### DIFF
--- a/src/lib/db/scoped/api-keys.test.ts
+++ b/src/lib/db/scoped/api-keys.test.ts
@@ -1,0 +1,282 @@
+/**
+ * In-memory DB tests for per-scope `resolveKey` memoization (issue #864).
+ *
+ * `resolveKey` previously ran a fresh D1 SELECT on `team_api_keys` for every
+ * LLM/fal sub-call; under the #801 90-sequence burst the redundant identical
+ * reads exhausted D1 and hard-failed sequences in phase 3. A `ScopedDb` is
+ * built once per workflow run / request, so memoizing the row lookup on the
+ * read-methods closure caps it to one read per provider per scope — with the
+ * cache lifetime bounded to that one run, there is no cross-run staleness, and
+ * the write methods invalidate the cache so a rotation within a scope can't
+ * keep serving the old key.
+ *
+ * Security: the cache holds the *encrypted* row only; `resolveKey` decrypts
+ * fresh on every call, so the plaintext key is never retained in the cache (the
+ * `decryptSpy` test pins this).
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import { teamApiKeys, teams, user } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+vi.doMock('#env', () => ({
+  getEnv: () => ({
+    API_KEY_ENCRYPTION_KEY: 'test-secret-for-api-keys-memoization',
+    OPENROUTER_KEY: 'platform-openrouter-key',
+    FAL_KEY: 'platform-fal-key',
+  }),
+}));
+
+// Wrap the real `decryptApiKey` in a spy (delegating to the actual impl) so a
+// test can assert decryption runs once per call — i.e. the cache holds
+// ciphertext, not plaintext. `encryptApiKey` stays real so `saveKey` round-trips.
+const decryptSpy = vi.fn();
+vi.doMock('@/lib/crypto/api-key-encryption', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/crypto/api-key-encryption')
+  >('@/lib/crypto/api-key-encryption');
+  decryptSpy.mockImplementation(actual.decryptApiKey);
+  return { ...actual, decryptApiKey: decryptSpy };
+});
+
+// Dynamic import so the mocks above apply to the module-under-test (and its
+// crypto dependency) — see CLAUDE.md module-mocking pattern.
+const { createApiKeysMethods, createApiKeysReadMethods } =
+  await import('./api-keys');
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let userId = '';
+
+/**
+ * Wrap `db` in a Proxy that tallies every `select` so a test can assert how
+ * many D1 reads a sequence of `resolveKey` calls actually issued. All methods
+ * are bound to the real db so drizzle's internals still see the right `this`.
+ */
+function countingDb(): { db: Database; selects: () => number } {
+  let selects = 0;
+  const proxy = new Proxy(db, {
+    get(target, prop) {
+      if (prop === 'select') selects++;
+      const value = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return { db: proxy, selects: () => selects };
+}
+
+async function seed() {
+  await db.delete(teamApiKeys);
+  await db.delete(teams);
+  await db.delete(user);
+
+  teamId = generateId();
+  userId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: `t-${teamId}` });
+  await db
+    .insert(user)
+    .values({ id: userId, name: 'U', email: `${userId}@example.com` });
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('resolveKey memoization (issue #864)', () => {
+  it('reads team_api_keys once across repeated resolveKey calls in one scope', async () => {
+    await createApiKeysMethods(db, teamId, userId).saveKey({
+      provider: 'openrouter',
+      apiKey: 'sk-team-123',
+    });
+
+    const { db: cdb, selects } = countingDb();
+    const scope = createApiKeysReadMethods(cdb, teamId);
+
+    const r1 = await scope.resolveKey('openrouter');
+    const r2 = await scope.resolveKey('openrouter');
+    const r3 = await scope.resolveKey('openrouter');
+
+    expect(r1).toEqual({ key: 'sk-team-123', source: 'team' });
+    expect(r2).toEqual(r1);
+    expect(r3).toEqual(r1);
+    expect(selects()).toBe(1);
+  });
+
+  it('decrypts per call and never caches the plaintext key', async () => {
+    await createApiKeysMethods(db, teamId, userId).saveKey({
+      provider: 'openrouter',
+      apiKey: 'sk-secret',
+    });
+
+    const { db: cdb, selects } = countingDb();
+    const scope = createApiKeysReadMethods(cdb, teamId);
+
+    decryptSpy.mockClear();
+    await scope.resolveKey('openrouter');
+    await scope.resolveKey('openrouter');
+    await scope.resolveKey('openrouter');
+
+    // One D1 read (the row is cached) but a fresh decrypt on every call — the
+    // plaintext is re-derived per call, never held in the cache.
+    expect(selects()).toBe(1);
+    expect(decryptSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('collapses concurrent in-flight resolves to a single read', async () => {
+    await createApiKeysMethods(db, teamId, userId).saveKey({
+      provider: 'openrouter',
+      apiKey: 'sk-team-concurrent',
+    });
+
+    const { db: cdb, selects } = countingDb();
+    const scope = createApiKeysReadMethods(cdb, teamId);
+
+    const [r1, r2, r3] = await Promise.all([
+      scope.resolveKey('openrouter'),
+      scope.resolveKey('openrouter'),
+      scope.resolveKey('openrouter'),
+    ]);
+
+    expect(r1).toEqual({ key: 'sk-team-concurrent', source: 'team' });
+    expect(r2).toEqual(r1);
+    expect(r3).toEqual(r1);
+    expect(selects()).toBe(1);
+  });
+
+  it('caches each provider independently (one read per provider)', async () => {
+    const writeScope = createApiKeysMethods(db, teamId, userId);
+    await writeScope.saveKey({ provider: 'openrouter', apiKey: 'sk-or' });
+    await writeScope.saveKey({ provider: 'fal', apiKey: 'sk-fal' });
+
+    const { db: cdb, selects } = countingDb();
+    const scope = createApiKeysReadMethods(cdb, teamId);
+
+    await scope.resolveKey('openrouter');
+    await scope.resolveKey('fal');
+    await scope.resolveKey('openrouter');
+    await scope.resolveKey('fal');
+
+    expect(selects()).toBe(2);
+  });
+
+  it('memoizes the platform fallback when the team has no key', async () => {
+    const { db: cdb, selects } = countingDb();
+    const scope = createApiKeysReadMethods(cdb, teamId);
+
+    const r1 = await scope.resolveKey('fal');
+    const r2 = await scope.resolveKey('fal');
+
+    expect(r1).toEqual({ key: 'platform-fal-key', source: 'platform' });
+    expect(r2).toEqual(r1);
+    expect(selects()).toBe(1);
+  });
+
+  it('re-reads in a fresh scope (cache lifetime is one scope)', async () => {
+    await createApiKeysMethods(db, teamId, userId).saveKey({
+      provider: 'openrouter',
+      apiKey: 'sk-team-456',
+    });
+
+    const first = countingDb();
+    await createApiKeysReadMethods(first.db, teamId).resolveKey('openrouter');
+    expect(first.selects()).toBe(1);
+
+    const second = countingDb();
+    const r = await createApiKeysReadMethods(second.db, teamId).resolveKey(
+      'openrouter'
+    );
+    expect(r).toEqual({ key: 'sk-team-456', source: 'team' });
+    expect(second.selects()).toBe(1);
+  });
+
+  it('re-reads after a key is rotated within the same scope', async () => {
+    const scope = createApiKeysMethods(db, teamId, userId);
+
+    await scope.saveKey({ provider: 'openrouter', apiKey: 'sk-v1' });
+    const r1 = await scope.resolveKey('openrouter');
+    expect(r1).toEqual({ key: 'sk-v1', source: 'team' });
+
+    // Rotating the key invalidates the cached resolve; the next call must see
+    // the new value, not the stale v1 it just cached.
+    await scope.saveKey({ provider: 'openrouter', apiKey: 'sk-v2' });
+    const r2 = await scope.resolveKey('openrouter');
+    expect(r2).toEqual({ key: 'sk-v2', source: 'team' });
+  });
+
+  it('re-reads after the key is deleted within the same scope', async () => {
+    const scope = createApiKeysMethods(db, teamId, userId);
+
+    await scope.saveKey({ provider: 'openrouter', apiKey: 'sk-team-del' });
+    expect(await scope.resolveKey('openrouter')).toEqual({
+      key: 'sk-team-del',
+      source: 'team',
+    });
+
+    await scope.deleteKey('openrouter');
+    expect(await scope.resolveKey('openrouter')).toEqual({
+      key: 'platform-openrouter-key',
+      source: 'platform',
+    });
+  });
+
+  it('does not cache a failed resolve, so a retry can re-read', async () => {
+    await createApiKeysMethods(db, teamId, userId).saveKey({
+      provider: 'openrouter',
+      apiKey: 'sk-team-xyz',
+    });
+
+    let selectCalls = 0;
+    const flakyDb = new Proxy(db, {
+      get(target, prop) {
+        if (prop === 'select') {
+          selectCalls++;
+          if (selectCalls === 1) {
+            // Simulate a transient D1 overload on the very first read.
+            return () => ({
+              from: () => ({
+                where: () => ({
+                  limit: () => Promise.reject(new Error('D1 overloaded')),
+                }),
+              }),
+            });
+          }
+        }
+        const value = Reflect.get(target, prop, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+
+    const scope = createApiKeysReadMethods(flakyDb, teamId);
+
+    await expect(scope.resolveKey('openrouter')).rejects.toThrow(
+      'D1 overloaded'
+    );
+    // The rejection must have been evicted — a second call re-reads and wins.
+    const r = await scope.resolveKey('openrouter');
+    expect(r).toEqual({ key: 'sk-team-xyz', source: 'team' });
+  });
+});

--- a/src/lib/db/scoped/api-keys.ts
+++ b/src/lib/db/scoped/api-keys.ts
@@ -14,7 +14,7 @@ import {
 } from '@/lib/crypto/api-key-encryption';
 import { type ApiKeyProvider, teamApiKeys } from '@/lib/db/schema';
 
-import { getLogger } from '@/lib/observability/logger';
+import { getLogger, serializeError } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'db', 'api-keys']);
 
@@ -37,7 +37,43 @@ export type ResolvedApiKey =
   | { key: string; source: 'team' }
   | { key: string; source: 'platform'; fallbackReason?: string };
 
+// The cached shape of a `team_api_keys` lookup. Holds the *encrypted* row
+// (ciphertext + invalid flag) only — never the decrypted key. `resolveKey`
+// memoizes this per scope to avoid redundant D1 reads, then decrypts fresh on
+// each call so plaintext is never retained in the cache (issue #864).
+type CachedKeyLookup =
+  | { found: false }
+  | {
+      found: true;
+      encryptedKey: string;
+      keyIv: string;
+      keyTag: string;
+      isInvalid: boolean;
+      invalidReason: string | null;
+    };
+
 export function createApiKeysReadMethods(db: Database, teamId: string) {
+  // Per-scope memoization of the `team_api_keys` row lookup. A ScopedDb is
+  // built fresh per workflow run / request, so this cache lives exactly one
+  // run — there is no cross-run staleness (issue #864). Without it, `resolveKey`
+  // runs a fresh D1 SELECT for every LLM/fal sub-call; under burst (the #801
+  // 90-sequence render) the redundant identical reads exhausted D1 and
+  // hard-failed sequences in phase 3.
+  //
+  // We cache only the *encrypted* row (ciphertext + invalid flag), never the
+  // decrypted key — `resolveKey` decrypts fresh on each call, so the plaintext
+  // key lives only for the duration of one call rather than the whole run. The
+  // cache is in-isolate heap, scoped to one team, and never persisted.
+  const keyLookupCache = new Map<ApiKeyProvider, Promise<CachedKeyLookup>>();
+
+  // Drop a cached lookup so the next resolveKey re-reads from D1. Called by the
+  // write methods after a save/delete/mark so a rotation or invalidation
+  // within the same scope can't keep serving the stale row.
+  function invalidateResolveKeyCache(provider?: ApiKeyProvider): void {
+    if (provider) keyLookupCache.delete(provider);
+    else keyLookupCache.clear();
+  }
+
   async function listKeys(): Promise<ApiKeyInfo[]> {
     const rows = await db
       .select({
@@ -91,17 +127,28 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
     return !!row;
   }
 
-  async function resolveKey(provider: ApiKeyProvider): Promise<ResolvedApiKey> {
-    const platformFallback = (fallbackReason?: string): ResolvedApiKey => {
-      const env = getEnv();
-      const platformKey =
-        provider === 'openrouter' ? env.OPENROUTER_KEY : env.FAL_KEY;
-      if (!platformKey) {
-        throw new Error(`No API key available for provider: ${provider}`);
-      }
-      return { key: platformKey, source: 'platform', fallbackReason };
-    };
+  // Read the encrypted `team_api_keys` row for `provider`, memoized per scope:
+  // D1 is hit at most once per provider per run, and concurrent in-flight reads
+  // collapse onto the same promise. A rejected read is evicted so a later caller
+  // (or a step retry in a surviving isolate) can re-read rather than inheriting
+  // a cached failure.
+  function readKeyRow(provider: ApiKeyProvider): Promise<CachedKeyLookup> {
+    const cached = keyLookupCache.get(provider);
+    if (cached) return cached;
 
+    const pending = readKeyRowUncached(provider);
+    keyLookupCache.set(provider, pending);
+    void pending.catch(() => {
+      if (keyLookupCache.get(provider) === pending) {
+        keyLookupCache.delete(provider);
+      }
+    });
+    return pending;
+  }
+
+  async function readKeyRowUncached(
+    provider: ApiKeyProvider
+  ): Promise<CachedKeyLookup> {
     const [row] = await db
       .select({
         encryptedKey: teamApiKeys.encryptedKey,
@@ -120,10 +167,46 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
       )
       .limit(1);
 
-    if (!row) return platformFallback();
+    if (!row) return { found: false };
+    return { found: true, ...row };
+  }
 
-    if (row.isInvalid) {
-      const reason = row.invalidReason ?? 'Team API key marked invalid';
+  // Resolve the usable key for `provider`. The D1 lookup is memoized per scope;
+  // the decrypted key is produced fresh on every call (and is GC-eligible as
+  // soon as the caller is done), so plaintext is never retained in the cache.
+  async function resolveKey(provider: ApiKeyProvider): Promise<ResolvedApiKey> {
+    const platformFallback = (fallbackReason?: string): ResolvedApiKey => {
+      const env = getEnv();
+      const platformKey =
+        provider === 'openrouter' ? env.OPENROUTER_KEY : env.FAL_KEY;
+      if (!platformKey) {
+        throw new Error(`No API key available for provider: ${provider}`);
+      }
+      return { key: platformKey, source: 'platform', fallbackReason };
+    };
+
+    let lookup: CachedKeyLookup;
+    try {
+      lookup = await readKeyRow(provider);
+    } catch (err) {
+      // The D1 read failed. Log the FULL cause chain here, in-isolate, while
+      // the underlying driver error is still on `DrizzleQueryError.cause` —
+      // that link is stripped once the error crosses a Cloudflare Workflows
+      // step boundary, so this is the only place the real D1 reason (overload
+      // vs connection-reset vs rate-limit) is observable. This read sits on
+      // every generation path and is the first to fail under burst (#864).
+      logger.error('team_api_keys read failed', {
+        provider,
+        teamId,
+        err: serializeError(err),
+      });
+      throw err;
+    }
+
+    if (!lookup.found) return platformFallback();
+
+    if (lookup.isInvalid) {
+      const reason = lookup.invalidReason ?? 'Team API key marked invalid';
       logger.warn('Falling back to platform key', {
         provider,
         teamId,
@@ -134,9 +217,9 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
 
     try {
       const decrypted = await decryptApiKey({
-        encryptedKey: row.encryptedKey,
-        keyIv: row.keyIv,
-        keyTag: row.keyTag,
+        encryptedKey: lookup.encryptedKey,
+        keyIv: lookup.keyIv,
+        keyTag: lookup.keyTag,
       });
       return { key: decrypted, source: 'team' };
     } catch (err) {
@@ -166,6 +249,12 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
             eq(teamApiKeys.provider, provider)
           )
         );
+      // Flip the cached lookup to invalid so other calls in this scope skip the
+      // doomed decrypt and don't re-issue the mark-invalid UPDATE.
+      keyLookupCache.set(
+        provider,
+        Promise.resolve({ ...lookup, isInvalid: true, invalidReason: reason })
+      );
       return platformFallback(reason);
     }
   }
@@ -210,6 +299,7 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
     hasInvalidKey,
     resolveKey,
     validateKey,
+    invalidateResolveKeyCache,
   };
 }
 
@@ -235,6 +325,7 @@ export function createApiKeysMethods(
       .where(
         and(eq(teamApiKeys.teamId, teamId), eq(teamApiKeys.provider, provider))
       );
+    readMethods.invalidateResolveKeyCache(provider);
   };
 
   const markKeyValid = async (provider: ApiKeyProvider): Promise<void> => {
@@ -249,6 +340,7 @@ export function createApiKeysMethods(
       .where(
         and(eq(teamApiKeys.teamId, teamId), eq(teamApiKeys.provider, provider))
       );
+    readMethods.invalidateResolveKeyCache(provider);
   };
 
   const revalidateStoredKey = async (
@@ -350,6 +442,8 @@ export function createApiKeysMethods(
         );
       }
 
+      readMethods.invalidateResolveKeyCache(params.provider);
+
       return {
         id: row.id,
         provider: row.provider,
@@ -373,6 +467,7 @@ export function createApiKeysMethods(
             eq(teamApiKeys.provider, provider)
           )
         );
+      readMethods.invalidateResolveKeyCache(provider);
     },
   };
 }

--- a/src/lib/observability/logger.test.ts
+++ b/src/lib/observability/logger.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for `serializeError` — the cause-chain walker that makes a wrapped
+ * driver error (e.g. the raw D1 error under drizzle's `DrizzleQueryError`)
+ * observable in logs. The structured `{ err }` we hand to `logger.error` only
+ * captures the top error's name/message/stack; `.cause` is dropped unless we
+ * walk it (issue #864).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { type SerializedError, serializeError, toErrorPayload } from './logger';
+
+/** Narrow a `SerializedError | string` to the object form, failing the test
+ * (rather than casting) when it isn't one. */
+function asSerialized(value: SerializedError | string): SerializedError {
+  if (typeof value === 'string') {
+    throw new Error(`expected a SerializedError object, got string: ${value}`);
+  }
+  return value;
+}
+
+describe('serializeError', () => {
+  it('walks the .cause chain', () => {
+    const root = new Error('D1_ERROR: storage overloaded');
+    const wrapper = new Error('Failed query: select … from team_api_keys', {
+      cause: root,
+    });
+
+    const result = serializeError(wrapper);
+
+    expect(result).toMatchObject({
+      name: 'Error',
+      message: 'Failed query: select … from team_api_keys',
+      cause: { name: 'Error', message: 'D1_ERROR: storage overloaded' },
+    });
+  });
+
+  it('captures a multi-level cause chain', () => {
+    const a = new Error('driver: connection reset');
+    const b = new Error('query failed', { cause: a });
+    const c = new Error('step failed', { cause: b });
+
+    const result = serializeError(c);
+
+    expect(result).toMatchObject({
+      message: 'step failed',
+      cause: {
+        message: 'query failed',
+        cause: { message: 'driver: connection reset' },
+      },
+    });
+  });
+
+  it('stops at maxDepth so a cyclic / very deep chain cannot recurse forever', () => {
+    const a = new Error('a');
+    const b = new Error('b', { cause: a });
+    // Force a cycle: a.cause -> b -> a -> …
+    a.cause = b;
+
+    const result = serializeError(a, 2);
+
+    // Depth 2 yields a -> b -> a, then truncates (no `cause` on the innermost).
+    expect(result).toMatchObject({
+      message: 'a',
+      cause: { message: 'b', cause: { message: 'a' } },
+    });
+    const innermost = asSerialized(
+      asSerialized(asSerialized(result).cause ?? '').cause ?? ''
+    );
+    expect(innermost.message).toBe('a');
+    expect(innermost.cause).toBeUndefined();
+  });
+
+  it('omits cause when there is none', () => {
+    const result = serializeError(new Error('plain'));
+    expect(result).toEqual({
+      name: 'Error',
+      message: 'plain',
+      stack: expect.any(String),
+    });
+  });
+
+  it('passes strings through and stringifies other non-errors', () => {
+    expect(serializeError('boom')).toBe('boom');
+    expect(serializeError(42)).toBe('42');
+    expect(serializeError(null)).toBe('null');
+  });
+});
+
+describe('toErrorPayload', () => {
+  it('includes the cause chain when the error wraps one', () => {
+    const root = new Error('D1_ERROR: too many connections');
+    const wrapper = new Error('Failed query', { cause: root });
+
+    const payload = toErrorPayload(wrapper);
+
+    expect(payload).toMatchObject({
+      code: 'UNKNOWN',
+      message: 'Failed query',
+      cause: { message: 'D1_ERROR: too many connections' },
+    });
+  });
+
+  it('has no cause field for a plain error', () => {
+    expect(toErrorPayload(new Error('plain')).cause).toBeUndefined();
+  });
+});

--- a/src/lib/observability/logger.ts
+++ b/src/lib/observability/logger.ts
@@ -386,25 +386,70 @@ function safeJsonParse(text: string): unknown {
 }
 
 /**
+ * A serialized error plus its full `cause` chain. The structured `{ err }` we
+ * pass to `logger.error` only captures `name`/`message`/`stack` of the top
+ * error — the `.cause` link (e.g. the raw D1 driver error that
+ * `DrizzleQueryError` wraps) is dropped. This walks the chain so the underlying
+ * reason is logged. Crucial because `.cause` is also stripped once an error
+ * crosses a Cloudflare Workflows step boundary, so logging the chain at the
+ * point it's thrown is the only way to observe it (issue #864).
+ */
+export type SerializedError = {
+  name?: string;
+  message: string;
+  stack?: string;
+  cause?: SerializedError | string;
+};
+
+export function serializeError(
+  error: unknown,
+  maxDepth = 4
+): SerializedError | string {
+  if (error instanceof Error) {
+    const out: SerializedError = { name: error.name, message: error.message };
+    if (error.stack) out.stack = error.stack;
+    if (error.cause != null && maxDepth > 0) {
+      out.cause = serializeError(error.cause, maxDepth - 1);
+    }
+    return out;
+  }
+  if (typeof error === 'string') return error;
+  return String(error);
+}
+
+/**
  * Standardised error payload for logger.error('...', { err }).
- * Normalises OpenStoryError vs unknown into a stable shape.
+ * Normalises OpenStoryError vs unknown into a stable shape, including the
+ * `.cause` chain so a wrapped driver error (e.g. D1 under `DrizzleQueryError`)
+ * is never silently dropped.
  */
 export function toErrorPayload(error: unknown): {
   code: string;
   message: string;
   statusCode?: number;
   stack?: string;
+  cause?: SerializedError | string;
 } {
+  const cause =
+    error instanceof Error && error.cause != null
+      ? serializeError(error.cause)
+      : undefined;
   if (error instanceof OpenStoryError) {
     return {
       code: error.code,
       message: error.message,
       statusCode: error.statusCode,
       stack: error.stack,
+      cause,
     };
   }
   if (error instanceof Error) {
-    return { code: 'UNKNOWN', message: error.message, stack: error.stack };
+    return {
+      code: 'UNKNOWN',
+      message: error.message,
+      stack: error.stack,
+      cause,
+    };
   }
   return { code: 'UNKNOWN', message: String(error) };
 }

--- a/src/lib/workflow/base-workflow.ts
+++ b/src/lib/workflow/base-workflow.ts
@@ -39,7 +39,7 @@ import {
   type WorkflowStep,
 } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
-import { getLogger } from '@/lib/observability/logger';
+import { getLogger, serializeError } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'cf', 'base']);
 
@@ -156,9 +156,12 @@ export abstract class OpenStoryWorkflowEntrypoint<
 
       const sanitized = sanitizeFailResponse(error);
       // Sanitized message inline in the headline; `err` carries the full
-      // original error (with stack) as a structured property.
+      // original error (with stack) plus its `.cause` chain as a structured
+      // property — so a wrapped driver error (e.g. D1 under DrizzleQueryError)
+      // is logged rather than dropped. Note the chain is only intact if the
+      // error hasn't already crossed a CF step boundary (#864).
       logger.error(`[${this.constructor.name}] Failure: ${sanitized}`, {
-        err: error,
+        err: serializeError(error),
       });
 
       if (this.onFailure) {


### PR DESCRIPTION
## Summary

Fixes #864: `resolveKey` ran a fresh D1 SELECT on `team_api_keys` for **every** LLM/fal sub-call. Under the 90-sequence sample render (#801) the redundant identical reads exhausted D1 and hard-failed two sequences in phase 3.

### 1. Memoize the key lookup per `ScopedDb` scope
- A `ScopedDb` is built fresh per workflow run / request, so the cache lives exactly one run — no cross-run staleness. Each `(team, provider)` key is now read from D1 at most once per scope instead of once per sub-call.
- Caches the **encrypted** row (ciphertext + invalid flag) only, **never** the decrypted key. `resolveKey` decrypts fresh on each call, so the plaintext key is never retained in the cache and lives only for the duration of one call.
- Concurrent in-flight reads collapse onto one promise; a rejected read is evicted so a transient D1 failure is not cached as a permanent error.
- Write methods (saveKey / deleteKey / markKeyInvalid / markKeyValid) invalidate the cache, so a key rotation within a scope cannot keep serving a stale value.

### 2. Surface the underlying D1 error cause
Investigation via `wrangler workflows instances describe` confirmed the failing step rejected **immediately (0s) and retried 6x over 5 minutes** (05:15 to 05:20 UTC) — a genuine load-driven D1 read rejection. But the real D1 reason was unrecoverable: `DrizzleQueryError` wraps the driver error on `.cause`, which our logging dropped **and** which Cloudflare strips once an error crosses a Workflows step boundary.

- New `serializeError()` walks the `.cause` chain; `toErrorPayload` now includes it.
- `resolveKey` logs the cause chain **in-isolate at the throw site** — the only place `.cause` is still intact.
- The base-workflow failure log uses it too (defense-in-depth for other errors).

## Validation
- New `api-keys.test.ts` (9): one D1 read per provider per scope, concurrent collapse, per-provider independence, fresh-scope re-read, rotation/delete invalidation, decrypt-per-call (plaintext not cached), failed-read eviction.
- New `logger.test.ts` (7): cause-chain walk, multi-level chain, depth cap, non-error passthrough, `toErrorPayload` cause.
- `bun typecheck` clean, 0 lint errors, 337 tests pass across workflow/db/observability.

## Follow-ups (not in this PR)
- The engine grace-abort cascade and the `notify-parent-failure` "internal error" tail seen in the same window are #839 territory, independent of this fix.
- Option 2 (thread resolved keys through child payloads to eliminate the per-child read entirely) remains available if per-scope caching proves insufficient under the next burst.
- A fully durable variant of the cause logging would fold `.cause` into the rethrown error message so it survives into CF's step record even when Workers Observability drops logs under burst.

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
