### PR TITLE
chore(dev): add bun explorer script + document local CF Explorer API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ AI-powered video sequence platform built with TanStack Start, deployed to Cloudf
 bun dev                            # App: env bootstrap, DB migrate + seed, Vite (Workerd via cf-plugin)
 bun dev:all                        # bun dev + the Stripe listener (billing webhooks)
 bun storybook                      # Storybook on :6006
+bun explorer                       # Open the local CF Explorer (KV/R2/D1/DOs/Workflows)
 bun db:studio:local                # Inspect local D1 tables (wrangler d1 execute)
 
 # Quality
@@ -47,6 +48,8 @@ bun deploy:production              # Workers Builds prod deploy command (migrate
 ```
 
 `bun dev` runs vite dev (cf-plugin → Workerd via Miniflare, port 3000). Its first step (`scripts/ensure-env.ts`) creates `.env.local` with generated secrets if missing, so a fresh clone needs only `bun install && bun dev`. Billing work uses `bun dev:all`, which additionally runs the Stripe listener (skipped without `STRIPE_SECRET_KEY`); it lives outside `bun dev` so a missing/uninstalled Stripe CLI never takes down the app server (e.g. in cloud preview sandboxes). The app runs in **Workerd locally** — same runtime as production — so D1, R2 bindings, **Cloudflare Workflows**, env.\* access, and request lifecycle all match prod. No QStash/Docker needed: workflows execute in-process in Workerd.
+
+**Local Cloudflare services via the Explorer API.** While `bun dev` is running you have access to local Cloudflare services (KV, R2, D1, Durable Objects, and Workflows) for this app via the Explorer API at `http://localhost:3000/cdn-cgi/explorer/api`. Fetch that URL to get the OpenAPI schema and discover available operations, then use those endpoints to list, query, and manage local resources during development. `bun explorer` opens the Explorer UI in a browser.
 
 **Bun-as-launcher pattern:** `bun script.ts` (no `--bun`) keeps Bun as the CLI launcher but executes under **Node**, while still autoloading `.env*`. Use `bun --env-file=<path>` to override the default `.env.local`. No `--bun` flag should appear in package.json scripts.
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -69,5 +69,6 @@ export default {
     // CLI tools / shell builtins invoked from package.json scripts.
     'stripe',
     'printf',
+    'open', // macOS URL/file opener (bun explorer)
   ],
 } satisfies KnipConfig;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "db:migrate:local": "bun scripts/migrate-local-d1.ts",
     "db:migrate:test": "bun scripts/migrate-local-d1.ts --test",
     "db:migrate:prd": "bun scripts/flatten-migrations.ts && wrangler d1 migrations apply DB --env=production --remote",
+    "explorer": "open http://localhost:3000/cdn-cgi/explorer/",
     "db:studio:local": "bun drizzle-kit studio --config=drizzle.config.local.ts",
     "db:studio:d1": "bun drizzle-kit studio --config=drizzle.config.d1.ts",
     "db:seed:local": "bun scripts/seed.ts --local",


### PR DESCRIPTION
## Summary

Adds a shortcut and documentation for the local Cloudflare Explorer.

- **`bun explorer`** — opens the local CF Explorer UI (`http://localhost:3000/cdn-cgi/explorer/`) for inspecting KV / R2 / D1 / Durable Objects / Workflows while `bun dev` is running.
- **CLAUDE.md** — lists `bun explorer` in the Dev commands and adds a "Local Cloudflare services via the Explorer API" note pointing at the Explorer API endpoint (`/cdn-cgi/explorer/api`) and its OpenAPI schema for scripting against local resources.
- **knip.config.ts** — allowlists the `open` binary so the dead-code check passes.

Docs/tooling only — no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
