### PR TITLE
Split dev server and Stripe listener into separate commands

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,18 @@
+{
+  // Preview server config for Claude Code (desktop + web).
+  // `bun dev` bootstraps .env.local, applies local D1 migrations, seeds, and
+  // starts Vite (Workerd via the cf-plugin) on port 3000. The Stripe listener
+  // it also spawns is skipped automatically when STRIPE_SECRET_KEY is unset.
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "openstory",
+      "runtimeExecutable": "bun",
+      "runtimeArgs": ["dev"],
+      // Vite is hardcoded to 3000 in vite.config.ts and does not honor $PORT,
+      // so the preview must use this exact port — keep autoPort off.
+      "port": 3000,
+      "autoPort": false
+    }
+  ]
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,8 +1,9 @@
 {
   // Preview server config for Claude Code (desktop + web).
   // `bun dev` bootstraps .env.local, applies local D1 migrations, seeds, and
-  // starts Vite (Workerd via the cf-plugin) on port 3000. The Stripe listener
-  // it also spawns is skipped automatically when STRIPE_SECRET_KEY is unset.
+  // starts Vite (Workerd via the cf-plugin) on port 3000. It is app-only — the
+  // Stripe listener lives in `dev:all` so it never disrupts the preview (the
+  // Stripe CLI isn't installed in cloud sandboxes).
   "version": "0.0.1",
   "configurations": [
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,8 @@ AI-powered video sequence platform built with TanStack Start, deployed to Cloudf
 
 ```bash
 # Dev
-bun dev                            # All-in-one: env bootstrap, DB migrate + seed, Vite (Workerd via cf-plugin), Stripe listener
+bun dev                            # App: env bootstrap, DB migrate + seed, Vite (Workerd via cf-plugin)
+bun dev:all                        # bun dev + the Stripe listener (billing webhooks)
 bun storybook                      # Storybook on :6006
 bun db:studio:local                # Inspect local D1 tables (wrangler d1 execute)
 
@@ -45,7 +46,7 @@ bun run deploy                     # Deploy-button deploy command (migrate + dep
 bun deploy:production              # Workers Builds prod deploy command (migrate --env=production + deploy)
 ```
 
-`bun dev` runs vite dev (cf-plugin → Workerd via Miniflare, port 3000) alongside the Stripe listener (skipped without `STRIPE_SECRET_KEY`). Its first step (`scripts/ensure-env.ts`) creates `.env.local` with generated secrets if missing, so a fresh clone needs only `bun install && bun dev`. The app runs in **Workerd locally** — same runtime as production — so D1, R2 bindings, **Cloudflare Workflows**, env.\* access, and request lifecycle all match prod. No QStash/Docker needed: workflows execute in-process in Workerd.
+`bun dev` runs vite dev (cf-plugin → Workerd via Miniflare, port 3000). Its first step (`scripts/ensure-env.ts`) creates `.env.local` with generated secrets if missing, so a fresh clone needs only `bun install && bun dev`. Billing work uses `bun dev:all`, which additionally runs the Stripe listener (skipped without `STRIPE_SECRET_KEY`); it lives outside `bun dev` so a missing/uninstalled Stripe CLI never takes down the app server (e.g. in cloud preview sandboxes). The app runs in **Workerd locally** — same runtime as production — so D1, R2 bindings, **Cloudflare Workflows**, env.\* access, and request lifecycle all match prod. No QStash/Docker needed: workflows execute in-process in Workerd.
 
 **Bun-as-launcher pattern:** `bun script.ts` (no `--bun`) keeps Bun as the CLI launcher but executes under **Node**, while still autoloading `.env*`. Use `bun --env-file=<path>` to override the default `.env.local`. No `--bun` flag should appear in package.json scripts.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,14 @@ Lefthook automatically tags commits with the issue number extracted from the bra
 
 ### Daily Development
 
-`bun dev` runs everything: env bootstrap, DB migration + seeding, the dev server, and the Stripe listener (skipped when `STRIPE_SECRET_KEY` isn't set).
+`bun dev` runs env bootstrap, DB migration + seeding, and the dev server. For billing work, `bun dev:all` also starts the Stripe listener (skipped when `STRIPE_SECRET_KEY` isn't set).
 
 Key commands:
 
 | Command         | Description                                                     |
 | --------------- | --------------------------------------------------------------- |
-| `bun dev`       | Start all dev services                                          |
+| `bun dev`       | Start the app dev services                                      |
+| `bun dev:all`   | Same as `bun dev` plus the Stripe listener                      |
 | `bun run build` | Build for production (**not** `bun build` — that's the bundler) |
 | `bun typecheck` | Type-check with tsgo                                            |
 | `bun run test`  | Run unit tests (Vitest)                                         |

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   },
   "scripts": {
     "setup": "bun scripts/setup.ts",
-    "dev": "bun scripts/ensure-env.ts && bun run --parallel dev:app stripe:dev",
+    "dev": "bun scripts/ensure-env.ts && bun run dev:app",
+    "dev:all": "bun scripts/ensure-env.ts && bun run --parallel dev:app stripe:dev",
     "dev:app": "bun --sequential db:migrate:local db:seed:local dev:vite",
     "dev:vite": "bun scripts/build-content-collections.ts && vite dev",
     "stripe:dev": "source .env.local 2>/dev/null; [ -z \"${STRIPE_SECRET_KEY}\" ] && echo 'Skipping Stripe (no STRIPE_SECRET_KEY)' && exit 0; stripe listen --forward-to localhost:3000/api/billing/webhook --api-key=${STRIPE_SECRET_KEY}",


### PR DESCRIPTION
## Related Issue

<!-- Issue number if applicable -->

## Summary of Changes

Separates the development workflow into two distinct commands:

- **`bun dev`** — Runs only the app dev server (env bootstrap, DB migrate + seed, Vite/Workerd on port 3000)
- **`bun dev:all`** — Runs `bun dev` plus the Stripe listener for billing webhook development

This change prevents the Stripe CLI from disrupting the app server when it's unavailable or uninstalled (e.g., in cloud preview sandboxes). The Stripe listener is now opt-in for developers working on billing features.

### Files Changed

- **`.claude/launch.json`** (new) — Claude Code desktop/web preview server configuration pointing to port 3000
- **`CLAUDE.md`** — Updated dev command documentation to reflect the split
- **`CONTRIBUTING.md`** — Updated daily development guide with new command structure
- **`package.json`** — Split `dev` script into `dev` (app only) and `dev:all` (app + Stripe)

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

The change is backward-compatible in spirit (developers can still run everything with `bun dev:all`), but `bun dev` now has different behavior. This is intentional and documented. No code logic changes; purely script/configuration reorganization.

## Additional Notes

- The `.claude/launch.json` file enables Claude Code to properly launch the preview server on the correct port
- Stripe listener still auto-skips gracefully when `STRIPE_SECRET_KEY` is not set
- All existing functionality preserved; just reorganized for better developer experience

https://claude.ai/code/session_01Dmh6zgMrDsvvkdfRpJFjup