### PR TITLE
fix(workflows): retry character-sheet content rejections, stop sequence on failure

### DIFF
--- a/src/lib/workflows/character-bible-workflow.ts
+++ b/src/lib/workflows/character-bible-workflow.ts
@@ -173,19 +173,33 @@ export class CharacterBibleWorkflow extends OpenStoryWorkflowEntrypoint<Characte
     const settled = await Promise.allSettled(spawnPromises);
 
     const seqCharacters: CharacterMinimal[] = [];
+    const failures: string[] = [];
     for (const [index, outcome] of settled.entries()) {
       if (outcome.status === 'rejected') {
-        // Log the per-child failure but do not throw — Promise.allSettled
-        // ensures one timed-out / failed child cannot tank the parent. The
-        // child's own `onFailure` already wrote the failed status + emitted
-        // the realtime event for the affected character row.
+        // A reference sheet is what anchors a character's identity across cuts
+        // (#801), and every character in the bible recurs by construction — so
+        // a missing sheet means the sequence would render an unanchored,
+        // different-looking person each cut. We therefore do NOT swallow a
+        // failed child and press on (the old behaviour, which left the row
+        // `completed` with a null sheet and silently continued); instead we
+        // collect every failure and throw once below so the parent
+        // (analyze-script) fails the whole sequence with a clear status error
+        // rather than completing it unanchored (#939). The child's own
+        // `onFailure` already wrote the failed status + emitted the realtime
+        // event for the affected character row.
         const character = input.characterBible[index];
+        const name = character?.name ?? `index ${index}`;
+        const reason =
+          outcome.reason instanceof Error
+            ? outcome.reason.message
+            : String(outcome.reason);
         logger.error(
-          `[CharacterBibleWorkflow:cf] Child character-sheet failed for ${character?.name ?? `index ${index}`}:`,
+          `[CharacterBibleWorkflow:cf] Child character-sheet failed for ${name}:`,
           {
             err: outcome.reason,
           }
         );
+        failures.push(`${name} (${reason})`);
         continue;
       }
 
@@ -204,6 +218,17 @@ export class CharacterBibleWorkflow extends OpenStoryWorkflowEntrypoint<Characte
         consistencyTag:
           castingAttrs?.consistencyTag ?? character.consistencyTag,
       });
+    }
+
+    if (failures.length > 0) {
+      // Stop the sequence rather than continue with an unanchored character
+      // (#939). This rejection propagates up through `spawnAndAwaitChild` to
+      // analyze-script's `charSettled.status === 'rejected'` branch, which marks
+      // the sequence `failed` with this message and emits `generation.failed`.
+      throw new Error(
+        `Character sheet generation failed for ${failures.length} of ${settled.length} character(s); ` +
+          `stopping rather than rendering an unanchored sequence: ${failures.join('; ')}`
+      );
     }
 
     return seqCharacters;

--- a/src/lib/workflows/character-sheet-workflow.ts
+++ b/src/lib/workflows/character-sheet-workflow.ts
@@ -14,6 +14,12 @@
  *   - Calls the snapshot DTO computers directly instead of going through
  *     the `context.snapshot.*` extension. */
 
+import {
+  CONTENT_REJECTION_EVENT,
+  CONTENT_REJECTION_RETRY_EVENT,
+  isContentRejectionError,
+} from '@/lib/ai/content-rejection';
+import { extractFalErrorMessage } from '@/lib/ai/fal-error';
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
 import {
   deductWorkflowCredits,
@@ -24,6 +30,7 @@ import type { ScopedDb } from '@/lib/db/scoped';
 import {
   generateImageWithProvider,
   type ImageGenerationParams,
+  type ImageGenerationResult,
 } from '@/lib/image/image-generation';
 import { buildCharacterSheetPrompt } from '@/lib/prompts/character-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
@@ -43,10 +50,21 @@ import {
   computeCharacterSheetHashCurrent,
   computeCharacterSheetHashFromDto,
 } from '@/lib/workflows/sheet-snapshots';
+import { NonRetryableError } from 'cloudflare:workflows';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'character-sheet']);
+
+/**
+ * Total sheet generation attempts on a content-flag rejection (#881/#939): the
+ * initial attempt plus 2 reseeded re-rolls. `generateImageWithProvider` is
+ * called without a fixed seed, so each attempt is naturally reseeded; the
+ * stochastic content-checker hits clear on a re-roll, while deterministic ones
+ * exhaust this budget and fail hard (a character with no reference sheet can't
+ * anchor identity across cuts, so we stop rather than continue unanchored).
+ */
+const MAX_SHEET_ATTEMPTS = 3;
 
 export class CharacterSheetWorkflow extends OpenStoryWorkflowEntrypoint<CharacterSheetWorkflowInput> {
   protected override async runImpl(
@@ -129,14 +147,86 @@ export class CharacterSheetWorkflow extends OpenStoryWorkflowEntrypoint<Characte
       }
     );
 
