### PR TITLE
fix(ai): route text-only vision calls to a DEFAULT_VISION_MODEL (#944)

### DIFF
--- a/src/lib/ai/__tests__/vision-model-routing.test.ts
+++ b/src/lib/ai/__tests__/vision-model-routing.test.ts
@@ -1,42 +1,34 @@
 import { describe, expect, it } from 'vitest';
 import {
   analysisModelSupportsVision,
-  getVisionCompanionModelId,
+  DEFAULT_VISION_MODEL,
   resolveVisionModel,
-  SCRIPT_ANALYSIS_MODELS,
 } from '../models.config';
 
-// GLM-5.2 is text-only but declares GLM-4.6V as its vision companion (#942):
-// image-bearing calls must transparently swap to the companion.
+// Text-only analysis models can't see the rendered still the motion-prompt pass
+// conditions on (#929), so an image-bearing call on one routes to
+// DEFAULT_VISION_MODEL. GLM-4.6V was tried as GLM-5.2's companion (#942) but
+// can't do strict structured outputs, so we fall back to the default (#944).
 describe('vision-model routing', () => {
-  it('GLM-5.2 is text-only and points at GLM-4.6V as its companion', () => {
+  it('routes a text-only model with an image to DEFAULT_VISION_MODEL', () => {
     expect(analysisModelSupportsVision('z-ai/glm-5.2')).toBe(false);
-    expect(analysisModelSupportsVision('z-ai/glm-4.6v')).toBe(true);
-    expect(getVisionCompanionModelId('z-ai/glm-5.2')).toBe('z-ai/glm-4.6v');
+    expect(resolveVisionModel('z-ai/glm-5.2', true)).toBe(DEFAULT_VISION_MODEL);
+    // Also any other text-only model — the fallback is universal, not per-model.
+    expect(resolveVisionModel('deepseek/deepseek-v3.2', true)).toBe(
+      DEFAULT_VISION_MODEL
+    );
   });
 
-  it('swaps a text-only model to its companion only when an image is present', () => {
-    expect(resolveVisionModel('z-ai/glm-5.2', true)).toBe('z-ai/glm-4.6v');
+  it('leaves a text-only model unchanged when there is no image', () => {
     expect(resolveVisionModel('z-ai/glm-5.2', false)).toBe('z-ai/glm-5.2');
   });
 
-  // The type system catches a typo'd companion id, but not a companion that
-  // points at a real-yet-text-only model — assert the semantic invariant.
-  it('every declared vision companion is itself a vision-capable model', () => {
-    for (const model of SCRIPT_ANALYSIS_MODELS) {
-      if ('visionCompanion' in model) {
-        expect(analysisModelSupportsVision(model.visionCompanion)).toBe(true);
-      }
-    }
+  it('leaves a vision-capable model unchanged even with an image', () => {
+    expect(resolveVisionModel('x-ai/grok-4.3', true)).toBe('x-ai/grok-4.3');
   });
 
-  it('leaves vision-capable models and companionless text models unchanged', () => {
-    // Already sees images — no swap.
-    expect(resolveVisionModel('x-ai/grok-4.3', true)).toBe('x-ai/grok-4.3');
-    // Text-only with no companion — stays put (caller drops the image).
-    expect(resolveVisionModel('deepseek/deepseek-v3.2', true)).toBe(
-      'deepseek/deepseek-v3.2'
-    );
-    expect(getVisionCompanionModelId('deepseek/deepseek-v3.2')).toBeUndefined();
+  // The fallback target must itself accept images, or routing to it is pointless.
+  it('DEFAULT_VISION_MODEL is itself vision-capable', () => {
+    expect(analysisModelSupportsVision(DEFAULT_VISION_MODEL)).toBe(true);
   });
 });

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -135,7 +135,6 @@ const STRUCTURED_OUTPUT_MODELS = new Set([
   'anthropic/claude-opus-4.8',
   'deepseek/deepseek-v3.2',
   'z-ai/glm-5.2',
-  'z-ai/glm-4.6v',
   'google/gemini-3.1-pro-preview',
   'openai/gpt-5.5',
   'google/gemini-3-flash-preview',

--- a/src/lib/ai/models.config.ts
+++ b/src/lib/ai/models.config.ts
@@ -77,26 +77,12 @@ export const SCRIPT_ANALYSIS_MODELS = [
     qualityRank: 7,
     contextWindow: 1_048_576,
     // GLM-5.2 is text-only. Image-bearing calls (the vision-conditioned motion
-    // path, #929/#942) transparently delegate to its multimodal sibling
-    // GLM-4.6V via `visionCompanion` — see `resolveVisionModel`.
+    // path, #929) transparently route to `DEFAULT_VISION_MODEL` — see
+    // `resolveVisionModel`. GLM's own vision sibling GLM-4.6V was tried (#942)
+    // but can't do strict structured outputs, which the motion-prompt call
+    // requires, so it failed; we fall back to the default vision model (#944).
     vision: false,
-    visionCompanion: 'z-ai/glm-4.6v',
     description: 'Large-scale reasoning model, 1M context, long-horizon agents',
-  },
-  {
-    id: 'z-ai/glm-4.6v',
-    name: 'GLM-4.6V',
-    provider: 'Z.ai',
-    license: 'open-source' as const,
-    // Hidden from the analysis-model picker: GLM-4.6V is GLM-5.2's vision
-    // sibling, used automatically for image-bearing calls when GLM-5.2 is the
-    // selected model (#942). Not offered as a standalone text-analysis choice.
-    qualityRank: 99,
-    contextWindow: 131_072,
-    vision: true,
-    hidden: true,
-    description:
-      'Multimodal vision sibling of GLM-5.2 for image-conditioned tasks',
   },
   {
     id: 'google/gemini-3.1-pro-preview',
@@ -213,32 +199,29 @@ export function analysisModelSupportsVision(modelId: string): boolean {
 }
 
 /**
- * The multimodal sibling a text-only model delegates image-bearing calls to,
- * if it declares one (e.g. GLM-5.2 → GLM-4.6V, #942). Undefined when the model
- * has no companion.
+ * Vision-capable model that image-bearing calls fall back to when the chosen
+ * analysis model is text-only (#944). The motion-prompt pass conditions on the
+ * rendered still (#929), so a text model selected for analysis still needs a
+ * multimodal model for that one call. Sonnet is the default: it does vision +
+ * strict structured outputs + reasoning, which the motion-prompt call requires
+ * (GLM's vision siblings can't do strict structured outputs — see #942/#944).
  */
-export function getVisionCompanionModelId(
-  modelId: string
-): AnalysisModelId | undefined {
-  const model = getAnalysisModelById(modelId);
-  return model && 'visionCompanion' in model
-    ? model.visionCompanion
-    : undefined;
-}
+export const DEFAULT_VISION_MODEL: AnalysisModelId =
+  'anthropic/claude-sonnet-4.6';
 
 /**
  * Resolve which model should actually run a call given whether it carries image
- * input. A text-only model with image input is swapped to its declared vision
- * companion so the image can be used; everything else runs as chosen. A
- * text-only model with image input but no companion stays put — the caller then
- * drops the image and falls back to the text-only path.
+ * input. A text-only model with image input is swapped to `DEFAULT_VISION_MODEL`
+ * so the image can be used; everything else runs as chosen. The effective model
+ * drives the adapter, context window, and cost; callers keep storing/hashing the
+ * requested model.
  */
 export function resolveVisionModel(
   modelId: AnalysisModelId,
   hasImageInput: boolean
 ): AnalysisModelId {
   if (!hasImageInput || analysisModelSupportsVision(modelId)) return modelId;
-  return getVisionCompanionModelId(modelId) ?? modelId;
+  return DEFAULT_VISION_MODEL;
 }
 /**
  * Default model to use when none is specified

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -207,10 +207,10 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
   callContext: DurableLLMCallContext
 ): Promise<z.infer<TSchema>> {
   const { name, phase } = config;
-  // Image-bearing calls on a text-only model transparently route to its vision
-  // companion (e.g. GLM-5.2 → GLM-4.6V, #942); everything else runs as chosen.
-  // The effective model drives the adapter, context window, and cost; callers
-  // keep storing/hashing the requested model.
+  // Image-bearing calls on a text-only model transparently route to
+  // DEFAULT_VISION_MODEL (e.g. GLM-5.2 → Claude Sonnet, #944); everything else
+  // runs as chosen. The effective model drives the adapter, context window, and
+  // cost; callers keep storing/hashing the requested model.
   const hasImageInput = (config.visionImageUrls?.length ?? 0) > 0;
   const modelId = resolveVisionModel(config.modelId, hasImageInput);
   const logName = `phase-${phase.number}-${name}`;
@@ -258,14 +258,14 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
       });
 
       // Only attach the still when the effective model accepts image input.
-      // Warn (don't fail — the text-only path is a supported mode) when an
-      // image was supplied but is being dropped: that means a text-only model
-      // with no vision companion is wired into a vision-conditioned call, which
-      // would otherwise be invisible in the logs.
+      // resolveVisionModel routes text-only models to DEFAULT_VISION_MODEL, so
+      // reaching here with an image but no vision support means that default is
+      // misconfigured to a text-only model. Warn and drop the image (don't fail
+      // — text-only is a supported mode) rather than send it to a text model.
       const effectiveSupportsVision = analysisModelSupportsVision(modelId);
       if (hasImageInput && !effectiveSupportsVision) {
         logger.warn(
-          `[LLM:${logName}:cf] Dropping vision image(s): effective model ${modelId} (requested ${config.modelId}) is text-only with no vision companion; running text-only`
+          `[LLM:${logName}:cf] Dropping vision image(s): effective model ${modelId} (requested ${config.modelId}) is text-only; DEFAULT_VISION_MODEL may be misconfigured — running text-only`
         );
       }
       const visionImageSources = effectiveSupportsVision
@@ -363,7 +363,7 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
 
   const { name, phase } = config;
   // See durableLLMCallCf: image-bearing calls on a text-only model route to
-  // their vision companion; the effective model drives adapter/window/cost.
+  // DEFAULT_VISION_MODEL; the effective model drives adapter/window/cost.
   const hasImageInput = (config.visionImageUrls?.length ?? 0) > 0;
   const modelId = resolveVisionModel(config.modelId, hasImageInput);
   const {

--- a/src/lib/workflows/motion-prompt-scene-workflow.ts
+++ b/src/lib/workflows/motion-prompt-scene-workflow.ts
@@ -121,10 +121,9 @@ export class MotionPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Motio
         reasoning: true,
         // Attach the rendered still whenever we have one. The LLM helper owns
         // the vision-routing policy: it runs the call on a vision-capable model
-        // (the chosen model if it sees images, else its `visionCompanion` —
-        // e.g. GLM-5.2 → GLM-4.6V, #942) and drops the image only when neither
-        // can, falling back to the text-only path. The staleness hash always
-        // folds in the image regardless, so a re-render re-stales the prompt.
+        // (the chosen model if it sees images, else DEFAULT_VISION_MODEL —
+        // e.g. GLM-5.2 → Claude Sonnet, #944). The staleness hash always folds
+        // in the image regardless, so a re-render re-stales the prompt.
         visionImageUrls: startingFrameImageUrl
           ? [startingFrameImageUrl]
           : undefined,


### PR DESCRIPTION
## Problem

GLM vision failed when generating motion prompts (#944). GLM-5.2 is text-only, so the vision-conditioned motion-prompt pass (#929) routed image-bearing calls to its sibling GLM-4.6V (#942). But the motion-prompt call needs **vision + strict structured outputs + reasoning** in one call, and OpenRouter reports that **no live GLM vision model supports `structured_outputs`**:

| Model | image in | `structured_outputs` | live on OpenRouter |
|---|---|---|---|
| GLM-5.2 (text) | ✗ | ✓ | ✓ — works (text-only path) |
| GLM-4.6V | ✓ | **✗** | ✓ |
| GLM-4.5V | ✓ | **✗** | ✓ |
| GLM-5V Turbo | ✓ | — | **✗ `endpoints: []`** |
| Claude Sonnet 4.6 | ✓ | ✓ | ✓ |

So GLM-4.6V failed deterministically. GLM-5V Turbo is the natural in-family fix but isn't deployed on OpenRouter yet.

## Change

Replace the per-model `visionCompanion` mechanism with a single `DEFAULT_VISION_MODEL` (Claude Sonnet 4.6 — vision + structured outputs + reasoning):

- `resolveVisionModel` now routes **any** text-only analysis model carrying an image to `DEFAULT_VISION_MODEL` for that one call. Text-only calls and vision-capable models are unchanged.
- Removed the hidden GLM-4.6V entry, the `visionCompanion` field, and `getVisionCompanionModelId`; dropped `glm-4.6v` from `STRUCTURED_OUTPUT_MODELS`.
- The image-drop warn path in `llm-call-helper.ts` is retained as a guard against `DEFAULT_VISION_MODEL` itself being misconfigured to a text model.

**Behavior note:** previously a text-only model with no companion dropped the still and ran text-only. Now image-bearing calls on *any* text-only model (e.g. DeepSeek) route to Sonnet, so vision conditioning always works regardless of the chosen analysis model. Swapping to `z-ai/glm-5v-turbo` later is a one-line change once OpenRouter deploys it.

## Verification

`bun typecheck` clean · 416 tests pass · `bun lint` 0 errors · `bun dead-code` clean.

Closes #944
