### PR TITLE
Add public Fork & Deploy flow (real GitHub fork + Cloudflare deploy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,3 +98,30 @@ BETTER_AUTH_SECRET=
 
 # System admin emails (comma-separated, for gift code management)
 # ADMIN_EMAILS=admin@example.com
+
+# =============================================================================
+# FORK & DEPLOY (optional) - powers the public /fork one-click fork+deploy
+#
+# Only the operator of a hosted instance sets these. When present, /fork lets a
+# visitor OAuth into GitHub (real fork of this repo) and Cloudflare (deploy to
+# their own account via the fork's CI). When absent, /fork shows the manual
+# deploy guide instead. Register two OAuth apps and supply their credentials:
+#
+#   GitHub OAuth App (Settings → Developer settings → OAuth Apps):
+#     Authorization callback URL: <VITE_APP_URL>/api/fork/github/callback
+#   Cloudflare self-managed OAuth client (Manage account → OAuth clients):
+#     Redirect URI: <VITE_APP_URL>/api/fork/cloudflare/callback
+#     https://developers.cloudflare.com/changelog/post/2026-06-03-public-oauth-clients/
+# =============================================================================
+
+# GITHUB_OAUTH_CLIENT_ID=
+# GITHUB_OAUTH_CLIENT_SECRET=
+# CLOUDFLARE_OAUTH_CLIENT_ID=
+# CLOUDFLARE_OAUTH_CLIENT_SECRET=          # omit for a public (PKCE-only) client
+# CLOUDFLARE_OAUTH_AUTHORIZE_URL=          # from the client's OAuth discovery doc
+# CLOUDFLARE_OAUTH_TOKEN_URL=
+# CLOUDFLARE_OAUTH_SCOPES=                 # space-separated; defaults to a sane set
+# Override the upstream that gets forked / the target worker name (defaults shown):
+# FORK_UPSTREAM_OWNER=openstory-so
+# FORK_UPSTREAM_REPO=openstory
+# FORK_WORKER_NAME=openstory

--- a/.github/workflows/fork-deploy.yml
+++ b/.github/workflows/fork-deploy.yml
@@ -1,0 +1,130 @@
+name: Fork Deploy
+
+# Deploys a FORK to its owner's Cloudflare account. Dispatched by the
+# fork-and-deploy flow (src/routes/api/fork/*) right after it writes
+# CLOUDFLARE_API_TOKEN + CLOUDFLARE_ACCOUNT_ID as Actions secrets on the fork,
+# and re-runs on every push to main so the fork stays deployed.
+#
+# This NEVER runs on the upstream repo (openstory-so/openstory) — upstream
+# deploys via Cloudflare Workers Builds. The `github.repository` guard makes
+# the whole workflow inert there even if it gets merged upstream.
+#
+# Unlike the button deploy, a plain `wrangler deploy` does not provision
+# D1/R2, so scripts/fork-provision.ts creates them and patches the placeholder
+# default wrangler block before deploying.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fork-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - id: check
+        run: |
+          if [ "${{ github.repository }}" = "openstory-so/openstory" ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=${{ secrets.CLOUDFLARE_API_TOKEN != '' && secrets.CLOUDFLARE_ACCOUNT_ID != '' }}" >> "$GITHUB_OUTPUT"
+          fi
+
+  deploy:
+    needs: check
+    if: needs.check.outputs.ready == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Provision Cloudflare resources
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: bun scripts/fork-provision.ts
+
+      - name: Apply D1 migrations
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          bun scripts/flatten-migrations.ts
+          bunx wrangler d1 migrations apply DB --remote
+
+      - name: Build
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VITE_APP_URL: ${{ secrets.VITE_APP_URL }}
+        run: |
+          bunx wrangler types
+          bun run build
+
+      - name: Deploy
+        id: deploy
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          output=$(bunx wrangler deploy 2>&1) || true
+          echo "$output"
+          url=$(echo "$output" | grep -oP 'https://[^[:space:]]+\.workers\.dev' | tail -1)
+          if [ -z "$url" ]; then
+            echo "::error::Wrangler deploy failed — no URL found in output"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure worker secrets
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          VITE_APP_URL: ${{ steps.deploy.outputs.url }}
+          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+        run: |
+          WORKER=openstory
+          existing=$(bunx wrangler secret list --name "$WORKER" 2>/dev/null || echo '[]')
+          have() { echo "$existing" | jq -e --arg n "$1" 'any(.[]?; .name==$n)' >/dev/null 2>&1; }
+
+          puts='{}'
+          have BETTER_AUTH_SECRET || puts=$(echo "$puts" | jq --arg v "$(openssl rand -hex 32)" '.BETTER_AUTH_SECRET=$v')
+          have API_KEY_ENCRYPTION_KEY || puts=$(echo "$puts" | jq --arg v "$(openssl rand -hex 32)" '.API_KEY_ENCRYPTION_KEY=$v')
+          [ -n "$VITE_APP_URL" ] && puts=$(echo "$puts" | jq --arg v "$VITE_APP_URL" '.VITE_APP_URL=$v')
+          [ -n "$EMAIL_FROM" ] && puts=$(echo "$puts" | jq --arg v "$EMAIL_FROM" '.EMAIL_FROM=$v')
+
+          if [ "$(echo "$puts" | jq 'length')" -gt 0 ]; then
+            echo "$puts" | bunx wrangler secret bulk --name "$WORKER"
+          else
+            echo "All core secrets already set."
+          fi
+
+      - name: Summary
+        run: |
+          {
+            echo "### Fork deployed :rocket:"
+            echo ""
+            echo "- **URL:** ${{ steps.deploy.outputs.url }}"
+            echo "- **Worker:** \`openstory\`"
+            echo ""
+            echo "Add \`FAL_KEY\` and \`OPENROUTER_KEY\` (Settings → API Keys in-app, or \`wrangler secret put\`) to enable generation."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@unpic/react": "^1.0.2",
         "@videojs/react": "^10.0.0-beta.23",
         "better-auth": "1.6.14",
+        "blakejs": "^1.2.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "diff": "^9.0.0",
@@ -83,6 +84,7 @@
         "stripe": "^22.1.1",
         "tailwind-merge": "^3.6.0",
         "tiptap-markdown": "^0.9.0",
+        "tweetnacl": "^1.0.3",
         "ulid": "^3.0.2",
         "unified": "^11.0.5",
         "zod": "^4.4.3",
@@ -1573,6 +1575,8 @@
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
+    "blakejs": ["blakejs@1.2.1", "", {}, "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -2786,6 +2790,8 @@
     "tsyringe": ["tsyringe@4.10.0", "", { "dependencies": { "tslib": "^1.9.3" } }, "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-fest": ["type-fest@5.6.0", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA=="],
 

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -17,6 +17,38 @@ The created repo is an independent clone, not a fork — there's no upstream lin
 
 AI keys (`FAL_KEY`, `OPENROUTER_KEY`) are deliberately not part of the deploy prompts — every field in that dialog is mandatory, and a placeholder value would be worse than none. Add them after deploy, either per team in the app (Settings → API Keys) or server-wide with `wrangler secret put`.
 
+## One-Click Fork (`/fork`)
+
+The deploy button **clones** the repo into a standalone copy — there's no
+upstream link, so GitHub's "Sync fork" never works. The public `/fork` page is
+the alternative: it OAuths the visitor into GitHub to create a **real fork**,
+OAuths them into Cloudflare, then dispatches the fork's own
+[`fork-deploy.yml`](https://github.com/openstory-so/openstory/blob/main/.github/workflows/fork-deploy.yml)
+workflow, which provisions D1/R2 (`scripts/fork-provision.ts`) and deploys to
+the visitor's account. The page polls the run and links them to their
+`*.workers.dev` domain when it finishes.
+
+`/fork` is inert until the **operator** of a hosted instance registers two
+OAuth apps and supplies their credentials as Worker secrets (see the
+"Fork & deploy" block in `.env.example`):
+
+- A **GitHub OAuth App** with callback `<VITE_APP_URL>/api/fork/github/callback`
+  → `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET`. Used to fork, write
+  Actions secrets, and dispatch the deploy workflow (scopes `repo workflow`).
+- A **Cloudflare [self-managed OAuth client](https://developers.cloudflare.com/changelog/post/2026-06-03-public-oauth-clients/)**
+  with redirect `<VITE_APP_URL>/api/fork/cloudflare/callback` →
+  `CLOUDFLARE_OAUTH_CLIENT_ID` (+ secret for confidential clients) and the
+  authorize/token URLs from its discovery doc
+  (`CLOUDFLARE_OAUTH_AUTHORIZE_URL` / `CLOUDFLARE_OAUTH_TOKEN_URL`). The
+  obtained token is written to the fork as `CLOUDFLARE_API_TOKEN` so its CI can
+  deploy.
+
+The flow never persists the Cloudflare token server-side — it lives only in the
+encrypted, HttpOnly flow cookie until it's handed to the fork's Actions secrets.
+The fork's CI generates `BETTER_AUTH_SECRET` / `API_KEY_ENCRYPTION_KEY` on first
+deploy; `FAL_KEY` / `OPENROUTER_KEY` are added by the new owner afterward (in
+app or via `wrangler secret put`), same as the button path.
+
 ## Guided Setup
 
 From your own clone, `bun setup --prod` walks through everything interactively: production env vars (`.env.production`), R2 domains + CORS, optional services, pushing secrets to Cloudflare and GitHub, and the first deploy. `bun setup --deploy` re-runs just the secrets-push + deploy phase, and `bun setup --pr-preview` pushes preview secrets to the GitHub `staging` environment used by PR preview deploys.

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@unpic/react": "^1.0.2",
     "@videojs/react": "^10.0.0-beta.23",
     "better-auth": "1.6.14",
+    "blakejs": "^1.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "diff": "^9.0.0",
@@ -150,6 +151,7 @@
     "stripe": "^22.1.1",
     "tailwind-merge": "^3.6.0",
     "tiptap-markdown": "^0.9.0",
+    "tweetnacl": "^1.0.3",
     "ulid": "^3.0.2",
     "unified": "^11.0.5",
     "zod": "^4.4.3"

--- a/scripts/fork-provision.ts
+++ b/scripts/fork-provision.ts
@@ -1,0 +1,140 @@
+/**
+ * Fork deploy: provision Cloudflare resources, then patch wrangler.jsonc.
+ *
+ * Runs in a fork's CI (see .github/workflows/fork-deploy.yml) before
+ * `wrangler deploy`. A plain `wrangler deploy` does NOT auto-create D1/R2 the
+ * way the Deploy-to-Cloudflare button does, and the default wrangler block
+ * ships a placeholder D1 id (`dev-local-d1`) that only resolves to a local
+ * Miniflare DB. So we:
+ *
+ *   1. Ensure a real D1 database exists and capture its id.
+ *   2. Ensure the R2 buckets exist.
+ *   3. Rewrite the default block's bindings to the real names + id.
+ *
+ * This mirrors how PR previews patch the config in deploy-cloudflare.yml.
+ * Requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN in the environment.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import JSON5 from 'json5';
+import { z } from 'zod';
+
+const DB_NAME = 'openstory';
+const PUBLIC_ASSETS_BUCKET = 'openstory-public-assets';
+const STORAGE_BUCKET = 'openstory-storage';
+const WRANGLER_PATH = 'wrangler.jsonc';
+
+const accountId = required('CLOUDFLARE_ACCOUNT_ID');
+const apiToken = required('CLOUDFLARE_API_TOKEN');
+const API = `https://api.cloudflare.com/client/v4/accounts/${accountId}`;
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function cf(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(`${API}${path}`, {
+    method: init?.method,
+    body: init?.body,
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+const d1ListSchema = z.object({
+  result: z.array(z.object({ uuid: z.string(), name: z.string() })).nullish(),
+});
+const d1CreateSchema = z.object({
+  success: z.boolean(),
+  result: z.object({ uuid: z.string() }).nullish(),
+  errors: z.unknown().optional(),
+});
+const errorsSchema = z.object({
+  errors: z
+    .array(
+      z.object({ code: z.number().optional(), message: z.string().optional() })
+    )
+    .nullish(),
+});
+
+/** Find or create the D1 database, returning its uuid. */
+async function ensureD1(): Promise<string> {
+  const listRes = await cf(`/d1/database?name=${encodeURIComponent(DB_NAME)}`);
+  const list = d1ListSchema.parse(await listRes.json());
+  const existing = list.result?.find((d) => d.name === DB_NAME)?.uuid;
+  if (existing) {
+    console.log(`Found D1 database ${DB_NAME}: ${existing}`);
+    return existing;
+  }
+
+  const createRes = await cf('/d1/database', {
+    method: 'POST',
+    body: JSON.stringify({ name: DB_NAME }),
+  });
+  const created = d1CreateSchema.parse(await createRes.json());
+  if (!created.success || !created.result?.uuid) {
+    console.error('Failed to create D1 database:', created.errors);
+    process.exit(1);
+  }
+  console.log(`Created D1 database ${DB_NAME}: ${created.result.uuid}`);
+  return created.result.uuid;
+}
+
+/** Create an R2 bucket, treating "already exists" as success. */
+async function ensureBucket(name: string): Promise<void> {
+  const res = await cf('/r2/buckets', {
+    method: 'POST',
+    body: JSON.stringify({ name }),
+  });
+  if (res.ok) {
+    console.log(`Created R2 bucket ${name}`);
+    return;
+  }
+  const body = errorsSchema
+    .catch({ errors: [] })
+    .parse(await res.json().catch(() => ({})));
+  // 10004 = bucket already exists.
+  const alreadyExists = body.errors?.some(
+    (e) => e.code === 10004 || /exist/i.test(e.message ?? '')
+  );
+  if (alreadyExists) {
+    console.log(`R2 bucket ${name} already exists`);
+    return;
+  }
+  console.error(`Failed to create R2 bucket ${name}:`, body.errors);
+  process.exit(1);
+}
+
+/** Rewrite the default wrangler block to use the provisioned resources. */
+function patchWranglerConfig(databaseId: string): void {
+  const raw = readFileSync(WRANGLER_PATH, 'utf8');
+  const config: Record<string, unknown> = JSON5.parse(raw);
+
+  config.d1_databases = [
+    {
+      binding: 'DB',
+      database_name: DB_NAME,
+      database_id: databaseId,
+      migrations_dir: 'drizzle/migrations-wrangler',
+    },
+  ];
+  config.r2_buckets = [
+    { bucket_name: PUBLIC_ASSETS_BUCKET, binding: 'R2_PUBLIC_ASSETS_BUCKET' },
+    { binding: 'R2_STORAGE_BUCKET', bucket_name: STORAGE_BUCKET },
+  ];
+
+  writeFileSync(WRANGLER_PATH, JSON.stringify(config, null, 2));
+  console.log(`Patched ${WRANGLER_PATH} (D1 id ${databaseId})`);
+}
+
+const databaseId = await ensureD1();
+await ensureBucket(PUBLIC_ASSETS_BUCKET);
+await ensureBucket(STORAGE_BUCKET);
+patchWranglerConfig(databaseId);

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -24,7 +24,7 @@ import { Route as sequencesNewRoute } from '@/routes/_app/sequences/new';
 import { Route as talentRoute } from '@/routes/_app/talent/index';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { useEffect } from 'react';
-import { LifeBuoy, MapPin, Plus, Users, Video } from 'lucide-react';
+import { GitFork, LifeBuoy, MapPin, Plus, Users, Video } from 'lucide-react';
 import { CreditBalancePill } from './credit-balance-pill';
 import { UserSidebarFooter } from './user-sidebar-footer';
 
@@ -108,6 +108,14 @@ export function AppSidebar() {
                 <GitHubIcon className="size-4" />
                 <span>GitHub</span>
               </a>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Fork & deploy">
+              <Link to="/fork">
+                <GitFork />
+                <span>Fork &amp; deploy</span>
+              </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>

--- a/src/functions/fork.ts
+++ b/src/functions/fork.ts
@@ -1,0 +1,13 @@
+/**
+ * Server functions for the public fork-and-deploy page.
+ */
+
+import { getForkConfig } from '@/lib/fork/config';
+import { createServerFn } from '@tanstack/react-start';
+
+/** Whether the operator has configured the OAuth apps that power /fork. */
+export const getForkEnabledFn = createServerFn({ method: 'GET' }).handler(
+  () => {
+    return { enabled: getForkConfig().enabled };
+  }
+);

--- a/src/lib/fork/cloudflare.test.ts
+++ b/src/lib/fork/cloudflare.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCloudflareAuthorizeUrl,
+  computeWorkerUrl,
+  generateCodeChallenge,
+  generateUrlSafeToken,
+} from './cloudflare';
+
+describe('buildCloudflareAuthorizeUrl', () => {
+  it('builds an authorization-code + PKCE URL', () => {
+    const url = new URL(
+      buildCloudflareAuthorizeUrl({
+        authorizeUrl: 'https://cf.example/oauth/authorize',
+        clientId: 'client-123',
+        redirectUri: 'https://app.test/api/fork/cloudflare/callback',
+        scopes: 'account:read d1:write',
+        csrfState: 'nonce',
+        codeChallenge: 'challenge',
+      })
+    );
+    expect(url.origin + url.pathname).toBe(
+      'https://cf.example/oauth/authorize'
+    );
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe('client-123');
+    expect(url.searchParams.get('code_challenge')).toBe('challenge');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('nonce');
+    expect(url.searchParams.get('scope')).toBe('account:read d1:write');
+  });
+});
+
+describe('generateCodeChallenge', () => {
+  it('matches the known S256 vector from RFC 7636', async () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    expect(await generateCodeChallenge(verifier)).toBe(
+      'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM'
+    );
+  });
+
+  it('produces URL-safe tokens with no padding', () => {
+    expect(generateUrlSafeToken()).not.toMatch(/[+/=]/);
+  });
+});
+
+describe('computeWorkerUrl', () => {
+  it('builds the workers.dev URL when the subdomain is known', () => {
+    expect(computeWorkerUrl('openstory', 'octocat')).toBe(
+      'https://openstory.octocat.workers.dev'
+    );
+  });
+
+  it('returns undefined without a subdomain', () => {
+    expect(computeWorkerUrl('openstory', null)).toBeUndefined();
+  });
+});

--- a/src/lib/fork/cloudflare.ts
+++ b/src/lib/fork/cloudflare.ts
@@ -1,0 +1,149 @@
+/**
+ * Cloudflare OAuth + API client for the fork-and-deploy flow.
+ *
+ * Uses Cloudflare's self-managed OAuth clients (authorization-code flow with
+ * PKCE) to obtain a token scoped to the visitor's account. The token is
+ * handed to the fork's CI (as the `CLOUDFLARE_API_TOKEN` Actions secret) to
+ * provision D1/R2 and deploy. We also read the account id and workers.dev
+ * subdomain so the UI can link the visitor straight to their deployed worker.
+ *
+ * Endpoint URLs and scopes are supplied via config (set when the OAuth client
+ * is registered) rather than hard-coded — see src/lib/fork/config.ts.
+ */
+
+import { z } from 'zod';
+
+const CLOUDFLARE_API = 'https://api.cloudflare.com/client/v4';
+
+/** Random URL-safe token (256 bits) — used as PKCE verifier and CSRF nonce. */
+export function generateUrlSafeToken(): string {
+  return uint8ToUrlSafeBase64(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+/** PKCE S256 challenge derived from the verifier. */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(verifier)
+  );
+  return uint8ToUrlSafeBase64(new Uint8Array(digest));
+}
+
+/** Build the Cloudflare OAuth authorize URL (authorization-code + PKCE). */
+export function buildCloudflareAuthorizeUrl(input: {
+  authorizeUrl: string;
+  clientId: string;
+  redirectUri: string;
+  scopes: string;
+  csrfState: string;
+  codeChallenge: string;
+}): string {
+  const url = new URL(input.authorizeUrl);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', input.clientId);
+  url.searchParams.set('redirect_uri', input.redirectUri);
+  url.searchParams.set('scope', input.scopes);
+  url.searchParams.set('state', input.csrfState);
+  url.searchParams.set('code_challenge', input.codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  return url.toString();
+}
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+/** Exchange an authorization code for an access token (PKCE). */
+export async function exchangeCloudflareCode(input: {
+  tokenUrl: string;
+  clientId: string;
+  clientSecret?: string;
+  code: string;
+  redirectUri: string;
+  codeVerifier: string;
+}): Promise<string> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: input.code,
+    redirect_uri: input.redirectUri,
+    client_id: input.clientId,
+    code_verifier: input.codeVerifier,
+  });
+  if (input.clientSecret) body.set('client_secret', input.clientSecret);
+
+  const response = await fetch(input.tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: body.toString(),
+  });
+  const data = tokenResponseSchema.parse(await response.json());
+  if (!data.access_token) {
+    throw new Error(
+      `Cloudflare token exchange failed: ${data.error_description ?? data.error ?? 'unknown error'}`
+    );
+  }
+  return data.access_token;
+}
+
+const accountsSchema = z.object({
+  result: z.array(z.object({ id: z.string(), name: z.string() })).nullable(),
+});
+
+/** Return the first account the token can access. */
+export async function getCloudflareAccountId(token: string): Promise<string> {
+  const response = await fetch(`${CLOUDFLARE_API}/accounts`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Cloudflare /accounts failed (${response.status})`);
+  }
+  const data = accountsSchema.parse(await response.json());
+  const accountId = data.result?.[0]?.id;
+  if (!accountId) {
+    throw new Error('No Cloudflare account accessible with this token');
+  }
+  return accountId;
+}
+
+const subdomainSchema = z.object({
+  result: z.object({ subdomain: z.string().nullable() }).nullable(),
+});
+
+/** Read the account's workers.dev subdomain (null if not yet registered). */
+export async function getWorkersSubdomain(
+  token: string,
+  accountId: string
+): Promise<string | null> {
+  const response = await fetch(
+    `${CLOUDFLARE_API}/accounts/${accountId}/workers/subdomain`,
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  if (!response.ok) return null;
+  const data = subdomainSchema.parse(await response.json());
+  return data.result?.subdomain ?? null;
+}
+
+/** The eventual workers.dev URL of the deployed worker, if the subdomain is known. */
+export function computeWorkerUrl(
+  workerName: string,
+  subdomain: string | null
+): string | undefined {
+  if (!subdomain) return undefined;
+  return `https://${workerName}.${subdomain}.workers.dev`;
+}
+
+// -- helpers --
+
+function uint8ToUrlSafeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}

--- a/src/lib/fork/config.test.ts
+++ b/src/lib/fork/config.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  env: {} as Record<string, string | undefined>,
+}));
+vi.mock('#env', () => ({ getEnv: () => h.env }));
+
+import { getForkConfig } from './config';
+
+const FULL_ENV = {
+  GITHUB_OAUTH_CLIENT_ID: 'gh-client',
+  GITHUB_OAUTH_CLIENT_SECRET: 'gh-secret',
+  CLOUDFLARE_OAUTH_CLIENT_ID: 'cf-client',
+  CLOUDFLARE_OAUTH_AUTHORIZE_URL: 'https://cf.example/authorize',
+  CLOUDFLARE_OAUTH_TOKEN_URL: 'https://cf.example/token',
+};
+
+describe('getForkConfig', () => {
+  beforeEach(() => {
+    h.env = {};
+  });
+
+  it('is disabled with no OAuth credentials', () => {
+    expect(getForkConfig().enabled).toBe(false);
+  });
+
+  it('is disabled when only GitHub is configured', () => {
+    h.env = {
+      GITHUB_OAUTH_CLIENT_ID: 'gh-client',
+      GITHUB_OAUTH_CLIENT_SECRET: 'gh-secret',
+    };
+    expect(getForkConfig().enabled).toBe(false);
+  });
+
+  it('is enabled once both GitHub and Cloudflare are configured', () => {
+    h.env = { ...FULL_ENV };
+    expect(getForkConfig().enabled).toBe(true);
+  });
+
+  it('treats empty-string env vars as missing', () => {
+    h.env = { ...FULL_ENV, GITHUB_OAUTH_CLIENT_ID: '' };
+    expect(getForkConfig().enabled).toBe(false);
+  });
+
+  it('defaults the upstream + worker name, overridable via env', () => {
+    h.env = { ...FULL_ENV };
+    const config = getForkConfig();
+    expect(config.upstream).toEqual({
+      owner: 'openstory-so',
+      repo: 'openstory',
+    });
+    expect(config.workerName).toBe('openstory');
+
+    h.env = {
+      ...FULL_ENV,
+      FORK_UPSTREAM_OWNER: 'acme',
+      FORK_WORKER_NAME: 'app',
+    };
+    const overridden = getForkConfig();
+    expect(overridden.upstream.owner).toBe('acme');
+    expect(overridden.workerName).toBe('app');
+  });
+});

--- a/src/lib/fork/config.ts
+++ b/src/lib/fork/config.ts
@@ -1,0 +1,88 @@
+/**
+ * Fork-and-deploy configuration.
+ *
+ * The public `/fork` flow forks this repo into a visitor's GitHub account and
+ * deploys it to their Cloudflare account. Both halves use OAuth, so the flow
+ * is only live once the operator registers two OAuth apps and supplies their
+ * credentials as Worker secrets:
+ *
+ *   - A GitHub OAuth App (to fork + set Actions secrets + dispatch the deploy
+ *     workflow on the visitor's fork).
+ *   - A Cloudflare self-managed OAuth client (to obtain a token the fork's CI
+ *     uses to provision D1/R2 and deploy). See
+ *     https://developers.cloudflare.com/changelog/post/2026-06-03-public-oauth-clients/
+ *
+ * Cloudflare's OAuth endpoint URLs are determined when the client is
+ * registered (RFC 8414 discovery), so they're read from env rather than
+ * hard-coded. When any required credential is missing, `getForkConfig()`
+ * reports `enabled: false` and the UI shows the manual deploy path instead.
+ */
+
+import { getEnv } from '#env';
+
+/** Read an arbitrary env var without fighting the generated Worker env type. */
+function readEnv(key: string): string | undefined {
+  const value: unknown = Reflect.get(getEnv(), key);
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export type ForkConfig = {
+  enabled: boolean;
+  upstream: { owner: string; repo: string };
+  /** Workflow file (on the fork) that provisions + deploys. */
+  workflowFile: string;
+  /** Worker name the fork deploys to (matches wrangler.jsonc `name`). */
+  workerName: string;
+  github: { clientId?: string; clientSecret?: string };
+  cloudflare: {
+    clientId?: string;
+    clientSecret?: string;
+    authorizeUrl?: string;
+    tokenUrl?: string;
+    scopes: string;
+  };
+};
+
+/** GitHub scopes needed to fork, write Actions secrets, and dispatch a run. */
+export const GITHUB_OAUTH_SCOPES = 'repo workflow';
+
+/** Default Cloudflare scopes — overridable via env to match the registered client. */
+const DEFAULT_CLOUDFLARE_SCOPES =
+  'account:read d1:write workers_scripts:write workers_kv:write';
+
+export function getForkConfig(): ForkConfig {
+  const githubClientId = readEnv('GITHUB_OAUTH_CLIENT_ID');
+  const githubClientSecret = readEnv('GITHUB_OAUTH_CLIENT_SECRET');
+  const cloudflareClientId = readEnv('CLOUDFLARE_OAUTH_CLIENT_ID');
+  const cloudflareClientSecret = readEnv('CLOUDFLARE_OAUTH_CLIENT_SECRET');
+  const cloudflareAuthorizeUrl = readEnv('CLOUDFLARE_OAUTH_AUTHORIZE_URL');
+  const cloudflareTokenUrl = readEnv('CLOUDFLARE_OAUTH_TOKEN_URL');
+  const cloudflareScopes =
+    readEnv('CLOUDFLARE_OAUTH_SCOPES') ?? DEFAULT_CLOUDFLARE_SCOPES;
+
+  const enabled = Boolean(
+    githubClientId &&
+    githubClientSecret &&
+    cloudflareClientId &&
+    cloudflareAuthorizeUrl &&
+    cloudflareTokenUrl
+  );
+
+  return {
+    enabled,
+    upstream: {
+      owner: readEnv('FORK_UPSTREAM_OWNER') ?? 'openstory-so',
+      repo: readEnv('FORK_UPSTREAM_REPO') ?? 'openstory',
+    },
+    workflowFile: readEnv('FORK_DEPLOY_WORKFLOW_FILE') ?? 'fork-deploy.yml',
+    workerName: readEnv('FORK_WORKER_NAME') ?? 'openstory',
+    github: { clientId: githubClientId, clientSecret: githubClientSecret },
+    cloudflare: {
+      clientId: cloudflareClientId,
+      clientSecret: cloudflareClientSecret,
+      authorizeUrl: cloudflareAuthorizeUrl,
+      tokenUrl: cloudflareTokenUrl,
+      scopes: cloudflareScopes,
+    },
+  };
+}

--- a/src/lib/fork/deploy.ts
+++ b/src/lib/fork/deploy.ts
@@ -1,0 +1,63 @@
+/**
+ * Deploy kickoff: wire the visitor's Cloudflare credentials onto their fork
+ * and dispatch the deploy workflow. The fork's own CI does the build +
+ * provisioning (D1/R2) + deploy — see .github/workflows/fork-deploy.yml.
+ */
+
+import type { ForkConfig } from './config';
+import {
+  dispatchWorkflow,
+  enableActions,
+  putActionsSecret,
+  waitForRepoReady,
+} from './github';
+
+export async function kickoffForkDeploy(input: {
+  config: ForkConfig;
+  githubToken: string;
+  forkOwner: string;
+  forkRepo: string;
+  ref: string;
+  cloudflareToken: string;
+  cloudflareAccountId: string;
+  workerUrl?: string;
+}): Promise<void> {
+  const { githubToken: token, forkOwner: owner, forkRepo: repo } = input;
+
+  // Forks are created asynchronously; the workflow file must exist on the
+  // default branch before a dispatch will resolve.
+  await waitForRepoReady({ token, owner, repo });
+  await enableActions({ token, owner, repo });
+
+  await putActionsSecret({
+    token,
+    owner,
+    repo,
+    name: 'CLOUDFLARE_API_TOKEN',
+    value: input.cloudflareToken,
+  });
+  await putActionsSecret({
+    token,
+    owner,
+    repo,
+    name: 'CLOUDFLARE_ACCOUNT_ID',
+    value: input.cloudflareAccountId,
+  });
+  if (input.workerUrl) {
+    await putActionsSecret({
+      token,
+      owner,
+      repo,
+      name: 'VITE_APP_URL',
+      value: input.workerUrl,
+    });
+  }
+
+  await dispatchWorkflow({
+    token,
+    owner,
+    repo,
+    workflowFile: input.config.workflowFile,
+    ref: input.ref,
+  });
+}

--- a/src/lib/fork/github-secret-seal.test.ts
+++ b/src/lib/fork/github-secret-seal.test.ts
@@ -1,0 +1,64 @@
+import { blake2b } from 'blakejs';
+import nacl from 'tweetnacl';
+import { describe, expect, it } from 'vitest';
+import { sealGithubSecret } from './github-secret-seal';
+
+function base64ToUint8(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary);
+}
+
+/** Reference `crypto_box_seal_open` to verify the seal round-trips. */
+function openSealed(
+  sealedBase64: string,
+  recipientPk: Uint8Array,
+  recipientSk: Uint8Array
+): string | null {
+  const sealed = base64ToUint8(sealedBase64);
+  const epk = sealed.slice(0, nacl.box.publicKeyLength);
+  const cipher = sealed.slice(nacl.box.publicKeyLength);
+  const nonceInput = new Uint8Array(epk.length + recipientPk.length);
+  nonceInput.set(epk, 0);
+  nonceInput.set(recipientPk, epk.length);
+  const nonce = blake2b(nonceInput, undefined, nacl.box.nonceLength);
+  const opened = nacl.box.open(cipher, nonce, epk, recipientSk);
+  return opened ? new TextDecoder().decode(opened) : null;
+}
+
+describe('sealGithubSecret', () => {
+  it('produces a sealed box the recipient can open', () => {
+    const recipient = nacl.box.keyPair();
+    const secret = 'super-secret-cloudflare-token-1234567890';
+
+    const sealed = sealGithubSecret(uint8ToBase64(recipient.publicKey), secret);
+
+    expect(openSealed(sealed, recipient.publicKey, recipient.secretKey)).toBe(
+      secret
+    );
+  });
+
+  it('is non-deterministic (fresh ephemeral key each call)', () => {
+    const recipient = nacl.box.keyPair();
+    const pk = uint8ToBase64(recipient.publicKey);
+    expect(sealGithubSecret(pk, 'value')).not.toBe(
+      sealGithubSecret(pk, 'value')
+    );
+  });
+
+  it('cannot be opened with the wrong key', () => {
+    const recipient = nacl.box.keyPair();
+    const attacker = nacl.box.keyPair();
+    const sealed = sealGithubSecret(uint8ToBase64(recipient.publicKey), 'x');
+    expect(
+      openSealed(sealed, recipient.publicKey, attacker.secretKey)
+    ).toBeNull();
+  });
+});

--- a/src/lib/fork/github-secret-seal.ts
+++ b/src/lib/fork/github-secret-seal.ts
@@ -1,0 +1,62 @@
+/**
+ * libsodium `crypto_box_seal` for GitHub Actions secrets.
+ *
+ * GitHub's "create or update a repository secret" API requires the value to be
+ * encrypted with the repo's public key using libsodium's sealed box. The
+ * Workers runtime has no libsodium and no X25519 in Web Crypto, so we
+ * reconstruct the sealed-box construction from primitives:
+ *
+ *   ephemeral_pk, ephemeral_sk = box_keypair()
+ *   nonce = blake2b(ephemeral_pk || recipient_pk, len = 24)
+ *   c = box(message, nonce, recipient_pk, ephemeral_sk)
+ *   sealed = ephemeral_pk || c
+ *
+ * tweetnacl (`box`) and blakejs (`blake2b`) are both pure JS, so this runs
+ * unchanged in Workerd. See
+ * https://docs.github.com/rest/actions/secrets#create-or-update-a-repository-secret
+ */
+
+import { blake2b } from 'blakejs';
+import nacl from 'tweetnacl';
+
+function base64ToUint8(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/**
+ * Seal `secretValue` for the GitHub repo whose Actions public key (base64) is
+ * `publicKeyBase64`. Returns the base64 sealed box GitHub expects.
+ */
+export function sealGithubSecret(
+  publicKeyBase64: string,
+  secretValue: string
+): string {
+  const recipientPk = base64ToUint8(publicKeyBase64);
+  const message = new TextEncoder().encode(secretValue);
+
+  const ephemeral = nacl.box.keyPair();
+
+  const nonceInput = new Uint8Array(
+    ephemeral.publicKey.length + recipientPk.length
+  );
+  nonceInput.set(ephemeral.publicKey, 0);
+  nonceInput.set(recipientPk, ephemeral.publicKey.length);
+  const nonce = blake2b(nonceInput, undefined, nacl.box.nonceLength);
+
+  const boxed = nacl.box(message, nonce, recipientPk, ephemeral.secretKey);
+
+  const sealed = new Uint8Array(ephemeral.publicKey.length + boxed.length);
+  sealed.set(ephemeral.publicKey, 0);
+  sealed.set(boxed, ephemeral.publicKey.length);
+
+  return uint8ToBase64(sealed);
+}

--- a/src/lib/fork/github.test.ts
+++ b/src/lib/fork/github.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { buildGithubAuthorizeUrl } from './github';
+
+describe('buildGithubAuthorizeUrl', () => {
+  it('builds a GitHub OAuth authorize URL with the requested scopes', () => {
+    const url = new URL(
+      buildGithubAuthorizeUrl({
+        clientId: 'gh-client',
+        redirectUri: 'https://app.test/api/fork/github/callback',
+        scopes: 'repo workflow',
+        csrfState: 'nonce',
+      })
+    );
+    expect(url.origin + url.pathname).toBe(
+      'https://github.com/login/oauth/authorize'
+    );
+    expect(url.searchParams.get('client_id')).toBe('gh-client');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://app.test/api/fork/github/callback'
+    );
+    expect(url.searchParams.get('scope')).toBe('repo workflow');
+    expect(url.searchParams.get('state')).toBe('nonce');
+  });
+});

--- a/src/lib/fork/github.ts
+++ b/src/lib/fork/github.ts
@@ -1,0 +1,285 @@
+/**
+ * GitHub API client for the fork-and-deploy flow.
+ *
+ * Covers the OAuth web flow (authorize URL + code exchange) and the repo
+ * operations performed on the visitor's behalf: forking upstream, enabling
+ * Actions on the fresh fork, writing the Cloudflare credentials as Actions
+ * secrets (sealed box), and dispatching the deploy workflow.
+ */
+
+import { z } from 'zod';
+import { sealGithubSecret } from './github-secret-seal';
+
+const GITHUB_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
+const GITHUB_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GITHUB_API = 'https://api.github.com';
+
+// GitHub rejects API requests without a User-Agent.
+const USER_AGENT = 'openstory-fork-deploy';
+
+function apiHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': USER_AGENT,
+  };
+}
+
+/** Build the GitHub OAuth authorize URL. `csrfState` is echoed back via `state`. */
+export function buildGithubAuthorizeUrl(input: {
+  clientId: string;
+  redirectUri: string;
+  scopes: string;
+  csrfState: string;
+}): string {
+  const params = new URLSearchParams({
+    client_id: input.clientId,
+    redirect_uri: input.redirectUri,
+    scope: input.scopes,
+    state: input.csrfState,
+    allow_signup: 'true',
+  });
+  return `${GITHUB_AUTHORIZE_URL}?${params.toString()}`;
+}
+
+const tokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
+
+/** Exchange an authorization code for a user access token. */
+export async function exchangeGithubCode(input: {
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+}): Promise<string> {
+  const response = await fetch(GITHUB_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify({
+      client_id: input.clientId,
+      client_secret: input.clientSecret,
+      code: input.code,
+      redirect_uri: input.redirectUri,
+    }),
+  });
+  const data = tokenResponseSchema.parse(await response.json());
+  if (!data.access_token) {
+    throw new Error(
+      `GitHub token exchange failed: ${data.error_description ?? data.error ?? 'unknown error'}`
+    );
+  }
+  return data.access_token;
+}
+
+/** Resolve the authenticated user's login. */
+export async function getGithubLogin(token: string): Promise<string> {
+  const response = await fetch(`${GITHUB_API}/user`, {
+    headers: apiHeaders(token),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub /user failed (${response.status})`);
+  }
+  const data = z.object({ login: z.string() }).parse(await response.json());
+  return data.login;
+}
+
+const repoSchema = z.object({
+  name: z.string(),
+  full_name: z.string(),
+  html_url: z.string(),
+  owner: z.object({ login: z.string() }),
+  default_branch: z.string().optional(),
+});
+
+export type ForkedRepo = {
+  owner: string;
+  repo: string;
+  htmlUrl: string;
+  defaultBranch: string;
+};
+
+/**
+ * Fork the upstream repo into the authenticated user's account. GitHub returns
+ * 202 with the (eventually-consistent) fork record; callers should poll
+ * {@link waitForRepoReady} before dispatching a workflow against it.
+ */
+export async function forkRepo(input: {
+  token: string;
+  owner: string;
+  repo: string;
+}): Promise<ForkedRepo> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.owner}/${input.repo}/forks`,
+    { method: 'POST', headers: apiHeaders(input.token) }
+  );
+  if (!response.ok) {
+    throw new Error(`GitHub fork failed (${response.status})`);
+  }
+  const data = repoSchema.parse(await response.json());
+  return {
+    owner: data.owner.login,
+    repo: data.name,
+    htmlUrl: data.html_url,
+    defaultBranch: data.default_branch ?? 'main',
+  };
+}
+
+/** Poll until the fork's default branch is populated (forks are async). */
+export async function waitForRepoReady(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  attempts?: number;
+}): Promise<boolean> {
+  const attempts = input.attempts ?? 10;
+  for (let i = 0; i < attempts; i++) {
+    const response = await fetch(
+      `${GITHUB_API}/repos/${input.owner}/${input.repo}/branches`,
+      { headers: apiHeaders(input.token) }
+    );
+    if (response.ok) {
+      const branches = z
+        .array(z.object({ name: z.string() }))
+        .catch([])
+        .parse(await response.json());
+      if (branches.length > 0) return true;
+    }
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  return false;
+}
+
+/**
+ * Enable GitHub Actions on the fork. Forks have Actions disabled by default,
+ * so the deploy workflow would never run without this.
+ */
+export async function enableActions(input: {
+  token: string;
+  owner: string;
+  repo: string;
+}): Promise<void> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.owner}/${input.repo}/actions/permissions`,
+    {
+      method: 'PUT',
+      headers: {
+        ...apiHeaders(input.token),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ enabled: true, allowed_actions: 'all' }),
+    }
+  );
+  if (!response.ok && response.status !== 204) {
+    throw new Error(`GitHub enable-actions failed (${response.status})`);
+  }
+}
+
+const publicKeySchema = z.object({ key_id: z.string(), key: z.string() });
+
+/** Set (or update) a repository Actions secret, sealing the value client-side. */
+export async function putActionsSecret(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  name: string;
+  value: string;
+}): Promise<void> {
+  const keyResponse = await fetch(
+    `${GITHUB_API}/repos/${input.owner}/${input.repo}/actions/secrets/public-key`,
+    { headers: apiHeaders(input.token) }
+  );
+  if (!keyResponse.ok) {
+    throw new Error(`GitHub get-public-key failed (${keyResponse.status})`);
+  }
+  const { key_id, key } = publicKeySchema.parse(await keyResponse.json());
+
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.owner}/${input.repo}/actions/secrets/${input.name}`,
+    {
+      method: 'PUT',
+      headers: {
+        ...apiHeaders(input.token),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        encrypted_value: sealGithubSecret(key, input.value),
+        key_id,
+      }),
+    }
+  );
+  if (!response.ok && response.status !== 201 && response.status !== 204) {
+    throw new Error(
+      `GitHub put-secret ${input.name} failed (${response.status})`
+    );
+  }
+}
+
+/** Dispatch a `workflow_dispatch` run of `workflowFile` on `ref`. */
+export async function dispatchWorkflow(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  workflowFile: string;
+  ref: string;
+}): Promise<void> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.owner}/${input.repo}/actions/workflows/${input.workflowFile}/dispatches`,
+    {
+      method: 'POST',
+      headers: {
+        ...apiHeaders(input.token),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ref: input.ref }),
+    }
+  );
+  if (!response.ok && response.status !== 204) {
+    throw new Error(`GitHub workflow dispatch failed (${response.status})`);
+  }
+}
+
+const runsSchema = z.object({
+  workflow_runs: z.array(
+    z.object({
+      id: z.number(),
+      status: z.string().nullable(),
+      conclusion: z.string().nullable(),
+      html_url: z.string(),
+      created_at: z.string(),
+    })
+  ),
+});
+
+export type WorkflowRun = {
+  id: number;
+  status: string | null;
+  conclusion: string | null;
+  htmlUrl: string;
+};
+
+/** Return the most recent run of `workflowFile`, or null if none yet. */
+export async function getLatestWorkflowRun(input: {
+  token: string;
+  owner: string;
+  repo: string;
+  workflowFile: string;
+}): Promise<WorkflowRun | null> {
+  const response = await fetch(
+    `${GITHUB_API}/repos/${input.owner}/${input.repo}/actions/workflows/${input.workflowFile}/runs?per_page=1`,
+    { headers: apiHeaders(input.token) }
+  );
+  if (!response.ok) return null;
+  const data = runsSchema.parse(await response.json());
+  const run = data.workflow_runs[0];
+  if (!run) return null;
+  return {
+    id: run.id,
+    status: run.status,
+    conclusion: run.conclusion,
+    htmlUrl: run.html_url,
+  };
+}

--- a/src/lib/fork/state-cookie.test.ts
+++ b/src/lib/fork/state-cookie.test.ts
@@ -1,0 +1,55 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('#env', () => ({ getEnv: () => process.env }));
+
+import {
+  getForkCookieName,
+  readForkCookie,
+  sealForkState,
+  unsealForkState,
+} from './state-cookie';
+
+beforeAll(() => {
+  process.env.API_KEY_ENCRYPTION_KEY = 'test-encryption-key-for-fork-state-ok';
+});
+
+const SAMPLE = {
+  githubToken: 'gho_token',
+  githubLogin: 'octocat',
+  forkOwner: 'octocat',
+  forkRepo: 'openstory',
+  forkUrl: 'https://github.com/octocat/openstory',
+};
+
+describe('fork state cookie', () => {
+  it('round-trips a sealed state', async () => {
+    const sealed = await sealForkState(SAMPLE);
+    expect(await unsealForkState(sealed)).toMatchObject(SAMPLE);
+  });
+
+  it('does not leak tokens in plaintext', async () => {
+    const sealed = await sealForkState(SAMPLE);
+    expect(sealed).not.toContain('gho_token');
+  });
+
+  it('returns null for tampered or malformed values', async () => {
+    expect(await unsealForkState(undefined)).toBeNull();
+    expect(await unsealForkState('not.a.cookie')).toBeNull();
+    const sealed = await sealForkState(SAMPLE);
+    expect(await unsealForkState(`${sealed}tampered`)).toBeNull();
+  });
+
+  it('names the cookie with the __Host- prefix only when secure', () => {
+    expect(getForkCookieName(true)).toBe('__Host-os-fork');
+    expect(getForkCookieName(false)).toBe('os-fork');
+  });
+
+  it('reads its value back from a Cookie header', async () => {
+    const sealed = await sealForkState(SAMPLE);
+    const request = new Request('https://app.test/', {
+      headers: { cookie: `other=1; __Host-os-fork=${sealed}; another=2` },
+    });
+    expect(readForkCookie(request, true)).toBe(sealed);
+    expect(readForkCookie(request, false)).toBeUndefined();
+  });
+});

--- a/src/lib/fork/state-cookie.ts
+++ b/src/lib/fork/state-cookie.ts
@@ -1,0 +1,114 @@
+/**
+ * Fork-flow state cookie.
+ *
+ * The fork-and-deploy flow spans several redirect hops (GitHub OAuth →
+ * Cloudflare OAuth → deploy dispatch → status polling). The in-progress state
+ * — OAuth CSRF nonces, PKCE verifier, access tokens, the created fork, the
+ * dispatched workflow run — rides along in a single encrypted, HttpOnly
+ * cookie rather than a server-side store, mirroring the OpenRouter OAuth
+ * cookie (#807). The payload is AES-256-GCM encrypted with
+ * API_KEY_ENCRYPTION_KEY, so the browser can neither read the access tokens
+ * nor forge the CSRF state.
+ */
+
+import { z } from 'zod';
+import { decryptApiKey, encryptApiKey } from '@/lib/crypto/api-key-encryption';
+
+/** How long an in-progress fork flow stays valid (covers the CI deploy wait). */
+const FORK_STATE_TTL = 3600; // seconds
+
+const COOKIE_BASE_NAME = 'os-fork';
+
+/**
+ * `__Host-` pins the cookie to this origin (requires Secure + Path=/ and no
+ * Domain). Plain-HTTP local dev falls back to the bare name since some
+ * browsers reject Secure cookies over http.
+ */
+export function getForkCookieName(secure: boolean): string {
+  return secure ? `__Host-${COOKIE_BASE_NAME}` : COOKIE_BASE_NAME;
+}
+
+const forkStateSchema = z.object({
+  // ── GitHub OAuth + fork ──
+  githubCsrf: z.string().optional(),
+  githubToken: z.string().optional(),
+  githubLogin: z.string().optional(),
+  forkOwner: z.string().optional(),
+  forkRepo: z.string().optional(),
+  forkUrl: z.string().optional(),
+  // ── Cloudflare OAuth ──
+  cloudflareCsrf: z.string().optional(),
+  cloudflarePkceVerifier: z.string().optional(),
+  cloudflareAccountId: z.string().optional(),
+  // ── Deploy ──
+  workflowRunId: z.number().optional(),
+  workerUrl: z.string().optional(),
+});
+
+export type ForkState = z.infer<typeof forkStateSchema>;
+
+const sealedPayloadSchema = forkStateSchema.extend({
+  expiresAt: z.number(),
+});
+
+/** Encrypt fork state for transport in the cookie. */
+export async function sealForkState(state: ForkState): Promise<string> {
+  const payload = JSON.stringify({
+    ...state,
+    expiresAt: Date.now() + FORK_STATE_TTL * 1000,
+  });
+  const { encryptedKey, keyIv, keyTag } = await encryptApiKey(payload);
+  return [keyIv, encryptedKey, keyTag].join('.');
+}
+
+/**
+ * Decrypt and validate a sealed fork-state cookie value.
+ * Returns null for anything tampered, malformed, or expired.
+ */
+export async function unsealForkState(
+  sealed: string | undefined
+): Promise<ForkState | null> {
+  if (!sealed) return null;
+  const [keyIv, encryptedKey, keyTag] = sealed.split('.');
+  if (!keyIv || !encryptedKey || !keyTag) return null;
+
+  try {
+    const plaintext = await decryptApiKey({ encryptedKey, keyIv, keyTag });
+    const payload = sealedPayloadSchema.parse(JSON.parse(plaintext));
+    if (payload.expiresAt < Date.now()) return null;
+
+    const { expiresAt: _expiresAt, ...state } = payload;
+    return state;
+  } catch {
+    // Wrong key, tampered ciphertext, or malformed payload — treat as absent.
+    return null;
+  }
+}
+
+/**
+ * Serialized `Set-Cookie` header carrying the sealed state. Used by the
+ * redirecting handlers, where framework `setCookie()` headers are dropped on
+ * the 302 (same caveat as {@link getForkCookieClearHeader}).
+ */
+export function serializeForkCookieHeader(
+  sealed: string,
+  secure: boolean
+): string {
+  const name = getForkCookieName(secure);
+  return `${name}=${sealed}; Max-Age=${FORK_STATE_TTL}; Path=/; HttpOnly; SameSite=Lax${secure ? '; Secure' : ''}`;
+}
+
+/** Read the raw fork cookie value off a request's Cookie header. */
+export function readForkCookie(
+  request: Request,
+  secure: boolean
+): string | undefined {
+  const header = request.headers.get('cookie');
+  if (!header) return undefined;
+  const name = getForkCookieName(secure);
+  for (const part of header.split(';')) {
+    const [k, ...rest] = part.trim().split('=');
+    if (k === name) return rest.join('=');
+  }
+  return undefined;
+}

--- a/src/lib/marketing/constants.ts
+++ b/src/lib/marketing/constants.ts
@@ -14,6 +14,8 @@ const APP_DOMAIN = (() => {
 export const CONTACT_EMAIL = `hello@${APP_DOMAIN}`;
 export const PRIVACY_EMAIL = `privacy@${APP_DOMAIN}`;
 
+const GITHUB_HREF = 'https://github.com/openstory-so/openstory';
+
 export const SITE_CONFIG = {
   name: APP_NAME,
   description:
@@ -24,7 +26,12 @@ export const SITE_CONFIG = {
   ogImage: `https://${VITE_R2_PUBLIC_ASSETS_DOMAIN}/images/marketing/og.jpg`,
   ctaText: 'Get Started',
   ctaHref: '/sequences/new',
