### PR TITLE
Implement proper cost tracking (#938)

### DIFF
--- a/scripts/update-fal-pricing.ts
+++ b/scripts/update-fal-pricing.ts
@@ -50,10 +50,10 @@ const endpoints = getFalEndpointIds();
 // "units" disambiguation
 //
 // The pricing API reports the ambiguous unit `"units"` for several distinct
-// billing kinds (flat-per-video, per-1000-token, and per-image all show up as
-// "units"). Tag the known ones so pre-flight ESTIMATION can predict a unit
-// count. This never affects an actual charge — billing always multiplies fal's
-// reported `unitsBilled` by `unitPrice` regardless of `unit`.
+// billing kinds (e.g. flat-per-video, per-1000-token, per-image, and per-second
+// all show up as "units"). Tag the known ones so pre-flight ESTIMATION can
+// predict a unit count. This never affects an actual charge — billing always
+// multiplies fal's reported `unitsBilled` by `unitPrice` regardless of `unit`.
 // ============================================================================
 
 const UNITS_KIND: Record<string, FalUnit> = {

--- a/scripts/update-fal-pricing.ts
+++ b/scripts/update-fal-pricing.ts
@@ -1,23 +1,23 @@
 /**
  * Fetch live pricing from fal.ai and write src/lib/ai/fal-pricing-data.ts
  * Usage:
- *   bun scripts/update-fal-pricing.ts            # API pricing only
- *   bun scripts/update-fal-pricing.ts --llms-txt  # Also fetch llms.txt pricing notes
+ *   bun scripts/update-fal-pricing.ts
+ *
+ * The output is a single flat map of `endpointId -> { unitPrice, unit }` taken
+ * verbatim from fal's pricing API. Actual credit deduction multiplies fal's
+ * reported `unitsBilled` by `unitPrice` (see `falCostFromUnits` in
+ * `src/lib/ai/fal-cost.ts`), so no per-model multipliers/matrices are needed —
+ * fal already accounts for resolution/audio/duration in `unitsBilled`. The
+ * `unit` field is only used by pre-flight cost ESTIMATION to predict a unit
+ * count before a generation runs.
  */
 import { writeFile } from 'node:fs/promises';
 import { getEnv } from '#env';
-import {
-  AUDIO_MODELS,
-  EDIT_ENDPOINTS,
-  IMAGE_MODELS,
-  IMAGE_TO_VIDEO_MODELS,
-} from '@/lib/ai/models';
-import { typedEntries } from '@/lib/utils/typed-object';
 import { getFalEndpointIds } from './fal-endpoints';
 
 /**
- * Wrapper to tag numeric values that should be serialized as `X as Microdollars`
- * in the generated output file. Multipliers stay as plain numbers.
+ * Wrapper to tag numeric values that should be serialized as `micros(X)` in the
+ * generated output file.
  */
 class MicrosValue {
   constructor(readonly value: number) {}
@@ -27,60 +27,16 @@ class MicrosValue {
 const m = (usd: number): MicrosValue =>
   new MicrosValue(Math.round(usd * 1_000_000));
 
-// ============================================================================
-// Builder types — mirror the output types but with MicrosValue for price fields
-// ============================================================================
+type FalUnit =
+  | 'images'
+  | 'megapixels'
+  | 'compute_seconds'
+  | 'seconds'
+  | 'minutes'
+  | 'tokens'
+  | 'flat';
 
-type BuilderImagePricing = {
-  basePrice: MicrosValue;
-  unit: 'per_image' | 'per_megapixel' | 'per_compute_second';
-  resolutionMultipliers?: Partial<Record<'0.5K' | '1K' | '2K' | '4K', number>>;
-  styleMultipliers?: Record<string, number>;
-  qualitySizeMatrix?: Record<string, Record<string, MicrosValue>>;
-  surcharges?: { webSearch?: MicrosValue };
-  pricingNotes?: string;
-};
-
-type BuilderVideoPricingPerSecond = {
-  mode: 'per_second';
-  basePrice: MicrosValue;
-  noAudioMultiplier?: number;
-  audioMultiplier?: number;
-  voiceControlMultiplier?: number;
-  resolutionPricing?: Record<string, MicrosValue>;
-  resolutionAudioPricing?: Record<
-    string,
-    { noAudio: MicrosValue; withAudio: MicrosValue }
-  >;
-  surcharges?: { imageInput?: MicrosValue };
-  pricingNotes?: string;
-};
-
-type BuilderVideoPricingPerToken = {
-  mode: 'per_token';
-  pricePerMillionTokens: MicrosValue;
-  pricingNotes?: string;
-};
-
-type BuilderVideoPricingFlat = {
-  mode: 'flat';
-  basePrice: MicrosValue;
-  pricingNotes?: string;
-};
-
-type BuilderVideoPricing =
-  | BuilderVideoPricingPerSecond
-  | BuilderVideoPricingPerToken
-  | BuilderVideoPricingFlat;
-
-type BuilderAudioPricing = {
-  basePrice: MicrosValue;
-  unit: 'per_second' | 'per_minute' | 'per_compute_second';
-  roundUpToMinute?: boolean;
-  pricingNotes?: string;
-};
-
-const fetchLlmsTxt = process.argv.includes('--llms-txt');
+type BuilderFalPricing = { unitPrice: MicrosValue; unit: FalUnit };
 
 const apiKey = getEnv().FAL_KEY;
 if (!apiKey) {
@@ -91,127 +47,50 @@ if (!apiKey) {
 const endpoints = getFalEndpointIds();
 
 // ============================================================================
-// Classify endpoints into image/video/audio
+// "units" disambiguation
+//
+// The pricing API reports the ambiguous unit `"units"` for several distinct
+// billing kinds (flat-per-video, per-1000-token, and per-image all show up as
+// "units"). Tag the known ones so pre-flight ESTIMATION can predict a unit
+// count. This never affects an actual charge — billing always multiplies fal's
+// reported `unitsBilled` by `unitPrice` regardless of `unit`.
 // ============================================================================
 
-const imageEndpointIds = new Set<string>(
-  Object.values(IMAGE_MODELS).map((m) => m.id)
-);
-// Include edit endpoints from the single source of truth
-for (const editId of Object.values(EDIT_ENDPOINTS)) {
-  if (editId) imageEndpointIds.add(editId);
+const UNITS_KIND: Record<string, FalUnit> = {
+  'openai/gpt-image-2': 'images',
+  'openai/gpt-image-2/edit': 'images',
+  'fal-ai/phota': 'images',
+  'fal-ai/phota/edit': 'images',
+  'fal-ai/ace-step-1.5': 'seconds',
+  'fal-ai/minimax/hailuo-2.3/pro/image-to-video': 'flat',
+  'bytedance/seedance-2.0/enterprise/v2/image-to-video': 'tokens',
+};
+
+function normalizeUnit(apiUnit: string, endpointId: string): FalUnit {
+  const u = apiUnit.toLowerCase();
+  // The bare "units" is ambiguous (flat / per-image / per-1000-token all report
+  // it), so it must be tagged in UNITS_KIND. Everything else is recognised by
+  // substring so variants like "processed megapixels" still resolve.
+  if (u === 'units') {
+    const kind = UNITS_KIND[endpointId];
+    if (!kind) {
+      console.warn(
+        `  ? ${endpointId}: unit "units" with no kind override — defaulting to 'flat' (estimation only)`
+      );
+      return 'flat';
+    }
+    return kind;
+  }
+  if (u.includes('megapixel')) return 'megapixels';
+  if (u.includes('compute second')) return 'compute_seconds';
+  if (u.includes('second')) return 'seconds';
+  if (u.includes('minute')) return 'minutes';
+  if (u.includes('image')) return 'images';
+  console.warn(
+    `  ? ${endpointId}: unknown unit "${apiUnit}" — defaulting to 'flat' (estimation only)`
+  );
+  return 'flat';
 }
-
-const videoEndpointIds = new Set<string>(
-  Object.values(IMAGE_TO_VIDEO_MODELS).map((m) => m.id)
-);
-
-const audioEndpointIds = new Set<string>(
-  Object.values(AUDIO_MODELS).map((m) => m.id)
-);
-
-function classifyEndpoint(id: string): 'image' | 'video' | 'audio' | 'unknown' {
-  if (imageEndpointIds.has(id)) return 'image';
-  if (videoEndpointIds.has(id)) return 'video';
-  if (audioEndpointIds.has(id)) return 'audio';
-  return 'unknown';
-}
-
-// ============================================================================
-// Manual overrides — conditional pricing that can't be auto-derived from API
-// ============================================================================
-
-const IMAGE_OVERRIDES: Record<string, Partial<BuilderImagePricing>> = {
-  'fal-ai/nano-banana-2': {
-    resolutionMultipliers: { '0.5K': 0.75, '1K': 1, '2K': 1.5, '4K': 2 },
-    surcharges: { webSearch: m(0.015) },
-  },
-  'fal-ai/nano-banana-2/edit': {
-    resolutionMultipliers: { '0.5K': 0.75, '1K': 1, '2K': 1.5, '4K': 2 },
-    surcharges: { webSearch: m(0.015) },
-  },
-  'fal-ai/nano-banana-pro': {
-    resolutionMultipliers: { '4K': 2 },
-    surcharges: { webSearch: m(0.015) },
-  },
-  'fal-ai/nano-banana-pro/edit': {
-    resolutionMultipliers: { '4K': 2 },
-    surcharges: { webSearch: m(0.015) },
-  },
-  'fal-ai/recraft/v3/text-to-image': {
-    styleMultipliers: { vector_illustration: 2, vector: 2 },
-  },
-  'fal-ai/gpt-image-1.5': {
-    basePrice: m(0), // Overridden by matrix
-    qualitySizeMatrix: {
-      // Prices from llms.txt + ~$0.01 buffer for prompt token processing costs
-      low: {
-        '1024x1024': m(0.02),
-        '1024x1536': m(0.025),
-        '1536x1024': m(0.025),
-      },
-      medium: {
-        '1024x1024': m(0.045),
-        '1024x1536': m(0.062),
-        '1536x1024': m(0.061),
-      },
-      high: {
-        '1024x1024': m(0.144),
-        '1024x1536': m(0.211),
-        '1536x1024': m(0.21),
-      },
-    },
-  },
-};
-
-const VIDEO_OVERRIDES: Record<
-  string,
-  | Partial<BuilderVideoPricingPerSecond>
-  // `tokensPerUnit`: how many tokens the pricing API's "unit" represents, used
-  // to scale unit_price up to a per-million-token rate (fal's token pricing is
-  // quoted per 1000 tokens, the default).
-  | { mode: 'per_token'; tokensPerUnit?: number }
-  | { mode: 'flat' }
-> = {
-  'fal-ai/minimax/hailuo-2.3/pro/image-to-video': {
-    // Flat $0.49/video fee regardless of duration (no duration param in schema)
-    mode: 'flat',
-  },
-  'fal-ai/veo3': {
-    // API returns audio-on rate ($0.40); no multiplier needed
-  },
-  'fal-ai/veo3.1/image-to-video': {
-    resolutionAudioPricing: {
-      '720p': { noAudio: m(0.2), withAudio: m(0.4) },
-      '1080p': { noAudio: m(0.2), withAudio: m(0.4) },
-      '4K': { noAudio: m(0.4), withAudio: m(0.6) },
-    },
-  },
-  'fal-ai/kling-video/v3/pro/image-to-video': {
-    noAudioMultiplier: 0.8,
-    audioMultiplier: 1.2,
-    voiceControlMultiplier: 1.4,
-  },
-  'wan/v2.6/image-to-video/flash': {
-    resolutionPricing: { '720p': m(0.05), '1080p': m(0.075) },
-  },
-  'xai/grok-imagine-video/v1.5/image-to-video': {
-    resolutionPricing: { '480p': m(0.08), '720p': m(0.14) },
-    surcharges: { imageInput: m(0.01) },
-  },
-  'bytedance/seedance-2.0/enterprise/v2/image-to-video': {
-    // fal bills $0.014 per 1000 tokens; the pricing API reports unit_price per
-    // 1000-token "unit", so scale up to a per-million-token rate ($14/M).
-    mode: 'per_token',
-    tokensPerUnit: 1000,
-  },
-};
-
-const AUDIO_OVERRIDES: Record<string, Partial<BuilderAudioPricing>> = {
-  'fal-ai/elevenlabs/music': {
-    roundUpToMinute: true,
-  },
-};
 
 // ============================================================================
 // Fetch pricing from API
@@ -248,196 +127,32 @@ if (missing.length > 0) {
 }
 
 // ============================================================================
-// Read existing file for diff and pricingNotes preservation
+// Read existing file for a price-change diff
 // ============================================================================
 
 const outPath = new URL('../src/lib/ai/fal-pricing-data.ts', import.meta.url)
   .pathname;
 
-type OldPricingEntry = {
-  basePrice?: number;
-  pricePerMillionTokens?: number;
-  pricingNotes?: string;
-};
-let oldImagePricing: Record<string, OldPricingEntry> = {};
-let oldVideoPricing: Record<string, OldPricingEntry> = {};
-let oldAudioPricing: Record<string, OldPricingEntry> = {};
+let oldPricing: Record<string, { unitPrice?: number }> = {};
 try {
   const existing = await import(outPath);
-  oldImagePricing = existing.IMAGE_PRICING ?? {};
-  oldVideoPricing = existing.VIDEO_PRICING ?? {};
-  oldAudioPricing = existing.AUDIO_PRICING ?? {};
+  oldPricing = existing.FAL_PRICING ?? {};
 } catch {
   // First run — no existing file
 }
 
 // ============================================================================
-// Build pricing maps (prices wrapped in MicrosValue for serialization)
+// Build the flat pricing map (prices wrapped in MicrosValue for serialization)
 // ============================================================================
 
-const imagePricing: Record<string, BuilderImagePricing> = {};
-const videoPricing: Record<string, BuilderVideoPricing> = {};
-const audioPricing: Record<string, BuilderAudioPricing> = {};
-
-function mapImageUnit(
-  apiUnit: string
-): 'per_image' | 'per_megapixel' | 'per_compute_second' {
-  const u = apiUnit.toLowerCase();
-  if (u === 'megapixels') return 'per_megapixel';
-  if (u === 'compute seconds') return 'per_compute_second';
-  return 'per_image';
-}
-
-function mapAudioUnit(
-  apiUnit: string
-): 'per_second' | 'per_minute' | 'per_compute_second' {
-  const u = apiUnit.toLowerCase();
-  if (u === 'minutes') return 'per_minute';
-  if (u === 'compute seconds') return 'per_compute_second';
-  return 'per_second';
-}
-
+const pricing: Record<string, BuilderFalPricing> = {};
 for (const p of data.prices.sort((a, b) =>
   a.endpoint_id.localeCompare(b.endpoint_id)
 )) {
-  const type = classifyEndpoint(p.endpoint_id);
-
-  switch (type) {
-    case 'image': {
-      const override = IMAGE_OVERRIDES[p.endpoint_id];
-      imagePricing[p.endpoint_id] = {
-        // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-        basePrice: override?.basePrice ?? m(p.unit_price),
-        // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-        unit: override?.unit ?? mapImageUnit(p.unit),
-        ...override,
-      };
-      break;
-    }
-    case 'video': {
-      const override = VIDEO_OVERRIDES[p.endpoint_id];
-      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-      if (override && 'mode' in override && override.mode === 'per_token') {
-        const tokensPerUnit = override.tokensPerUnit ?? 1000;
-        videoPricing[p.endpoint_id] = {
-          mode: 'per_token',
-          pricePerMillionTokens: m((p.unit_price * 1_000_000) / tokensPerUnit),
-        };
-      } else if (override && 'mode' in override && override.mode === 'flat') {
-        videoPricing[p.endpoint_id] = {
-          mode: 'flat',
-          basePrice: m(p.unit_price),
-        };
-      } else {
-        const secOverride = override as
-          | Partial<BuilderVideoPricingPerSecond>
-          | undefined;
-        videoPricing[p.endpoint_id] = {
-          mode: 'per_second',
-          basePrice: secOverride?.basePrice ?? m(p.unit_price),
-          ...secOverride,
-        };
-      }
-      break;
-    }
-    case 'audio': {
-      const override = AUDIO_OVERRIDES[p.endpoint_id];
-      audioPricing[p.endpoint_id] = {
-        basePrice: m(p.unit_price),
-        // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-        unit: override?.unit ?? mapAudioUnit(p.unit),
-        ...override,
-      };
-      break;
-    }
-    default:
-      console.warn(`  ? ${p.endpoint_id}: unclassified, skipping`);
-  }
-}
-
-// ============================================================================
-// Fetch llms.txt pricing notes
-// ============================================================================
-
-type PricingEntry = { pricingNotes?: string };
-const allPricing = new Map<string, PricingEntry>();
-for (const [id, p] of typedEntries(imagePricing)) allPricing.set(id, p);
-for (const [id, p] of typedEntries(videoPricing)) allPricing.set(id, p);
-for (const [id, p] of typedEntries(audioPricing)) allPricing.set(id, p);
-
-if (fetchLlmsTxt) {
-  console.log('\nFetching llms.txt pricing notes...\n');
-
-  const falEndpoints = endpoints.filter(
-    (id) =>
-      id.startsWith('fal-ai/') ||
-      id.startsWith('xai/') ||
-      id.startsWith('wan/') ||
-      id.startsWith('beatoven/')
-  );
-
-  const results = await Promise.allSettled(
-    falEndpoints.map(async (endpointId) => {
-      const llmsUrl = `https://fal.ai/models/${endpointId}/llms.txt`;
-      const res = await fetch(llmsUrl);
-      if (!res.ok) return { endpointId, notes: null };
-      const text = await res.text();
-      return { endpointId, notes: text };
-    })
-  );
-
-  for (const result of results) {
-    if (result.status !== 'fulfilled' || !result.value.notes) {
-      const id =
-        result.status === 'fulfilled' ? result.value.endpointId : 'unknown';
-      console.log(`  \u23ED ${id}: no llms.txt`);
-      continue;
-    }
-
-    const { endpointId, notes } = result.value;
-
-    const pricingMatch = notes.match(
-      /## Pricing\s*\n([\s\S]*?)(?=\n## |\n# |$)/
-    );
-    if (!pricingMatch) {
-      console.log(`  \u23ED ${endpointId}: no pricing section`);
-      continue;
-    }
-
-    const pricingText = (pricingMatch[1] ?? '').trim();
-    console.log(`  \u2713 ${endpointId}:`);
-    console.log(`    ${pricingText.split('\n').join('\n    ')}\n`);
-
-    const entry = allPricing.get(endpointId);
-    if (entry) {
-      entry.pricingNotes = pricingText;
-    }
-  }
-}
-
-// Preserve existing pricingNotes when not fetching llms.txt
-if (!fetchLlmsTxt) {
-  for (const [id, entry] of typedEntries(imagePricing)) {
-    const old = oldImagePricing[id];
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-    if (old?.pricingNotes && !entry.pricingNotes) {
-      entry.pricingNotes = old.pricingNotes;
-    }
-  }
-  for (const [id, entry] of typedEntries(videoPricing)) {
-    const old = oldVideoPricing[id];
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-    if (old?.pricingNotes && !entry.pricingNotes) {
-      entry.pricingNotes = old.pricingNotes;
-    }
-  }
-  for (const [id, entry] of typedEntries(audioPricing)) {
-    const old = oldAudioPricing[id];
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-    if (old?.pricingNotes && !entry.pricingNotes) {
-      entry.pricingNotes = old.pricingNotes;
-    }
-  }
+  pricing[p.endpoint_id] = {
+    unitPrice: m(p.unit_price),
+    unit: normalizeUnit(p.unit, p.endpoint_id),
+  };
 }
 
 // ============================================================================
@@ -445,234 +160,83 @@ if (!fetchLlmsTxt) {
 // ============================================================================
 
 let changes = 0;
-
-function getBasePrice(entry: OldPricingEntry): number {
-  return entry.basePrice ?? entry.pricePerMillionTokens ?? 0;
-}
-
-function getMicrosBasePrice(
-  entry: BuilderImagePricing | BuilderVideoPricing | BuilderAudioPricing
-): number {
-  if ('basePrice' in entry) return entry.basePrice.value;
-  if ('pricePerMillionTokens' in entry)
-    return entry.pricePerMillionTokens.value;
-  return 0;
-}
-
-function diffMap(
-  label: string,
-  newIds: string[],
-  oldIds: string[],
-  getNew: (id: string) => number,
-  getOld: (id: string) => number | undefined
-) {
-  for (const id of newIds) {
-    const bp = getNew(id);
-    const oldBp = getOld(id);
-    if (oldBp === undefined) {
-      console.log(`  + [${label}] ${id}: ${bp} micros (new)`);
-      changes++;
-    } else if (oldBp !== bp) {
-      console.log(`  ~ [${label}] ${id}: ${oldBp} → ${bp} micros`);
-      changes++;
-    }
-  }
-  for (const id of oldIds) {
-    if (!newIds.includes(id)) {
-      console.log(`  - [${label}] ${id}: removed`);
-      changes++;
-    }
+for (const [id, entry] of Object.entries(pricing)) {
+  // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
+  const old = oldPricing[id];
+  const newPrice = entry.unitPrice.value;
+  if (!old) {
+    console.log(`  + ${id}: ${newPrice} micros (new)`);
+    changes++;
+  } else if (old.unitPrice !== newPrice) {
+    console.log(`  ~ ${id}: ${old.unitPrice} → ${newPrice} micros`);
+    changes++;
   }
 }
-
-diffMap(
-  'image',
-  Object.keys(imagePricing),
-  Object.keys(oldImagePricing),
-  (id) => {
-    const entry = imagePricing[id];
-    if (!entry) throw new Error(`unknown image pricing id: ${id}`);
-    return getMicrosBasePrice(entry);
-  },
-  // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-  (id) => (oldImagePricing[id] ? getBasePrice(oldImagePricing[id]) : undefined)
-);
-diffMap(
-  'video',
-  Object.keys(videoPricing),
-  Object.keys(oldVideoPricing),
-  (id) => {
-    const entry = videoPricing[id];
-    if (!entry) throw new Error(`unknown video pricing id: ${id}`);
-    return getMicrosBasePrice(entry);
-  },
-  // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-  (id) => (oldVideoPricing[id] ? getBasePrice(oldVideoPricing[id]) : undefined)
-);
-diffMap(
-  'audio',
-  Object.keys(audioPricing),
-  Object.keys(oldAudioPricing),
-  (id) => {
-    const entry = audioPricing[id];
-    if (!entry) throw new Error(`unknown audio pricing id: ${id}`);
-    return getMicrosBasePrice(entry);
-  },
-  // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- Record lookup returns undefined for missing keys
-  (id) => (oldAudioPricing[id] ? getBasePrice(oldAudioPricing[id]) : undefined)
-);
+for (const id of Object.keys(oldPricing)) {
+  if (!(id in pricing)) {
+    console.log(`  - ${id}: removed`);
+    changes++;
+  }
+}
 
 // ============================================================================
 // Write the generated file
 // ============================================================================
 
-function escapeString(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\n/g, '\\n');
-}
-
 /** Format large integers with underscore separators for readability */
 function formatMicros(value: number): string {
   if (value === 0) return '0';
   const str = String(value);
-  // Add underscore separators for values >= 1000
   if (value >= 1000) {
     return str.replace(/\B(?=(\d{3})+(?!\d))/g, '_');
   }
   return str;
 }
 
-function serializeValue(value: unknown, indent: number): string {
-  const pad = '  '.repeat(indent);
-  const padInner = '  '.repeat(indent + 1);
-
-  if (value === undefined || value === null) return 'undefined';
-  if (value instanceof MicrosValue)
-    return `micros(${formatMicros(value.value)})`;
-  if (typeof value === 'string') return `'${escapeString(value)}'`;
-  if (typeof value === 'number' || typeof value === 'boolean')
-    return String(value);
-
-  if (Array.isArray(value)) {
-    const items = value.map((v) => serializeValue(v, indent + 1));
-    return `[${items.join(', ')}]`;
-  }
-
-  if (typeof value === 'object') {
-    const entries = Object.entries(value).filter(([, v]) => v !== undefined);
-    if (entries.length === 0) return '{}';
-    const lines = entries.map(
-      ([k, v]) => `${padInner}${quoteKey(k)}: ${serializeValue(v, indent + 1)}`
-    );
-    return `{\n${lines.join(',\n')},\n${pad}}`;
-  }
-
-  return JSON.stringify(value);
-}
-
-function quoteKey(key: string): string {
-  return /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key) ? key : `'${key}'`;
-}
-
-function serializeMap(
-  name: string,
-  type: string,
-  map: Record<
-    string,
-    BuilderImagePricing | BuilderVideoPricing | BuilderAudioPricing
-  >
-): string {
-  const entries = Object.entries(map)
-    .map(([id, p]) => `  '${id}': ${serializeValue(p, 1)},`)
-    .join('\n');
-
-  return `export const ${name}: Record<string, ${type}> = {\n${entries}\n};`;
-}
+const entries = Object.entries(pricing)
+  .map(
+    ([id, p]) =>
+      `  '${id}': { unitPrice: micros(${formatMicros(p.unitPrice.value)}), unit: '${p.unit}' },`
+  )
+  .join('\n');
 
 const now = new Date().toISOString();
 const output = `// AUTO-GENERATED — do not edit manually. Run: bun scripts/update-fal-pricing.ts
-// Manual overrides (multipliers, matrices) are maintained in scripts/update-fal-pricing.ts
+// The "units" disambiguation map is maintained in scripts/update-fal-pricing.ts
 
 import { type Microdollars, micros } from '@/lib/billing/money';
 
 // ============================================================================
-// Image Pricing (all prices in microdollars: 1 USD = 1,000,000)
+// Fal Pricing (all prices in microdollars: 1 USD = 1,000,000)
+//
+// \`unitPrice\` is fal's per-unit price, taken verbatim from the pricing API.
+// Actual cost = unitsBilled (from the adapter) * unitPrice. \`unit\` is the
+// billed unit, used only by pre-flight cost estimation.
 // ============================================================================
 
-type ImagePricingUnit = 'per_image' | 'per_megapixel' | 'per_compute_second';
+export type FalUnit =
+  | 'images'
+  | 'megapixels'
+  | 'compute_seconds'
+  | 'seconds'
+  | 'minutes'
+  | 'tokens'
+  | 'flat';
 
-export type ImagePricing = {
-  basePrice: Microdollars;
-  unit: ImagePricingUnit;
-  resolutionMultipliers?: Partial<Record<'0.5K' | '1K' | '2K' | '4K', number>>;
-  styleMultipliers?: Record<string, number>;
-  qualitySizeMatrix?: Record<string, Record<string, Microdollars>>;
-  surcharges?: { webSearch?: Microdollars };
-  pricingNotes?: string;
+export type FalPricing = {
+  unitPrice: Microdollars;
+  unit: FalUnit;
 };
 
-${serializeMap('IMAGE_PRICING', 'ImagePricing', imagePricing)}
-
-// ============================================================================
-// Video Pricing (all prices in microdollars: 1 USD = 1,000,000)
-// ============================================================================
-
-type VideoPricingBase = { pricingNotes?: string };
-
-type VideoPricingPerSecond = VideoPricingBase & {
-  mode: 'per_second';
-  basePrice: Microdollars;
-  noAudioMultiplier?: number;
-  audioMultiplier?: number;
-  voiceControlMultiplier?: number;
-  resolutionPricing?: Record<string, Microdollars>;
-  resolutionAudioPricing?: Record<string, { noAudio: Microdollars; withAudio: Microdollars }>;
-  surcharges?: { imageInput?: Microdollars };
+export const FAL_PRICING: Record<string, FalPricing> = {
+${entries}
 };
-
-type VideoPricingPerToken = VideoPricingBase & {
-  mode: 'per_token';
-  pricePerMillionTokens: Microdollars;
-};
-
-type VideoPricingFlat = VideoPricingBase & {
-  mode: 'flat';
-  basePrice: Microdollars;
-};
-
-export type VideoPricing =
-  | VideoPricingPerSecond
-  | VideoPricingPerToken
-  | VideoPricingFlat;
-
-${serializeMap('VIDEO_PRICING', 'VideoPricing', videoPricing)}
-
-// ============================================================================
-// Audio Pricing (all prices in microdollars: 1 USD = 1,000,000)
-// ============================================================================
-
-type AudioPricingUnit = 'per_second' | 'per_minute' | 'per_compute_second';
-
-export type AudioPricing = {
-  basePrice: Microdollars;
-  unit: AudioPricingUnit;
-  roundUpToMinute?: boolean;
-  pricingNotes?: string;
-};
-
-${serializeMap('AUDIO_PRICING', 'AudioPricing', audioPricing)}
 
 export const PRICING_LAST_UPDATED = '${now}';
 `;
 
 await writeFile(outPath, output);
 
-const total =
-  Object.keys(imagePricing).length +
-  Object.keys(videoPricing).length +
-  Object.keys(audioPricing).length;
 console.log(
-  `\nWrote ${total} endpoints to fal-pricing-data.ts (${changes} changes)`
-);
-console.log(
-  `  Image: ${Object.keys(imagePricing).length}, Video: ${Object.keys(videoPricing).length}, Audio: ${Object.keys(audioPricing).length}`
+  `\nWrote ${Object.keys(pricing).length} endpoints to fal-pricing-data.ts (${changes} changes)`
 );

--- a/scripts/verify-fal-costs.ts
+++ b/scripts/verify-fal-costs.ts
@@ -18,18 +18,13 @@
  *   bun scripts/verify-fal-costs.ts --compare            # fetch usage for existing results
  */
 
-import {
-  calculateAudioCost,
-  calculateImageCost,
-  calculateVideoCost,
-} from '@/lib/ai/fal-cost';
+import { estimateFalCost } from '@/lib/ai/fal-cost';
 import {
   AUDIO_MODELS,
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
   type AudioModel,
   type TextToImageModel,
-  videoModelSupportsAudio,
 } from '@/lib/ai/models';
 import { buildModelInput } from '@/lib/motion/build-model-input';
 import { snapDuration } from '@/lib/motion/motion-generation';
@@ -183,8 +178,7 @@ function calculateImageCostForVariation(
   variation: ImageVariation
 ): number {
   const dims = IMAGE_DIMS[variation];
-  return calculateImageCost({
-    endpointId,
+  return estimateFalCost(endpointId, {
     numImages: 1,
     widthPx: dims.width,
     heightPx: dims.height,
@@ -263,10 +257,8 @@ function buildVideoTasks(imageUrl: string): Task[] {
         variation: label,
         tier,
         input: input as Record<string, unknown>,
-        estimatedCost: calculateVideoCost({
-          endpointId: config.id,
+        estimatedCost: estimateFalCost(config.id, {
           durationSeconds: duration,
-          audioEnabled: videoModelSupportsAudio(modelKey),
           resolution,
         }),
       });
@@ -337,8 +329,7 @@ function buildAudioTasks(): Task[] {
         variation: label,
         tier,
         input: buildAudioInput(modelKey, config, duration),
-        estimatedCost: calculateAudioCost({
-          endpointId: config.id,
+        estimatedCost: estimateFalCost(config.id, {
           durationSeconds: duration,
         }),
       });

--- a/scripts/verify-fal-costs.ts
+++ b/scripts/verify-fal-costs.ts
@@ -118,7 +118,7 @@ function buildImageInput(
   const isHighRes = variation === 'high_res';
 
   switch (modelKey) {
-    // Nano Banana Pro/2 — aspect_ratio + resolution (has cost multipliers)
+    // Nano Banana Pro/2 — aspect_ratio + resolution
     case 'nano_banana_pro':
       return {
         ...base,

--- a/src/lib/ai/fal-cost.test.ts
+++ b/src/lib/ai/fal-cost.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'vitest';
 import { estimateFalCost, falCostFromUnits } from './fal-cost';
+import { FAL_PRICING } from './fal-pricing-data';
+import {
+  AUDIO_MODELS,
+  EDIT_ENDPOINTS,
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+} from '@/lib/ai/models';
 import { micros, usdToMicros, ZERO_MICROS } from '@/lib/billing/money';
 
 const usd = (n: number) => usdToMicros(n);
@@ -87,5 +94,21 @@ describe('estimateFalCost', () => {
     expect(estimateFalCost('unknown/model', { numImages: 1 })).toBe(
       ZERO_MICROS
     );
+  });
+});
+
+describe('FAL_PRICING coverage', () => {
+  // Every model we can generate with must have pricing, or it bills $0 at
+  // runtime (a loud error, but only after free generations). This turns a
+  // missing entry — e.g. after a model bump — into a pre-merge failure.
+  const endpointIds = [
+    ...Object.values(IMAGE_MODELS).map((m) => m.id),
+    ...Object.values(IMAGE_TO_VIDEO_MODELS).map((m) => m.id),
+    ...Object.values(AUDIO_MODELS).map((m) => m.id),
+    ...Object.values(EDIT_ENDPOINTS).filter((id): id is string => !!id),
+  ];
+
+  test.each([...new Set(endpointIds)])('has pricing for %s', (id) => {
+    expect(FAL_PRICING[id]).toBeDefined();
   });
 });

--- a/src/lib/ai/fal-cost.test.ts
+++ b/src/lib/ai/fal-cost.test.ts
@@ -1,316 +1,91 @@
 import { describe, expect, test } from 'vitest';
-import {
-  calculateImageCost,
-  calculateVideoCost,
-  calculateAudioCost,
-} from './fal-cost';
-import { micros, ZERO_MICROS, usdToMicros } from '@/lib/billing/money';
+import { estimateFalCost, falCostFromUnits } from './fal-cost';
+import { micros, usdToMicros, ZERO_MICROS } from '@/lib/billing/money';
 
-/** Helper: convert expected USD to micros for comparison */
 const usd = (n: number) => usdToMicros(n);
 
-describe('calculateImageCost', () => {
-  test('per_compute_second model (grok-imagine-image-quality)', () => {
-    const cost = calculateImageCost({
-      endpointId: 'xai/grok-imagine-image/quality/text-to-image',
-      numImages: 2,
-    });
-    // 170 micros * 3 (DEFAULT_COMPUTE_SECONDS) * 2 = 1_020
-    expect(cost).toBe(micros(1_020));
+describe('falCostFromUnits', () => {
+  test('per-image: unitsBilled * unitPrice (resolution premium is in the count)', () => {
+    // nano-banana-2 = $0.08/image. A 2K image fal bills as 1.5 units.
+    expect(falCostFromUnits('fal-ai/nano-banana-2', 1)).toBe(micros(80_000));
+    expect(falCostFromUnits('fal-ai/nano-banana-2', 1.5)).toBe(micros(120_000));
   });
 
-  test('per_megapixel model (flux-2-max)', () => {
-    const cost = calculateImageCost({
-      endpointId: 'fal-ai/flux-2-max',
-      numImages: 1,
-      widthPx: 1024,
-      heightPx: 1024,
-    });
-    const megapixels = (1024 * 1024) / 1_000_000;
-    // 70_000 micros * megapixels
-    expect(cost).toBe(micros(Math.round(70_000 * megapixels)));
+  test('per-megapixel: fractional units', () => {
+    // flux-2-max = $0.07/megapixel.
+    expect(falCostFromUnits('fal-ai/flux-2-max', 1.05)).toBe(micros(73_500));
   });
 
-  test('per_compute_second model (hunyuan-image instruct/edit)', () => {
-    const cost = calculateImageCost({
-      endpointId: 'fal-ai/hunyuan-image/v3/instruct/edit',
-      numImages: 1,
-    });
-    // 1_670 micros * 3 (default compute seconds) = 5_010
-    expect(cost).toBe(micros(5_010));
+  test('flat: hailuo bills 1 unit at $0.49', () => {
+    expect(
+      falCostFromUnits('fal-ai/minimax/hailuo-2.3/pro/image-to-video', 1)
+    ).toBe(usd(0.49));
   });
 
-  test('nano-banana-2 base resolution', () => {
-    const cost = calculateImageCost({
-      endpointId: 'fal-ai/nano-banana-2',
-      numImages: 1,
-    });
-    expect(cost).toBe(micros(80_000));
+  test('per-token: seedance bills 1000-token units at $0.014', () => {
+    expect(
+      falCostFromUnits(
+        'bytedance/seedance-2.0/enterprise/v2/image-to-video',
+        108
+      )
+    ).toBe(micros(1_512_000));
   });
 
-  test('nano-banana-2 at 4K resolution (2x multiplier)', () => {
-    const cost = calculateImageCost({
-      endpointId: 'fal-ai/nano-banana-2',
-      numImages: 1,
-      resolution: '4K',
-    });
-    expect(cost).toBe(micros(160_000));
+  test('audio per-minute: elevenlabs bills 1 unit at $0.80', () => {
+    expect(falCostFromUnits('fal-ai/elevenlabs/music', 1)).toBe(usd(0.8));
   });
 
-  test('nano-banana-2 at 0.5K resolution (0.75x multiplier)', () => {
-    const cost = calculateImageCost({
-      endpointId: 'fal-ai/nano-banana-2',
-      numImages: 1,
-      resolution: '0.5K',
-    });
-    expect(cost).toBe(micros(60_000));
+  test('missing unitsBilled charges nothing', () => {
+    expect(falCostFromUnits('fal-ai/nano-banana-2', undefined)).toBe(
+      ZERO_MICROS
+    );
   });
 
-  test('nano-banana-pro at 4K (2x multiplier)', () => {
-    const cost = calculateImageCost({
-      endpointId: 'fal-ai/nano-banana-pro',
-      numImages: 1,
-      resolution: '4K',
-    });
-    expect(cost).toBe(micros(300_000));
-  });
-
-  test('unknown endpoint returns 0', () => {
-    const cost = calculateImageCost({
-      endpointId: 'unknown/model',
-      numImages: 1,
-    });
-    expect(cost).toBe(ZERO_MICROS);
+  test('unknown endpoint charges nothing', () => {
+    expect(falCostFromUnits('unknown/model', 5)).toBe(ZERO_MICROS);
   });
 });
 
-describe('calculateVideoCost', () => {
-  test('Veo3.1 audio on at 1080p ($0.40/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/veo3.1/image-to-video',
-      durationSeconds: 8,
-      audioEnabled: true,
-      resolution: '1080p',
-    });
-    // 400_000 * 8 = 3_200_000
-    expect(cost).toBe(usd(3.2));
+describe('estimateFalCost', () => {
+  test('per-image scales by numImages', () => {
+    expect(estimateFalCost('fal-ai/nano-banana-2', { numImages: 2 })).toBe(
+      micros(160_000)
+    );
   });
 
-  test('Veo3.1 audio off at 1080p ($0.20/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/veo3.1/image-to-video',
-      durationSeconds: 8,
-      audioEnabled: false,
-      resolution: '1080p',
-    });
-    // 200_000 * 8 = 1_600_000
-    expect(cost).toBe(usd(1.6));
+  test('per-second scales by duration', () => {
+    expect(
+      estimateFalCost('fal-ai/veo3.1/image-to-video', { durationSeconds: 8 })
+    ).toBe(usd(3.2));
   });
 
-  test('Veo3.1 at 1080p with audio ($0.40/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/veo3.1/image-to-video',
-      durationSeconds: 8,
-      audioEnabled: true,
-      resolution: '1080p',
-    });
-    expect(cost).toBe(usd(3.2));
+  test('per-minute rounds up', () => {
+    expect(
+      estimateFalCost('fal-ai/elevenlabs/music', { durationSeconds: 61 })
+    ).toBe(usd(1.6));
   });
 
-  test('Veo3.1 at 4K with audio ($0.60/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/veo3.1/image-to-video',
-      durationSeconds: 8,
-      audioEnabled: true,
-      resolution: '4K',
-    });
-    expect(cost).toBe(usd(4.8));
+  test('compute-seconds uses a fixed estimate', () => {
+    // grok-imagine-image = $0.00017/compute-second, 3s default * 2 images.
+    expect(
+      estimateFalCost('xai/grok-imagine-image/quality/text-to-image', {
+        numImages: 2,
+      })
+    ).toBe(micros(1_020));
   });
 
-  test('Veo3.1 at 4K no audio ($0.40/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/veo3.1/image-to-video',
-      durationSeconds: 8,
-      audioEnabled: false,
-      resolution: '4K',
-    });
-    expect(cost).toBe(usd(3.2));
+  test('tokens estimate from resolution', () => {
+    expect(
+      estimateFalCost('bytedance/seedance-2.0/enterprise/v2/image-to-video', {
+        durationSeconds: 5,
+        resolution: '720p',
+      })
+    ).toBe(micros(1_587_600));
   });
 
-  test('Veo3.1 at 1080p no audio ($0.20/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/veo3.1/image-to-video',
-      durationSeconds: 8,
-      audioEnabled: false,
-      resolution: '1080p',
-    });
-    expect(cost).toBe(usd(1.6));
-  });
-
-  test('Kling v3 Pro audio off (0.8x multiplier)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/kling-video/v3/pro/image-to-video',
-      durationSeconds: 5,
-      audioEnabled: false,
-    });
-    // 140_000 * 0.8 = 112_000 per second, * 5 = 560_000
-    expect(cost).toBe(micros(560_000));
-  });
-
-  test('Kling v3 Pro audio on (1.2x multiplier)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/kling-video/v3/pro/image-to-video',
-      durationSeconds: 5,
-      audioEnabled: true,
-    });
-    // 140_000 * 1.2 = 168_000 per second, * 5 = 840_000
-    expect(cost).toBe(micros(840_000));
-  });
-
-  test('Kling v3 Pro voice control (1.4x multiplier)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/kling-video/v3/pro/image-to-video',
-      durationSeconds: 5,
-      audioEnabled: true,
-      voiceControl: true,
-    });
-    // 140_000 * 1.4 = 196_000 per second, * 5 = 980_000
-    expect(cost).toBe(micros(980_000));
-  });
-
-  test('LTX 2.3 simple per_second pricing ($0.08/s)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'fal-ai/ltx-2.3/image-to-video',
-      durationSeconds: 5,
-    });
-    // 80_000 * 5 = 400_000
-    expect(cost).toBe(micros(400_000));
-  });
-
-  test('Minimax Hailuo 2.3 Pro flat per-video pricing ($0.49, duration-independent)', () => {
-    const cost5s = calculateVideoCost({
-      endpointId: 'fal-ai/minimax/hailuo-2.3/pro/image-to-video',
-      durationSeconds: 5,
-    });
-    const cost10s = calculateVideoCost({
-      endpointId: 'fal-ai/minimax/hailuo-2.3/pro/image-to-video',
-      durationSeconds: 10,
-    });
-    // Flat fee — same cost regardless of requested duration
-    expect(cost5s).toBe(micros(490_000));
-    expect(cost10s).toBe(micros(490_000));
-  });
-
-  test('Grok Video 1.5 480p ($0.08/s + $0.01)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'xai/grok-imagine-video/v1.5/image-to-video',
-      durationSeconds: 6,
-      resolution: '480p',
-    });
-    // 80_000 * 6 + 10_000 = 490_000
-    expect(cost).toBe(micros(490_000));
-  });
-
-  test('Grok Video 1.5 720p ($0.14/s + $0.01)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'xai/grok-imagine-video/v1.5/image-to-video',
-      durationSeconds: 6,
-      resolution: '720p',
-    });
-    // 140_000 * 6 + 10_000 = 850_000
-    expect(cost).toBe(micros(850_000));
-  });
-
-  test('Seedance 2.0 per_token at 720p ($0.014/1k tokens)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'bytedance/seedance-2.0/enterprise/v2/image-to-video',
-      durationSeconds: 5,
-      resolution: '720p',
-    });
-    // tokens = 1280*720*24*5/1024 = 108_000 → 0.108M * 1.05 overhead = 0.1134M
-    // 14_000_000 * 0.1134 = 1_587_600 (~$0.32/s, matches fal's quoted $0.3024/s + overhead)
-    expect(cost).toBe(micros(1_587_600));
-  });
-
-  test('Seedance 2.0 per_token at 1080p ($0.014/1k tokens)', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'bytedance/seedance-2.0/enterprise/v2/image-to-video',
-      durationSeconds: 5,
-      resolution: '1080p',
-    });
-    // tokens = 1920*1080*24*5/1024 = 243_000 → 0.243M * 1.05 = 0.25515M
-    // 14_000_000 * 0.25515 = 3_572_100 (~$0.71/s, matches fal's quoted $0.682/s + overhead)
-    expect(cost).toBe(micros(3_572_100));
-  });
-
-  test('per_token explicit dimensions take precedence over resolution', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'bytedance/seedance-2.0/enterprise/v2/image-to-video',
-      durationSeconds: 5,
-      resolution: '720p',
-      widthPx: 1920,
-      heightPx: 1080,
-    });
-    expect(cost).toBe(micros(3_572_100));
-  });
-
-  test('unknown endpoint returns 0', () => {
-    const cost = calculateVideoCost({
-      endpointId: 'unknown/model',
-      durationSeconds: 5,
-    });
-    expect(cost).toBe(ZERO_MICROS);
-  });
-});
-
-describe('calculateAudioCost', () => {
-  test('ElevenLabs Music 30s (rounds to 1 min)', () => {
-    const cost = calculateAudioCost({
-      endpointId: 'fal-ai/elevenlabs/music',
-      durationSeconds: 30,
-    });
-    expect(cost).toBe(usd(0.8));
-  });
-
-  test('ElevenLabs Music 60s (exactly 1 min)', () => {
-    const cost = calculateAudioCost({
-      endpointId: 'fal-ai/elevenlabs/music',
-      durationSeconds: 60,
-    });
-    expect(cost).toBe(usd(0.8));
-  });
-
-  test('ElevenLabs Music 61s (rounds to 2 min)', () => {
-    const cost = calculateAudioCost({
-      endpointId: 'fal-ai/elevenlabs/music',
-      durationSeconds: 61,
-    });
-    expect(cost).toBe(usd(1.6));
-  });
-
-  test('ACE-Step per_second pricing', () => {
-    const cost = calculateAudioCost({
-      endpointId: 'fal-ai/ace-step/prompt-to-audio',
-      durationSeconds: 60,
-    });
-    // 200 micros * 60 = 12_000
-    expect(cost).toBe(micros(12_000));
-  });
-
-  test('ACE-Step 1.5 per_second pricing', () => {
-    const cost = calculateAudioCost({
-      endpointId: 'fal-ai/ace-step-1.5',
-      durationSeconds: 60,
-    });
-    // 300 * 60 = 18_000
-    expect(cost).toBe(micros(18_000));
-  });
-
-  test('unknown endpoint returns 0', () => {
-    const cost = calculateAudioCost({
-      endpointId: 'unknown/model',
-      durationSeconds: 60,
-    });
-    expect(cost).toBe(ZERO_MICROS);
+  test('unknown endpoint estimates nothing', () => {
+    expect(estimateFalCost('unknown/model', { numImages: 1 })).toBe(
+      ZERO_MICROS
+    );
   });
 });

--- a/src/lib/ai/fal-cost.ts
+++ b/src/lib/ai/fal-cost.ts
@@ -2,130 +2,27 @@ import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'ai', 'fal-cost']);
 /**
- * Type-safe fal.ai cost calculation with per-output-type pricing.
+ * Fal.ai cost calculation.
  *
- * Three domain-specific functions accept real generation parameters
- * instead of generic quantity/unit pairs. All return Microdollars.
+ * Billing is exact: fal reports the quantity it billed for a generation as
+ * `unitsBilled` (via the `x-fal-billable-units` header, surfaced by the TanStack
+ * AI adapter), denominated in the endpoint's priced unit. The cost is simply
+ * `unitsBilled * unitPrice` — fal already accounts for resolution, audio,
+ * duration, etc. in the unit count, so no per-model multipliers are needed.
+ *
+ * `estimateFalCost` predicts a cost BEFORE a generation runs (no `unitsBilled`
+ * yet) for the pre-flight credit gate. It is deliberately rough.
  */
 