-    // Step 2: Generate the character sheet image
-    const imageResult = await step.do('generate-sheet-image', async () => {
-      logger.info(
-        `[CharacterSheetWorkflow:cf] Generating sheet for ${input.characterName} with model ${generationParams.model}`
+    // Step 2: Generate the character sheet image with a bounded same-model
+    // reseed retry on content-flag rejections (#881/#939). A content rejection
+    // is caught INSIDE the step and surfaced as a sentinel so CF's per-step
+    // retry doesn't burn its budget re-rolling it — the loop owns that re-roll;
+    // genuine transient errors still throw and lean on CF's per-step retries.
+    // The sheet anchors a character's identity across cuts (#801), so an
+    // exhausted budget is a HARD failure: we throw rather than persist a null
+    // sheet and let the sequence render an unanchored character (#939).
+    let imageResult: ImageGenerationResult | null = null;
+    let lastRejection: string | null = null;
+    for (let attempt = 0; attempt < MAX_SHEET_ATTEMPTS; attempt++) {
+      const tag = attempt === 0 ? '' : `-retry-${attempt}`;
+      const outcome = await step.do(
+        `generate-sheet-image${tag}`,
+        async (): Promise<
+          | { ok: true; result: ImageGenerationResult }
+          | { ok: false; rejection: string }
+        > => {
+          logger.info(
+            `[CharacterSheetWorkflow:cf] Generating sheet for ${input.characterName} with model ${generationParams.model} (attempt ${attempt + 1}/${MAX_SHEET_ATTEMPTS})`
+          );
+          try {
+            const result = await generateImageWithProvider(generationParams, {
+              scopedDb,
+            });
+            return { ok: true, result };
+          } catch (error) {
+            if (isContentRejectionError(error)) {
+              return { ok: false, rejection: extractFalErrorMessage(error) };
+            }
+            // Not a content flag → transient. Let CF retry the step.
+            throw error;
+          }
+        }
       );
 
-      return await generateImageWithProvider(generationParams, { scopedDb });
-    });
+      if (outcome.ok) {
+        imageResult = outcome.result;
+        if (attempt > 0) {
+          logger.info(
+            `[CharacterSheetWorkflow:cf] content-flag retry rescued sheet for character ${input.characterDbId} on attempt ${attempt + 1}`,
+            {
+              event: CONTENT_REJECTION_RETRY_EVENT,
+              outcome: 'rescued',
+              kind: 'character-sheet',
+              model: generationParams.model,
+              attempts: attempt + 1,
+              characterDbId: input.characterDbId,
+              sequenceId: input.sequenceId,
+            }
+          );
+        }
+        break;
+      }
+
+      lastRejection = outcome.rejection;
+      logger.warn(
+        `[CharacterSheetWorkflow:cf] content-flag rejection on sheet attempt ${attempt + 1}/${MAX_SHEET_ATTEMPTS} for character ${input.characterDbId}: ${outcome.rejection}`
+      );
+    }
+
+    if (!imageResult) {
+      logger.error(
+        `[CharacterSheetWorkflow:cf] content-flag retry exhausted for character ${input.characterDbId} after ${MAX_SHEET_ATTEMPTS} attempts`,
+        {
+          event: CONTENT_REJECTION_RETRY_EVENT,
+          outcome: 'exhausted',
+          kind: 'character-sheet',
+          model: generationParams.model,
+          attempts: MAX_SHEET_ATTEMPTS,
+          characterDbId: input.characterDbId,
+          sequenceId: input.sequenceId,
+          rejection: lastRejection,
+        }
+      );
+      throw new NonRetryableError(
+        `Character sheet rejected by content filter after ${MAX_SHEET_ATTEMPTS} attempts: ${lastRejection ?? 'unknown rejection'}`,
+        'ContentRejectionExhausted'
+      );
+    }
 
     // Deduct credits for image generation (skip if team used own fal key)
     await step.do('deduct-credits', async () => {
@@ -341,6 +431,22 @@ export class CharacterSheetWorkflow extends OpenStoryWorkflowEntrypoint<Characte
           {
             characterId: input.characterDbId,
             status: 'failed',
+            error,
+          }
+        );
+      }
+
+      if (isContentRejectionError(error)) {
+        // Mirror image/motion `onFailure` so "how many sheets failed a content
+        // checker" is one queryable PostHog Logs metric across all three paths.
+        logger.warn(
+          `[CharacterSheetWorkflow:cf] character ${input.characterDbId} sheet failed a content checker`,
+          {
+            event: CONTENT_REJECTION_EVENT,
+            kind: 'character-sheet',
+            model: input.imageModel ?? DEFAULT_IMAGE_MODEL,
+            characterDbId: input.characterDbId,
+            sequenceId: input.sequenceId,
             error,
           }
         );


### PR DESCRIPTION
## Problem

When a character's **reference sheet** generation was rejected by the content checker, two things went wrong (#939):

1. **No retry.** The #881 content-rejection reseed retry was wired into `image-workflow.ts` and `motion-workflow.ts` but **not** `character-sheet-workflow.ts`, so a content-flagged sheet failed on the first hit while frame images recovered.
2. **The failure was silently swallowed.** `CharacterBibleWorkflow` awaited its per-character sheet children with `Promise.allSettled` and only logged rejections, leaving the character row `completed` with a null `sheetImageUrl` and letting the sequence finish **unanchored** (a different-looking person each cut), surfaced only as a placeholder avatar.

Observed: a perfume-editorial sample (GPT Image 2) rendered all 3 frame images fine but its character's reference sheet was content-rejected → swallowed → sequence completed anyway.

## Fix

### `character-sheet-workflow.ts` — reseed retry + hard stop
- Bounded **3-attempt same-model reseed loop** (`MAX_SHEET_ATTEMPTS = 3`) around sheet generation, mirroring `motion-workflow.ts`. A content rejection is caught *inside* the `step.do` and returned as a sentinel so CF's per-step retry doesn't burn its budget re-rolling it — the loop owns the re-roll. Genuine transient errors still `throw` and lean on CF retries.
- Each attempt calls `generateImageWithProvider` with no fixed seed (naturally reseeded). On exhaustion it throws `NonRetryableError('…ContentRejectionExhausted')` instead of persisting a null sheet — a character with no reference sheet can't anchor identity across cuts (#801).
- Reuses `content-rejection.ts`: `isContentRejectionError` for classification, `CONTENT_REJECTION_RETRY_EVENT` (rescued/exhausted) telemetry, and `CONTENT_REJECTION_EVENT` in `onFailure` so "how many sheets failed a content checker" is queryable across image/motion/sheet.

### `character-bible-workflow.ts` — stop the sequence, don't continue unanchored
- The `Promise.allSettled` loop no longer swallows per-child failures. It still logs each one (and the child's `onFailure` already marked the row failed + emitted the realtime event), but now collects them and **throws** if any character sheet failed.
- That rejection propagates through `spawnAndAwaitChild` → analyze-script's existing `charSettled.status === 'rejected'` branch → marks the sequence `failed` with a clear message and emits `generation.failed`.

**Decision:** per the issue's "default should be stop," **any** failed character sheet stops the sequence. Every bible entry is a recurring character by construction (there's no importance flag to distinguish "minor" ones), so each one matters for consistency.

### Surfacing
The failure is now loud at two levels: the character row flips to `failed` with the error (realtime `character-sheet:progress`), and it escalates to a full **sequence failure** (`generation.failed` + status error) instead of a silent log line + null `sheetImageUrl`.

## Testing
Typecheck, lint, and related unit tests (`content-rejection`, `sheet-snapshots`, `wiring-consistency`) pass. No new tests added — there are no existing execution tests for these workflows, the logic mirrors the already-tested motion pattern, and `content-rejection.ts` is already covered.

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)