-  githubHref: 'https://github.com/openstory-so/openstory',
+  githubHref: GITHUB_HREF,
+  // Cloudflare's "Deploy to Cloudflare" flow: connects the visitor's GitHub
+  // (OAuth) to clone/fork this repo, connects their Cloudflare account (OAuth),
+  // provisions the D1/R2/Workflows resources declared in wrangler.jsonc, and
+  // deploys to their own account — landing them on their own worker domain.
+  deployHref: `https://deploy.workers.cloudflare.com/?url=${GITHUB_HREF}`,
 };
 
 export const TOP_TIER_FEATURES = [

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as ApiRealtimeRouteImport } from './routes/api/realtime'
 import { Route as MarketingTermsRouteImport } from './routes/_marketing/terms'
 import { Route as MarketingPrivacyRouteImport } from './routes/_marketing/privacy'
+import { Route as MarketingForkRouteImport } from './routes/_marketing/fork'
 import { Route as AuthVerifyRouteImport } from './routes/_auth/verify'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AppCreditsRouteImport } from './routes/_app/credits'
@@ -55,6 +56,7 @@ import { Route as ApiTestCharacterRouteImport } from './routes/api/test/characte
 import { Route as ApiStorageUploadRouteImport } from './routes/api/storage/upload'
 import { Route as ApiStorageMultipartRouteImport } from './routes/api/storage/multipart'
 import { Route as ApiOpenrouterCallbackRouteImport } from './routes/api/openrouter/callback'
