### PR TITLE
fix(ai): route GLM-5.2 vision calls to GLM-4.6V (#942)

### DIFF
--- a/src/components/eval/eval-toolbar.tsx
+++ b/src/components/eval/eval-toolbar.tsx
@@ -307,10 +307,12 @@ export const EvalToolbar: React.FC<EvalToolbarProps> = ({
   // Build options for select components
   const analysisModelOptions = [
     { value: 'all', label: 'All Analysis Models' },
-    ...SCRIPT_ANALYSIS_MODELS.map((model) => ({
-      value: model.id,
-      label: model.name,
-    })),
+    ...SCRIPT_ANALYSIS_MODELS.filter((model) => !('hidden' in model)).map(
+      (model) => ({
+        value: model.id,
+        label: model.name,
+      })
+    ),
   ];
 
   const imageModelOptions = [

--- a/src/components/model/model-selector.tsx
+++ b/src/components/model/model-selector.tsx
@@ -24,6 +24,7 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   const models = useMemo(
     () =>
       [...SCRIPT_ANALYSIS_MODELS]
+        .filter((m) => !('hidden' in m))
         .sort((a, b) => a.qualityRank - b.qualityRank)
         .map((m) => ({
           id: m.id,

--- a/src/lib/ai/__tests__/vision-model-routing.test.ts
+++ b/src/lib/ai/__tests__/vision-model-routing.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  analysisModelSupportsVision,
+  getVisionCompanionModelId,
+  resolveVisionModel,
+} from '../models.config';
+
+// GLM-5.2 is text-only but declares GLM-4.6V as its vision companion (#942):
+// image-bearing calls must transparently swap to the companion.
+describe('vision-model routing', () => {
+  it('GLM-5.2 is text-only and points at GLM-4.6V as its companion', () => {
+    expect(analysisModelSupportsVision('z-ai/glm-5.2')).toBe(false);
+    expect(analysisModelSupportsVision('z-ai/glm-4.6v')).toBe(true);
+    expect(getVisionCompanionModelId('z-ai/glm-5.2')).toBe('z-ai/glm-4.6v');
+  });
+
+  it('swaps a text-only model to its companion only when an image is present', () => {
+    expect(resolveVisionModel('z-ai/glm-5.2', true)).toBe('z-ai/glm-4.6v');
+    expect(resolveVisionModel('z-ai/glm-5.2', false)).toBe('z-ai/glm-5.2');
+  });
+
+  it('leaves vision-capable models and companionless text models unchanged', () => {
+    // Already sees images — no swap.
+    expect(resolveVisionModel('x-ai/grok-4.3', true)).toBe('x-ai/grok-4.3');
+    // Text-only with no companion — stays put (caller drops the image).
+    expect(resolveVisionModel('deepseek/deepseek-v3.2', true)).toBe(
+      'deepseek/deepseek-v3.2'
+    );
+    expect(getVisionCompanionModelId('deepseek/deepseek-v3.2')).toBeUndefined();
+  });
+});

--- a/src/lib/ai/__tests__/vision-model-routing.test.ts
+++ b/src/lib/ai/__tests__/vision-model-routing.test.ts
@@ -3,6 +3,7 @@ import {
   analysisModelSupportsVision,
   getVisionCompanionModelId,
   resolveVisionModel,
+  SCRIPT_ANALYSIS_MODELS,
 } from '../models.config';
 
 // GLM-5.2 is text-only but declares GLM-4.6V as its vision companion (#942):
@@ -17,6 +18,16 @@ describe('vision-model routing', () => {
   it('swaps a text-only model to its companion only when an image is present', () => {
     expect(resolveVisionModel('z-ai/glm-5.2', true)).toBe('z-ai/glm-4.6v');
     expect(resolveVisionModel('z-ai/glm-5.2', false)).toBe('z-ai/glm-5.2');
+  });
+
+  // The type system catches a typo'd companion id, but not a companion that
+  // points at a real-yet-text-only model — assert the semantic invariant.
+  it('every declared vision companion is itself a vision-capable model', () => {
+    for (const model of SCRIPT_ANALYSIS_MODELS) {
+      if ('visionCompanion' in model) {
+        expect(analysisModelSupportsVision(model.visionCompanion)).toBe(true);
+      }
+    }
   });
 
   it('leaves vision-capable models and companionless text models unchanged', () => {

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -135,6 +135,7 @@ const STRUCTURED_OUTPUT_MODELS = new Set([
   'anthropic/claude-opus-4.8',
   'deepseek/deepseek-v3.2',
   'z-ai/glm-5.2',
+  'z-ai/glm-4.6v',
   'google/gemini-3.1-pro-preview',
   'openai/gpt-5.5',
   'google/gemini-3-flash-preview',

--- a/src/lib/ai/models.config.ts
+++ b/src/lib/ai/models.config.ts
@@ -76,10 +76,27 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'open-source' as const,
     qualityRank: 7,
     contextWindow: 1_048_576,
-    // Treated as text-only for the vision-conditioned motion path (#929)
-    // until confirmed to accept image input.
+    // GLM-5.2 is text-only. Image-bearing calls (the vision-conditioned motion
+    // path, #929/#942) transparently delegate to its multimodal sibling
+    // GLM-4.6V via `visionCompanion` — see `resolveVisionModel`.
     vision: false,
+    visionCompanion: 'z-ai/glm-4.6v',
     description: 'Large-scale reasoning model, 1M context, long-horizon agents',
+  },
+  {
+    id: 'z-ai/glm-4.6v',
+    name: 'GLM-4.6V',
+    provider: 'Z.ai',
+    license: 'open-source' as const,
+    // Hidden from the analysis-model picker: GLM-4.6V is GLM-5.2's vision
+    // sibling, used automatically for image-bearing calls when GLM-5.2 is the
+    // selected model (#942). Not offered as a standalone text-analysis choice.
+    qualityRank: 99,
+    contextWindow: 131_072,
+    vision: true,
+    hidden: true,
+    description:
+      'Multimodal vision sibling of GLM-5.2 for image-conditioned tasks',
   },
   {
     id: 'google/gemini-3.1-pro-preview',
@@ -193,6 +210,35 @@ export function getContextWindow(modelId: string): number {
  */
 export function analysisModelSupportsVision(modelId: string): boolean {
   return getAnalysisModelById(modelId)?.vision ?? false;
+}
+
+/**
+ * The multimodal sibling a text-only model delegates image-bearing calls to,
+ * if it declares one (e.g. GLM-5.2 → GLM-4.6V, #942). Undefined when the model
+ * has no companion.
+ */
+export function getVisionCompanionModelId(
+  modelId: string
+): AnalysisModelId | undefined {
+  const model = getAnalysisModelById(modelId);
+  return model && 'visionCompanion' in model
+    ? model.visionCompanion
+    : undefined;
+}
+
+/**
+ * Resolve which model should actually run a call given whether it carries image
+ * input. A text-only model with image input is swapped to its declared vision
+ * companion so the image can be used; everything else runs as chosen. A
+ * text-only model with image input but no companion stays put — the caller then
+ * drops the image and falls back to the text-only path.
+ */
+export function resolveVisionModel(
+  modelId: AnalysisModelId,
+  hasImageInput: boolean
+): AnalysisModelId {
+  if (!hasImageInput || analysisModelSupportsVision(modelId)) return modelId;
+  return getVisionCompanionModelId(modelId) ?? modelId;
 }
 /**
  * Default model to use when none is specified

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -16,7 +16,11 @@ import {
   PROMPT_REASONING,
 } from '@/lib/ai/llm-client';
 import type { TextModel } from '@/lib/ai/models';
-import { getContextWindow } from '@/lib/ai/models.config';
+import {
+  analysisModelSupportsVision,
+  getContextWindow,
+  resolveVisionModel,
+} from '@/lib/ai/models.config';
 import { extractStreamingStringField } from '@/lib/ai/stream-extract';
 import type { Microdollars } from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
@@ -202,7 +206,13 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
   config: DurableLLMCallConfig<TSchema>,
   callContext: DurableLLMCallContext
 ): Promise<z.infer<TSchema>> {
-  const { name, phase, modelId } = config;
+  const { name, phase } = config;
+  // Image-bearing calls on a text-only model transparently route to its vision
+  // companion (e.g. GLM-5.2 → GLM-4.6V, #942); everything else runs as chosen.
+  // The effective model drives the adapter, context window, and cost; callers
+  // keep storing/hashing the requested model.
+  const hasImageInput = (config.visionImageUrls?.length ?? 0) > 0;
+  const modelId = resolveVisionModel(config.modelId, hasImageInput);
   const logName = `phase-${phase.number}-${name}`;
   const logTags = [name, `phase-${phase.number}`, 'analysis'];
   const logMetadata = {
@@ -241,14 +251,17 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
 
       logger.info(`[LLM:${logName}:cf] Starting call`, {
         model: modelId,
+        requestedModel: config.modelId,
         keySource: llmKeyInfo.source,
         keyVia: llmKeyInfo.via,
         messageCount: messages.length,
       });
 
-      const visionImageSources = await resolveVisionImageSources(
-        config.visionImageUrls
-      );
+      // Only attach the still when the effective model accepts image input —
+      // otherwise drop it and let the text-only path handle the call.
+      const visionImageSources = analysisModelSupportsVision(modelId)
+        ? await resolveVisionImageSources(config.visionImageUrls)
+        : undefined;
       const { systemPrompts, chatMessages } = buildChatMessages(
         messages,
         visionImageSources
@@ -267,9 +280,7 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
           abortController,
           modelOptions: {
             ...reasoningModelOptions(config.reasoning),
-            maxCompletionTokens: Math.floor(
-              getContextWindow(config.modelId) * 0.5
-            ),
+            maxCompletionTokens: Math.floor(getContextWindow(modelId) * 0.5),
           },
           metadata: {
             observationName: logName,
@@ -341,7 +352,11 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
     return durableLLMCallCf(step, config, callContext);
   }
 
-  const { name, phase, modelId } = config;
+  const { name, phase } = config;
+  // See durableLLMCallCf: image-bearing calls on a text-only model route to
+  // their vision companion; the effective model drives adapter/window/cost.
+  const hasImageInput = (config.visionImageUrls?.length ?? 0) > 0;
+  const modelId = resolveVisionModel(config.modelId, hasImageInput);
   const {
     frameId,
     promptType,
@@ -376,6 +391,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
 
       logger.info(`[LLM:${logName}:cf] Starting streaming call`, {
         model: modelId,
+        requestedModel: config.modelId,
         keySource: llmKeyInfo.source,
         keyVia: llmKeyInfo.via,
         messageCount: messages.length,
@@ -383,9 +399,10 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
         promptType,
       });
 
-      const visionImageSources = await resolveVisionImageSources(
-        config.visionImageUrls
-      );
+      // Only attach the still when the effective model accepts image input.
+      const visionImageSources = analysisModelSupportsVision(modelId)
+        ? await resolveVisionImageSources(config.visionImageUrls)
+        : undefined;
       const { systemPrompts, chatMessages } = buildChatMessages(
         messages,
         visionImageSources
@@ -418,9 +435,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
           abortController,
           modelOptions: {
             ...reasoningModelOptions(config.reasoning),
-            maxCompletionTokens: Math.floor(
-              getContextWindow(config.modelId) * 0.5
-            ),
+            maxCompletionTokens: Math.floor(getContextWindow(modelId) * 0.5),
           },
           metadata: {
             observationName: logName,

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -257,9 +257,18 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
         messageCount: messages.length,
       });
 
-      // Only attach the still when the effective model accepts image input —
-      // otherwise drop it and let the text-only path handle the call.
-      const visionImageSources = analysisModelSupportsVision(modelId)
+      // Only attach the still when the effective model accepts image input.
+      // Warn (don't fail — the text-only path is a supported mode) when an
+      // image was supplied but is being dropped: that means a text-only model
+      // with no vision companion is wired into a vision-conditioned call, which
+      // would otherwise be invisible in the logs.
+      const effectiveSupportsVision = analysisModelSupportsVision(modelId);
+      if (hasImageInput && !effectiveSupportsVision) {
+        logger.warn(
+          `[LLM:${logName}:cf] Dropping vision image(s): effective model ${modelId} (requested ${config.modelId}) is text-only with no vision companion; running text-only`
+        );
+      }
+      const visionImageSources = effectiveSupportsVision
         ? await resolveVisionImageSources(config.visionImageUrls)
         : undefined;
       const { systemPrompts, chatMessages } = buildChatMessages(
@@ -399,8 +408,15 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
         promptType,
       });
 
-      // Only attach the still when the effective model accepts image input.
-      const visionImageSources = analysisModelSupportsVision(modelId)
+      // Only attach the still when the effective model accepts image input;
+      // warn (don't fail) when an image is dropped — see durableLLMCallCf.
+      const effectiveSupportsVision = analysisModelSupportsVision(modelId);
+      if (hasImageInput && !effectiveSupportsVision) {
+        logger.warn(
+          `[LLM:${logName}:cf] Dropping vision image(s): effective model ${modelId} (requested ${config.modelId}) is text-only with no vision companion; running text-only`
+        );
+      }
+      const visionImageSources = effectiveSupportsVision
         ? await resolveVisionImageSources(config.visionImageUrls)
         : undefined;
       const { systemPrompts, chatMessages } = buildChatMessages(

--- a/src/lib/workflows/motion-prompt-scene-workflow.ts
+++ b/src/lib/workflows/motion-prompt-scene-workflow.ts
@@ -14,7 +14,6 @@
  *     by `step.do`. */
 
 import { computeMotionPromptInputHash } from '@/lib/ai/input-hash';
-import { analysisModelSupportsVision } from '@/lib/ai/models.config';
 import { narrowFramePromptContext } from '@/lib/ai/prompt-context';
 import {
   motionPromptSchema,
@@ -120,15 +119,15 @@ export class MotionPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Motio
         responseSchema: motionPromptSchema,
         additionalMetadata: { frameId },
         reasoning: true,
-        // Only attach the still when the chosen analysis model accepts image
-        // input; otherwise OpenRouter would reject the request. Non-vision
-        // models still get the (now image-aware) text prompt. The staleness
-        // hash always folds in the image regardless, so switching to a vision
-        // model later re-generates with the still.
-        visionImageUrls:
-          startingFrameImageUrl && analysisModelSupportsVision(analysisModelId)
-            ? [startingFrameImageUrl]
-            : undefined,
+        // Attach the rendered still whenever we have one. The LLM helper owns
+        // the vision-routing policy: it runs the call on a vision-capable model
+        // (the chosen model if it sees images, else its `visionCompanion` —
+        // e.g. GLM-5.2 → GLM-4.6V, #942) and drops the image only when neither
+        // can, falling back to the text-only path. The staleness hash always
+        // folds in the image regardless, so a re-render re-stales the prompt.
+        visionImageUrls: startingFrameImageUrl
+          ? [startingFrameImageUrl]
+          : undefined,
       },
       {
         sequenceId,


### PR DESCRIPTION
Closes #942.

## Problem
GLM-5.2 is text-only, so when a team selects it as their analysis model the vision-conditioned motion-prompt pass (#929) silently dropped the rendered starting frame and fell back to a text-only prompt.

## Approach — vision-companion model swap ("combine the two models")
GLM-5.2 keeps doing text reasoning, but image-bearing calls transparently delegate to its multimodal sibling **GLM-4.6V** (`z-ai/glm-4.6v`) — without forcing the user to pick a different model.

- Register `z-ai/glm-4.6v` as a **hidden** vision-capable model (not a standalone picker choice).
- GLM-5.2 declares `visionCompanion: 'z-ai/glm-4.6v'`.
- The durable LLM helper (`llm-call-helper.ts`) resolves the *effective* model per call via `resolveVisionModel`: if a call carries image input and the chosen model can't see images, route it to the declared companion (else stay text-only and drop the image). Adapter, context-window sizing, cost attribution, and billing all use the effective model; the stored `framePromptVariants.analysisModel` and the staleness hash keep recording the user's chosen model (GLM-5.2), so the swap is purely an execution detail.
- `motion-prompt-scene-workflow.ts` now always passes the still as `visionImageUrls`; the helper owns the vision-routing policy.

Chose this over a describe-then-feed "vision as a tool" design (GLM-4.6V captions the frame, GLM-5.2 reasons over text) because that doubles LLM calls/billing, needs a new captioning prompt, and loses visual fidelity to a lossy text description. The `element-vision` path already hardcodes Claude Sonnet 4.6 and is unaffected.

## Verification
- `bun tsgo --noEmit` clean · lint clean (0 new warnings) · knip clean
- 415 AI/workflow tests + 42 component tests pass, plus a new focused routing unit test (`vision-model-routing.test.ts`)
- LLM billing needed no pricing-table change — OpenRouter reports authoritative per-request cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)