### PR TITLE
build(deploy): move production deploys to Workers Builds, retire the deploy-production Action job

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -1,8 +1,14 @@
 name: Deploy Cloudflare
 
+# PR previews only. Production deploys to `main` run on Cloudflare Workers
+# Builds (dashboard-connected, wrangler-authenticated — no Cloudflare secrets
+# in GitHub for the prod path): build command `bun run build` with
+# CLOUDFLARE_ENV=production, deploy command `bun run deploy:production`.
+# See docs/deployment/cloudflare.md and issue #900. Previews stay here
+# because Workers Builds branch previews share production bindings — no
+# per-PR D1 provisioning, no workflow-name namespacing (#805), no teardown.
+
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, closed]
 
@@ -21,44 +27,6 @@ jobs:
     steps:
       - id: check
         run: echo "has-cf-token=${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}" >> "$GITHUB_OUTPUT"
-
-  # ── Production deploy (push to main) ──────────────────────────────
-  deploy-production:
-    needs: check-secrets
-    if: >-
-      needs.check-secrets.outputs.has-cf-token == 'true'
-      && github.event_name == 'push'
-      && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment: production
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 24
-
-      - name: Install dependencies
-        run: bun install
-
-      # Migrations are applied inside cf:deploy:prd (wrangler d1 migrations
-      # apply DB --env=production --remote, after the build and before the
-      # deploy). Seeding happens at runtime: the worker self-seeds system
-      # templates on first request (src/server.ts). See #897.
-      - name: Deploy to production
-        run: bun cf:deploy:prd
-        env:
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          VITE_PUBLIC_POSTHOG_PROJECT_TOKEN: ${{ secrets.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN }}
-          VITE_PUBLIC_POSTHOG_HOST: ${{ vars.VITE_PUBLIC_POSTHOG_HOST }}
-          # Baked into sheet/preview URLs by the runtime self-seed
-          # (import.meta.env, build-time).
-          VITE_R2_PUBLIC_ASSETS_DOMAIN: ${{ vars.VITE_R2_PUBLIC_ASSETS_DOMAIN }}
 
   # ── PR preview deploy ─────────────────────────────────────────────
   deploy-preview:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ bun db:studio:d1                   # Drizzle Studio against production D1
 # Build / deploy
 bun run build                      # Vite production build (NOT `bun build`)
 bun cf:dev                         # wrangler dev against built worker (preview)