+import { Route as ApiForkStatusRouteImport } from './routes/api/fork/status'
 import { Route as ApiDevMemoryRouteImport } from './routes/api/dev/memory'
 import { Route as ApiBillingWebhookRouteImport } from './routes/api/billing/webhook'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
@@ -68,6 +70,10 @@ import { Route as AppAdminUsageRouteImport } from './routes/_app/admin/usage'
 import { Route as AppSequencesIdRouteRouteImport } from './routes/_app/sequences/$id/route'
 import { Route as ApiV1SequencesIdRouteImport } from './routes/api/v1/sequences.$id'
 import { Route as ApiV1ScriptsEnhanceRouteImport } from './routes/api/v1/scripts.enhance'
+import { Route as ApiForkGithubStartRouteImport } from './routes/api/fork/github/start'
+import { Route as ApiForkGithubCallbackRouteImport } from './routes/api/fork/github/callback'
+import { Route as ApiForkCloudflareStartRouteImport } from './routes/api/fork/cloudflare/start'
+import { Route as ApiForkCloudflareCallbackRouteImport } from './routes/api/fork/cloudflare/callback'
 import { Route as AppSequencesIdTheatreRouteImport } from './routes/_app/sequences/$id/theatre'
 import { Route as AppSequencesIdScriptRouteImport } from './routes/_app/sequences/$id/script'
 import { Route as AppSequencesIdScenesRouteImport } from './routes/_app/sequences/$id/scenes'
