### PR TITLE
fix(byok): resolve fal key before uploading reference images (#924)

### DIFF
--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -159,23 +159,28 @@ async function generateImageInternal(
   modelId: string,
   options?: ImageGenerationOptions
 ): Promise<ImageGenerationResult> {
+  // Get the fal API key - byok or global. Resolved BEFORE normalizing
+  // reference URLs: the fal-storage upload below authenticates with this key,
+  // so on a BYOK-only deployment (no platform FAL_KEY) the platform key would
+  // be empty and the upload would fail with "Authorization header is required"
+  // before we ever reach generation (#924).
+  const falApiKeyInfo = options?.scopedDb
+    ? await options.scopedDb.apiKeys.resolveKey('fal')
+    : { key: getEnv().FAL_KEY, source: 'platform' as const };
+
   // Locally-served /r2/ reference URLs aren't reachable by real fal — swap
   // them for fal-storage uploads first (no-op in prod and e2e replay).
   const params: ImageGenerationParams = rawParams.referenceImageUrls?.length
     ? {
         ...rawParams,
         referenceImageUrls: await ensureExternallyFetchableUrls(
-          rawParams.referenceImageUrls
+          rawParams.referenceImageUrls,
+          falApiKeyInfo.key
         ),
       }
     : rawParams;
   const prompt = truncatePromptForModel(params.prompt, params.model);
   const startTime = Date.now();
-
-  // Get the fal API key - byok or global
-  const falApiKeyInfo = options?.scopedDb
-    ? await options.scopedDb.apiKeys.resolveKey('fal')
-    : { key: getEnv().FAL_KEY, source: 'platform' as const };
 
   const modelOptions = buildFalModelOptions(params);
 

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -74,9 +74,21 @@ export async function submitMotionJob(
   const modelKey = options.model || DEFAULT_VIDEO_MODEL;
   const modelConfig = IMAGE_TO_VIDEO_MODELS[modelKey];
 
+  // Resolve the API key for the motion generation with BYOK if available.
+  // Resolved BEFORE normalizing the image URL: the fal-storage upload below
+  // authenticates with this key, so on a BYOK-only deployment (no platform
+  // FAL_KEY) the platform key would be empty and the upload would fail with
+  // "Authorization header is required" before submission (#924).
+  const falApiKeyInfo = options.scopedDb
+    ? await options.scopedDb.apiKeys.resolveKey('fal')
+    : { key: getEnv().FAL_KEY, source: 'platform' as const };
+
   // Locally-served /r2/ image URLs aren't reachable by real fal — swap them
   // for a fal-storage upload first (no-op in prod and e2e replay).
-  const imageUrl = await ensureExternallyFetchableUrl(options.imageUrl);
+  const imageUrl = await ensureExternallyFetchableUrl(
+    options.imageUrl,
+    falApiKeyInfo.key
+  );
 
   // Prepare the model input
   const modelInput = buildModelInput(
@@ -96,11 +108,6 @@ export async function submitMotionJob(
     promptLength: optimisedPrompt.length,
     modelOptions,
   });
-
-  // Resolve the API key for the motion generation with BYOK if available
-  const falApiKeyInfo = options.scopedDb
-    ? await options.scopedDb.apiKeys.resolveKey('fal')
-    : { key: getEnv().FAL_KEY, source: 'platform' as const };
 
   // Create the Tanstack AI adapter and submit the job
   // Note this is typesafe - only options compatible with modelConfig.id are allowed

--- a/src/lib/storage/external-url.test.ts
+++ b/src/lib/storage/external-url.test.ts
@@ -9,9 +9,8 @@ const readStorageObject = vi.fn();
 vi.doMock('#storage', () => ({ readStorageObject }));
 
 const falUpload = vi.fn<(file: File) => Promise<string>>();
-vi.doMock('@fal-ai/client', () => ({
-  createFalClient: () => ({ storage: { upload: falUpload } }),
-}));
+const createFalClient = vi.fn(() => ({ storage: { upload: falUpload } }));
+vi.doMock('@fal-ai/client', () => ({ createFalClient }));
 
 // Dynamic import so the mocks apply (vi.doMock is not hoisted).
 const {
@@ -29,6 +28,7 @@ beforeEach(() => {
   setEnv({});
   readStorageObject.mockReset();
   falUpload.mockReset();
+  createFalClient.mockClear();
 });
 
 const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
@@ -93,6 +93,42 @@ describe('ensureExternallyFetchableUrl', () => {
     expect(uploaded?.type).toBe('image/png');
   });
 
+  it('uploads with the caller-supplied BYOK key when no platform FAL_KEY is set (#924)', async () => {
+    // BYOK-only deployment: no platform FAL_KEY in env.
+    setEnv({});
+    readStorageObject.mockResolvedValue({
+      bytes: PNG_BYTES,
+      contentType: 'image/png',
+    });
+    falUpload.mockResolvedValue('https://v3.fal.media/files/b/abc/frame.png');
+
+    await expect(
+      ensureExternallyFetchableUrl(
+        '/r2/thumbnails/team/frame.png',
+        'byok-team-key'
+      )
+    ).resolves.toBe('https://v3.fal.media/files/b/abc/frame.png');
+
+    expect(createFalClient).toHaveBeenCalledWith({
+      credentials: 'byok-team-key',
+    });
+  });
+
+  it('falls back to the platform FAL_KEY when no key is supplied', async () => {
+    setEnv({ FAL_KEY: 'platform-key' });
+    readStorageObject.mockResolvedValue({
+      bytes: PNG_BYTES,
+      contentType: 'image/png',
+    });
+    falUpload.mockResolvedValue('https://v3.fal.media/files/b/abc/frame.png');
+
+    await ensureExternallyFetchableUrl('/r2/thumbnails/team/frame.png');
+
+    expect(createFalClient).toHaveBeenCalledWith({
+      credentials: 'platform-key',
+    });
+  });
+
   it('throws on a missing stored object instead of sending a broken URL', async () => {
     readStorageObject.mockResolvedValue(null);
 
@@ -117,6 +153,24 @@ describe('ensureExternallyFetchableUrls', () => {
       'https://storage.example.com/talent/team/ref.png',
       'https://v3.fal.media/files/b/abc/out.png',
     ]);
+  });
+
+  it('threads the supplied fal key into each upload (#924)', async () => {
+    setEnv({});
+    readStorageObject.mockResolvedValue({
+      bytes: PNG_BYTES,
+      contentType: 'image/png',
+    });
+    falUpload.mockResolvedValue('https://v3.fal.media/files/b/abc/ref.png');
+
+    await ensureExternallyFetchableUrls(
+      ['/r2/talent/team/ref.png'],
+      'byok-team-key'
+    );
+
+    expect(createFalClient).toHaveBeenCalledWith({
+      credentials: 'byok-team-key',
+    });
   });
 });
 

--- a/src/lib/storage/external-url.ts
+++ b/src/lib/storage/external-url.ts
@@ -53,9 +53,14 @@ async function readStoredBytes(
  * absolutize; local `/r2/` URLs are uploaded to fal storage (short-lived
  * scratch space — these are model inputs, not user content); everything else
  * passes through.
+ *
+ * `falApiKey` credentials the storage client — pass the caller's resolved fal
+ * key (BYOK when present) so the upload authenticates on deployments with no
+ * platform `FAL_KEY`; falls back to the platform key (#924).
  */
 export async function ensureExternallyFetchableUrl(
-  url: string
+  url: string,
+  falApiKey?: string
 ): Promise<string> {
   const key = r2KeyFromUrl(url);
   if (key === null) return url;
@@ -63,16 +68,19 @@ export async function ensureExternallyFetchableUrl(
   if (cdnUrl) return cdnUrl;
   if (isReplayMode()) return url;
   const { bytes, contentType } = await readStoredBytes(key);
-  const fal = createFalClient({ credentials: getEnv().FAL_KEY });
+  const fal = createFalClient({ credentials: falApiKey ?? getEnv().FAL_KEY });
   const filename = key.split('/').pop() || 'upload';
   const file = new File([bytes], filename, { type: contentType });
   return fal.storage.upload(file);
 }
 
 export async function ensureExternallyFetchableUrls(
-  urls: string[]
+  urls: string[],
+  falApiKey?: string
 ): Promise<string[]> {
-  return Promise.all(urls.map((url) => ensureExternallyFetchableUrl(url)));
+  return Promise.all(
+    urls.map((url) => ensureExternallyFetchableUrl(url, falApiKey))
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes BYOK fal reference-image upload using the absent platform `FAL_KEY`, which broke image/motion generation for any frame carrying reference images.

**Root cause:** `ensureExternallyFetchableUrl()` built its fal-storage client with `getEnv().FAL_KEY` only. On a BYOK-only deployment that's empty, so uploading local `/r2/` reference bytes failed with *"Authorization header is required"* — and it ran *before* the BYOK key was resolved. Preview/sheet images (no references) skip this path, hence the "previews fine, frames fail" split.

## Changes

- **`external-url.ts`** — `ensureExternallyFetchableUrl` / `ensureExternallyFetchableUrls` take an optional `falApiKey` used as the storage-client credentials (falls back to `getEnv().FAL_KEY`).
- **`image-generation.ts`** — resolve `resolveKey('fal')` *before* normalizing reference URLs and thread the key into `ensureExternallyFetchableUrls`.
- **`motion-generation.ts`** — same reorder in `submitMotionJob`, fixing the latent motion-from-local-image BYOK bug.
- **`external-url.test.ts`** — mock now captures credentials; regression tests assert the caller-supplied BYOK key is used, falls back to the platform key, and is threaded through the plural helper.

## Testing

- `bun run test src/lib/storage/external-url.test.ts` — 16 passed
- `bun typecheck` — clean
- `bun lint` — 0 errors

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)
