### PR TITLE
fix(enhancer): raise enhance max_tokens so reasoning doesn't truncate the script

### DIFF
--- a/src/functions/ai.ts
+++ b/src/functions/ai.ts
@@ -392,7 +392,12 @@ export async function* streamScriptEnhancement(
   for await (const chunk of callLLMStream({
     model,
     messages,
-    max_tokens: 4000,
+    // Must hold reasoning tokens (PROMPT_REASONING, medium) PLUS a full
+    // multi-scene script (up to ~3500 words / 180s). At 4000 the reasoning ate
+    // the budget and the visible script truncated mid-first-scene, so 30s+
+    // targets rendered as a single scene (#915). Sized like the other
+    // reasoning calls (scene-split/visual-prompt) which scale to the model.
+    max_tokens: 16000,
     temperature: 0.7,
     ...(useWebSearch && { webSearch: true }),
     reasoning: PROMPT_REASONING,


### PR DESCRIPTION
## Problem

`POST /api/v1/scripts/enhance` (and the in-app enhancer) **truncates the enhanced script for 30s+ targets**, so the scene-splitter sees only a partial first scene and the sequence renders as a **single scene**.

Repro — enhance API with `{ "script": "A product ad for makeup", "style": "Product Ad", "targetSeconds": 30 }` returns an `enhancedScript` that cuts off mid-`SCENE 1` ("…matte white body, a"); there is no `SCENE 2`/`SCENE 3`.

## Root cause

The enhance call hardcoded `max_tokens: 4000` while #875 turned on `reasoning: PROMPT_REASONING` (`{ enabled: true, effort: 'medium' }`). Reasoning tokens count against `max_tokens`, so the model spends most of the 4000 thinking and the visible script truncates (`finish_reason: length`).

Duration-dependent, which is why it slipped through: a 15s target (~400 words) fits under 4000, so the sample renders looked fine; 30s+ (~800–3500 words) does not. The other reasoning calls are unaffected because they size the budget to the model (`getContextWindow(model) * 0.65` for scene-split, `* 0.5` for visual-prompt) — enhance was the only one with a fixed `4000`.

## Fix

Raise the enhance `max_tokens` to `16000` (headroom for reasoning + a full multi-scene script up to the ~3500-word/180s ceiling), with a comment tying the value to the reasoning budget.

**Validated** by replaying the exact enhance prompt (Sonnet 4.6, `reasoning: medium`):

| max_tokens | finish_reason | result |
|---|---|---|
| 4000 (before) | `length` | truncated / empty |
| 16000 (after) | `stop` | complete **5-scene** script, natural ending |

Closes #915.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
