### PR TITLE
Show sequence style as a deterministically-colored badge

### DIFF
--- a/src/components/eval/eval-sequence-metadata.tsx
+++ b/src/components/eval/eval-sequence-metadata.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { AspectRatioIcon } from '@/components/icons/aspect-ratio-icon';
 import { ModelBadge } from '@/components/model/model-badge';
+import { StyleBadge } from '@/components/style/style-badge';
 import type { SequenceWithFrames } from '@/hooks/use-sequences-with-frames';
 import { getImageModelById } from '@/lib/ai/models';
 import { getAspectRatioData } from '@/lib/constants/aspect-ratios';
@@ -46,7 +47,10 @@ export const EvalSequenceMetadata: React.FC<EvalSequenceMetadataProps> = ({
 
       <CreatorIdentity sequence={sequence} />
 
-      <ModelBadge model={sequence.analysisModel} />
+      <div className="flex flex-wrap items-center gap-1">
+        <ModelBadge model={sequence.analysisModel} />
+        <StyleBadge styleId={sequence.styleId} />
+      </div>
 
       {imageModel && (
         <div className="flex items-center gap-1 text-xs text-muted-foreground">

--- a/src/components/style/style-badge.tsx
+++ b/src/components/style/style-badge.tsx
@@ -1,0 +1,61 @@
+import type React from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useStyles } from '@/hooks/use-styles';
+import { cn } from '@/lib/utils';
+
+// Tinted chip treatments from the Tailwind palette. A style name always hashes
+// to the same entry, so the same style gets the same color everywhere.
+const BADGE_COLORS = [
+  'bg-red-500/15 text-red-700 dark:text-red-400',
+  'bg-orange-500/15 text-orange-700 dark:text-orange-400',
+  'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  'bg-lime-500/15 text-lime-700 dark:text-lime-400',
+  'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400',
+  'bg-teal-500/15 text-teal-700 dark:text-teal-400',
+  'bg-cyan-500/15 text-cyan-700 dark:text-cyan-400',
+  'bg-sky-500/15 text-sky-700 dark:text-sky-400',
+  'bg-blue-500/15 text-blue-700 dark:text-blue-400',
+  'bg-violet-500/15 text-violet-700 dark:text-violet-400',
+  'bg-fuchsia-500/15 text-fuchsia-700 dark:text-fuchsia-400',
+  'bg-rose-500/15 text-rose-700 dark:text-rose-400',
+];
+
+function getStyleBadgeColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash << 5) - hash + name.charCodeAt(i);
+    hash |= 0;
+  }
+  return BADGE_COLORS[Math.abs(hash) % BADGE_COLORS.length] ?? '';
+}
+
+type StyleBadgeProps = {
+  // undefined while the owning sequence is still loading
+  styleId?: string;
+};
+
+/**
+ * Shows a sequence's style name as a deterministically-colored badge (#886).
+ * Resolves the name from the team+public style catalogue already cached by
+ * `useStyles`, so rendering many badges costs a single query.
+ */
+export const StyleBadge: React.FC<StyleBadgeProps> = ({ styleId }) => {
+  const { data: styles } = useStyles();
+
+  if (!styleId || !styles) {
+    return <Skeleton className="w-[80px] h-[20px] rounded-4xl" />;
+  }
+
+  const style = styles.find((s) => s.id === styleId);
+  if (!style) return null;
+
+  return (
+    <Badge
+      className={cn('text-xs', getStyleBadgeColor(style.name))}
+      title={`Style: ${style.name}`}
+    >
+      {style.name}
+    </Badge>
+  );
+};

--- a/src/routes/_app/sequences/$id/route.tsx
+++ b/src/routes/_app/sequences/$id/route.tsx
@@ -10,6 +10,7 @@ import {
   useSequenceTabItems,
 } from '@/components/sequence/sequence-tabs';
 import { PageHeader } from '@/components/typography/page-header';
+import { StyleBadge } from '@/components/style/style-badge';
 import { getSequenceFn } from '@/functions/sequences';
 import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
 import { useSwipeNavigation } from '@/hooks/use-swipe-navigation';
@@ -83,6 +84,7 @@ function SequenceLayout() {
         <PageHeader>
           <div className="hidden md:flex flex-row flex-wrap items-center gap-2">
             <ModelBadge model={sequence?.analysisModel} />
+            <StyleBadge styleId={sequence?.styleId} />
             <SequenceImageModelSelector
               sequenceId={sequenceId}
               sequenceImageModel={sequence?.imageModel}


### PR DESCRIPTION
Closes #886

## What

Shows each sequence's style as a badge — on the sequences list rows and in the sequence page header. The badge shows just the style name and is deterministically colored: the name is hashed into a fixed 12-entry palette of tinted Tailwind chips, so the same style always gets the same color everywhere.

## How

- New `StyleBadge` component (`src/components/style/style-badge.tsx`): takes a `styleId`, resolves the name from the team+public style catalogue already cached by `useStyles()` — one shared query for the whole list page, no server/schema changes. Shows a badge-shaped `Skeleton` while loading, renders nothing if the style can't be resolved (e.g. deleted).
- Sequences list (`eval-sequence-metadata.tsx`): badge sits next to the analysis-model badge in a flex-wrap row.
- Sequence page (`sequences/$id/route.tsx`): added to the `PageHeader` badge row after `ModelBadge` (this row is `hidden md:flex`, same as the existing model badges).

## Testing

- `bun typecheck`, `bun lint` pass (knip failures are pre-existing, none from this change).
- Manual: `/sequences` rows show a colored style chip; sequence page header shows the same chip; sequences sharing a style show identical colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