-import {
-  IMAGE_PRICING,
-  VIDEO_PRICING,
-  AUDIO_PRICING,
-  type ImagePricing,
-  type VideoPricing,
-  type AudioPricing,
-} from '@/lib/ai/fal-pricing-data';
+import { FAL_PRICING } from '@/lib/ai/fal-pricing-data';
 import {
   type Microdollars,
   ZERO_MICROS,
   multiplyMicros,
-  addMicros,
 } from '@/lib/billing/money';
 
 /** Default compute time estimate for compute_seconds-priced models */
 const DEFAULT_COMPUTE_SECONDS = 3;
-
-// ============================================================================
-// Image Cost
-// ============================================================================
-
-export type ImageCostParams = {
-  endpointId: string;
-  numImages: number;
-  widthPx?: number;
-  heightPx?: number;
-  resolution?: '0.5K' | '1K' | '2K' | '4K';
-  style?: string;
-  quality?: string;
-  imageSize?: string;
-};
-
-export function calculateImageCost(params: ImageCostParams): Microdollars {
-  const pricing = IMAGE_PRICING[params.endpointId] as ImagePricing | undefined;
-  if (!pricing) {
-    logger.error(`No image pricing data for endpoint: ${params.endpointId}`);
-    return ZERO_MICROS;
-  }
-
-  // Quality/size matrix (e.g. GPT Image 1.5)
-  if (pricing.qualitySizeMatrix && params.quality && params.imageSize) {
-    const qualityPrices = pricing.qualitySizeMatrix[params.quality];
-    if (qualityPrices) {
-      const price = qualityPrices[params.imageSize];
-      if (price !== undefined) {
-        return multiplyMicros(price, params.numImages);
-      }
-    }
-    // Fall through to base price if matrix doesn't match
-  }
-
-  if (pricing.unit === 'per_megapixel') {
-    const w = params.widthPx ?? 1024;
-    const h = params.heightPx ?? 1024;
-    const megapixels = (w * h) / 1_000_000;
-    return multiplyMicros(pricing.basePrice, megapixels * params.numImages);
-  }
-
-  if (pricing.unit === 'per_compute_second') {
-    return multiplyMicros(
-      pricing.basePrice,
-      DEFAULT_COMPUTE_SECONDS * params.numImages
-    );
-  }
-
-  // per_image
-  let cost = multiplyMicros(pricing.basePrice, params.numImages);
-
-  // Apply resolution multiplier
-  if (pricing.resolutionMultipliers && params.resolution) {
-    const mult = pricing.resolutionMultipliers[params.resolution];
-    if (mult !== undefined) cost = multiplyMicros(cost, mult);
-  }
-
-  // Apply style multiplier
-  if (pricing.styleMultipliers && params.style) {
-    const mult = pricing.styleMultipliers[params.style];
-    if (mult !== undefined) cost = multiplyMicros(cost, mult);
-  }
-
-  return cost;
-}
-
-// ============================================================================
-// Video Cost
-// ============================================================================
-
-export type VideoCostParams = {
-  endpointId: string;
-  durationSeconds: number;
-  audioEnabled?: boolean;
-  voiceControl?: boolean;
-  resolution?: string;
-  widthPx?: number;
-  heightPx?: number;
-  fps?: number;
-};
-
-export function calculateVideoCost(params: VideoCostParams): Microdollars {
-  const pricing = VIDEO_PRICING[params.endpointId] as VideoPricing | undefined;
-  if (!pricing) {
-    logger.error(`No video pricing data for endpoint: ${params.endpointId}`);
-    return ZERO_MICROS;
-  }
-
-  if (pricing.mode === 'per_token') {
-    return calculateTokenBasedVideoCost(pricing, params);
-  }
-
-  // Flat per-video fee (e.g. MiniMax Hailuo 2.3): one price regardless of
-  // requested duration.
-  if (pricing.mode === 'flat') {
-    return pricing.basePrice;
-  }
-
-  return calculateSecondBasedVideoCost(pricing, params);
-}
 
 /** Assumed 16:9 output dimensions per resolution tier for token-priced models */
 const TOKEN_RESOLUTION_DIMENSIONS: Record<
