### PR TITLE
Re-add db:fork:local / db:promote:local scripts (#893 removed them; Cursor worktree setup needs them)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "db:studio:local": "bun drizzle-kit studio --config=drizzle.config.local.ts",
     "db:studio:d1": "bun drizzle-kit studio --config=drizzle.config.d1.ts",
     "db:seed:local": "bun scripts/seed.ts --local",
+    "db:fork:local": "bun scripts/db-worktree.ts --fork",
+    "db:promote:local": "bun scripts/db-worktree.ts --promote",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "motion:codegen": "bun scripts/pull-motion-schemas.ts",


### PR DESCRIPTION
## Summary

Restores the `db:fork:local` and `db:promote:local` package.json aliases that #893 (#885 "simplify local setup") removed in its script-cleanup sweep.

The underlying script `scripts/db-worktree.ts` was never removed — only the aliases — but `.cursor/worktrees.json`'s `setup-worktree` hook still calls `bun db:fork:local`:

```json
"bun db:fork:local || echo '  (no main D1 to fork; run bun db:migrate:local + bun db:seed:local to bootstrap)'"
```

So creating a worktree in Cursor hit the `||` fallback every time, leaving new worktrees without the main repo's local D1.

```json
"db:fork:local": "bun scripts/db-worktree.ts --fork",
"db:promote:local": "bun scripts/db-worktree.ts --promote",
```

`db:promote:local` (the `--promote` counterpart) was removed in the same sweep and is restored alongside.

## Test plan

- [x] `bun run db:fork:local` resolves and reaches `scripts/db-worktree.ts` (prints its own "only makes sense from a worktree" guard when run from the main repo)
- [x] `bun run db:promote:local` registered
- [ ] Cursor `setup-worktree` forks the main D1 into a new worktree without the fallback

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)