-bun cf:deploy:prd                  # Cloudflare Workers production deploy (build → migrate → deploy)
-bun run deploy                     # Deploy-button / Workers Builds deploy command (migrate + deploy, default env)
+bun cf:deploy:prd                  # Manual production deploy (build → migrate → deploy)
+bun run deploy                     # Deploy-button deploy command (migrate + deploy, default env)
+bun deploy:production              # Workers Builds prod deploy command (migrate --env=production + deploy)
 ```
 
 `bun dev` runs vite dev (cf-plugin → Workerd via Miniflare, port 3000) alongside the Stripe listener (skipped without `STRIPE_SECRET_KEY`). Its first step (`scripts/ensure-env.ts`) creates `.env.local` with generated secrets if missing, so a fresh clone needs only `bun install && bun dev`. The app runs in **Workerd locally** — same runtime as production — so D1, R2 bindings, **Cloudflare Workflows**, env.\* access, and request lifecycle all match prod. No QStash/Docker needed: workflows execute in-process in Workerd.
@@ -242,13 +243,13 @@ bun db:migrate   # Apply migrations to local.db
 **The structure.** `wrangler.jsonc` separates dev from prod via env blocks:
 
 - **default** (no env) — triple duty: (1) `bun dev` / `vite dev` / `bun cf:dev` local simulation, (2) the patch base for PR-preview deploys (CI rewrites D1/bucket/workflow names in place), and (3) the provisioning template for Deploy-to-Cloudflare button deploys — its `database_name`/`bucket_name` are what a button user's fresh resources get called, and `tail_consumers` must stay `[]` so button deploys don't reference our log-forwarder Worker. The D1 binding has a **placeholder** `database_id: "dev-local-d1"` so any misrouted remote call (or buggy preview patch, or wrong-env deploy) 404s against Cloudflare rather than silently writing to prod. R2 buckets are **local Miniflare** too — reads are served by the worker's `/r2/$` route because `getPublicUrl()` falls back to `${VITE_APP_URL}/r2/<key>` when `R2_PUBLIC_STORAGE_DOMAIN` is unset. Local dev needs no Cloudflare credentials. (Opt back into remote R2 by setting `"remote": true` on the binding + `R2_PUBLIC_STORAGE_DOMAIN` in `.env.local`; revert when done.)
-- **`[env.production]`** — real prod D1 (`database_id: d6a35f64-...`). Production deploys MUST use `wrangler deploy --env=production` (already wired in `cf:deploy:prd`).
+- **`[env.production]`** — real prod D1 (`database_id: d6a35f64-...`). Production builds MUST set `CLOUDFLARE_ENV=production` (so the built `dist/server/wrangler.json` bakes this block) and the migrate step MUST pass `--env=production` (wired in `deploy:production` / `cf:deploy:prd`).
 - **`[env.test]`** — Playwright e2e. Local Miniflare D1 (`database_id: "openstory-test-local"`) AND local Miniflare R2 — fully hermetic, no Cloudflare credentials in CI. Activated via `CLOUDFLARE_ENV=test` (set in `playwright.config.ts` envPrefix and CI workflow env block) for `vite dev`, or `wrangler dev --env=test` for the built-server path.
 
 **Rules:**
 
 - Never add `"remote": true` to a D1 binding. The placeholder-id strategy is the safety net.
-- Production deploys go through `bun cf:deploy:prd` which passes `--env=production`. Don't bypass with raw `wrangler deploy` — that hits the default block (placeholder D1) and fails.
+- Production deploys run on **Workers Builds** (dashboard-connected to `main`, #900): build command `bun run build` with `CLOUDFLARE_ENV=production` as a build env var, deploy command `bun run deploy:production`. Manual fallback: `bun cf:deploy:prd`. Don't deploy a build made without `CLOUDFLARE_ENV=production` — it bakes the default block (placeholder D1) and fails loudly.
 - PR-preview deploys patch the default block at runtime in `.github/workflows/deploy-cloudflare.yml` and deploy without `--env`. Each PR gets its own real D1 named `openstory-pr-<n>`.
 
 **Local guardrail:** `bun dev` prints a wrangler-bindings banner on startup showing each binding's `local` / `REMOTE` status. If `DB` ever shows REMOTE, kill the server immediately and fix the config before any write lands in prod.
@@ -257,7 +258,7 @@ bun db:migrate   # Apply migrations to local.db
 
 ### D1 table-rebuild trap — READ BEFORE CHANGING SCHEMA
 
-Remote migrations apply via `wrangler d1 migrations apply` (#897: the `deploy` script for button deploys / Workers Builds, `db:migrate:prd` inside `cf:deploy:prd` for prod CI), which sends each migration file as one multi-statement body. D1 wraps multi-statement bodies in an implicit transaction, and SQLite **silently** ignores `PRAGMA foreign_keys = OFF` inside a transaction. So when the standard SQLite "table rebuild" pattern (`CREATE __new_X` → `INSERT SELECT` → `DROP X` → `RENAME`) drops the parent table, every inbound `ON DELETE CASCADE` FK fires and child rows are deleted. (The original #612 incident hit the same trap through drizzle-kit's `d1-http` migrator, which no longer touches remote DBs — drizzle-kit only generates migrations now. Note drizzle-kit emits nested `<dir>/migration.sql` files; `scripts/flatten-migrations.ts` renders the flat gitignored `drizzle/migrations-wrangler/` dir that wrangler reads.)
+Remote migrations apply via `wrangler d1 migrations apply` (#897/#900: the `deploy` script for button deploys, `deploy:production` for upstream prod on Workers Builds, `db:migrate:prd` inside `cf:deploy:prd` for manual deploys), which sends each migration file as one multi-statement body. D1 wraps multi-statement bodies in an implicit transaction, and SQLite **silently** ignores `PRAGMA foreign_keys = OFF` inside a transaction. So when the standard SQLite "table rebuild" pattern (`CREATE __new_X` → `INSERT SELECT` → `DROP X` → `RENAME`) drops the parent table, every inbound `ON DELETE CASCADE` FK fires and child rows are deleted. (The original #612 incident hit the same trap through drizzle-kit's `d1-http` migrator, which no longer touches remote DBs — drizzle-kit only generates migrations now. Note drizzle-kit emits nested `<dir>/migration.sql` files; `scripts/flatten-migrations.ts` renders the flat gitignored `drizzle/migrations-wrangler/` dir that wrangler reads.)
 
 This destroyed `team_members`, `session`, `account`, and `passkey` in production on 2026-04-29 (issue #612, migration `20260428013041_productive_kabuki`). `PRAGMA defer_foreign_keys = ON` does **not** help — it defers constraint _checks_ but CASCADE still fires.
 
@@ -402,7 +403,7 @@ When re-mocking inside an `it()` block to test a different code path, call `vi.r
 
 ## Platform & Deployment
 