@@ -137,97 +34,103 @@ const TOKEN_RESOLUTION_DIMENSIONS: Record<
   '1080p': { width: 1920, height: 1080 },
 };
 
-function calculateTokenBasedVideoCost(
-  pricing: Extract<VideoPricing, { mode: 'per_token' }>,
-  params: VideoCostParams
+// ============================================================================
+// Actual cost (billing) — unitsBilled * unitPrice
+// ============================================================================
+
+/**
+ * Exact fal cost for a completed generation: `unitsBilled * unitPrice`.
+ *
+ * Returns `ZERO_MICROS` and logs an error when pricing is missing or fal did
+ * not report `unitsBilled` — we charge nothing rather than guess, so a usage
+ * regression surfaces loudly instead of silently mis-billing.
+ */
+export function falCostFromUnits(
+  endpointId: string,
+  unitsBilled: number | undefined
 ): Microdollars {
-  const dims = params.resolution
-    ? TOKEN_RESOLUTION_DIMENSIONS[params.resolution]
-    : undefined;
-  const w = params.widthPx ?? dims?.width ?? 1920;
-  const h = params.heightPx ?? dims?.height ?? 1080;
-  const fps = params.fps ?? 24;
-  const tokens = (w * h * fps * params.durationSeconds) / 1024;
-  // Actual rendered frames slightly exceed nominal fps (~3% overhead)
-  const millionTokens = (tokens / 1_000_000) * 1.05;
-  return multiplyMicros(pricing.pricePerMillionTokens, millionTokens);
-}
-
-function calculateSecondBasedVideoCost(
-  pricing: Extract<VideoPricing, { mode: 'per_second' }>,
-  params: VideoCostParams
-): Microdollars {
-  let rate = pricing.basePrice;
-
-  // Resolution+audio matrix (e.g. Veo 3.1)
-  if (pricing.resolutionAudioPricing && params.resolution) {
-    const resPricing = pricing.resolutionAudioPricing[params.resolution];
-    if (resPricing) {
-      rate = params.audioEnabled ? resPricing.withAudio : resPricing.noAudio;
-      let cost = multiplyMicros(rate, params.durationSeconds);
-      if (pricing.surcharges?.imageInput) {
-        cost = addMicros(cost, pricing.surcharges.imageInput);
-      }
-      return cost;
-    }
+  const pricing = FAL_PRICING[endpointId];
+  if (!pricing) {
+    logger.error(`No fal pricing data for endpoint: ${endpointId}`);
+    return ZERO_MICROS;
   }
-
-  // Resolution-only pricing (e.g. Wan Flash, Grok Video)
-  if (pricing.resolutionPricing && params.resolution) {
-    const resRate = pricing.resolutionPricing[params.resolution];
-    if (resRate !== undefined) rate = resRate;
+  if (unitsBilled == null || !Number.isFinite(unitsBilled)) {
+    logger.error(
+      `No unitsBilled reported for ${endpointId} — charging nothing`,
+      { unitsBilled }
+    );
+    return ZERO_MICROS;
   }
-
-  // Audio/voice multipliers (e.g. Kling v3 Pro, Veo3)
-  if (params.voiceControl && pricing.voiceControlMultiplier) {
-    rate = multiplyMicros(pricing.basePrice, pricing.voiceControlMultiplier);
-  } else if (params.audioEnabled && pricing.audioMultiplier) {
-    rate = multiplyMicros(pricing.basePrice, pricing.audioMultiplier);
-  } else if (!params.audioEnabled && pricing.noAudioMultiplier) {
-    rate = multiplyMicros(pricing.basePrice, pricing.noAudioMultiplier);
-  }
-
-  let cost = multiplyMicros(rate, params.durationSeconds);
-
-  // Image input surcharge (e.g. Grok Video)
-  if (pricing.surcharges?.imageInput) {
-    cost = addMicros(cost, pricing.surcharges.imageInput);
-  }
-
-  return cost;
+  return multiplyMicros(pricing.unitPrice, unitsBilled);
 }
 
 // ============================================================================
-// Audio Cost
+// Pre-flight estimation — predicts a unit count from generation params
 // ============================================================================
 
-export type AudioCostParams = {
-  endpointId: string;
-  durationSeconds: number;
+export type FalCostEstimateParams = {
+  numImages?: number;
+  durationSeconds?: number;
+  widthPx?: number;
+  heightPx?: number;
+  fps?: number;
+  resolution?: string;
 };
 
-export function calculateAudioCost(params: AudioCostParams): Microdollars {
-  const pricing = AUDIO_PRICING[params.endpointId] as AudioPricing | undefined;
+/**
+ * Rough pre-flight cost estimate, used only for the credit-availability gate
+ * before a generation runs. Predicts the billed unit count from the requested
+ * parameters, then multiplies by `unitPrice`. Audio/resolution premiums are
+ * intentionally ignored — the exact charge comes from `falCostFromUnits` once
+ * fal reports `unitsBilled`.
+ */
+export function estimateFalCost(
+  endpointId: string,
+  params: FalCostEstimateParams
+): Microdollars {
+  const pricing = FAL_PRICING[endpointId];
   if (!pricing) {
-    logger.error(`No audio pricing data for endpoint: ${params.endpointId}`);
+    logger.error(`No fal pricing data for endpoint: ${endpointId}`);
     return ZERO_MICROS;
   }
 
-  if (pricing.roundUpToMinute) {
-    return multiplyMicros(
-      pricing.basePrice,
-      Math.ceil(params.durationSeconds / 60)
-    );
-  }
+  const numImages = params.numImages ?? 1;
+  const duration = params.durationSeconds ?? 0;
 
-  if (pricing.unit === 'per_second') {
-    return multiplyMicros(pricing.basePrice, params.durationSeconds);
-  }
+  switch (pricing.unit) {
+    case 'images':
+    case 'flat':
+      return multiplyMicros(pricing.unitPrice, numImages);
 
-  if (pricing.unit === 'per_minute') {
-    return multiplyMicros(pricing.basePrice, params.durationSeconds / 60);
-  }
+    case 'megapixels': {
+      const w = params.widthPx ?? 1024;
+      const h = params.heightPx ?? 1024;
+      const megapixels = (w * h) / 1_000_000;
+      return multiplyMicros(pricing.unitPrice, megapixels * numImages);
+    }
 
-  // per_compute_second
-  return multiplyMicros(pricing.basePrice, DEFAULT_COMPUTE_SECONDS);
+    case 'compute_seconds':
+      return multiplyMicros(
+        pricing.unitPrice,
+        DEFAULT_COMPUTE_SECONDS * numImages
+      );
+
+    case 'seconds':
+      return multiplyMicros(pricing.unitPrice, duration);
+
+    case 'minutes':
+      return multiplyMicros(pricing.unitPrice, Math.ceil(duration / 60));
+
+    case 'tokens': {
+      const dims = params.resolution
+        ? TOKEN_RESOLUTION_DIMENSIONS[params.resolution]
+        : undefined;
+      const w = params.widthPx ?? dims?.width ?? 1920;
+      const h = params.heightPx ?? dims?.height ?? 1080;
+      const fps = params.fps ?? 24;
+      // fal prices per 1000-token unit; ~5% overhead on nominal frames.
+      const units = ((w * h * fps * duration) / 1024 / 1000) * 1.05;
+      return multiplyMicros(pricing.unitPrice, units);
+    }
+  }
 }

--- a/src/lib/ai/fal-cost.ts
+++ b/src/lib/ai/fal-cost.ts
@@ -128,9 +128,16 @@ export function estimateFalCost(
       const w = params.widthPx ?? dims?.width ?? 1920;
       const h = params.heightPx ?? dims?.height ?? 1080;
       const fps = params.fps ?? 24;
-      // fal prices per 1000-token unit; ~5% overhead on nominal frames.
+      // fal derives tokens from pixels (≈ w·h·fps·sec / 1024) and prices per
+      // 1000-token unit; ~5% overhead on nominal frames.
       const units = ((w * h * fps * duration) / 1024 / 1000) * 1.05;
       return multiplyMicros(pricing.unitPrice, units);
+    }
+
+    default: {
+      // Exhaustiveness guard: a new FalUnit without a case fails to compile.
+      const _exhaustive: never = pricing.unit;
+      return _exhaustive;
     }
   }
 }

--- a/src/lib/ai/fal-pricing-data.ts
+++ b/src/lib/ai/fal-pricing-data.ts
@@ -1,292 +1,108 @@
 // AUTO-GENERATED — do not edit manually. Run: bun scripts/update-fal-pricing.ts
-// Manual overrides (multipliers, matrices) are maintained in scripts/update-fal-pricing.ts
+// The "units" disambiguation map is maintained in scripts/update-fal-pricing.ts
 
 import { type Microdollars, micros } from '@/lib/billing/money';
 
 // ============================================================================
-// Image Pricing (all prices in microdollars: 1 USD = 1,000,000)
+// Fal Pricing (all prices in microdollars: 1 USD = 1,000,000)
+//
+// `unitPrice` is fal's per-unit price, taken verbatim from the pricing API.
+// Actual cost = unitsBilled (from the adapter) * unitPrice. `unit` is the
+// billed unit, used only by pre-flight cost estimation.
 // ============================================================================
 
-type ImagePricingUnit = 'per_image' | 'per_megapixel' | 'per_compute_second';
+export type FalUnit =
+  | 'images'
+  | 'megapixels'
+  | 'compute_seconds'
+  | 'seconds'
+  | 'minutes'
+  | 'tokens'
+  | 'flat';
 
-export type ImagePricing = {
-  basePrice: Microdollars;
-  unit: ImagePricingUnit;
-  resolutionMultipliers?: Partial<Record<'0.5K' | '1K' | '2K' | '4K', number>>;
-  styleMultipliers?: Record<string, number>;
-  qualitySizeMatrix?: Record<string, Record<string, Microdollars>>;
-  surcharges?: { webSearch?: Microdollars };
-  pricingNotes?: string;
+export type FalPricing = {
+  unitPrice: Microdollars;
+  unit: FalUnit;
 };
 
-export const IMAGE_PRICING: Record<string, ImagePricing> = {
+export const FAL_PRICING: Record<string, FalPricing> = {
+  'bytedance/seedance-2.0/enterprise/v2/image-to-video': {
+    unitPrice: micros(14_000),
+    unit: 'tokens',
+  },
+  'fal-ai/ace-step-1.5': { unitPrice: micros(300), unit: 'seconds' },
+  'fal-ai/ace-step/prompt-to-audio': {
+    unitPrice: micros(200),
+    unit: 'seconds',
+  },
   'fal-ai/bytedance/seedream/v5/lite/edit': {
-    basePrice: micros(35_000),
-    unit: 'per_image',
+    unitPrice: micros(35_000),
+    unit: 'images',
   },
   'fal-ai/bytedance/seedream/v5/lite/text-to-image': {
-    basePrice: micros(35_000),
-    unit: 'per_image',
+    unitPrice: micros(35_000),
+    unit: 'images',
   },
-  'fal-ai/flux-2': {
-    basePrice: micros(1_670),
-    unit: 'per_compute_second',
-    pricingNotes:
-      '- **Price**: $0.012 per megapixels\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/flux-2-max': {
-    basePrice: micros(70_000),
-    unit: 'per_megapixel',
-  },
-  'fal-ai/flux-2-max/edit': {
-    basePrice: micros(70_000),
-    unit: 'per_image',
-  },
-  'fal-ai/flux-2/edit': {
-    basePrice: micros(1_670),
-    unit: 'per_compute_second',
-  },
-  'fal-ai/flux-2/turbo': {
-    basePrice: micros(8_000),
-    unit: 'per_megapixel',
-    pricingNotes:
-      '- **Price**: $0.008 per megapixels\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
+  'fal-ai/elevenlabs/music': { unitPrice: micros(800_000), unit: 'minutes' },
+  'fal-ai/flux-2': { unitPrice: micros(1_670), unit: 'compute_seconds' },
+  'fal-ai/flux-2-max': { unitPrice: micros(70_000), unit: 'megapixels' },
+  'fal-ai/flux-2-max/edit': { unitPrice: micros(70_000), unit: 'megapixels' },
+  'fal-ai/flux-2/edit': { unitPrice: micros(1_670), unit: 'compute_seconds' },
+  'fal-ai/flux-2/turbo': { unitPrice: micros(8_000), unit: 'megapixels' },
   'fal-ai/flux-2/turbo/edit': {
-    basePrice: micros(1_670),
-    unit: 'per_compute_second',
+    unitPrice: micros(1_670),
+    unit: 'compute_seconds',
   },
-  'fal-ai/hidream-i1-full': {
-    basePrice: micros(50_000),
-    unit: 'per_megapixel',
-    pricingNotes:
-      '- **Price**: $0.05 per megapixels\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
+  'fal-ai/hidream-i1-full': { unitPrice: micros(50_000), unit: 'megapixels' },
   'fal-ai/hunyuan-image/v3/instruct/edit': {
-    basePrice: micros(1_670),
-    unit: 'per_compute_second',
+    unitPrice: micros(1_670),
+    unit: 'compute_seconds',
   },
   'fal-ai/hunyuan-image/v3/text-to-image': {
-    basePrice: micros(100_000),
-    unit: 'per_megapixel',
-  },
-  'fal-ai/nano-banana-2': {
-    basePrice: micros(80_000),
-    unit: 'per_image',
-    resolutionMultipliers: {
-      '0.5K': 0.75,
-      '1K': 1,
-      '2K': 1.5,
-      '4K': 2,
-    },
-    surcharges: {
-      webSearch: micros(15_000),
-    },
-    pricingNotes:
-      'Your request will cost **$0.08** per image. For **$1.00**, you can run this model **12** times. 2K and 4K outputs will be charged at **1.5** times and **2** times the standard rate, respectively. 0.5K (512px) resolution outputs will be charged at **0.75** times the standard rate. If web search is used, an additional $0.015 will be charged. **Note: Pricing is subject to change.**\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/nano-banana-2/edit': {
-    basePrice: micros(80_000),
-    unit: 'per_image',
-    resolutionMultipliers: {
-      '0.5K': 0.75,
-      '1K': 1,
-      '2K': 1.5,
-      '4K': 2,
-    },
-    surcharges: {
-      webSearch: micros(15_000),
-    },
-    pricingNotes:
-      'Your request will cost **$0.08** per image. For **$1.00**, you can run this model **12** times. 2K and 4K outputs will be charged at **1.5** times and **2** times the standard rate, respectively. 0.5K (512px) resolution outputs will be charged at **0.75** times the standard rate. If web search is used, an additional $0.015 will be charged. **Note: Pricing is subject to change.**\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/nano-banana-pro': {
-    basePrice: micros(150_000),
-    unit: 'per_image',
-    resolutionMultipliers: {
-      '4K': 2,
-    },
-    surcharges: {
-      webSearch: micros(15_000),
-    },
-    pricingNotes:
-      'Your request will cost **$0.15** per image. For **$1.00**, you can run this model **7** times. 4K outputs will be charged at double the standard rate. If web search is used, an additional $0.015 will be charged. Note: Pricing may change in the future.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/nano-banana-pro/edit': {
-    basePrice: micros(150_000),
-    unit: 'per_image',
-    resolutionMultipliers: {
-      '4K': 2,
-    },
-    surcharges: {
-      webSearch: micros(15_000),
-    },
-    pricingNotes:
-      'Your request will cost **$0.15** per image. For **$1.00**, you can run this model **7** times. 4K outputs will be charged at double the standard rate. If web search is used, an additional $0.015 will be charged. Note: Pricing may change in the future.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/phota': {
-    basePrice: micros(90_000),
-    unit: 'per_image',
-  },
-  'fal-ai/phota/edit': {
-    basePrice: micros(90_000),
-    unit: 'per_image',
-  },
-  'fal-ai/qwen-image-2/pro/edit': {
-    basePrice: micros(75_000),
-    unit: 'per_image',
-  },
-  'fal-ai/qwen-image-2/pro/text-to-image': {
-    basePrice: micros(75_000),
-    unit: 'per_image',
-  },
-  'openai/gpt-image-2': {
-    basePrice: micros(1_000_000),
-    unit: 'per_image',
-  },
-  'openai/gpt-image-2/edit': {
-    basePrice: micros(1_000_000),
-    unit: 'per_image',
-  },
-  'xai/grok-imagine-image/quality/edit': {
-    basePrice: micros(170),
-    unit: 'per_compute_second',
-  },
-  'xai/grok-imagine-image/quality/text-to-image': {
-    basePrice: micros(170),
-    unit: 'per_compute_second',
-  },
-};
-
-// ============================================================================
-// Video Pricing (all prices in microdollars: 1 USD = 1,000,000)
-// ============================================================================
-
-type VideoPricingBase = { pricingNotes?: string };
-
-type VideoPricingPerSecond = VideoPricingBase & {
-  mode: 'per_second';
-  basePrice: Microdollars;
-  noAudioMultiplier?: number;
-  audioMultiplier?: number;
-  voiceControlMultiplier?: number;
-  resolutionPricing?: Record<string, Microdollars>;
-  resolutionAudioPricing?: Record<
-    string,
-    { noAudio: Microdollars; withAudio: Microdollars }
-  >;
-  surcharges?: { imageInput?: Microdollars };
-};
-
-type VideoPricingPerToken = VideoPricingBase & {
-  mode: 'per_token';
-  pricePerMillionTokens: Microdollars;
-};
-
-type VideoPricingFlat = VideoPricingBase & {
-  mode: 'flat';
-  basePrice: Microdollars;
-};
-
-export type VideoPricing =
-  | VideoPricingPerSecond
-  | VideoPricingPerToken
-  | VideoPricingFlat;
-
-export const VIDEO_PRICING: Record<string, VideoPricing> = {
-  'bytedance/seedance-2.0/enterprise/v2/image-to-video': {
-    mode: 'per_token',
-    pricePerMillionTokens: micros(14_000_000),
-    pricingNotes:
-      'Your request will cost **$0.014 per 1000 tokens**. The number of tokens is given by (height of output video * width of output video * duration * 24) / 1024 — about **$0.30/second** at 720p. Audio generation does not change the price.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
+    unitPrice: micros(100_000),
+    unit: 'megapixels',
   },
   'fal-ai/kling-video/v3/pro/image-to-video': {
-    mode: 'per_second',
-    basePrice: micros(140_000),
-    noAudioMultiplier: 0.8,
-    audioMultiplier: 1.2,
-    voiceControlMultiplier: 1.4,
-    pricingNotes:
-      'For every second of video you generated, you will be charged **$0.112** (audio off) or **$0.168** (audio on), if voice control is used while generating audio you will be charged **$0.196**. For example, a 5s video with audio on and voice control will cost **$0.98**\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
+    unitPrice: micros(140_000),
+    unit: 'seconds',
   },
   'fal-ai/ltx-2.3/image-to-video': {
-    mode: 'per_second',
-    basePrice: micros(80_000),
+    unitPrice: micros(80_000),
+    unit: 'seconds',
   },
   'fal-ai/minimax/hailuo-2.3/pro/image-to-video': {
-    mode: 'flat',
-    basePrice: micros(490_000),
-    pricingNotes:
-      'Your request will cost **$0.49** per video generation (flat fee, independent of duration).\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
+    unitPrice: micros(490_000),
+    unit: 'flat',
+  },
+  'fal-ai/nano-banana-2': { unitPrice: micros(80_000), unit: 'images' },
+  'fal-ai/nano-banana-2/edit': { unitPrice: micros(80_000), unit: 'images' },
+  'fal-ai/nano-banana-pro': { unitPrice: micros(150_000), unit: 'images' },
+  'fal-ai/nano-banana-pro/edit': { unitPrice: micros(150_000), unit: 'images' },
+  'fal-ai/phota': { unitPrice: micros(90_000), unit: 'images' },
+  'fal-ai/phota/edit': { unitPrice: micros(90_000), unit: 'images' },
+  'fal-ai/qwen-image-2/pro/edit': { unitPrice: micros(75_000), unit: 'images' },
+  'fal-ai/qwen-image-2/pro/text-to-image': {
+    unitPrice: micros(75_000),
+    unit: 'images',
   },
   'fal-ai/veo3.1/image-to-video': {
-    mode: 'per_second',
-    basePrice: micros(400_000),
-    resolutionAudioPricing: {
-      '720p': {
-        noAudio: micros(200_000),
-        withAudio: micros(400_000),
-      },
-      '1080p': {
-        noAudio: micros(200_000),
-        withAudio: micros(400_000),
-      },
-      '4K': {
-        noAudio: micros(400_000),
-        withAudio: micros(600_000),
-      },
-    },
-    pricingNotes:
-      'For every second of video you generate you will be charged **$0.20** without audio or **$0.40** with audio for 720p or 1080p. At 4k, you will be charged **$0.40** per second without audio, or **$0.60** with. For example, a **5 second video** at **1080p** with **audio on** will cost **$2.00**.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
+    unitPrice: micros(400_000),
+    unit: 'seconds',
+  },
+  'openai/gpt-image-2': { unitPrice: micros(1_000_000), unit: 'images' },
+  'openai/gpt-image-2/edit': { unitPrice: micros(1_000_000), unit: 'images' },
+  'xai/grok-imagine-image/quality/edit': {
+    unitPrice: micros(170),
+    unit: 'compute_seconds',
+  },
+  'xai/grok-imagine-image/quality/text-to-image': {
+    unitPrice: micros(170),
+    unit: 'compute_seconds',
   },
   'xai/grok-imagine-video/v1.5/image-to-video': {
-    mode: 'per_second',
-    basePrice: micros(10_000),
-    resolutionPricing: {
-      '480p': micros(80_000),
-      '720p': micros(140_000),
-    },
-    surcharges: {
-      imageInput: micros(10_000),
-    },
-    pricingNotes:
-      'A 6s 480p video will cost **$0.49** (**$0.08** per second of 480p video + **$0.01** for image input). At an output resolution of 480p, every second costs **$0.08**, and at 720p, every second costs **$0.14**.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
+    unitPrice: micros(10_000),
+    unit: 'seconds',
   },
 };
 
-// ============================================================================
-// Audio Pricing (all prices in microdollars: 1 USD = 1,000,000)
-// ============================================================================
-
-type AudioPricingUnit = 'per_second' | 'per_minute' | 'per_compute_second';
-
-export type AudioPricing = {
-  basePrice: Microdollars;
-  unit: AudioPricingUnit;
-  roundUpToMinute?: boolean;
-  pricingNotes?: string;
-};
-
-export const AUDIO_PRICING: Record<string, AudioPricing> = {
-  'fal-ai/ace-step-1.5': {
-    basePrice: micros(300),
-    unit: 'per_second',
-    pricingNotes:
-      'Your request will cost $0.0003 per output second.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/ace-step/prompt-to-audio': {
-    basePrice: micros(200),
-    unit: 'per_second',
-    pricingNotes:
-      'Your request will cost $0.0002 per second of generated audio. For $1 you can run generate 5000 seconds (83 minutes) of music from lyrics.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-  'fal-ai/elevenlabs/music': {
-    basePrice: micros(800_000),
-    unit: 'per_minute',
-    roundUpToMinute: true,
-    pricingNotes:
-      'Your request will cost **$0.8** per output audio minute. The audio will be **rounded up** to the closest minute. For instance, a generation with 30 seconds output will be billed as 1 minute.\n\nFor more details, see [fal.ai pricing](https://fal.ai/pricing).',
-  },
-};
-
-export const PRICING_LAST_UPDATED = '2026-06-18T00:37:23.432Z';
+export const PRICING_LAST_UPDATED = '2026-06-18T02:03:11.319Z';

--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -1,3 +1,5 @@
+import { usdToMicros, ZERO_MICROS } from '@/lib/billing/money';
+import type { TokenUsage } from '@tanstack/ai';
 import { convertWebSearchToolToAdapterFormat } from '@tanstack/ai-openrouter/tools';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
@@ -30,7 +32,15 @@ vi.doMock('./create-adapter', () => ({
 // Dynamic import so vi.doMock above is in effect when llm-client (and its
 // `./create-adapter` import) resolves. Static imports are hoisted above
 // vi.doMock and would bypass the mocks.
-const { callLLM, callLLMStream } = await import('./llm-client');
+const { callLLM, callLLMStream, llmCostFromUsage } =
+  await import('./llm-client');
+
+const usage = (cost?: number): TokenUsage => ({
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+  cost,
+});
 
 describe('llm-client', () => {
   beforeEach(() => {
@@ -599,6 +609,24 @@ describe('llm-client', () => {
           responseSchema: schema,
         })
       ).rejects.toThrow(/no validated object/);
+    });
+  });
+
+  describe('llmCostFromUsage', () => {
+    it('charges the provider-reported cost (USD → micros)', () => {
+      expect(llmCostFromUsage(usage(0.0123), 'model')).toBe(
+        usdToMicros(0.0123)
+      );
+    });
+
+    it('charges nothing when usage or cost is missing / non-finite', () => {
+      expect(llmCostFromUsage(undefined, 'model')).toBe(ZERO_MICROS);
+      expect(llmCostFromUsage(usage(undefined), 'model')).toBe(ZERO_MICROS);
+      expect(llmCostFromUsage(usage(Number.NaN), 'model')).toBe(ZERO_MICROS);
+    });
+
+    it('treats explicit zero cost as zero', () => {
+      expect(llmCostFromUsage(usage(0), 'model')).toBe(ZERO_MICROS);
     });
   });
 });

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -4,8 +4,13 @@
  */
 
 import type { TextModel } from '@/lib/ai/models';
+import {
+  usdToMicros,
+  ZERO_MICROS,
+  type Microdollars,
+} from '@/lib/billing/money';
 import type { ChatMessage } from '@/lib/prompts';
-import { chat, type DebugOption } from '@tanstack/ai';
+import { chat, type DebugOption, type TokenUsage } from '@tanstack/ai';
 import type { ProviderPreferences } from '@tanstack/ai-openrouter';
 import { webSearchTool } from '@tanstack/ai-openrouter/tools';
 import { z } from 'zod';
@@ -15,6 +20,30 @@ import { createAdapter, type LlmKeyInfo } from './create-adapter';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'ai', 'llm-client']);
+
+/**
+ * Convert a completed LLM call's usage into a charge. OpenRouter reports an
+ * authoritative per-request `cost` (USD) on every response; we charge that raw
+ * cost (markup is applied downstream in `deductCredits`). Logs and charges
+ * nothing when no cost was reported, surfacing the gap rather than guessing.
+ */
+export function llmCostFromUsage(
+  usage: TokenUsage | undefined,
+  modelId: string
+): Microdollars {
+  if (
+    !usage ||
+    typeof usage.cost !== 'number' ||
+    !Number.isFinite(usage.cost)
+  ) {
+    logger.error(
+      `No usage cost reported for LLM call (${modelId}) — charging nothing`,
+      { usage }
+    );
+    return ZERO_MICROS;
+  }
+  return usdToMicros(usage.cost);
+}
 
 export type StreamChunk<T = never> =
   | { done: false; delta: string; accumulated: string }
@@ -28,6 +57,12 @@ export type StreamChunk<T = never> =
        * (undefined when the stream ended without a `structured-output.complete` event).
        */
       parsed: T | undefined;
+      /**
+       * Provider-reported usage for the call (OpenRouter carries `cost`).
+       * `undefined` when the adapter reported none. Pass to `llmCostFromUsage`
+       * to bill the call.
+       */
+      usage: TokenUsage | undefined;
     };
 
 export type LLMRequestParams<T = unknown> = {
@@ -482,6 +517,7 @@ export async function* callLLMStream<T>(
 ): AsyncGenerator<StreamChunk<T>> {
   let accumulated = '';
   let parsed: T | undefined;
+  let usage: TokenUsage | undefined;
 
   const baseOptions = {
     ...baseChatOptions(params),
@@ -490,6 +526,15 @@ export async function* callLLMStream<T>(
       ...buildModelOptions(params),
       streamOptions: { includeUsage: true },
     },
+    // Capture the terminal usage (carries OpenRouter's `cost`) so callers can
+    // bill the call via `llmCostFromUsage`.
+    middleware: [
+      {
+        onFinish: (_ctx: unknown, info: { usage?: TokenUsage }) => {
+          usage = info.usage;
+        },
+      },
+    ],
     stream: true as const,
   };
 
@@ -534,5 +579,5 @@ export async function* callLLMStream<T>(
     }
   }
 
-  yield { delta: '', accumulated, done: true, parsed };
+  yield { delta: '', accumulated, done: true, parsed, usage };
 }

--- a/src/lib/audio/music-generation.ts
+++ b/src/lib/audio/music-generation.ts
@@ -1,5 +1,5 @@
 import { getEnv } from '#env';
-import { calculateAudioCost } from '@/lib/ai/fal-cost';
+import { falCostFromUnits } from '@/lib/ai/fal-cost';
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
 import {
   AUDIO_MODELS,
@@ -202,10 +202,8 @@ async function callFalAudio(
     throw new Error('No audio URL returned from music generation');
   }
 
-  const cost = calculateAudioCost({
-    endpointId: modelConfig.id,
-    durationSeconds: billedDuration,
-  });
+  // Exact cost from fal's reported billed units.
+  const cost = falCostFromUnits(modelConfig.id, result.usage?.unitsBilled);
 
   return {
     success: true,

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -4,11 +4,7 @@
  * All functions return Microdollars for exact arithmetic.
  */
 
-import {
-  calculateAudioCost,
-  calculateImageCost,
-  calculateVideoCost,
-} from '@/lib/ai/fal-cost';
+import { estimateFalCost } from '@/lib/ai/fal-cost';
 import {
   AUDIO_MODELS,
   IMAGE_MODELS,
@@ -16,56 +12,41 @@ import {
   type AudioModel,
   type ImageToVideoModel,
   type TextToImageModel,
-  videoModelSupportsAudio,
 } from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { aspectRatioToDimensions } from '@/lib/constants/aspect-ratios';
 import { type Microdollars, addMicros, micros, multiplyMicros } from './money';
 
 /**
- * Estimate the raw cost (before markup) of generating images
+ * Estimate the raw cost (before markup) of generating images. Rough pre-flight
+ * gate only — the exact charge comes from fal's reported units post-generation.
  */
 export function estimateImageCost(
   model: TextToImageModel,
   aspectRatio: AspectRatio,
   numImages: number,
-  opts?: {
-    resolution?: '0.5K' | '1K' | '2K' | '4K';
-    style?: string;
-    quality?: string;
-    imageSize?: string;
-  }
+  opts?: { resolution?: string }
 ): Microdollars {
-  const endpointId = IMAGE_MODELS[model].id;
   const { width, height } = aspectRatioToDimensions(aspectRatio);
 
-  return calculateImageCost({
-    endpointId,
+  return estimateFalCost(IMAGE_MODELS[model].id, {
     numImages,
     widthPx: width,
     heightPx: height,
     resolution: opts?.resolution,
-    style: opts?.style,
-    quality: opts?.quality,
-    imageSize: opts?.imageSize,
   });
 }
 
 /**
- * Estimate the raw cost (before markup) of generating video
+ * Estimate the raw cost (before markup) of generating video.
  */
 export function estimateVideoCost(
   model: ImageToVideoModel,
   durationSeconds: number,
-  opts?: { audioEnabled?: boolean; resolution?: string }
+  opts?: { resolution?: string }
 ): Microdollars {
-  const modelConfig = IMAGE_TO_VIDEO_MODELS[model];
-  const endpointId = modelConfig.id;
-
-  return calculateVideoCost({
-    endpointId,
+  return estimateFalCost(IMAGE_TO_VIDEO_MODELS[model].id, {
     durationSeconds,
-    audioEnabled: opts?.audioEnabled ?? videoModelSupportsAudio(model),
     resolution: opts?.resolution,
   });
 }
@@ -77,10 +58,7 @@ export function estimateAudioCost(
   model: AudioModel,
   durationSeconds: number
 ): Microdollars {
-  return calculateAudioCost({
-    endpointId: AUDIO_MODELS[model].id,
-    durationSeconds,
-  });
+  return estimateFalCost(AUDIO_MODELS[model].id, { durationSeconds });
 }
 
 /**

--- a/src/lib/billing/workflow-deduction.ts
+++ b/src/lib/billing/workflow-deduction.ts
@@ -70,8 +70,8 @@ export async function deductWorkflowCredits(
 
 /**
  * Extract the cost from a fal.ai generation result's metadata.
- * Returns ZERO_MICROS if missing. Cost is already in Microdollars
- * from calculateImageCost/calculateVideoCost/calculateAudioCost.
+ * Returns ZERO_MICROS if missing. Cost is already in Microdollars,
+ * computed from fal's reported billed units (see `falCostFromUnits`).
  */
 export function extractImageCost(metadata: {
   cost?: Microdollars;

--- a/src/lib/image/image-generation.ts
+++ b/src/lib/image/image-generation.ts
@@ -1,4 +1,4 @@
-import { calculateImageCost } from '@/lib/ai/fal-cost';
+import { falCostFromUnits } from '@/lib/ai/fal-cost';
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
 import {
   getEditEndpoint,
@@ -237,22 +237,9 @@ async function generateImageInternal(
 
   const processingTimeMs = Date.now() - startTime;
 
-  const imageSize = params.imageSize ?? DEFAULT_IMAGE_SIZE;
-  const dims = IMAGE_SIZE_DIMENSIONS[imageSize];
-  const sizeMap: Record<ImageSize, string> = {
-    square_hd: '1024x1024',
-    portrait_16_9: '1024x1536',
-    landscape_16_9: '1536x1024',
-  };
-  const cost = calculateImageCost({
-    endpointId: endpoint,
-    numImages: imageUrls.length,
-    widthPx: dims.width,
-    heightPx: dims.height,
-    resolution: params.resolution,
-    style: params.style,
-    imageSize: sizeMap[imageSize],
-  });
+  // Exact cost from fal's reported billed units (resolution/style premiums are
+  // already baked into the count by fal).
+  const cost = falCostFromUnits(endpoint, result.usage?.unitsBilled);
 
   return {
     imageUrls,
@@ -440,13 +427,3 @@ function buildFalModelOptions(
     }
   }
 }
-
-/** Pixel dimensions for megapixel-based cost calculation */
-const IMAGE_SIZE_DIMENSIONS: Record<
-  ImageSize,
-  { width: number; height: number }
-> = {
-  square_hd: { width: 1024, height: 1024 },
-  portrait_16_9: { width: 576, height: 1024 },
-  landscape_16_9: { width: 1344, height: 768 },
-};

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -1,10 +1,9 @@
 import { getEnv } from '#env';
-import { calculateVideoCost } from '@/lib/ai/fal-cost';
+import { estimateFalCost } from '@/lib/ai/fal-cost';
 import {
   DEFAULT_VIDEO_MODEL,
   IMAGE_TO_VIDEO_MODELS,
   type ImageToVideoModel,
-  videoModelSupportsAudio,
 } from '@/lib/ai/models';
 import type { Microdollars } from '@/lib/billing/money';
 import { type AspectRatio } from '@/lib/constants/aspect-ratios';
@@ -159,7 +158,9 @@ export async function pollMotionJob(
 }
 
 /**
- * Calculate motion cost + metadata after job completes.
+ * Pre-flight motion cost estimate + metadata, computed before the job runs.
+ * `cost` is a rough estimate used for the credit-availability gate — the exact
+ * charge comes from `falCostFromUnits` once fal reports `unitsBilled`.
  */
 export function calculateMotionMetadata(options: GenerateMotionOptions): {
   cost: Microdollars;
@@ -173,12 +174,8 @@ export function calculateMotionMetadata(options: GenerateMotionOptions): {
   const validatedDuration = snapDuration(options.duration, modelKey);
 
   const providerInput = buildModelInput(options, modelConfig, modelKey);
-  const audioEnabled =
-    videoModelSupportsAudio(modelKey) && options.generateAudio !== false;
-  const cost = calculateVideoCost({
-    endpointId: modelConfig.id,
+  const cost = estimateFalCost(modelConfig.id, {
     durationSeconds: validatedDuration,
-    audioEnabled,
     resolution:
       'resolution' in providerInput &&
       typeof providerInput.resolution === 'string'

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -17,7 +17,11 @@ import {
 import type { TextModel } from '@/lib/ai/models';
 import { getContextWindow } from '@/lib/ai/models.config';
 import { extractStreamingStringField } from '@/lib/ai/stream-extract';
-import { ZERO_MICROS } from '@/lib/billing/money';
+import {
+  usdToMicros,
+  ZERO_MICROS,
+  type Microdollars,
+} from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { getLogger } from '@/lib/observability/logger';
@@ -28,12 +32,37 @@ import {
 } from '@/lib/prompts';
 import { getFramePromptChannel } from '@/lib/realtime';
 import { toVisionImageSource } from '@/lib/storage/external-url';
-import { chat } from '@tanstack/ai';
+import { chat, type TokenUsage } from '@tanstack/ai';
 import type { WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
 import type { z } from 'zod';
 
 const logger = getLogger(['openstory', 'workflow', 'llm-call-helper']);
+
+/**
+ * Convert a completed LLM call's usage into a charge. OpenRouter reports an
+ * authoritative per-request `cost` (USD) on every response; we charge that raw
+ * cost (markup is applied downstream in `deductCredits`). Logs and charges
+ * nothing when no cost was reported (e.g. a provider that doesn't surface it),
+ * surfacing the gap rather than guessing.
+ */
+function llmCostFromUsage(
+  usage: TokenUsage | undefined,
+  modelId: string
+): Microdollars {
+  if (
+    !usage ||
+    typeof usage.cost !== 'number' ||
+    !Number.isFinite(usage.cost)
+  ) {
+    logger.error(
+      `No usage cost reported for LLM call (${modelId}) — charging nothing`,
+      { usage }
+    );
+    return ZERO_MICROS;
+  }
+  return usdToMicros(usage.cost);
+}
 
 export type DurableLLMCallConfig<TSchema extends z.ZodType> = {
   name: string;
@@ -224,74 +253,89 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
   const llmKeyInfo = await resolveCallKey(callContext);
 
   // Step 2: Durable LLM call. JSON-stringifies the parsed object so CF's
-  // Rpc.Serializable<T> check passes regardless of the Zod-inferred shape.
-  const jsonText = await step.do(name, async (): Promise<string> => {
-    const adapter = createAdapter(modelId, llmKeyInfo);
+  // Rpc.Serializable<T> check passes regardless of the Zod-inferred shape, and
+  // carries the provider-reported cost across the step boundary for deduction.
+  const { jsonText, costMicros } = await step.do(
+    name,
+    async (): Promise<{ jsonText: string; costMicros: Microdollars }> => {
+      const adapter = createAdapter(modelId, llmKeyInfo);
 
-    // Refetch prompt inside the LLM step — promptReference can't cross the
-    // step boundary (not Rpc.Serializable).
-    const { prompt: promptReference } = await getChatPrompt(
-      config.promptName,
-      config.promptVariables
-    );
+      // Refetch prompt inside the LLM step — promptReference can't cross the
+      // step boundary (not Rpc.Serializable).
+      const { prompt: promptReference } = await getChatPrompt(
+        config.promptName,
+        config.promptVariables
+      );
 
-    logger.info(`[LLM:${logName}:cf] Starting call`, {
-      model: modelId,
-      keySource: llmKeyInfo.source,
-      keyVia: llmKeyInfo.via,
-      messageCount: messages.length,
-    });
-
-    const visionImageSources = await resolveVisionImageSources(
-      config.visionImageUrls
-    );
-    const { systemPrompts, chatMessages } = buildChatMessages(
-      messages,
-      visionImageSources
-    );
-
-    const abortController = new AbortController();
-    const timeout = setTimeout(() => abortController.abort(), 300_000);
-
-    try {
-      const text = await chat({
-        adapter,
-        messages: chatMessages,
-        systemPrompts: systemPrompts,
-        stream: false,
-        abortController,
-        modelOptions: {
-          ...reasoningModelOptions(config.reasoning),
-          maxCompletionTokens: Math.floor(
-            getContextWindow(config.modelId) * 0.5
-          ),
-        },
-        metadata: {
-          observationName: logName,
-          prompt: promptReference,
-          tags: logTags,
-          metadata: logMetadata,
-          sessionId: callContext.sequenceId,
-          userId: callContext.userId,
-        },
-        outputSchema: config.responseSchema,
-        debug: false,
+      logger.info(`[LLM:${logName}:cf] Starting call`, {
+        model: modelId,
+        keySource: llmKeyInfo.source,
+        keyVia: llmKeyInfo.via,
+        messageCount: messages.length,
       });
-      logger.info(`[LLM:${logName}:cf] Call succeeded`);
-      // Return as JSON string — round-trips through step.do without hitting
-      // CF's Rpc.Serializable constraint on the Zod-inferred shape.
-      return JSON.stringify(text);
-    } finally {
-      clearTimeout(timeout);
+
+      const visionImageSources = await resolveVisionImageSources(
+        config.visionImageUrls
+      );
+      const { systemPrompts, chatMessages } = buildChatMessages(
+        messages,
+        visionImageSources
+      );
+
+      const abortController = new AbortController();
+      const timeout = setTimeout(() => abortController.abort(), 300_000);
+
+      let capturedUsage: TokenUsage | undefined;
+      try {
+        const text = await chat({
+          adapter,
+          messages: chatMessages,
+          systemPrompts: systemPrompts,
+          stream: false,
+          abortController,
+          modelOptions: {
+            ...reasoningModelOptions(config.reasoning),
+            maxCompletionTokens: Math.floor(
+              getContextWindow(config.modelId) * 0.5
+            ),
+          },
+          metadata: {
+            observationName: logName,
+            prompt: promptReference,
+            tags: logTags,
+            metadata: logMetadata,
+            sessionId: callContext.sequenceId,
+            userId: callContext.userId,
+          },
+          outputSchema: config.responseSchema,
+          middleware: [
+            {
+              onFinish: (_ctx, info) => {
+                capturedUsage = info.usage;
+              },
+            },
+          ],
+          debug: false,
+        });
+        logger.info(`[LLM:${logName}:cf] Call succeeded`);
+        // Return as JSON string — round-trips through step.do without hitting
+        // CF's Rpc.Serializable constraint on the Zod-inferred shape.
+        return {
+          jsonText: JSON.stringify(text),
+          costMicros: llmCostFromUsage(capturedUsage, modelId),
+        };
+      } finally {
+        clearTimeout(timeout);
+      }
     }
-  });
+  );
 
   if (callContext.scopedDb) {
     const scopedDb = callContext.scopedDb;
     await step.do(`deduct-llm-credits-${name}`, async () => {
       await deductWorkflowCredits({
         scopedDb,
-        costMicros: ZERO_MICROS,
+        costMicros,
         usedOwnKey: llmKeyInfo.source === 'team',
         description: `LLM analysis (${modelId})`,
         idempotencyKey: `${callContext.workflowRunId}:llm-${name}`,
@@ -301,6 +345,7 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
           phaseName: phase.name,
           stepName: name,
           sequenceId: callContext.sequenceId,
+          costMicros,
         },
       });
     });
@@ -348,9 +393,9 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
 
   const llmKeyInfo = await resolveCallKey(callContext);
 
-  const jsonText = await step.do(
+  const { jsonText, costMicros } = await step.do(
     `${name}-stream`,
-    async (): Promise<string> => {
+    async (): Promise<{ jsonText: string; costMicros: Microdollars }> => {
       const adapter = createAdapter(modelId, llmKeyInfo);
       const { prompt: promptReference } = await getChatPrompt(
         config.promptName,
@@ -382,6 +427,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
       let lastExtracted = '';
       let pendingDelta = '';
       let lastEmitAt = 0;
+      let capturedUsage: TokenUsage | undefined;
 
       const flushDelta = async () => {
         if (!pendingDelta) return;
@@ -413,6 +459,13 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
             userId: callContext.userId,
           },
           outputSchema: config.responseSchema,
+          middleware: [
+            {
+              onFinish: (_ctx, info) => {
+                capturedUsage = info.usage;
+              },
+            },
+          ],
           debug: false,
         })) {
           if (
@@ -440,7 +493,10 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
         }
         await flushDelta();
         logger.info(`[LLM:${logName}:cf] Streaming call succeeded`);
-        return accumulated;
+        return {
+          jsonText: accumulated,
+          costMicros: llmCostFromUsage(capturedUsage, modelId),
+        };
       } finally {
         clearTimeout(timeout);
       }
@@ -452,7 +508,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
     await step.do(`deduct-llm-credits-${name}`, async () => {
       await deductWorkflowCredits({
         scopedDb,
-        costMicros: ZERO_MICROS,
+        costMicros,
         usedOwnKey: llmKeyInfo.source === 'team',
         description: `LLM analysis (${modelId})`,
         idempotencyKey: `${callContext.workflowRunId}:llm-${name}`,
@@ -462,6 +518,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
           phaseName: phase.name,
           stepName: name,
           sequenceId: callContext.sequenceId,
+          costMicros,
         },
       });
     });

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -12,16 +12,13 @@ import { createAdapter, getPlatformLlmKey } from '@/lib/ai/create-adapter';
 import {
   extractRunError,
   formatRunErrorMessage,
+  llmCostFromUsage,
   PROMPT_REASONING,
 } from '@/lib/ai/llm-client';
 import type { TextModel } from '@/lib/ai/models';
 import { getContextWindow } from '@/lib/ai/models.config';
 import { extractStreamingStringField } from '@/lib/ai/stream-extract';
-import {
-  usdToMicros,
-  ZERO_MICROS,
-  type Microdollars,
-} from '@/lib/billing/money';
+import type { Microdollars } from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { getLogger } from '@/lib/observability/logger';
@@ -38,31 +35,6 @@ import { NonRetryableError } from 'cloudflare:workflows';
 import type { z } from 'zod';
 
 const logger = getLogger(['openstory', 'workflow', 'llm-call-helper']);
-
-/**
- * Convert a completed LLM call's usage into a charge. OpenRouter reports an
- * authoritative per-request `cost` (USD) on every response; we charge that raw
- * cost (markup is applied downstream in `deductCredits`). Logs and charges
- * nothing when no cost was reported (e.g. a provider that doesn't surface it),
- * surfacing the gap rather than guessing.
- */
-function llmCostFromUsage(
-  usage: TokenUsage | undefined,
-  modelId: string
-): Microdollars {
-  if (
-    !usage ||
-    typeof usage.cost !== 'number' ||
-    !Number.isFinite(usage.cost)
-  ) {
-    logger.error(
-      `No usage cost reported for LLM call (${modelId}) — charging nothing`,
-      { usage }
-    );
-    return ZERO_MICROS;
-  }
-  return usdToMicros(usage.cost);
-}
 
 export type DurableLLMCallConfig<TSchema extends z.ZodType> = {
   name: string;

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -22,6 +22,7 @@ import {
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
 import { computeMotionPromptInputHash } from '@/lib/ai/input-hash';
+import { falCostFromUnits } from '@/lib/ai/fal-cost';
 import { DEFAULT_VIDEO_MODEL, IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
 import { loadNarrowFramePromptContext } from '@/lib/ai/prompt-context';
 import { microsToUsd, type Microdollars } from '@/lib/billing/money';
@@ -79,7 +80,7 @@ const MAX_MOTION_ATTEMPTS = 3;
  *  whole submit→poll cycle; a non-content `failed` is a hard stop as today. */
 type MotionPollOutcome =
   | { kind: 'pending' }
-  | { kind: 'completed'; url: string }
+  | { kind: 'completed'; url: string; unitsBilled?: number }
   | { kind: 'rejected'; rejection: string }
   | { kind: 'failed'; error: string };
 
@@ -148,8 +149,10 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
       );
     }
 
-    // Step 0: Get cost and check if team has enough credits
-    const { cost, duration } = await step.do('check-credits', async () => {
+    // Step 0: Estimate cost and check the team can afford it. The estimate only
+    // gates affordability — the exact charge is computed from fal's billed
+    // units after the clip completes (see actualCost below).
+    const { duration } = await step.do('check-credits', async () => {
       const { cost, duration } = calculateMotionMetadata({
         imageUrl: input.imageUrl,
         prompt: input.prompt,
@@ -329,6 +332,9 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // exhausts its budget fails only its own slot — motion-batch's
     // Promise.allSettled keeps sibling clips and the sequence alive.
     let videoUrl = '';
+    // Real quantity fal billed for the clip that succeeded — drives the exact
+    // credit deduction below (the check-credits estimate only gates affordability).
+    let billedUnits: number | undefined;
     let lastRejection: string | null = null;
     // The job behind the clip that ultimately succeeded — its `submittedAt` /
     // `usedOwnKey` drive observation timing and credit deduction below.
@@ -454,7 +460,11 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
               if (pollResult.status === 'completed') {
                 if (pollResult.url) {
                   logger.info(`[MotionWorkflow:cf] Generation completed`);
-                  return { kind: 'completed', url: pollResult.url };
+                  return {
+                    kind: 'completed',
+                    url: pollResult.url,
+                    unitsBilled: pollResult.usage?.unitsBilled,
+                  };
                 }
                 return classifyMotionFailure(
                   pollResult.error || 'No URL returned'
@@ -477,6 +487,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
 
         if (poll.kind === 'completed') {
           videoUrl = poll.url;
+          billedUnits = poll.unitsBilled;
           break;
         }
         if (poll.kind === 'rejected') {
@@ -551,13 +562,20 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // narrowing (a `let` could be reassigned, so TS widens it inside closures).
     const job = succeededJob;
 
+    // Exact charge from fal's reported billed units (the check-credits `cost`
+    // was only an estimate for the affordability gate).
+    const actualCost = falCostFromUnits(
+      IMAGE_TO_VIDEO_MODELS[model].id,
+      billedUnits
+    );
+
     await step.do('record-motion-observation', async () => {
       recordMotionObservation({
         model,
         prompt: input.prompt,
         imageUrl: input.imageUrl,
         videoUrl,
-        cost: cost,
+        cost: actualCost,
         videoDuration: duration,
         generationTimeMs: Date.now() - job.submittedAt,
       });
@@ -567,11 +585,11 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // deductWorkflowCredits so insufficient balances warn-and-skip (with an
     // auto-top-up attempt) like every other workflow, instead of debiting
     // the balance negative.
-    if (cost > 0 && input.teamId && !job.usedOwnKey) {
+    if (actualCost > 0 && input.teamId && !job.usedOwnKey) {
       await step.do('deduct-credits', async () => {
         await deductWorkflowCredits({
           scopedDb,
-          costMicros: cost,
+          costMicros: actualCost,
           usedOwnKey: job.usedOwnKey,
           description: `Motion generation (${model})`,
           idempotencyKey: `${event.instanceId}:motion`,
@@ -580,6 +598,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
             frameId: input.frameId,
             sequenceId: input.sequenceId,
             duration: duration,
+            unitsBilled: billedUnits,
           },
           workflowName: 'MotionWorkflow:cf',
         });

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -21,7 +21,11 @@
  *     JSON-stringify around the step boundary (same pattern as
  *     `visual-prompt-scene-workflow.ts`). */
 
-import { callLLMStream, PROMPT_REASONING } from '@/lib/ai/llm-client';
+import {
+  callLLMStream,
+  llmCostFromUsage,
+  PROMPT_REASONING,
+} from '@/lib/ai/llm-client';
 import { PREVIEW_IMAGE_MODEL } from '@/lib/ai/models';
 import { getContextWindow } from '@/lib/ai/models.config';
 import {
@@ -32,7 +36,8 @@ import {
   createStreamingSceneParser,
   type SceneSplittingScene,
 } from '@/lib/ai/streaming-scene-parser';
-import { ZERO_MICROS } from '@/lib/billing/money';
+import type { Microdollars } from '@/lib/billing/money';
+import type { TokenUsage } from '@tanstack/ai';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { NewFrame } from '@/lib/db/schema';
@@ -76,6 +81,8 @@ type StreamResult = {
   characterBible: SceneSplittingResult['characterBible'];
   locationBible: SceneSplittingResult['locationBible'];
   elementBible: SceneSplittingResult['elementBible'];
+  /** Provider-reported cost for the LLM call, billed after reconciliation. */
+  llmCostMicros: Microdollars;
 };
 
 export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWorkflowInput> {
@@ -152,6 +159,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         let prevScene: SceneSplittingScene | undefined = undefined;
         let prevFrameId: string | undefined = undefined;
         let parsedResult: SceneSplittingResult | undefined;
+        let capturedUsage: TokenUsage | undefined;
 
         for await (const chunk of callLLMStream<SceneSplittingResult>({
           model: modelId,
@@ -167,8 +175,9 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
           userId: input.userId,
           sessionId: input.sequenceId,
         })) {
-          if (chunk.done && chunk.parsed !== undefined) {
-            parsedResult = chunk.parsed;
+          if (chunk.done) {
+            if (chunk.parsed !== undefined) parsedResult = chunk.parsed;
+            capturedUsage = chunk.usage;
           }
           chunkCount++;
           finalText = chunk.accumulated;
@@ -395,6 +404,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
           characterBible: parsed.characterBible,
           locationBible: parsed.locationBible,
           elementBible: parsed.elementBible,
+          llmCostMicros: llmCostFromUsage(capturedUsage, modelId),
         };
         return JSON.stringify(streamResult);
       }
@@ -529,7 +539,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
     await step.do('deduct-llm-credits-scene-splitting', async () => {
       await deductWorkflowCredits({
         scopedDb,
-        costMicros: ZERO_MICROS,
+        costMicros: streamResult.llmCostMicros,
         usedOwnKey: llmCreditKeyInfo.source === 'team',
         description: `LLM analysis (${modelId})`,
         idempotencyKey: `${event.instanceId}:llm-${STEP_NAME}`,
@@ -539,6 +549,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
           phaseName: PHASE.name,
           stepName: STEP_NAME,
           sequenceId,
+          costMicros: streamResult.llmCostMicros,
         },
       });
     });

--- a/src/lib/workflows/visual-prompt-scene-workflow.ts
+++ b/src/lib/workflows/visual-prompt-scene-workflow.ts
@@ -21,6 +21,7 @@ import { computeVisualPromptInputHash } from '@/lib/ai/input-hash';
 import {
   extractRunError,
   formatRunErrorMessage,
+  llmCostFromUsage,
   PROMPT_REASONING,
 } from '@/lib/ai/llm-client';
 import { getContextWindow } from '@/lib/ai/models.config';
@@ -31,7 +32,7 @@ import {
   visualPromptResultSchema,
 } from '@/lib/ai/scene-analysis.schema';
 import { extractStreamingStringField } from '@/lib/ai/stream-extract';
-import { ZERO_MICROS } from '@/lib/billing/money';
+import type { Microdollars } from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { getLogger } from '@/lib/observability/logger';
@@ -40,7 +41,7 @@ import { getFramePromptChannel, getGenerationChannel } from '@/lib/realtime';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type { VisualPromptSceneWorkflowInput } from '@/lib/workflow/types';
-import { chat } from '@tanstack/ai';
+import { chat, type TokenUsage } from '@tanstack/ai';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 
 const logger = getLogger(['openstory', 'workflow', 'visual-prompt-scene']);
@@ -142,62 +143,122 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
     // members confuse the check), but is JSON-safe at runtime. JSON-stringify
     // around the step boundary so the type round-trips through Serializable
     // cleanly.
-    const resultJson = await step.do(llmStepName, async (): Promise<string> => {
-      const adapter = createAdapter(analysisModelId, llmKeyInfo);
+    const { resultJson, costMicros } = await step.do(
+      llmStepName,
+      async (): Promise<{ resultJson: string; costMicros: Microdollars }> => {
+        const adapter = createAdapter(analysisModelId, llmKeyInfo);
+        let capturedUsage: TokenUsage | undefined;
+        const captureUsage = [
+          {
+            onFinish: (_ctx: unknown, info: { usage?: TokenUsage }) => {
+              capturedUsage = info.usage;
+            },
+          },
+        ];
 
-      logger.info(
-        `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Starting${
-          streamConfig ? ' streaming' : ''
-        } call`,
-        {
-          model: analysisModelId,
-          keySource: llmKeyInfo.source,
-          keyVia: llmKeyInfo.via,
-          messageCount: messages.length,
-          ...(streamConfig
-            ? {
-                frameId: streamConfig.frameId,
-                promptType: streamConfig.promptType,
-              }
-            : {}),
+        logger.info(
+          `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Starting${
+            streamConfig ? ' streaming' : ''
+          } call`,
+          {
+            model: analysisModelId,
+            keySource: llmKeyInfo.source,
+            keyVia: llmKeyInfo.via,
+            messageCount: messages.length,
+            ...(streamConfig
+              ? {
+                  frameId: streamConfig.frameId,
+                  promptType: streamConfig.promptType,
+                }
+              : {}),
+          }
+        );
+
+        const systemPrompts: string[] = [];
+        const chatMessages: Array<{
+          role: 'user' | 'assistant';
+          content: string;
+        }> = [];
+        for (const msg of messages) {
+          const flat =
+            typeof msg.content === 'string'
+              ? msg.content
+              : msg.content
+                  .map((part) => (part.type === 'text' ? part.content : ''))
+                  .filter(Boolean)
+                  .join('\n');
+          if (msg.role === 'system') {
+            systemPrompts.push(flat);
+          } else {
+            chatMessages.push({ role: msg.role, content: flat });
+          }
         }
-      );
 
-      const systemPrompts: string[] = [];
-      const chatMessages: Array<{
-        role: 'user' | 'assistant';
-        content: string;
-      }> = [];
-      for (const msg of messages) {
-        const flat =
-          typeof msg.content === 'string'
-            ? msg.content
-            : msg.content
-                .map((part) => (part.type === 'text' ? part.content : ''))
-                .filter(Boolean)
-                .join('\n');
-        if (msg.role === 'system') {
-          systemPrompts.push(flat);
-        } else {
-          chatMessages.push({ role: msg.role, content: flat });
-        }
-      }
+        const abortController = new AbortController();
+        const timeout = setTimeout(() => abortController.abort(), 300_000);
 
-      const abortController = new AbortController();
-      const timeout = setTimeout(() => abortController.abort(), 300_000);
+        // Reasoning lifts prompt-generation quality. Enabled in E2E too — it's
+        // deterministic once recorded, so aimock records + replays it normally.
+        const reasoningOptions = { reasoning: PROMPT_REASONING };
 
-      // Reasoning lifts prompt-generation quality. Enabled in E2E too — it's
-      // deterministic once recorded, so aimock records + replays it normally.
-      const reasoningOptions = { reasoning: PROMPT_REASONING };
+        try {
+          if (!streamConfig) {
+            const text = await chat({
+              adapter,
+              messages: chatMessages,
+              systemPrompts: systemPrompts,
+              outputSchema: visualPromptResultSchema,
+              stream: false,
+              abortController,
+              modelOptions: {
+                ...reasoningOptions,
+                maxCompletionTokens: Math.floor(
+                  getContextWindow(analysisModelId) * 0.5
+                ),
+              },
+              metadata: {
+                observationName: LOG_NAME,
+                prompt: promptReference,
+                tags: [...LOG_TAGS],
+                metadata: logMetadata,
+                sessionId: sequenceId,
+                userId,
+              },
+              middleware: captureUsage,
+              debug: false,
+            });
+            logger.info(
+              `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Call succeeded`
+            );
+            return {
+              resultJson: JSON.stringify(text),
+              costMicros: llmCostFromUsage(capturedUsage, analysisModelId),
+            };
+          }
 
-      try {
-        if (!streamConfig) {
-          const text = await chat({
+          // Streaming path — emit visible `fullPrompt` deltas while accumulating.
+          const channel = getFramePromptChannel(streamConfig.frameId);
+          let accumulated = '';
+          let lastExtracted = '';
+          let pendingDelta = '';
+          let lastEmitAt = 0;
+
+          const flushDelta = async () => {
+            if (!pendingDelta) return;
+            const delta = pendingDelta;
+            pendingDelta = '';
+            lastEmitAt = Date.now();
+            await channel.emit('framePrompt.streaming', {
+              promptType: streamConfig.promptType,
+              delta,
+            });
+          };
+
+          for await (const streamEvent of chat({
             adapter,
             messages: chatMessages,
             systemPrompts: systemPrompts,
-            outputSchema: visualPromptResultSchema,
-            stream: false,
+            stream: true,
             abortController,
             modelOptions: {
               ...reasoningOptions,
@@ -208,98 +269,60 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
             metadata: {
               observationName: LOG_NAME,
               prompt: promptReference,
-              tags: [...LOG_TAGS],
+              tags: [...LOG_TAGS_STREAM],
               metadata: logMetadata,
               sessionId: sequenceId,
               userId,
             },
+            outputSchema: visualPromptResultSchema,
+            middleware: captureUsage,
             debug: false,
-          });
-          logger.info(
-            `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Call succeeded`
-          );
-          return JSON.stringify(text);
-        }
-
-        // Streaming path — emit visible `fullPrompt` deltas while accumulating.
-        const channel = getFramePromptChannel(streamConfig.frameId);
-        let accumulated = '';
-        let lastExtracted = '';
-        let pendingDelta = '';
-        let lastEmitAt = 0;
-
-        const flushDelta = async () => {
-          if (!pendingDelta) return;
-          const delta = pendingDelta;
-          pendingDelta = '';
-          lastEmitAt = Date.now();
-          await channel.emit('framePrompt.streaming', {
-            promptType: streamConfig.promptType,
-            delta,
-          });
-        };
-
-        for await (const streamEvent of chat({
-          adapter,
-          messages: chatMessages,
-          systemPrompts: systemPrompts,
-          stream: true,
-          abortController,
-          modelOptions: {
-            ...reasoningOptions,
-            maxCompletionTokens: Math.floor(
-              getContextWindow(analysisModelId) * 0.5
-            ),
-          },
-          metadata: {
-            observationName: LOG_NAME,
-            prompt: promptReference,
-            tags: [...LOG_TAGS_STREAM],
-            metadata: logMetadata,
-            sessionId: sequenceId,
-            userId,
-          },
-          outputSchema: visualPromptResultSchema,
-          debug: false,
-        })) {
-          if (
-            streamEvent.type === 'TEXT_MESSAGE_CONTENT' &&
-            typeof streamEvent.delta === 'string'
-          ) {
-            accumulated += streamEvent.delta;
-            const next = extractStreamingStringField(accumulated, 'fullPrompt');
-            if (next.length > lastExtracted.length) {
-              pendingDelta += next.slice(lastExtracted.length);
-              lastExtracted = next;
-            }
+          })) {
             if (
-              pendingDelta &&
-              Date.now() - lastEmitAt >= streamConfig.flushIntervalMs
+              streamEvent.type === 'TEXT_MESSAGE_CONTENT' &&
+              typeof streamEvent.delta === 'string'
             ) {
-              await flushDelta();
+              accumulated += streamEvent.delta;
+              const next = extractStreamingStringField(
+                accumulated,
+                'fullPrompt'
+              );
+              if (next.length > lastExtracted.length) {
+                pendingDelta += next.slice(lastExtracted.length);
+                lastExtracted = next;
+              }
+              if (
+                pendingDelta &&
+                Date.now() - lastEmitAt >= streamConfig.flushIntervalMs
+              ) {
+                await flushDelta();
+              }
+              continue;
             }
-            continue;
+            const runError = extractRunError(streamEvent);
+            if (runError) {
+              logger.error(
+                `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Streaming call RUN_ERROR`,
+                { runError: runError.event }
+              );
+              throw new Error(formatRunErrorMessage(runError));
+            }
           }
-          const runError = extractRunError(streamEvent);
-          if (runError) {
-            logger.error(
-              `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Streaming call RUN_ERROR`,
-              { runError: runError.event }
-            );
-            throw new Error(formatRunErrorMessage(runError));
-          }
+          await flushDelta();
+          logger.info(
+            `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Streaming call succeeded`
+          );
+          return {
+            resultJson: JSON.stringify(
+              visualPromptResultSchema.parse(JSON.parse(accumulated))
+            ),
+            costMicros: llmCostFromUsage(capturedUsage, analysisModelId),
+          };
+        } finally {
+          clearTimeout(timeout);
         }
-        await flushDelta();
-        logger.info(
-          `[VisualPromptSceneWorkflow:cf] [LLM:${LOG_NAME}] Streaming call succeeded`
-        );
-        return JSON.stringify(
-          visualPromptResultSchema.parse(JSON.parse(accumulated))
-        );
-      } finally {
-        clearTimeout(timeout);
       }
-    });
+    );
     const result: VisualPromptResult = visualPromptResultSchema.parse(
       JSON.parse(resultJson)
     );
@@ -308,7 +331,7 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
     await step.do(`deduct-llm-credits-${STEP_NAME}`, async () => {
       await deductWorkflowCredits({
         scopedDb,
-        costMicros: ZERO_MICROS,
+        costMicros,
         usedOwnKey: llmKeyInfo.source === 'team',
         description: `LLM analysis (${analysisModelId})`,
         idempotencyKey: `${event.instanceId}:llm-${STEP_NAME}`,
@@ -318,6 +341,7 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
           phaseName: PHASE.name,
           stepName: STEP_NAME,
           sequenceId,
+          costMicros,
         },
       });
     });


### PR DESCRIPTION
## Summary

Implements proper cost tracking (#938). Credit deduction now uses **real provider usage** rather than param-based guesses.

- **Fal media** (image/video/audio): exact cost = `unitsBilled × unitPrice`, where `unitsBilled` comes from fal's `x-fal-billable-units` header (surfaced as `usage.unitsBilled` by the TanStack AI adapter). fal already accounts for resolution/audio/duration in the count, so the old reconstruction multipliers/matrices are removed.
- **LLM text** (was hardcoded to `$0`): charges OpenRouter's authoritative per-request `usage.cost`, captured via a `chat()` `onFinish` middleware in both the streaming and non-streaming durable-call paths.
- **Missing usage**: logs an error and charges nothing — no fallback to the estimate, so a usage regression surfaces loudly.

## Pricing data
`scripts/update-fal-pricing.ts` now emits one flat `FAL_PRICING: Record<endpointId, { unitPrice, unit }>` taken verbatim from the fal pricing API. The only override left is `UNITS_KIND`, which disambiguates the API's ambiguous `"units"` (flat / per-token / per-image) for pre-flight estimation only — billing multiplies `unitsBilled × unitPrice` regardless of `unit`. `src/lib/ai/fal-pricing-data.ts` is regenerated; never hand-edit it.

## Key files
- `src/lib/ai/fal-cost.ts` — `falCostFromUnits` (billing) + `estimateFalCost` (pre-flight gate)
- `image-generation.ts` / `music-generation.ts` — bill from `result.usage?.unitsBilled`
- `motion-workflow.ts` — threads the completed poll's `usage.unitsBilled` into the deduction (the `check-credits` estimate now only gates affordability)
- `llm-call-helper.ts` — captures `usage.cost` and deducts it
- `cost-estimation.ts` — delegates to `estimateFalCost`

Net: ~970 fewer lines.

## Verification
- `bun tsgo --noEmit` — clean
- `bun lint` — no new issues
- `bun run test` — 1394/1394 pass (rewrote `fal-cost.test.ts`)

Note: e2e replay mocks don't carry `x-fal-billable-units` / OpenRouter `cost`, so under aimock those flows compute `$0` + log the "charging nothing" error. No e2e test asserts credits, so nothing breaks; updating the mocks to emit usage is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)