@@ -173,6 +179,11 @@ const MarketingTermsRoute = MarketingTermsRouteImport.update({
 const MarketingPrivacyRoute = MarketingPrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
+  getParentRoute: () => MarketingRoute,
+} as any)
+const MarketingForkRoute = MarketingForkRouteImport.update({
+  id: '/fork',
+  path: '/fork',
   getParentRoute: () => MarketingRoute,
 } as any)
 const AuthVerifyRoute = AuthVerifyRouteImport.update({
@@ -305,6 +316,11 @@ const ApiOpenrouterCallbackRoute = ApiOpenrouterCallbackRouteImport.update({
   path: '/api/openrouter/callback',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiForkStatusRoute = ApiForkStatusRouteImport.update({
+  id: '/api/fork/status',
+  path: '/api/fork/status',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiDevMemoryRoute = ApiDevMemoryRouteImport.update({
   id: '/api/dev/memory',
   path: '/api/dev/memory',
@@ -370,6 +386,27 @@ const ApiV1ScriptsEnhanceRoute = ApiV1ScriptsEnhanceRouteImport.update({
   path: '/api/v1/scripts/enhance',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiForkGithubStartRoute = ApiForkGithubStartRouteImport.update({
+  id: '/api/fork/github/start',
+  path: '/api/fork/github/start',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiForkGithubCallbackRoute = ApiForkGithubCallbackRouteImport.update({
+  id: '/api/fork/github/callback',
+  path: '/api/fork/github/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiForkCloudflareStartRoute = ApiForkCloudflareStartRouteImport.update({
+  id: '/api/fork/cloudflare/start',
+  path: '/api/fork/cloudflare/start',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiForkCloudflareCallbackRoute =
+  ApiForkCloudflareCallbackRouteImport.update({
+    id: '/api/fork/cloudflare/callback',
+    path: '/api/fork/cloudflare/callback',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const AppSequencesIdTheatreRoute = AppSequencesIdTheatreRouteImport.update({
   id: '/theatre',
   path: '/theatre',
@@ -431,6 +468,7 @@ export interface FileRoutesByFullPath {
   '/credits': typeof AppCreditsRoute
   '/login': typeof AuthLoginRoute
   '/verify': typeof AuthVerifyRoute
+  '/fork': typeof MarketingForkRoute
   '/privacy': typeof MarketingPrivacyRoute
   '/terms': typeof MarketingTermsRoute
   '/api/realtime': typeof ApiRealtimeRoute
@@ -454,6 +492,7 @@ export interface FileRoutesByFullPath {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/billing/webhook': typeof ApiBillingWebhookRoute
   '/api/dev/memory': typeof ApiDevMemoryRoute
+  '/api/fork/status': typeof ApiForkStatusRoute
   '/api/openrouter/callback': typeof ApiOpenrouterCallbackRoute
   '/api/storage/multipart': typeof ApiStorageMultipartRoute
   '/api/storage/upload': typeof ApiStorageUploadRoute
@@ -479,6 +518,10 @@ export interface FileRoutesByFullPath {
   '/sequences/$id/scenes': typeof AppSequencesIdScenesRoute
   '/sequences/$id/script': typeof AppSequencesIdScriptRoute
   '/sequences/$id/theatre': typeof AppSequencesIdTheatreRoute
+  '/api/fork/cloudflare/callback': typeof ApiForkCloudflareCallbackRoute
+  '/api/fork/cloudflare/start': typeof ApiForkCloudflareStartRoute
+  '/api/fork/github/callback': typeof ApiForkGithubCallbackRoute
+  '/api/fork/github/start': typeof ApiForkGithubStartRoute
   '/api/v1/scripts/enhance': typeof ApiV1ScriptsEnhanceRoute
   '/api/v1/sequences/$id': typeof ApiV1SequencesIdRoute
   '/sequences/$id/cast/$characterId': typeof AppSequencesIdCastCharacterIdRoute
@@ -496,6 +539,7 @@ export interface FileRoutesByTo {
   '/credits': typeof AppCreditsRoute
   '/login': typeof AuthLoginRoute
   '/verify': typeof AuthVerifyRoute
+  '/fork': typeof MarketingForkRoute
   '/privacy': typeof MarketingPrivacyRoute
   '/terms': typeof MarketingTermsRoute
   '/api/realtime': typeof ApiRealtimeRoute
@@ -519,6 +563,7 @@ export interface FileRoutesByTo {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/billing/webhook': typeof ApiBillingWebhookRoute
   '/api/dev/memory': typeof ApiDevMemoryRoute
+  '/api/fork/status': typeof ApiForkStatusRoute
   '/api/openrouter/callback': typeof ApiOpenrouterCallbackRoute
   '/api/storage/multipart': typeof ApiStorageMultipartRoute
   '/api/storage/upload': typeof ApiStorageUploadRoute
@@ -544,6 +589,10 @@ export interface FileRoutesByTo {
   '/sequences/$id/scenes': typeof AppSequencesIdScenesRoute
   '/sequences/$id/script': typeof AppSequencesIdScriptRoute
   '/sequences/$id/theatre': typeof AppSequencesIdTheatreRoute
+  '/api/fork/cloudflare/callback': typeof ApiForkCloudflareCallbackRoute
+  '/api/fork/cloudflare/start': typeof ApiForkCloudflareStartRoute
+  '/api/fork/github/callback': typeof ApiForkGithubCallbackRoute
+  '/api/fork/github/start': typeof ApiForkGithubStartRoute
   '/api/v1/scripts/enhance': typeof ApiV1ScriptsEnhanceRoute
   '/api/v1/sequences/$id': typeof ApiV1SequencesIdRoute
   '/sequences/$id/cast/$characterId': typeof AppSequencesIdCastCharacterIdRoute
@@ -566,6 +615,7 @@ export interface FileRoutesById {
   '/_app/credits': typeof AppCreditsRoute
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/verify': typeof AuthVerifyRoute
+  '/_marketing/fork': typeof MarketingForkRoute
   '/_marketing/privacy': typeof MarketingPrivacyRoute
   '/_marketing/terms': typeof MarketingTermsRoute
   '/api/realtime': typeof ApiRealtimeRoute
@@ -590,6 +640,7 @@ export interface FileRoutesById {
   '/api/auth/$': typeof ApiAuthSplatRoute
   '/api/billing/webhook': typeof ApiBillingWebhookRoute
   '/api/dev/memory': typeof ApiDevMemoryRoute
+  '/api/fork/status': typeof ApiForkStatusRoute
   '/api/openrouter/callback': typeof ApiOpenrouterCallbackRoute
   '/api/storage/multipart': typeof ApiStorageMultipartRoute
   '/api/storage/upload': typeof ApiStorageUploadRoute
@@ -615,6 +666,10 @@ export interface FileRoutesById {
   '/_app/sequences/$id/scenes': typeof AppSequencesIdScenesRoute
   '/_app/sequences/$id/script': typeof AppSequencesIdScriptRoute
   '/_app/sequences/$id/theatre': typeof AppSequencesIdTheatreRoute
+  '/api/fork/cloudflare/callback': typeof ApiForkCloudflareCallbackRoute
+  '/api/fork/cloudflare/start': typeof ApiForkCloudflareStartRoute
+  '/api/fork/github/callback': typeof ApiForkGithubCallbackRoute
+  '/api/fork/github/start': typeof ApiForkGithubStartRoute
   '/api/v1/scripts/enhance': typeof ApiV1ScriptsEnhanceRoute
   '/api/v1/sequences/$id': typeof ApiV1SequencesIdRoute
   '/_app/sequences/$id/cast/$characterId': typeof AppSequencesIdCastCharacterIdRoute
@@ -636,6 +691,7 @@ export interface FileRouteTypes {
     | '/credits'
     | '/login'
     | '/verify'
+    | '/fork'
     | '/privacy'
     | '/terms'
     | '/api/realtime'
@@ -659,6 +715,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/billing/webhook'
     | '/api/dev/memory'
+    | '/api/fork/status'
     | '/api/openrouter/callback'
     | '/api/storage/multipart'
     | '/api/storage/upload'
@@ -684,6 +741,10 @@ export interface FileRouteTypes {
     | '/sequences/$id/scenes'
     | '/sequences/$id/script'
     | '/sequences/$id/theatre'
+    | '/api/fork/cloudflare/callback'
+    | '/api/fork/cloudflare/start'
+    | '/api/fork/github/callback'
+    | '/api/fork/github/start'
     | '/api/v1/scripts/enhance'
     | '/api/v1/sequences/$id'
     | '/sequences/$id/cast/$characterId'
@@ -701,6 +762,7 @@ export interface FileRouteTypes {
     | '/credits'
     | '/login'
     | '/verify'
+    | '/fork'
     | '/privacy'
     | '/terms'
     | '/api/realtime'
@@ -724,6 +786,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/billing/webhook'
     | '/api/dev/memory'
+    | '/api/fork/status'
     | '/api/openrouter/callback'
     | '/api/storage/multipart'
     | '/api/storage/upload'
@@ -749,6 +812,10 @@ export interface FileRouteTypes {
     | '/sequences/$id/scenes'
     | '/sequences/$id/script'
     | '/sequences/$id/theatre'
+    | '/api/fork/cloudflare/callback'
+    | '/api/fork/cloudflare/start'
+    | '/api/fork/github/callback'
+    | '/api/fork/github/start'
     | '/api/v1/scripts/enhance'
     | '/api/v1/sequences/$id'
     | '/sequences/$id/cast/$characterId'
@@ -770,6 +837,7 @@ export interface FileRouteTypes {
     | '/_app/credits'
     | '/_auth/login'
     | '/_auth/verify'
+    | '/_marketing/fork'
     | '/_marketing/privacy'
     | '/_marketing/terms'
     | '/api/realtime'
@@ -794,6 +862,7 @@ export interface FileRouteTypes {
     | '/api/auth/$'
     | '/api/billing/webhook'
     | '/api/dev/memory'
+    | '/api/fork/status'
     | '/api/openrouter/callback'
     | '/api/storage/multipart'
     | '/api/storage/upload'
@@ -819,6 +888,10 @@ export interface FileRouteTypes {
     | '/_app/sequences/$id/scenes'
     | '/_app/sequences/$id/script'
     | '/_app/sequences/$id/theatre'
+    | '/api/fork/cloudflare/callback'
+    | '/api/fork/cloudflare/start'
+    | '/api/fork/github/callback'
+    | '/api/fork/github/start'
     | '/api/v1/scripts/enhance'
     | '/api/v1/sequences/$id'
     | '/_app/sequences/$id/cast/$characterId'
@@ -845,12 +918,17 @@ export interface RootRouteChildren {
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiBillingWebhookRoute: typeof ApiBillingWebhookRoute
   ApiDevMemoryRoute: typeof ApiDevMemoryRoute
+  ApiForkStatusRoute: typeof ApiForkStatusRoute
   ApiOpenrouterCallbackRoute: typeof ApiOpenrouterCallbackRoute
   ApiStorageMultipartRoute: typeof ApiStorageMultipartRoute
   ApiStorageUploadRoute: typeof ApiStorageUploadRoute
   ApiV1OpenapiDotjsonRoute: typeof ApiV1OpenapiDotjsonRoute
   ApiV1SequencesRoute: typeof ApiV1SequencesRouteWithChildren
   ApiV1IndexRoute: typeof ApiV1IndexRoute
+  ApiForkCloudflareCallbackRoute: typeof ApiForkCloudflareCallbackRoute
+  ApiForkCloudflareStartRoute: typeof ApiForkCloudflareStartRoute
+  ApiForkGithubCallbackRoute: typeof ApiForkGithubCallbackRoute
+  ApiForkGithubStartRoute: typeof ApiForkGithubStartRoute
   ApiV1ScriptsEnhanceRoute: typeof ApiV1ScriptsEnhanceRoute
 }
 
@@ -994,6 +1072,13 @@ declare module '@tanstack/react-router' {
       path: '/privacy'
       fullPath: '/privacy'
       preLoaderRoute: typeof MarketingPrivacyRouteImport
+      parentRoute: typeof MarketingRoute
+    }
+    '/_marketing/fork': {
+      id: '/_marketing/fork'
+      path: '/fork'
+      fullPath: '/fork'
+      preLoaderRoute: typeof MarketingForkRouteImport
       parentRoute: typeof MarketingRoute
     }
     '/_auth/verify': {
@@ -1178,6 +1263,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiOpenrouterCallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/fork/status': {
+      id: '/api/fork/status'
+      path: '/api/fork/status'
+      fullPath: '/api/fork/status'
+      preLoaderRoute: typeof ApiForkStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/dev/memory': {
       id: '/api/dev/memory'
       path: '/api/dev/memory'
@@ -1267,6 +1359,34 @@ declare module '@tanstack/react-router' {
       path: '/api/v1/scripts/enhance'
       fullPath: '/api/v1/scripts/enhance'
       preLoaderRoute: typeof ApiV1ScriptsEnhanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fork/github/start': {
+      id: '/api/fork/github/start'
+      path: '/api/fork/github/start'
+      fullPath: '/api/fork/github/start'
+      preLoaderRoute: typeof ApiForkGithubStartRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fork/github/callback': {
+      id: '/api/fork/github/callback'
+      path: '/api/fork/github/callback'
+      fullPath: '/api/fork/github/callback'
+      preLoaderRoute: typeof ApiForkGithubCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fork/cloudflare/start': {
+      id: '/api/fork/cloudflare/start'
+      path: '/api/fork/cloudflare/start'
+      fullPath: '/api/fork/cloudflare/start'
+      preLoaderRoute: typeof ApiForkCloudflareStartRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fork/cloudflare/callback': {
+      id: '/api/fork/cloudflare/callback'
+      path: '/api/fork/cloudflare/callback'
+      fullPath: '/api/fork/cloudflare/callback'
+      preLoaderRoute: typeof ApiForkCloudflareCallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_app/sequences/$id/theatre': {
@@ -1437,12 +1557,14 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 )
 
 interface MarketingRouteChildren {
+  MarketingForkRoute: typeof MarketingForkRoute
   MarketingPrivacyRoute: typeof MarketingPrivacyRoute
   MarketingTermsRoute: typeof MarketingTermsRoute
   MarketingIndexRoute: typeof MarketingIndexRoute
 }
 
 const MarketingRouteChildren: MarketingRouteChildren = {
+  MarketingForkRoute: MarketingForkRoute,
   MarketingPrivacyRoute: MarketingPrivacyRoute,
   MarketingTermsRoute: MarketingTermsRoute,
   MarketingIndexRoute: MarketingIndexRoute,
@@ -1528,12 +1650,17 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiBillingWebhookRoute: ApiBillingWebhookRoute,
   ApiDevMemoryRoute: ApiDevMemoryRoute,
+  ApiForkStatusRoute: ApiForkStatusRoute,
   ApiOpenrouterCallbackRoute: ApiOpenrouterCallbackRoute,
   ApiStorageMultipartRoute: ApiStorageMultipartRoute,
   ApiStorageUploadRoute: ApiStorageUploadRoute,
   ApiV1OpenapiDotjsonRoute: ApiV1OpenapiDotjsonRoute,
   ApiV1SequencesRoute: ApiV1SequencesRouteWithChildren,
   ApiV1IndexRoute: ApiV1IndexRoute,
+  ApiForkCloudflareCallbackRoute: ApiForkCloudflareCallbackRoute,
+  ApiForkCloudflareStartRoute: ApiForkCloudflareStartRoute,
+  ApiForkGithubCallbackRoute: ApiForkGithubCallbackRoute,
+  ApiForkGithubStartRoute: ApiForkGithubStartRoute,
   ApiV1ScriptsEnhanceRoute: ApiV1ScriptsEnhanceRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/_marketing/fork.tsx
+++ b/src/routes/_marketing/fork.tsx
@@ -1,0 +1,274 @@
+import { GitHubIcon } from '@/components/icons/github-icon';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { getForkEnabledFn } from '@/functions/fork';
+import { SITE_CONFIG } from '@/lib/marketing/constants';
+import { createFileRoute } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { zodValidator } from '@tanstack/zod-adapter';
+import {
+  CircleCheck,
+  Cloud,
+  GitFork,
+  KeyRound,
+  LoaderCircle,
+  Rocket,
+  TriangleAlert,
+} from 'lucide-react';
+import { z } from 'zod';
+
+const title = `Fork & Deploy — ${SITE_CONFIG.name}`;
+const description = `Fork ${SITE_CONFIG.name} into your own GitHub account and deploy it to your own Cloudflare account in a few clicks.`;
+
+const searchSchema = z.object({
+  step: z.enum(['deploying']).optional(),
+  error: z.string().optional(),
+});
+
+export const Route = createFileRoute('/_marketing/fork')({
+  component: ForkPage,
+  validateSearch: zodValidator(searchSchema),
+  loader: async () => await getForkEnabledFn(),
+  head: () => ({
+    meta: [
+      { title },
+      { name: 'description', content: description },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:url', content: `${SITE_CONFIG.url}/fork` },
+      { name: 'twitter:title', content: title },
+    ],
+  }),
+});
+
+const STEPS = [
+  {
+    icon: GitHubIcon,
+    title: 'Connect GitHub',
+    body: 'Authorize with GitHub. We create a real fork of this repository in your account — linked to upstream, so you can pull future updates.',
+  },
+  {
+    icon: Cloud,
+    title: 'Connect Cloudflare',
+    body: 'Authorize with Cloudflare. Your fork uses the token to provision a D1 database and R2 buckets on your account.',
+  },
+  {
+    icon: Rocket,
+    title: 'Deploy & open',
+    body: "Your fork's CI builds and deploys to Cloudflare Workers, then you open the app on your own workers.dev domain.",
+  },
+] as const;
+
+const ERROR_MESSAGES: Record<string, string> = {
+  disabled:
+    'Fork & deploy is not configured on this instance yet. Use the manual deploy option below.',
+  github_state: 'GitHub sign-in could not be verified. Please try again.',
+  github_fork: 'We could not create the fork. Please try again.',
+  cloudflare_state:
+    'Cloudflare sign-in could not be verified. Please start over.',
+  cloudflare_deploy:
+    'We connected your accounts but could not start the deploy. Please try again.',
+};
+
+function StepIcon({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary [&_svg]:size-4">
+      {children}
+    </span>
+  );
+}
+
+type ForkStatus = {
+  step: 'idle' | 'deploying';
+  forkUrl?: string;
+  workerUrl?: string;
+  run?: {
+    status: string | null;
+    conclusion: string | null;
+    htmlUrl: string;
+  } | null;
+};
+
+function DeployProgress() {
+  const { data } = useQuery<ForkStatus>({
+    queryKey: ['fork-status'],
+    queryFn: async () => {
+      const res = await fetch('/api/fork/status');
+      if (!res.ok) throw new Error('status check failed');
+      return res.json();
+    },
+    refetchInterval: (query) =>
+      query.state.data?.run?.conclusion ? false : 4000,
+  });
+
+  const run = data?.run;
+  const done = run?.conclusion === 'success';
+  const failed = run?.conclusion != null && run.conclusion !== 'success';
+  const target = data?.workerUrl ?? data?.forkUrl;
+
+  return (
+    <section className="flex flex-col gap-6">
+      <div className="flex items-start gap-4">
+        <StepIcon>
+          {done ? (
+            <CircleCheck className="size-4" />
+          ) : failed ? (
+            <TriangleAlert className="size-4" />
+          ) : (
+            <LoaderCircle className="size-4 animate-spin" />
+          )}
+        </StepIcon>
+        <div className="flex flex-col gap-1">
+          <h2 className="font-semibold">
+            {done
+              ? 'Your copy is live'
+              : failed
+                ? 'Deploy needs attention'
+                : 'Deploying your fork…'}
+          </h2>
+          <p className="leading-relaxed text-muted-foreground">
+            {done
+              ? 'Your fork built and deployed to Cloudflare Workers.'
+              : failed
+                ? 'The deploy workflow did not finish successfully. Check the logs on GitHub.'
+                : 'We forked the repo and started its deploy workflow. This takes a few minutes — this page updates automatically.'}
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {done && target && (
+          <Button size="lg" asChild>
+            <a href={target} target="_blank" rel="noopener noreferrer">
+              <Rocket />
+              Open your app
+            </a>
+          </Button>
+        )}
+        {data?.run && (
+          <Button variant="outline" asChild>
+            <a
+              href={data.run.htmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View deploy logs
+            </a>
+          </Button>
+        )}
+        {data?.forkUrl && (
+          <Button variant="ghost" asChild>
+            <a href={data.forkUrl} target="_blank" rel="noopener noreferrer">
+              <GitHubIcon className="size-4" />
+              Your fork
+            </a>
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function ForkPage() {
+  const { enabled } = Route.useLoaderData();
+  const { step, error } = Route.useSearch();
+
+  return (
+    <main className="mx-auto flex max-w-2xl flex-col gap-12 px-6 py-32">
+      <header className="flex flex-col gap-4">
+        <span className="flex size-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+          <GitFork className="size-6" />
+        </span>
+        <h1 className="font-heading text-4xl font-bold tracking-tight">
+          Fork &amp; deploy your own {SITE_CONFIG.name}
+        </h1>
+        <p className="text-lg leading-relaxed text-muted-foreground">
+          {SITE_CONFIG.name} is open source. Fork it into your GitHub account
+          and run your own copy on Cloudflare — your code, your database, your
+          account.
+        </p>
+      </header>
+
+      {error && (
+        <Alert variant="destructive">
+          <TriangleAlert />
+          <AlertTitle>Something went wrong</AlertTitle>
+          <AlertDescription>
+            {ERROR_MESSAGES[error] ?? 'Please try again.'}
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {step === 'deploying' ? (
+        <DeployProgress />
+      ) : (
+        <>
+          <ol className="flex flex-col gap-6">
+            {STEPS.map(({ icon: Icon, title: stepTitle, body }) => (
+              <li key={stepTitle} className="flex items-start gap-4">
+                <StepIcon>
+                  <Icon className="size-4" />
+                </StepIcon>
+                <div className="flex flex-col gap-1">
+                  <h2 className="font-semibold">{stepTitle}</h2>
+                  <p className="leading-relaxed text-muted-foreground">
+                    {body}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          {enabled ? (
+            <div className="flex flex-col items-start gap-3">
+              <Button size="lg" asChild>
+                <a href="/api/fork/github/start">
+                  <GitFork />
+                  Fork &amp; deploy
+                </a>
+              </Button>
+              <p className="text-sm text-muted-foreground">
+                You&rsquo;ll authorize GitHub, then Cloudflare. We only use the
+                access to fork the repo and deploy it to your account.
+              </p>
+            </div>
+          ) : (
+            <Alert>
+              <TriangleAlert />
+              <AlertTitle>One-click fork isn&rsquo;t set up here</AlertTitle>
+              <AlertDescription>
+                This instance hasn&rsquo;t configured the GitHub and Cloudflare
+                OAuth apps. You can still deploy manually with the{' '}
+                <a
+                  href="/docs/deployment/cloudflare"
+                  className="underline underline-offset-4 hover:text-foreground"
+                >
+                  Cloudflare deployment guide
+                </a>
+                .
+              </AlertDescription>
+            </Alert>
+          )}
+        </>
+      )}
+
+      <div className="flex items-start gap-4 rounded-lg border bg-muted/50 p-4">
+        <StepIcon>
+          <KeyRound className="size-4" />
+        </StepIcon>
+        <div className="flex flex-col gap-1 text-sm leading-relaxed">
+          <p className="font-medium">After it deploys: add your AI keys</p>
+          <p className="text-muted-foreground">
+            Generation needs a fal.ai key and an OpenRouter key. Add them per
+            team from Settings &rarr; API Keys in your deployed copy, or
+            server-wide with{' '}
+            <code className="rounded bg-background px-1 py-0.5 font-mono text-xs">
+              wrangler secret put
+            </code>
+            .
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/routes/api/fork/cloudflare/callback.ts
+++ b/src/routes/api/fork/cloudflare/callback.ts
@@ -1,0 +1,126 @@
+/**
+ * GET /api/fork/cloudflare/callback — Cloudflare OAuth redirect target.
+ *
+ * Verifies the CSRF nonce, exchanges the code (PKCE) for a Cloudflare token,
+ * resolves the account + workers.dev URL, writes the credentials onto the
+ * fork as Actions secrets, and dispatches the deploy workflow. Then sends the
+ * visitor to /fork to watch the deploy.
+ */
+
+import { getForkConfig } from '@/lib/fork/config';
+import {
+  computeWorkerUrl,
+  exchangeCloudflareCode,
+  getCloudflareAccountId,
+  getWorkersSubdomain,
+} from '@/lib/fork/cloudflare';
+import { kickoffForkDeploy } from '@/lib/fork/deploy';
+import {
+  readForkCookie,
+  sealForkState,
+  serializeForkCookieHeader,
+  unsealForkState,
+} from '@/lib/fork/state-cookie';
+import { getServerAppUrl } from '@/lib/utils/environment';
+import { getLogger } from '@/lib/observability/logger';
+import { createFileRoute } from '@tanstack/react-router';
+
+const logger = getLogger([
+  'openstory',
+  'api',
+  'fork',
+  'cloudflare',
+  'callback',
+]);
+
+export const Route = createFileRoute('/api/fork/cloudflare/callback')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const config = getForkConfig();
+        const appUrl = getServerAppUrl(request);
+        const secure = appUrl.startsWith('https:');
+        const url = new URL(request.url);
+        const code = url.searchParams.get('code');
+        const state = url.searchParams.get('state');
+
+        const fail = (reason: string) =>
+          Response.redirect(`${appUrl}/fork?error=${reason}`, 302);
+
+        if (
+          !config.enabled ||
+          !config.cloudflare.clientId ||
+          !config.cloudflare.tokenUrl
+        ) {
+          return fail('disabled');
+        }
+
+        const existing = await unsealForkState(readForkCookie(request, secure));
+        if (
+          !code ||
+          !state ||
+          !existing?.cloudflareCsrf ||
+          existing.cloudflareCsrf !== state ||
+          !existing.cloudflarePkceVerifier ||
+          !existing.githubToken ||
+          !existing.forkOwner ||
+          !existing.forkRepo
+        ) {
+          return fail('cloudflare_state');
+        }
+
+        try {
+          const cloudflareToken = await exchangeCloudflareCode({
+            tokenUrl: config.cloudflare.tokenUrl,
+            clientId: config.cloudflare.clientId,
+            clientSecret: config.cloudflare.clientSecret,
+            code,
+            redirectUri: `${appUrl}/api/fork/cloudflare/callback`,
+            codeVerifier: existing.cloudflarePkceVerifier,
+          });
+
+          const accountId = await getCloudflareAccountId(cloudflareToken);
+          const subdomain = await getWorkersSubdomain(
+            cloudflareToken,
+            accountId
+          );
+          const workerUrl = computeWorkerUrl(config.workerName, subdomain);
+
+          await kickoffForkDeploy({
+            config,
+            githubToken: existing.githubToken,
+            forkOwner: existing.forkOwner,
+            forkRepo: existing.forkRepo,
+            ref: 'main',
+            cloudflareToken,
+            cloudflareAccountId: accountId,
+            workerUrl,
+          });
+
+          // Keep the GitHub token (status polling reads run state); drop the
+          // Cloudflare token + PKCE/CSRF nonces now that the deploy is wired.
+          const sealed = await sealForkState({
+            githubToken: existing.githubToken,
+            githubLogin: existing.githubLogin,
+            forkOwner: existing.forkOwner,
+            forkRepo: existing.forkRepo,
+            forkUrl: existing.forkUrl,
+            cloudflareAccountId: accountId,
+            workerUrl,
+          });
+
+          return new Response(null, {
+            status: 302,
+            headers: {
+              Location: `${appUrl}/fork?step=deploying`,
+              'Set-Cookie': serializeForkCookieHeader(sealed, secure),
+            },
+          });
+        } catch (error) {
+          logger.error('Cloudflare deploy kickoff failed', { err: error });
+          return fail('cloudflare_deploy');
+        }
+      },
+    },
+  },
+});

--- a/src/routes/api/fork/cloudflare/start.ts
+++ b/src/routes/api/fork/cloudflare/start.ts
@@ -1,0 +1,76 @@
+/**
+ * GET /api/fork/cloudflare/start — connect the visitor's Cloudflare account.
+ *
+ * Reached after the GitHub fork. Mints a CSRF nonce + PKCE verifier, stashes
+ * them in the encrypted cookie, and redirects to Cloudflare's OAuth consent
+ * screen. The callback wires the credentials onto the fork and dispatches the
+ * deploy workflow.
+ */
+
+import { getForkConfig } from '@/lib/fork/config';
+import {
+  buildCloudflareAuthorizeUrl,
+  generateCodeChallenge,
+  generateUrlSafeToken,
+} from '@/lib/fork/cloudflare';
+import {
+  readForkCookie,
+  sealForkState,
+  serializeForkCookieHeader,
+  unsealForkState,
+} from '@/lib/fork/state-cookie';
+import { getServerAppUrl } from '@/lib/utils/environment';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/api/fork/cloudflare/start')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const config = getForkConfig();
+        const appUrl = getServerAppUrl(request);
+        const secure = appUrl.startsWith('https:');
+
+        const existing = await unsealForkState(readForkCookie(request, secure));
+        if (
+          !config.enabled ||
+          !config.cloudflare.clientId ||
+          !config.cloudflare.authorizeUrl ||
+          !existing?.githubToken ||
+          !existing.forkOwner
+        ) {
+          return Response.redirect(
+            `${appUrl}/fork?error=cloudflare_state`,
+            302
+          );
+        }
+
+        const csrfState = generateUrlSafeToken();
+        const codeVerifier = generateUrlSafeToken();
+        const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+        const sealed = await sealForkState({
+          ...existing,
+          cloudflareCsrf: csrfState,
+          cloudflarePkceVerifier: codeVerifier,
+        });
+
+        const authUrl = buildCloudflareAuthorizeUrl({
+          authorizeUrl: config.cloudflare.authorizeUrl,
+          clientId: config.cloudflare.clientId,
+          redirectUri: `${appUrl}/api/fork/cloudflare/callback`,
+          scopes: config.cloudflare.scopes,
+          csrfState,
+          codeChallenge,
+        });
+
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: authUrl,
+            'Set-Cookie': serializeForkCookieHeader(sealed, secure),
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api/fork/github/callback.ts
+++ b/src/routes/api/fork/github/callback.ts
@@ -1,0 +1,96 @@
+/**
+ * GET /api/fork/github/callback — GitHub OAuth redirect target.
+ *
+ * Verifies the CSRF nonce, exchanges the code for a user token, forks the
+ * upstream repo into the visitor's account, stashes the token + fork details
+ * in the encrypted cookie, then continues to the Cloudflare OAuth step.
+ */
+
+import { getForkConfig } from '@/lib/fork/config';
+import {
+  exchangeGithubCode,
+  forkRepo,
+  getGithubLogin,
+} from '@/lib/fork/github';
+import {
+  readForkCookie,
+  sealForkState,
+  serializeForkCookieHeader,
+  unsealForkState,
+} from '@/lib/fork/state-cookie';
+import { getServerAppUrl } from '@/lib/utils/environment';
+import { getLogger } from '@/lib/observability/logger';
+import { createFileRoute } from '@tanstack/react-router';
+
+const logger = getLogger(['openstory', 'api', 'fork', 'github', 'callback']);
+
+export const Route = createFileRoute('/api/fork/github/callback')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const config = getForkConfig();
+        const appUrl = getServerAppUrl(request);
+        const secure = appUrl.startsWith('https:');
+        const url = new URL(request.url);
+        const code = url.searchParams.get('code');
+        const state = url.searchParams.get('state');
+
+        const fail = (reason: string) =>
+          Response.redirect(`${appUrl}/fork?error=${reason}`, 302);
+
+        if (
+          !config.enabled ||
+          !config.github.clientId ||
+          !config.github.clientSecret
+        ) {
+          return fail('disabled');
+        }
+
+        const existing = await unsealForkState(readForkCookie(request, secure));
+        if (
+          !code ||
+          !state ||
+          !existing?.githubCsrf ||
+          existing.githubCsrf !== state
+        ) {
+          return fail('github_state');
+        }
+
+        try {
+          const token = await exchangeGithubCode({
+            clientId: config.github.clientId,
+            clientSecret: config.github.clientSecret,
+            code,
+            redirectUri: `${appUrl}/api/fork/github/callback`,
+          });
+          const login = await getGithubLogin(token);
+          const fork = await forkRepo({
+            token,
+            owner: config.upstream.owner,
+            repo: config.upstream.repo,
+          });
+
+          const sealed = await sealForkState({
+            githubToken: token,
+            githubLogin: login,
+            forkOwner: fork.owner,
+            forkRepo: fork.repo,
+            forkUrl: fork.htmlUrl,
+          });
+
+          // Continue straight into the Cloudflare connect step.
+          return new Response(null, {
+            status: 302,
+            headers: {
+              Location: `${appUrl}/api/fork/cloudflare/start`,
+              'Set-Cookie': serializeForkCookieHeader(sealed, secure),
+            },
+          });
+        } catch (error) {
+          logger.error('GitHub fork failed', { err: error });
+          return fail('github_fork');
+        }
+      },
+    },
+  },
+});

--- a/src/routes/api/fork/github/start.ts
+++ b/src/routes/api/fork/github/start.ts
@@ -1,0 +1,51 @@
+/**
+ * GET /api/fork/github/start — begin the fork-and-deploy flow.
+ *
+ * Public route. Mints a CSRF nonce, stashes it in the encrypted fork cookie,
+ * and redirects the visitor to GitHub's OAuth consent screen. The callback
+ * forks the repo and continues to the Cloudflare step.
+ */
+
+import { getForkConfig, GITHUB_OAUTH_SCOPES } from '@/lib/fork/config';
+import { generateUrlSafeToken } from '@/lib/fork/cloudflare';
+import { buildGithubAuthorizeUrl } from '@/lib/fork/github';
+import {
+  sealForkState,
+  serializeForkCookieHeader,
+} from '@/lib/fork/state-cookie';
+import { getServerAppUrl } from '@/lib/utils/environment';
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/api/fork/github/start')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const config = getForkConfig();
+        const appUrl = getServerAppUrl(request);
+        const secure = appUrl.startsWith('https:');
+
+        if (!config.enabled || !config.github.clientId) {
+          return Response.redirect(`${appUrl}/fork?error=disabled`, 302);
+        }
+
+        const csrfState = generateUrlSafeToken();
+        const sealed = await sealForkState({ githubCsrf: csrfState });
+
+        const authUrl = buildGithubAuthorizeUrl({
+          clientId: config.github.clientId,
+          redirectUri: `${appUrl}/api/fork/github/callback`,
+          scopes: GITHUB_OAUTH_SCOPES,
+          csrfState,
+        });
+
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: authUrl,
+            'Set-Cookie': serializeForkCookieHeader(sealed, secure),
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api/fork/status.ts
+++ b/src/routes/api/fork/status.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /api/fork/status — current fork-deploy progress for the active session.
+ *
+ * Reads the encrypted fork cookie and reports the dispatched workflow run's
+ * status so the /fork page can poll and surface a link to the deployed worker
+ * when CI finishes. Returns `{ step: 'idle' }` when no flow is in progress.
+ */
+
+import { getForkConfig } from '@/lib/fork/config';
+import { getLatestWorkflowRun } from '@/lib/fork/github';
+import { readForkCookie, unsealForkState } from '@/lib/fork/state-cookie';
+import { getServerAppUrl } from '@/lib/utils/environment';
+import { createFileRoute } from '@tanstack/react-router';
+import { json } from '@tanstack/react-start';
+
+export const Route = createFileRoute('/api/fork/status')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const config = getForkConfig();
+        const secure = getServerAppUrl(request).startsWith('https:');
+        const state = await unsealForkState(readForkCookie(request, secure));
+
+        if (!state?.forkOwner || !state.forkRepo || !state.githubToken) {
+          return json({ step: 'idle' as const });
+        }
+
+        const run = await getLatestWorkflowRun({
+          token: state.githubToken,
+          owner: state.forkOwner,
+          repo: state.forkRepo,
+          workflowFile: config.workflowFile,
+        });
+
+        return json({
+          step: 'deploying' as const,
+          forkUrl: state.forkUrl,
+          workerUrl: state.workerUrl,
+          run: run
+            ? {
+                status: run.status,
+                conclusion: run.conclusion,
+                htmlUrl: run.htmlUrl,
+              }
+            : null,
+        });
+      },
+    },
+  },
+});


### PR DESCRIPTION
Adds a publicly accessible /fork page and a "Fork & deploy" button under
the GitHub link in the app sidebar. Unlike the Deploy-to-Cloudflare button
(which clones, with no upstream link), this creates a real GitHub fork and
deploys it to the visitor's own Cloudflare account:

- GitHub OAuth -> real fork of the upstream repo
- Cloudflare self-managed OAuth -> token written to the fork's Actions
  secrets; the fork's own CI (fork-deploy.yml + scripts/fork-provision.ts)
  provisions D1/R2 and deploys
- /fork polls the run and links the visitor to their workers.dev domain

OAuth credentials are operator-provided via env (config reports disabled
until set, and the page falls back to the manual deploy guide). The
multi-hop flow state (CSRF, PKCE, tokens) rides in an encrypted HttpOnly
cookie, mirroring the OpenRouter OAuth pattern. GitHub Actions secrets are
sealed with libsodium crypto_box_seal (tweetnacl + blakejs).

https://claude.ai/code/session_01RJWBRG7DXtNNb5vCVhQKrC