-Production target: **Cloudflare Workers** (the only supported platform). Deployment-context helpers (preview/local detection) live in `src/lib/utils/environment.ts`. CI auto-deploys main; PRs get preview deployments with unique D1 databases. See `.env.example` for required vars (or `bun setup` for local defaults).
+Production target: **Cloudflare Workers** (the only supported platform). Deployment-context helpers (preview/local detection) live in `src/lib/utils/environment.ts`. Workers Builds auto-deploys main (same mechanism as Deploy-button clones); PRs get GitHub Actions preview deployments with unique D1 databases. See `.env.example` for required vars (or `bun setup` for local defaults).
 
 <!-- intent-skills:start -->
 

--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ See [`.env.example`](.env.example) for all optional configuration (Google OAuth,
 
 ### Build & Deploy
 
-| Command             | Description                                  |
-| ------------------- | -------------------------------------------- |
-| `bun run build`     | Build for production (note: not `bun build`) |
-| `bun setup --prod`  | Interactive production setup + deploy        |
-| `bun cf:deploy:prd` | Deploy to Cloudflare Workers (production)    |
+| Command             | Description                                         |
+| ------------------- | --------------------------------------------------- |
+| `bun run build`     | Build for production (note: not `bun build`)        |
+| `bun setup --prod`  | Interactive production setup + deploy               |
+| `bun cf:deploy:prd` | Manual production deploy (build → migrate → deploy) |
 
 ## Project Structure
 
@@ -148,7 +148,7 @@ scripts/          # CLI utilities and setup
 
 The deploy button clones the repo into your Cloudflare account, provisions the resources declared in [`wrangler.jsonc`](wrangler.jsonc), and sets up CI. For a guided setup from your own clone, run `bun setup --prod`.
 
-**CI/CD:** GitHub Actions auto-deploys on push to `main`. Pull requests get preview deployments with dedicated D1 databases.
+**CI/CD:** Cloudflare Workers Builds auto-deploys on push to `main` — the same mechanism deploy-button clones use. Pull requests get GitHub Actions preview deployments with dedicated D1 databases.
 
 > See the [Platform & Deployment](CLAUDE.md#platform--deployment) section in CLAUDE.md for environment variable configuration and platform detection.
 

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -39,11 +39,33 @@ The Worker entry point is `src/server.ts` with `nodejs_compat` enabled.
 
 ## Build & Deploy
 
+Upstream production (`openstory-so/openstory` → the `openstory` worker) deploys
+through [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/)
+— the same mechanism Deploy-to-Cloudflare button clones use, so upstream
+dogfoods the exact pipeline users get. Workers Builds is wrangler-authenticated,
+so the prod path needs no Cloudflare secrets in GitHub. The dashboard
+configuration (the only deploy state not versioned in the repo):
+
+- **Repository / branch**: `openstory-so/openstory`, `main`
+- **Build command**: `bun run build`
+- **Build env vars**: `CLOUDFLARE_ENV=production` (bakes the
+  `[env.production]` block into `dist/server/wrangler.json`),
+  `VITE_R2_PUBLIC_ASSETS_DOMAIN`, `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN`,
+  `VITE_PUBLIC_POSTHOG_HOST`
+- **Deploy command**: `bun run deploy:production` — flatten migrations →
+  `wrangler d1 migrations apply DB --env=production --remote` →
+  `wrangler deploy`. The plain `wrangler deploy` picks up the flattened
+  `dist/server/wrangler.json` via `.wrangler/deploy/config.json`; the
+  `--env` flag matters only for the migrate step, which reads the source
+  `wrangler.jsonc`.
+
+For a manual deploy from a local checkout:
+
 ```bash
 # Generate Worker types from wrangler.jsonc
 bun cf:typegen
 
-# Deploy to production (typegen, CLOUDFLARE_ENV=production build, wrangler deploy)
+# Deploy to production (typegen, CLOUDFLARE_ENV=production build, migrate, wrangler deploy)
 bun cf:deploy:prd
 ```
 
@@ -59,17 +81,20 @@ wrangler can't read, `scripts/flatten-migrations.ts` renders them to flat
 run it automatically:
 
 ```bash
-bun run deploy          # flatten → wrangler d1 migrations apply DB --remote → wrangler deploy
-                        # (what the Deploy to Cloudflare button / Workers Builds runs)
-bun db:migrate:prd      # flatten → wrangler d1 migrations apply DB --env=production --remote
+bun run deploy             # flatten → wrangler d1 migrations apply DB --remote → wrangler deploy
+                           # (what Deploy to Cloudflare button clones run)
+bun run deploy:production  # same, but --env=production on the migrate step
+                           # (what upstream's Workers Builds runs)
+bun db:migrate:prd         # flatten → wrangler d1 migrations apply DB --env=production --remote
 ```
 
-- **Button deploys / Workers Builds**: the `deploy` package script is picked
-  up as the deploy command and re-runs on every push, so new migrations apply
-  idempotently. It references the binding name `DB` (not the database name) so
-  it works whatever the user named their database.
-- **Production CI**: `cf:deploy:prd` runs `db:migrate:prd` between build and
-  deploy.
+- **Button deploys**: the `deploy` package script is picked up as the deploy
+  command and re-runs on every push, so new migrations apply idempotently. It
+  references the binding name `DB` (not the database name) so it works
+  whatever the user named their database.
+- **Upstream production (Workers Builds)**: `deploy:production` is the
+  configured deploy command — identical to `deploy` except the migrate step
+  targets the `[env.production]` D1.
 - **PR previews**: CI applies migrations with `wrangler d1 migrations apply DB
 --remote` after patching the PR's database id into the config.
 - **Local dev / e2e**: unchanged — drizzle-orm's migrator applies the nested
@@ -160,9 +185,8 @@ reopen the PR to get a fresh, wrangler-tracked preview database.
 
 ## CI/CD
 
-[`deploy-cloudflare.yml`](https://github.com/anthropics/openstory/blob/main/.github/workflows/deploy-cloudflare.yml) handles:
+Production pushes to `main` deploy via Workers Builds (see [Build & Deploy](#build--deploy) above). [`deploy-cloudflare.yml`](https://github.com/anthropics/openstory/blob/main/.github/workflows/deploy-cloudflare.yml) handles the PR previews, which stay on GitHub Actions because Workers Builds branch previews share production bindings — no per-PR D1 provisioning, no workflow-name namespacing, no teardown on close:
 
-- **Production**: pushes to `main` run `bun cf:deploy:prd` (build → migrate → deploy).
 - **PR previews**: each PR gets its own Worker (`pr-<number>`) and D1 database (`openstory-pr-<number>`), with secrets pushed and the preview URL posted as a PR comment.
 - **Cleanup**: closing a PR deletes both the Worker and the D1 database.
 

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "cf:typegen": "wrangler types",
     "cf:dev": "wrangler dev",
     "cf:deploy:prd": "bun run cf:typegen && CLOUDFLARE_ENV=production bun run build && bun run db:migrate:prd && wrangler deploy --env=production",
-    "deploy": "bun scripts/flatten-migrations.ts && wrangler d1 migrations apply DB --remote && wrangler deploy"
+    "deploy": "bun scripts/flatten-migrations.ts && wrangler d1 migrations apply DB --remote && wrangler deploy",
+    "deploy:production": "bun scripts/flatten-migrations.ts && wrangler d1 migrations apply DB --env=production --remote && wrangler deploy"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1047.0",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -46,8 +46,10 @@
   // true), the request would 404 against Cloudflare rather than silently
   // writing to production.
   //
-  // PROD D1 lives in [env.production] below. Deploys MUST pass
-  // `--env=production` (see .github/workflows/deploy-cloudflare.yml).
+  // PROD D1 lives in [env.production] below. Prod builds MUST set
+  // CLOUDFLARE_ENV=production (a Workers Builds build env var; see
+  // docs/deployment/cloudflare.md) and the migrate step MUST pass
+  // `--env=production` (wired in the `deploy:production` package script).
   // PR-preview deploys patch this default block in CI before deploying.
   // ─────────────────────────────────────────────────────────────────────────
   "d1_databases": [
@@ -273,8 +275,9 @@
   ],
   "env": {
     // Production deploy target. @cloudflare/vite-plugin selects the env at
-    // BUILD time via CLOUDFLARE_ENV — `cf:deploy:prd` sets
-    // `CLOUDFLARE_ENV=production bun run build`, which bakes these bindings
+    // BUILD time via CLOUDFLARE_ENV — Workers Builds sets it as a dashboard
+    // build env var (manual deploys: `cf:deploy:prd` sets
+    // `CLOUDFLARE_ENV=production bun run build`), which bakes these bindings
     // into dist/server/wrangler.json. The `--env=production` flag on
     // `wrangler deploy` is a no-op against that generated (already-flattened)
     // config; without CLOUDFLARE_ENV the build bakes the DEFAULT block (whose


### PR DESCRIPTION
## Summary

Retires the `deploy-production` job in `deploy-cloudflare.yml` and moves upstream prod deploys to **Cloudflare Workers Builds** — the same mechanism Deploy-to-Cloudflare button clones use, so upstream dogfoods the exact pipeline users get. Workers Builds is wrangler-authenticated, so the prod path needs no Cloudflare secrets in GitHub.

- **New `deploy:production` package script** — `bun scripts/flatten-migrations.ts && wrangler d1 migrations apply DB --env=production --remote && wrangler deploy`. Identical to the button-deploy `deploy` script except the migrate step targets the `[env.production]` D1 (the plain `wrangler deploy` picks up the `CLOUDFLARE_ENV=production`-baked `dist/server/wrangler.json` via `.wrangler/deploy/config.json`).
- **`deploy-cloudflare.yml`** — `deploy-production` job and the `push: [main]` trigger removed (nothing else ran on push, so `check-secrets` no longer burns a runner per merge). PR-preview and cleanup jobs untouched; header comment explains why previews stay on Actions (shared-binding hazard, #805).
- **Docs** — `docs/deployment/cloudflare.md` now documents the Workers Builds dashboard config (build command, build env vars, deploy command) so the unversioned dashboard state has a versioned reference; CLAUDE.md, README, and `wrangler.jsonc` comments updated to match. `cf:deploy:prd` stays as the manual fallback.

## Cutover order (avoids any double-deploy window)

1. **Before merging:** connect `openstory-so/openstory` → Workers Builds on the `openstory` worker in the dashboard — branch `main`, build command `bun run build`, build env vars `CLOUDFLARE_ENV=production`, `VITE_R2_PUBLIC_ASSETS_DOMAIN`, `VITE_PUBLIC_POSTHOG_PROJECT_TOKEN`, `VITE_PUBLIC_POSTHOG_HOST`, deploy command `bun run deploy:production`. An initial build of current main will fail (the script doesn't exist yet) — harmless, the previous deploy keeps serving.
2. **Merge this PR.** The merge push is the first real Workers Builds deploy, and the same commit removes the Action job — no double deploy.
3. If the first deploy goes red, `bun cf:deploy:prd` is the manual escape hatch while fixing the dashboard config.

Closes #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
