### PR TITLE
feat(#909): scene-level image + video model selection

### DIFF
--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -1,4 +1,3 @@
-import { MotionModelSelector } from '@/components/model/motion-model-selector';
 import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -10,13 +9,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import {
-  DEFAULT_MUSIC_MODEL,
-  DEFAULT_VIDEO_MODEL,
-  videoModelSupportsAudio,
-  type AudioModel,
-  type ImageToVideoModel,
-} from '@/lib/ai/models';
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { cn } from '@/lib/utils';
 import type { Shot } from '@/types/database';
@@ -37,12 +30,8 @@ type MobileSceneDrawerProps = {
   musicPromptsReady: boolean;
   /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
   hideBatchButton?: boolean;
-  /** Initial motion model for the batch selector (from `sequence.videoModel`). */
-  initialMotionModel?: ImageToVideoModel;
   /** Initial music model for the batch selector (from `sequence.musicModel`). */
   initialMusicModel?: AudioModel;
-  /** Current style category — used to filter style-restricted motion models. */
-  styleCategory?: string;
 };
 
 const isCompleted = (frame: Shot) => {
@@ -61,31 +50,16 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   onBatchGenerateMotion,
   musicPromptsReady,
   hideBatchButton = false,
-  initialMotionModel,
   initialMusicModel,
-  styleCategory,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(false);
   const [generateAudio, setGenerateAudio] = useState(true);
-  const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
-    initialMotionModel ?? DEFAULT_VIDEO_MODEL
-  );
   const [musicModel, setMusicModel] = useState<AudioModel>(
     initialMusicModel ?? DEFAULT_MUSIC_MODEL
   );
 
-  const motionSupportsAudio = videoModelSupportsAudio(motionModel);
-
-  const prevInitialMotionRef = useRef(initialMotionModel);
-  if (
-    initialMotionModel &&
-    initialMotionModel !== prevInitialMotionRef.current
-  ) {
-    prevInitialMotionRef.current = initialMotionModel;
-    setMotionModel(initialMotionModel);
-  }
   const prevInitialMusicRef = useRef(initialMusicModel);
   if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
     prevInitialMusicRef.current = initialMusicModel;
@@ -133,9 +107,8 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
     try {
       await onBatchGenerateMotion({
         includeMusic,
-        motionModel,
         musicModel,
-        generateAudio: motionSupportsAudio ? generateAudio : false,
+        generateAudio,
       });
     } finally {
       setIsGenerating(false);
@@ -229,18 +202,8 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
 
           {showFooter && (
             <SheetFooter className="border-t pt-4 px-4 flex-col items-stretch gap-3">
-              <div className="flex flex-col gap-1">
-                <span className="text-xs text-muted-foreground">
-                  Motion model
-                </span>
-                <MotionModelSelector
-                  selectedModel={motionModel}
-                  onModelChange={setMotionModel}
-                  disabled={isGenerating || isMotionInProgress}
-                  aspectRatio={aspectRatio}
-                  styleCategory={styleCategory}
-                />
-              </div>
+              {/* Each shot renders with its scene's chosen video model (#909);
+                  no model selector here — this is the batch-all action. */}
               {includeMusic && (
                 <div className="flex flex-col gap-1">
                   <span className="text-xs text-muted-foreground">
@@ -296,21 +259,21 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
                   )}
                 </span>
               </label>
-              {motionSupportsAudio && (
-                <label
-                  htmlFor="mobile-batch-generate-audio"
-                  className="flex items-center gap-2 text-sm text-muted-foreground justify-center"
-                >
-                  <Checkbox
-                    id="mobile-batch-generate-audio"
-                    checked={generateAudio}
-                    onCheckedChange={(checked) =>
-                      setGenerateAudio(checked === true)
-                    }
-                  />
-                  <span>Include SFX &amp; dialogue</span>
-                </label>
-              )}
+              {/* Audio is opt-out for any scene whose model emits it; ignored
+                  server-side for models without audio output. */}
+              <label
+                htmlFor="mobile-batch-generate-audio"
+                className="flex items-center gap-2 text-sm text-muted-foreground justify-center"
+              >
+                <Checkbox
+                  id="mobile-batch-generate-audio"
+                  checked={generateAudio}
+                  onCheckedChange={(checked) =>
+                    setGenerateAudio(checked === true)
+                  }
+                />
+                <span>Include SFX &amp; dialogue</span>
+              </label>
             </SheetFooter>
           )}
         </SheetContent>

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -1,15 +1,8 @@
-import { MotionModelSelector } from '@/components/model/motion-model-selector';
 import { MusicModelSelector } from '@/components/model/music-model-selector';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import {
-  DEFAULT_MUSIC_MODEL,
-  DEFAULT_VIDEO_MODEL,
-  videoModelSupportsAudio,
-  type AudioModel,
-  type ImageToVideoModel,
-} from '@/lib/ai/models';
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import type { Shot, ShotVariant } from '@/lib/db/schema';
 import { Loader2, Video } from 'lucide-react';
@@ -18,10 +11,9 @@ import { SceneListItem } from './scene-list-item';
 
 export type BatchGenerateMotionArgs = {
   includeMusic: boolean;
-  motionModel: ImageToVideoModel;
   musicModel: AudioModel;
-  /** When the motion model emits audio (sfx/dialogue/ambient), allow the
-   *  user to suppress it. Ignored for models without audio output. */
+  /** When any scene's motion model emits audio (sfx/dialogue/ambient), allow
+   *  the user to suppress it. Ignored for models without audio output. */
   generateAudio: boolean;
 };
 
@@ -39,12 +31,8 @@ type SceneListProps = {
   /** Live divergent alternates for the current sequence (filtered per-frame). */
   divergentVariants?: ShotVariant[];
   onCompareDivergent?: (variant: ShotVariant) => void;
-  /** Initial motion model for the batch selector (from `sequence.videoModel`). */
-  initialMotionModel?: ImageToVideoModel;
   /** Initial music model for the batch selector (from `sequence.musicModel`). */
   initialMusicModel?: AudioModel;
-  /** Current style category — used to filter style-restricted motion models. */
-  styleCategory?: string;
   /**
    * Scenes the pinned image model hasn't generated yet (#547). Those cards show
    * a "No {model}" badge so the thumbnail (which still shows the primary image)
@@ -73,9 +61,7 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   hideBatchButton = false,
   divergentVariants,
   onCompareDivergent,
-  initialMotionModel,
   initialMusicModel,
-  styleCategory,
   modelMissingFrameIds,
   modelMissingLabel,
 }) => {
@@ -93,25 +79,12 @@ const SceneListComponent: React.FC<SceneListProps> = ({
   const [isGenerating, setIsGenerating] = useState(false);
   const [includeMusic, setIncludeMusic] = useState(true);
   const [generateAudio, setGenerateAudio] = useState(true);
-  const [motionModel, setMotionModel] = useState<ImageToVideoModel>(
-    initialMotionModel ?? DEFAULT_VIDEO_MODEL
-  );
   const [musicModel, setMusicModel] = useState<AudioModel>(
     initialMusicModel ?? DEFAULT_MUSIC_MODEL
   );
 
-  const motionSupportsAudio = videoModelSupportsAudio(motionModel);
-
   // Sync local selection when the sequence's saved model changes from outside
   // (e.g. after generation completes and the workflow persists the new model).
-  const prevInitialMotionRef = useRef(initialMotionModel);
-  if (
-    initialMotionModel &&
-    initialMotionModel !== prevInitialMotionRef.current
-  ) {
-    prevInitialMotionRef.current = initialMotionModel;
-    setMotionModel(initialMotionModel);
-  }
   const prevInitialMusicRef = useRef(initialMusicModel);
   if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
     prevInitialMusicRef.current = initialMusicModel;
@@ -152,9 +125,8 @@ const SceneListComponent: React.FC<SceneListProps> = ({
     try {
       await onBatchGenerateMotion({
         includeMusic,
-        motionModel,
         musicModel,
-        generateAudio: motionSupportsAudio ? generateAudio : false,
+        generateAudio,
       });
     } finally {
       setIsGenerating(false);
@@ -223,19 +195,12 @@ const SceneListComponent: React.FC<SceneListProps> = ({
         </div>
       </ScrollArea>
 
-      {/* Sticky footer with Generate Motion button */}
+      {/* Sticky footer: sequence-level "generate all motion" (#909). Each shot
+          renders with its scene's chosen video model — picked in the scene
+          header — so there's no model selector here; this is the secondary
+          batch action across every scene. */}
       {showButton && (
         <div className="sticky bottom-0 border-t bg-background p-4 flex flex-col gap-3">
-          <div className="flex flex-col gap-1">
-            <span className="text-xs text-muted-foreground">Motion model</span>
-            <MotionModelSelector
-              selectedModel={motionModel}
-              onModelChange={setMotionModel}
-              disabled={isGenerating || isMotionInProgress}
-              aspectRatio={aspectRatio}
-              styleCategory={styleCategory}
-            />
-          </div>
           {includeMusic && (
             <div className="flex flex-col gap-1">
               <span className="text-xs text-muted-foreground">Music model</span>
@@ -289,21 +254,19 @@ const SceneListComponent: React.FC<SceneListProps> = ({
               )}
             </span>
           </label>
-          {motionSupportsAudio && (
-            <label
-              htmlFor="batch-generate-audio"
-              className="flex items-center gap-2 text-sm text-muted-foreground"
-            >
-              <Checkbox
-                id="batch-generate-audio"
-                checked={generateAudio}
-                onCheckedChange={(checked) =>
-                  setGenerateAudio(checked === true)
-                }
-              />
-              <span>Include SFX &amp; dialogue</span>
-            </label>
-          )}
+          {/* Audio is opt-out for any scene whose model emits it; ignored
+              server-side for models without audio output. */}
+          <label
+            htmlFor="batch-generate-audio"
+            className="flex items-center gap-2 text-sm text-muted-foreground"
+          >
+            <Checkbox
+              id="batch-generate-audio"
+              checked={generateAudio}
+              onCheckedChange={(checked) => setGenerateAudio(checked === true)}
+            />
+            <span>Include SFX &amp; dialogue</span>
+          </label>
         </div>
       )}
     </div>
@@ -321,9 +284,7 @@ const areEqual = (
     prevProps.selectedFrameId !== nextProps.selectedFrameId ||
     prevProps.aspectRatio !== nextProps.aspectRatio ||
     prevProps.musicPromptsReady !== nextProps.musicPromptsReady ||
-    prevProps.initialMotionModel !== nextProps.initialMotionModel ||
     prevProps.initialMusicModel !== nextProps.initialMusicModel ||
-    prevProps.styleCategory !== nextProps.styleCategory ||
     prevProps.modelMissingLabel !== nextProps.modelMissingLabel ||
     prevProps.modelMissingFrameIds !== nextProps.modelMissingFrameIds
   ) {

--- a/src/components/scenes/scene-model-header.tsx
+++ b/src/components/scenes/scene-model-header.tsx
@@ -1,0 +1,126 @@
+import { ImageModelSelector } from '@/components/model/image-model-selector';
+import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
+import { useScenes, useUpdateSceneModels } from '@/hooks/use-scenes';
+import {
+  resolveSceneImageModel,
+  resolveSceneVideoModel,
+} from '@/lib/model/resolve-scene-model';
+import {
+  getCompatibleModel,
+  type ImageToVideoModel,
+  type TextToImageModel,
+} from '@/lib/ai/models';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type { Sequence } from '@/types/database';
+import { toast } from 'sonner';
+
+type SceneModelHeaderProps = {
+  sequenceId: string;
+  /** The scene whose models this header controls (the selected shot's scene). */
+  sceneId: string | null | undefined;
+  sequence: Sequence | undefined;
+  aspectRatio: AspectRatio;
+  styleCategory?: string;
+  styleName?: string;
+  recommendedImageModel?: string | null;
+  recommendedVideoModel?: string | null;
+  /** Per-model generation status across the scene's shots — ✓/⟳/! markers. */
+  imageModelStatuses?: Map<string, ModelGenerationStatus>;
+  videoModelStatuses?: Map<string, ModelGenerationStatus>;
+};
+
+/**
+ * Scene-level model pickers (#909). A scene owns one "look" (image model) and
+ * one "motion character" (video model); these replace the former per-shot
+ * pickers so every shot in the scene shares a model. Picking a model persists
+ * `scene.imageModel` / `scene.videoModel` via {@link useUpdateSceneModels};
+ * `null` columns inherit the sequence default through `resolveScene*Model`.
+ */
+export const SceneModelHeader: React.FC<SceneModelHeaderProps> = ({
+  sequenceId,
+  sceneId,
+  sequence,
+  aspectRatio,
+  styleCategory,
+  styleName,
+  recommendedImageModel,
+  recommendedVideoModel,
+  imageModelStatuses,
+  videoModelStatuses,
+}) => {
+  const { data: scenes } = useScenes(sequenceId);
+  const updateModels = useUpdateSceneModels();
+
+  const scene = scenes?.find((s) => s.id === sceneId);
+
+  // Resolve through the scene → sequence → default chain so the selectors show
+  // the effective model even before a scene override is set.
+  const imageModel = resolveSceneImageModel(scene, sequence);
+  const resolvedVideo = resolveSceneVideoModel(scene, sequence);
+  // Keep the resolved motion model usable: snap to an aspect-ratio compatible
+  // model so the selector never highlights an incompatible option.
+  const videoModel: ImageToVideoModel = getCompatibleModel(
+    resolvedVideo,
+    aspectRatio
+  );
+
+  const handleImageModelChange = (model: TextToImageModel) => {
+    if (!sceneId) return;
+    updateModels.mutate(
+      { sequenceId, sceneId, imageModel: model },
+      {
+        onError: (error) =>
+          toast.error('Failed to set image model', {
+            description:
+              error instanceof Error ? error.message : 'Unknown error',
+          }),
+      }
+    );
+  };
+
+  const handleVideoModelChange = (model: ImageToVideoModel) => {
+    if (!sceneId) return;
+    updateModels.mutate(
+      { sequenceId, sceneId, videoModel: model },
+      {
+        onError: (error) =>
+          toast.error('Failed to set video model', {
+            description:
+              error instanceof Error ? error.message : 'Unknown error',
+          }),
+      }
+    );
+  };
+
+  const disabled = !sceneId || updateModels.isPending;
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:gap-6">
+      <div className="flex flex-1 flex-col gap-1.5">
+        <span className="text-sm font-medium">Look</span>
+        <ImageModelSelector
+          selectedModel={imageModel}
+          onModelChange={handleImageModelChange}
+          disabled={disabled}
+          recommendedImageModel={recommendedImageModel}
+          styleName={styleName}
+          generatedStatuses={imageModelStatuses}
+        />
+      </div>
+      <div className="flex flex-1 flex-col gap-1.5">
+        <span className="text-sm font-medium">Motion character</span>
+        <MotionModelSelector
+          selectedModel={videoModel}
+          onModelChange={handleVideoModelChange}
+          disabled={disabled}
+          aspectRatio={aspectRatio}
+          styleCategory={styleCategory}
+          recommendedVideoModel={recommendedVideoModel}
+          styleName={styleName}
+          generatedStatuses={videoModelStatuses}
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/components/scenes/scene-script-prompts.stories.tsx
+++ b/src/components/scenes/scene-script-prompts.stories.tsx
@@ -142,6 +142,8 @@ const meta: Meta<typeof SceneScriptPrompts> = {
     regeneratingMotion: new Set<string>(),
     regeneratingSceneVariants: new Set<string>(),
     onRegenerateStart: fn(),
+    sceneImageModel: 'nano_banana_2',
+    sceneVideoModel: 'seedance_v2',
   },
   decorators: [
     (Story) => (

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1,7 +1,4 @@
 import { BillingGateDialog } from '@/components/billing/billing-gate-dialog';
-import { ImageModelSelector } from '@/components/model/image-model-selector';
-import { MotionModelSelector } from '@/components/model/motion-model-selector';
-import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
 import { ThinkingBar } from '@/components/ai/thinking-bar';
 import { PromptHistorySheet } from '@/components/prompts/prompt-history-sheet';
 import { DivergentAlternateBanner } from '@/components/staleness/divergent-alternate-banner';
@@ -27,8 +24,6 @@ import { updateShotFn } from '@/functions/shots';
 import { generateShotImageFn } from '@/functions/shot-image';
 import { generateShotMotionFn } from '@/functions/motion-functions';
 import { regenerateFramePromptFn } from '@/functions/prompt-variants';
-import { useActiveImageModel } from '@/hooks/use-active-image-model';
-import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { useFalBillingGate } from '@/hooks/use-billing-gate';
 import {
@@ -49,7 +44,6 @@ import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_VIDEO_MODEL,
   IMAGE_TO_VIDEO_MODELS,
-  getCompatibleModel,
   safeImageToVideoModel,
   safeTextToImageModel,
   videoModelSupportsAudio,
@@ -122,28 +116,18 @@ type SceneScriptPromptsProps = {
   variantForSelectedModel?: ShotVariant;
   /** The selected scene's video variant for the effective video model (#545). */
   videoVariantForSelectedModel?: ShotVariant;
-  /** Per-scene generation status by model — drives the ✓/⟳/! dropdown markers (#545). */
-  imageModelStatuses?: Map<string, ModelGenerationStatus>;
-  videoModelStatuses?: Map<string, ModelGenerationStatus>;
-  onImageModelChange?: (model: string) => void;
-  /** Per-scene video-model preview switch (#545), mirror of onImageModelChange. */
-  onVideoModelChange?: (model: string) => void;
-  /** Current style category, used to show/hide style-restricted motion models */
-  styleCategory?: string;
-  /** Current style name, used in recommendation tooltips */
-  styleName?: string;
-  /** Style-recommended image model — drives the "Recommended" badge */
-  recommendedImageModel?: string | null;
-  /** Style-recommended video model — drives the "Recommended" badge */
-  recommendedVideoModel?: string | null;
+  /**
+   * Effective image model for this shot's scene (#909). Resolved from
+   * `scene.imageModel ?? sequence.imageModel` in scenes-view; the model is
+   * chosen in the scene header, so generate/regenerate/set actions here read it
+   * rather than a per-shot picker.
+   */
+  sceneImageModel: TextToImageModel;
+  /** Effective video model for this shot's scene (#909). Mirror of the above. */
+  sceneVideoModel: ImageToVideoModel;
   /** Live divergent alternates for the current frame across variant types. */
   frameDivergentVariants?: ShotVariant[];
   onCompareDivergent?: (variant: ShotVariant) => void;
-  /**
-   * Sequence-level motion model. Used as the display fallback when the user
-   * hasn't picked one in the dropdown and the frame has no completed motion.
-   */
-  sequenceMotionModel?: ImageToVideoModel;
 };
 
 export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
@@ -158,17 +142,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   aspectRatio,
   variantForSelectedModel,
   videoVariantForSelectedModel,
-  imageModelStatuses,
-  videoModelStatuses,
-  onImageModelChange,
-  onVideoModelChange,
-  styleCategory,
-  styleName,
-  recommendedImageModel,
-  recommendedVideoModel,
+  sceneImageModel,
+  sceneVideoModel,
   frameDivergentVariants,
   onCompareDivergent,
-  sequenceMotionModel,
 }) => {
   const divergentImageVariant = useMemo(
     () => frameDivergentVariants?.find((v) => v.variantType === 'image'),
@@ -179,11 +156,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     [frameDivergentVariants]
   );
   const [copiedTab, setCopiedTab] = useState<string | null>(null);
-  // Sequence-level model pins from the header dropdowns (#547). Fold them into
-  // the per-scene effective model below so switching a header model also moves
-  // this scene's image/video tab selector.
-  const { activeImageModel } = useActiveImageModel(sequenceId);
-  const { activeVideoModel } = useActiveVideoModel(sequenceId);
   const [historyOpen, setHistoryOpen] = useState<'visual' | 'motion' | null>(
     null
   );
@@ -193,47 +165,21 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     success: string | null;
   }>({ loading: false, error: null, success: null });
 
-  // Image & motion regeneration state
+  // Prompt edit state. The model is no longer chosen here — it lives at the
+  // scene level (#909) and arrives via `sceneImageModel` / `sceneVideoModel`;
+  // only the prompt drafts are local.
   const [editPrompts, setEditPrompts] = useState({
     imagePrompt: '' as string,
-    imageModel: undefined as TextToImageModel | undefined,
     motionPrompt: '' as string,
-    motionModel: undefined as ImageToVideoModel | undefined,
   });
-  const {
-    imagePrompt: editedImagePrompt,
-    imageModel: selectedImageModel,
-    motionPrompt: editedMotionPrompt,
-    motionModel: selectedMotionModel,
-  } = editPrompts;
+  const { imagePrompt: editedImagePrompt, motionPrompt: editedMotionPrompt } =
+    editPrompts;
   const setEditedImagePrompt = (v: string) =>
     setEditPrompts((s) => ({ ...s, imagePrompt: v }));
-  const setSelectedImageModel = (v: TextToImageModel | undefined) =>
-    setEditPrompts((s) => ({ ...s, imageModel: v }));
   const setEditedMotionPrompt = (v: string) =>
     setEditPrompts((s) => ({ ...s, motionPrompt: v }));
-  const setSelectedMotionModel = (v: ImageToVideoModel | undefined) =>
-    setEditPrompts((s) => ({ ...s, motionModel: v }));
   // SFX/dialogue toggle for audio-capable models (kling v3, veo3, etc.)
   const [generateAudio, setGenerateAudio] = useState(true);
-
-  const handleImageModelChange = useCallback(
-    (model: TextToImageModel) => {
-      setSelectedImageModel(model);
-      onImageModelChange?.(model);
-    },
-    [onImageModelChange]
-  );
-
-  // Picking a motion model both sets the regen target and (mirroring the image
-  // flow) previews that model's existing video variant for this scene (#545).
-  const handleMotionModelChange = useCallback(
-    (model: ImageToVideoModel) => {
-      setSelectedMotionModel(model);
-      onVideoModelChange?.(model);
-    },
-    [onVideoModelChange]
-  );
 
   // Script tab edit state — `undefined` means "no draft" (textarea mirrors the
   // saved value); a string means "user has typed". We reset to `undefined` when
@@ -516,51 +462,20 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
 
   // Get imagePrompt early so it can be used in handleShortenPrompt
   const scriptText = frame?.metadata?.originalScript.extract;
-  const imageModel = safeTextToImageModel(
+  // The frame's own recorded image model — used only to decide whether the
+  // scene's effective model already produced this shot's primary thumbnail.
+  const frameImageModel = safeTextToImageModel(
     frame?.imageModel,
     DEFAULT_IMAGE_MODEL
   );
-  // The model this scene's image tab targets, mirroring scenes-view's
-  // effectiveImageModel so the selector, the Generate/Set state, and the
-  // previewed image all agree. Precedence: explicit per-scene pick → the
-  // sequence-level header pin (#547) → the frame's own model. `selectedImageModel`
-  // is ONLY a deliberate dropdown pick (reset on frame switch), so the pin isn't
-  // shadowed by a frame-synced value. `regenImageModel` drops the frame fallback
-  // so "nothing chosen" passes undefined and lets the server default.
-  const effectiveImageModel =
-    selectedImageModel ?? activeImageModel ?? imageModel;
-  const regenImageModel = selectedImageModel ?? activeImageModel ?? undefined;
-  // Resolved motion model for this scene. Precedence:
-  //   1. explicit per-scene dropdown pick
-  //   2. sequence-level header pin (#547) — switching it moves this selector
-  //   3. frame already has completed motion → show what it was generated with
-  //   4. sequence-level model (reflects most recent batch pick or creation)
-  //   5. global default
-  const baseMotionModel: ImageToVideoModel =
-    selectedMotionModel ||
-    activeVideoModel ||
-    (frame?.videoStatus === 'completed' && frame.motionModel
-      ? safeImageToVideoModel(frame.motionModel, DEFAULT_VIDEO_MODEL)
-      : undefined) ||
-    sequenceMotionModel ||
-    DEFAULT_VIDEO_MODEL;
-  // Keep the resolved model usable for this scene: snap to an aspect-ratio
-  // compatible model, then fall back to the default when it's gated to a
-  // different style category (e.g. Seedance 2 is animation-only). This used to
-  // live in a render-phase frame→state sync, which pre-filled the dropdown
-  // selection and shadowed the header pin — folding it here lets the pin drive.
-  const aspectCompatibleMotion = aspectRatio
-    ? getCompatibleModel(baseMotionModel, aspectRatio)
-    : baseMotionModel;
-  const motionModelConfig = IMAGE_TO_VIDEO_MODELS[aspectCompatibleMotion];
-  const effectiveMotionModel: ImageToVideoModel =
-    'requiredStyleCategory' in motionModelConfig &&
-    motionModelConfig.requiredStyleCategory !== styleCategory
-      ? DEFAULT_VIDEO_MODEL
-      : aspectCompatibleMotion;
-  // Regen target (mirror of regenImageModel): explicit pick → header pin, else
-  // undefined so the server defaults rather than re-asserting a model.
-  const regenMotionModel = selectedMotionModel ?? activeVideoModel ?? undefined;
+  // Effective image/video model now comes from the SCENE (#909): the model is
+  // chosen in the scene header and resolved (scene → sequence → default) in
+  // scenes-view, then handed down. The selector previously here is gone, so
+  // generate/regenerate/set all read these directly and always pass a model.
+  const effectiveImageModel = sceneImageModel;
+  const regenImageModel = sceneImageModel;
+  const effectiveMotionModel: ImageToVideoModel = sceneVideoModel;
+  const regenMotionModel = sceneVideoModel;
   const imagePrompt =
     frame?.imagePrompt || frame?.metadata?.prompts?.visual?.fullPrompt;
 
@@ -577,7 +492,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // thumbnail but no variant row.
   const imageModelGenerated =
     !!variantForSelectedModel ||
-    (!!frame?.thumbnailUrl && effectiveImageModel === imageModel);
+    (!!frame?.thumbnailUrl && effectiveImageModel === frameImageModel);
 
   const handleSetImageFromVariant = useCallback(async () => {
     if (!frame?.id || !frame.sequenceId) return;
@@ -891,12 +806,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     prevScriptFrameIdRef.current = frame?.id;
     setEditedScript(undefined);
     setEditedDurationSeconds(undefined);
-    // Clear per-scene dropdown picks so the next scene starts from its header
-    // pin / own model (#547). Storing the frame's model here previously shadowed
-    // the pin; aspect-ratio + style-category fallback now lives in
-    // effectiveMotionModel instead.
-    setSelectedImageModel(undefined);
-    setSelectedMotionModel(undefined);
   }
 
   if (imagePrompt !== prevImagePromptRef.current) {
@@ -1070,19 +979,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               className="min-h-[120px]"
               disabled={isGenerating || isStreamingVisualPrompt}
               mentionItems={mentionItems}
-            />
-          </div>
-
-          {/* Model selector */}
-          <div className="space-y-2">
-            <span className="text-sm font-medium">Model</span>
-            <ImageModelSelector
-              selectedModel={effectiveImageModel}
-              onModelChange={handleImageModelChange}
-              disabled={isGenerating}
-              recommendedImageModel={recommendedImageModel}
-              styleName={styleName}
-              generatedStatuses={imageModelStatuses}
             />
           </div>
 
@@ -1262,21 +1158,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 isGenerating || isGeneratingMotion || isStreamingMotionPrompt
               }
               mentionItems={mentionItems}
-            />
-          </div>
-
-          {/* Model selector */}
-          <div className="space-y-2">
-            <span className="text-sm font-medium">Model</span>
-            <MotionModelSelector
-              selectedModel={effectiveMotionModel}
-              onModelChange={handleMotionModelChange}
-              disabled={isGenerating || isGeneratingMotion}
-              aspectRatio={aspectRatio}
-              styleCategory={styleCategory}
-              recommendedVideoModel={recommendedVideoModel}
-              styleName={styleName}
-              generatedStatuses={videoModelStatuses}
             />
           </div>
 
@@ -1462,19 +1343,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               No variant image available. Generate variants to see options.
             </div>
           )}
-
-          {/* Model selector */}
-          <div className="space-y-2">
-            <span className="text-sm font-medium">Model</span>
-            <ImageModelSelector
-              selectedModel={effectiveImageModel}
-              onModelChange={handleImageModelChange}
-              disabled={isGenerating || isGeneratingSceneVariants}
-              recommendedImageModel={recommendedImageModel}
-              styleName={styleName}
-              generatedStatuses={imageModelStatuses}
-            />
-          </div>
 
           {/* Regenerate button */}
           <Button

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -4,6 +4,7 @@ import { ScenePlayer } from '@/components/motion/scene-player';
 import { MobileSceneDrawer } from '@/components/scenes/mobile-scene-drawer';
 import { SceneList } from '@/components/scenes/scene-list';
 import type { BatchGenerateMotionArgs } from '@/components/scenes/scene-list';
+import { SceneModelHeader } from '@/components/scenes/scene-model-header';
 import {
   SceneScriptPrompts,
   type TabValue,
@@ -24,7 +25,12 @@ import {
 } from '@/hooks/use-shots';
 import { useActiveImageModel } from '@/hooks/use-active-image-model';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
-import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
+import { useScenes } from '@/hooks/use-scenes';
+import {
+  resolveSceneImageModel,
+  resolveSceneVideoModel,
+} from '@/lib/model/resolve-scene-model';
+import { computeSceneModelStatuses } from '@/lib/model/scene-model-status';
 import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
 import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-dialog';
 import { getDivergentVariantPromptDiffFn } from '@/functions/prompt-variants';
@@ -167,16 +173,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     Set<string>
   >(() => new Set());
 
-  const [imageModelOverride, setImageModelOverride] = useState<string | null>(
-    null
-  );
-
-  // Per-scene video-model preview (#545) — the motion mirror of
-  // imageModelOverride. Transient: resets on frame switch.
-  const [videoModelOverride, setVideoModelOverride] = useState<string | null>(
-    null
-  );
-
   // Poll sequence while a motion batch is in flight so per-frame statuses stay
   // fresh. The refetchInterval fn reads from the query cache each tick to
   // avoid a circular dependency between sequence state and the poll condition.
@@ -196,10 +192,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   const isProcessing = sequence?.status === 'processing';
   const { data: style } = useStyle(sequence?.styleId ?? '');
   const styleCategory = style?.category ?? undefined;
-  const sequenceMotionModel = safeImageToVideoModel(
-    sequence?.videoModel,
-    DEFAULT_VIDEO_MODEL
-  );
   const sequenceMusicModel = safeAudioModel(
     sequence?.musicModel,
     DEFAULT_MUSIC_MODEL
@@ -407,6 +399,19 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     [frames, curSelectedFrameId]
   );
 
+  // Scene-level model selection (#909): the image/video model is owned by the
+  // selected shot's scene. Resolve it through scene → sequence → default so the
+  // prompts panel + variant preview target the scene's chosen model rather than
+  // a per-shot picker.
+  const { data: scenes } = useScenes(sequenceId);
+  const selectedSceneId = selectedFrame?.sceneId ?? null;
+  const selectedScene = useMemo(
+    () => scenes?.find((s) => s.id === selectedSceneId),
+    [scenes, selectedSceneId]
+  );
+  const sceneImageModel = resolveSceneImageModel(selectedScene, sequence);
+  const sceneVideoModel = resolveSceneVideoModel(selectedScene, sequence);
+
   // In-flight retry state (#882) for the selected frame. Image retry matters
   // before the thumbnail exists; video retry after — the image entry is cleared
   // once it completes, so preferring it is correct in both stages.
@@ -424,38 +429,20 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     );
   }, [imageVariants, curSelectedFrameId]);
 
-  // Reset model overrides when switching frames
-  useEffect(() => {
-    setImageModelOverride(null);
-    setVideoModelOverride(null);
-  }, [curSelectedFrameId]);
-
-  // Derive variant preview state from model override + variants. The
-  // sequence-level header pin (#547) sits below an explicit per-scene override
-  // but above the frame's own model, so the previewed variant + Set/Generate
-  // state track whatever the header switched to.
-  const effectiveImageModel =
-    imageModelOverride ??
-    activeImageModel ??
-    safeTextToImageModel(selectedFrame?.imageModel, DEFAULT_IMAGE_MODEL);
+  // Variant preview now tracks the scene's chosen models (#909): the prompts
+  // panel's Generate/Set state and previewed variant target the model the scene
+  // is set to render with, replacing the former per-shot override.
+  const effectiveImageModel = sceneImageModel;
 
   const variantForSelectedModel = useMemo(() => {
     if (!selectedShotVariants) return undefined;
     return selectedShotVariants.find((v) => v.model === effectiveImageModel);
   }, [selectedShotVariants, effectiveImageModel]);
 
-  // Video equivalent (#545): the selected scene's video variant for the
-  // effective video model (override → frame's own model). Excludes divergent /
-  // discarded alternates so only the primary per-model row is matched.
-  // `null` = unknown: a never-generated frame has no recorded `motionModel`, so
-  // we surface no model rather than silently asserting DEFAULT_VIDEO_MODEL
-  // (which would attribute a model the scene was never generated with).
-  const effectiveVideoModel =
-    videoModelOverride ??
-    activeVideoModel ??
-    (selectedFrame?.motionModel
-      ? safeImageToVideoModel(selectedFrame.motionModel, DEFAULT_VIDEO_MODEL)
-      : null);
+  // Video equivalent: the selected scene's video variant for the scene's chosen
+  // video model. Excludes divergent / discarded alternates so only the primary
+  // per-model row is matched.
+  const effectiveVideoModel: string | null = sceneVideoModel;
 
   const videoVariantForSelectedModel = useMemo(() => {
     if (!curSelectedFrameId) return undefined;
@@ -469,58 +456,43 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
       );
   }, [videoVariantsByFrame, curSelectedFrameId, effectiveVideoModel]);
 
-  // Per-model generation status for the selected scene (#545) — feeds the
-  // ✓/⟳/! markers in the image + video model dropdowns. Primary rows only
-  // (divergent/discarded alternates are excluded).
-  // The "set" model is the one whose variant is the frame's live primary
-  // (url match), falling back to the frame's recorded model for legacy frames
-  // with no variant row. It gets the distinct ✓-in-circle marker; other
-  // completed models show a plain ✓ (selectable, then "Set" to promote).
-  const imageModelStatuses = useMemo(() => {
-    const map = new Map<string, ModelGenerationStatus>();
-    const variants = (selectedShotVariants ?? []).filter(
-      (v) => v.divergedAt === null && v.discardedAt === null
-    );
-    const primaryUrl = selectedFrame?.thumbnailUrl ?? null;
-    const setModel = primaryUrl
-      ? (variants.find((v) => v.url === primaryUrl)?.model ??
-        selectedFrame?.imageModel ??
-        null)
-      : null;
-    for (const v of variants) {
-      map.set(v.model, v.model === setModel ? 'set' : v.status);
+  // The shots that make up the selected scene. Today every scene is a single
+  // shot (#907 1:1), but the scene-granular coverage below aggregates across
+  // these so the markers stay correct once #910 lands multi-shot scenes.
+  const selectedSceneShots = useMemo(() => {
+    if (!frames) return [];
+    if (selectedSceneId) {
+      return frames.filter((f) => f.sceneId === selectedSceneId);
     }
-    if (setModel && !map.has(setModel)) map.set(setModel, 'set');
-    return map;
-  }, [
-    selectedShotVariants,
-    selectedFrame?.thumbnailUrl,
-    selectedFrame?.imageModel,
-  ]);
+    // Orphan shot (no scene yet) — treat the shot itself as its scene.
+    return selectedFrame ? [selectedFrame] : [];
+  }, [frames, selectedSceneId, selectedFrame]);
 
-  const videoModelStatuses = useMemo(() => {
-    const map = new Map<string, ModelGenerationStatus>();
-    if (!curSelectedFrameId) return map;
-    const variants = (
-      videoVariantsByFrame.get(curSelectedFrameId) ?? []
-    ).filter((v) => v.divergedAt === null && v.discardedAt === null);
-    const primaryUrl = selectedFrame?.videoUrl ?? null;
-    const setModel = primaryUrl
-      ? (variants.find((v) => v.url === primaryUrl)?.model ??
-        selectedFrame?.motionModel ??
-        null)
-      : null;
-    for (const v of variants) {
-      map.set(v.model, v.model === setModel ? 'set' : v.status);
-    }
-    if (setModel && !map.has(setModel)) map.set(setModel, 'set');
-    return map;
-  }, [
-    videoVariantsByFrame,
-    curSelectedFrameId,
-    selectedFrame?.videoUrl,
-    selectedFrame?.motionModel,
-  ]);
+  // Per-model generation status for the selected SCENE (#909) — feeds the
+  // ✓/⟳/! markers in the scene header model pickers. A model is the scene's
+  // "set" model when it's the scene's chosen model (sceneImage/VideoModel);
+  // other models that have a completed variant for every shot in the scene read
+  // `completed`, any in-flight reads `generating`, else `failed`/`pending`.
+  // Primary rows only (divergent/discarded alternates excluded).
+  const imageModelStatuses = useMemo(
+    () =>
+      computeSceneModelStatuses({
+        shots: selectedSceneShots,
+        variantsByFrame: imageVariantsByFrame,
+        setModel: sceneImageModel,
+      }),
+    [selectedSceneShots, imageVariantsByFrame, sceneImageModel]
+  );
+
+  const videoModelStatuses = useMemo(
+    () =>
+      computeSceneModelStatuses({
+        shots: selectedSceneShots,
+        variantsByFrame: videoVariantsByFrame,
+        setModel: sceneVideoModel,
+      }),
+    [selectedSceneShots, videoVariantsByFrame, sceneVideoModel]
+  );
 
   const { previewVariantUrl, previewVariantVideoUrl, playerBadgeMessage } =
     useMemo(() => {
@@ -783,11 +755,12 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     }
   }, [sequenceId, queryClient]);
 
-  // Handler for batch motion generation (server determines eligible frames)
+  // Handler for batch motion generation (server determines eligible frames).
+  // The video model is resolved per-scene server-side (#909), so no model is
+  // passed here — each shot renders with its scene's chosen model.
   const handleBatchMotionGeneration = useCallback(
     async ({
       includeMusic,
-      motionModel,
       musicModel,
       generateAudio,
     }: BatchGenerateMotionArgs) => {
@@ -824,7 +797,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
         sequence_id: sequenceId,
         include_music: includeMusic,
         eligible_frame_count: eligibleFrameIds.length,
-        motion_model: motionModel,
         music_model: includeMusic ? musicModel : undefined,
         generate_audio: generateAudio,
       });
@@ -834,14 +806,12 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
           data: {
             sequenceId,
             includeMusic,
-            model: motionModel,
             musicModel: includeMusic ? musicModel : undefined,
             generateAudio,
           },
         });
-        // Server may have updated sequence.videoModel / sequence.musicModel to
-        // the batch picks; invalidate so the header badge, footer pre-fill,
-        // and per-frame fallback all reflect the new values.
+        // Server may have updated sequence.musicModel to the batch pick;
+        // invalidate so the header badge and footer pre-fill reflect it.
         void queryClient.invalidateQueries({
           queryKey: sequenceKeys.detail(sequenceId),
         });
@@ -949,9 +919,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             }
             divergentVariants={divergentVariants}
             onCompareDivergent={(variant) => setCompareVariant(variant)}
-            initialMotionModel={sequenceMotionModel}
             initialMusicModel={sequenceMusicModel}
-            styleCategory={styleCategory}
             modelMissingFrameIds={framesMissingActiveImage}
             modelMissingLabel={activeImageModelLabel}
           />
@@ -971,9 +939,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             hideBatchButton={
               phaseConfig.autoGenerateMotion && isGenerationActive
             }
-            initialMotionModel={sequenceMotionModel}
             initialMusicModel={sequenceMusicModel}
-            styleCategory={styleCategory}
           />
         </div>
 
@@ -1007,6 +973,20 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
               wrapperClassName={PLAYER_MAX_W_BY_RATIO[aspectRatio]}
             />
           </div>
+          {/* Scene-level model pickers (#909): one look + one motion character
+              per scene, replacing the former per-shot pickers. */}
+          <SceneModelHeader
+            sequenceId={sequenceId}
+            sceneId={selectedSceneId}
+            sequence={sequence}
+            aspectRatio={aspectRatio}
+            styleCategory={styleCategory}
+            styleName={styleName}
+            recommendedImageModel={recommendedImageModel}
+            recommendedVideoModel={recommendedVideoModel}
+            imageModelStatuses={imageModelStatuses}
+            videoModelStatuses={videoModelStatuses}
+          />
           <SceneScriptPrompts
             frame={selectedFrame}
             sequenceId={sequenceId}
@@ -1019,15 +999,8 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             aspectRatio={aspectRatio}
             variantForSelectedModel={variantForSelectedModel}
             videoVariantForSelectedModel={videoVariantForSelectedModel}
-            imageModelStatuses={imageModelStatuses}
-            videoModelStatuses={videoModelStatuses}
-            onImageModelChange={setImageModelOverride}
-            onVideoModelChange={setVideoModelOverride}
-            styleCategory={styleCategory}
-            sequenceMotionModel={sequenceMotionModel}
-            styleName={styleName}
-            recommendedImageModel={recommendedImageModel}
-            recommendedVideoModel={recommendedVideoModel}
+            sceneImageModel={sceneImageModel}
+            sceneVideoModel={sceneVideoModel}
             frameDivergentVariants={divergentVariants?.filter(
               (v) => v.shotId === curSelectedFrameId
             )}

--- a/src/functions/__tests__/smart-retry.test.ts
+++ b/src/functions/__tests__/smart-retry.test.ts
@@ -145,6 +145,9 @@ function makeContext(sequence: Sequence, frames: Shot[]) {
   const listWithSheets = vi.fn(async () => []);
   const stub = {
     shots: { listBySequence },
+    // No scene overrides in these tests → frames inherit the sequence model
+    // (#909 scene-level resolution falls back to the sequence default).
+    scenes: { listBySequence: vi.fn(async () => []) },
     characters: { listWithSheets },
     sequence: vi.fn(() => ({ updateStatus, updateMusicFields })),
   };

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -13,8 +13,10 @@ import {
   safeImageToVideoModel,
 } from '@/lib/ai/models';
 import { estimateVideoCost } from '@/lib/billing/cost-estimation';
-import { multiplyMicros } from '@/lib/billing/money';
+import { addMicros, ZERO_MICROS } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
+import { dbSceneId } from '@/lib/db/schema';
+import { resolveSceneVideoModel } from '@/lib/model/resolve-scene-model';
 import { resolveFrameDuration } from '@/lib/motion/resolve-frame-duration';
 import { snapDuration } from '@/lib/motion/motion-generation';
 import { generateMotionSchema } from '@/lib/schemas/frame.schemas';
@@ -45,8 +47,13 @@ export const generateShotMotionFn = createServerFn({ method: 'POST' })
       throw new Error('Frame has no thumbnail to generate motion from');
     }
 
+    // Model resolution is scene-level (#909): an explicit override wins,
+    // otherwise the shot's scene chooses, falling back to the sequence default.
+    const scene = frame.sceneId
+      ? await context.scopedDb.scenes.getById(dbSceneId(frame.sceneId))
+      : null;
     const model = safeImageToVideoModel(
-      data.model || frame.motionModel || sequence.videoModel,
+      data.model || resolveSceneVideoModel(scene, sequence),
       DEFAULT_VIDEO_MODEL
     );
 
@@ -158,35 +165,48 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
       throw new Error('No eligible frames for motion generation');
     }
 
-    const batchModel = data.model ?? DEFAULT_VIDEO_MODEL;
-    const batchDuration = snapDuration(data.duration, batchModel);
+    // Model resolution is scene-level (#909): each shot renders with its
+    // scene's chosen video model (scene → sequence default). `data.model`, when
+    // present, is a sequence-wide override ("generate all" secondary action).
+    const scenes = await context.scopedDb.scenes.listBySequence(sequence.id);
+    const sceneById = new Map(scenes.map((s) => [s.id, s]));
+    const modelForFrame = (frame: (typeof eligibleFrames)[number]) =>
+      safeImageToVideoModel(
+        data.model ??
+          resolveSceneVideoModel(
+            frame.sceneId ? sceneById.get(dbSceneId(frame.sceneId)) : null,
+            sequence
+          ),
+        DEFAULT_VIDEO_MODEL
+      );
 
-    await requireCredits(
-      context.scopedDb,
-      multiplyMicros(
-        estimateVideoCost(batchModel, batchDuration),
-        eligibleFrames.length
-      ),
-      {
-        errorMessage: `Insufficient credits for batch motion generation (${eligibleFrames.length} frames)`,
-      }
-    );
+    // Per-frame cost: each shot may use a different scene model, so sum the
+    // estimate across the eligible shots rather than multiplying one price.
+    const totalCost = eligibleFrames.reduce((sum, frame) => {
+      const model = modelForFrame(frame);
+      return addMicros(
+        sum,
+        estimateVideoCost(model, snapDuration(data.duration, model))
+      );
+    }, ZERO_MICROS);
+
+    await requireCredits(context.scopedDb, totalCost, {
+      errorMessage: `Insufficient credits for batch motion generation (${eligibleFrames.length} frames)`,
+    });
 
     const includeMusic =
       (data.includeMusic ?? false) && sequence.musicStatus !== 'generating';
 
-    // Persist the batch model picks so the sequence header chip, future batch
-    // sessions, and storyboard regen reflect what the user just chose.
-    const videoModelChanged = data.model && data.model !== sequence.videoModel;
+    // Persist the music model pick so the header chip + future sessions reflect
+    // it. The video model is no longer a batch-level pick (it lives per scene).
     const musicModelChanged =
       includeMusic &&
       data.musicModel &&
       data.musicModel !== sequence.musicModel;
-    if (videoModelChanged || musicModelChanged) {
+    if (musicModelChanged) {
       await context.scopedDb.sequences.update({
         id: sequence.id,
-        ...(videoModelChanged ? { videoModel: data.model } : {}),
-        ...(musicModelChanged ? { musicModel: data.musicModel } : {}),
+        musicModel: data.musicModel,
       });
     }
 
@@ -218,10 +238,7 @@ export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
       sequenceId: sequence.id,
       includeMusic,
       shots: eligibleFrames.map((frame) => {
-        const frameModel = safeImageToVideoModel(
-          data.model || frame.motionModel || sequence.videoModel,
-          DEFAULT_VIDEO_MODEL
-        );
+        const frameModel = modelForFrame(frame);
         return {
           shotId: frame.id,
           imageUrl: frame.thumbnailUrl ?? '',

--- a/src/functions/scenes.ts
+++ b/src/functions/scenes.ts
@@ -1,0 +1,74 @@
+/**
+ * Scene server functions (#909).
+ *
+ * Scenes are the narrative unit that owns a "look" (image model) and a "motion
+ * character" (video model). These endpoints read the scene rows for a sequence
+ * and persist the scene-level model choice. NULL on either column means inherit
+ * the sequence default — see `resolveScene{Image,Video}Model`.
+ */
+
+import { dbSceneId, type SceneRow } from '@/lib/db/schema';
+import {
+  isValidImageToVideoModel,
+  isValidTextToImageModel,
+} from '@/lib/ai/models';
+import { ulidSchema } from '@/lib/schemas/id.schemas';
+import { createServerFn } from '@tanstack/react-start';
+import { zodValidator } from '@tanstack/zod-adapter';
+import { z } from 'zod';
+import { sequenceAccessMiddleware } from './middleware';
+
+export const getScenesFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }): Promise<SceneRow[]> => {
+    return context.scopedDb.scenes.listBySequence(context.sequence.id);
+  });
+
+/**
+ * Persist a scene's image and/or video model. A `null` value clears the
+ * override so the scene re-inherits the sequence default; omitting a field
+ * leaves it unchanged. Validates the scene belongs to the sequence in scope
+ * before writing.
+ */
+export const updateSceneModelsFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        sceneId: ulidSchema,
+        imageModel: z
+          .string()
+          .nullable()
+          .optional()
+          .refine((v) => v == null || isValidTextToImageModel(v), {
+            message: 'Unknown image model',
+          }),
+        videoModel: z
+          .string()
+          .nullable()
+          .optional()
+          .refine((v) => v == null || isValidImageToVideoModel(v), {
+            message: 'Unknown video model',
+          }),
+      })
+    )
+  )
+  .handler(async ({ data, context }): Promise<SceneRow> => {
+    const sceneId = dbSceneId(data.sceneId);
+    const scene = await context.scopedDb.scenes.getById(sceneId);
+    if (!scene || scene.sequenceId !== context.sequence.id) {
+      throw new Error('Scene not found in this sequence');
+    }
+
+    const update: { imageModel?: string | null; videoModel?: string | null } =
+      {};
+    if (data.imageModel !== undefined) update.imageModel = data.imageModel;
+    if (data.videoModel !== undefined) update.videoModel = data.videoModel;
+
+    const updated = await context.scopedDb.scenes.update(sceneId, update);
+    if (!updated) {
+      throw new Error('Scene update returned no data');
+    }
+    return updated;
+  });

--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -15,11 +15,16 @@ import {
   estimateStoryboardCost,
   estimateVideoCost,
 } from '@/lib/billing/cost-estimation';
-import { addMicros, multiplyMicros, ZERO_MICROS } from '@/lib/billing/money';
+import { addMicros, ZERO_MICROS } from '@/lib/billing/money';
 import { requireCredits } from '@/lib/billing/preflight';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { ScopedDb } from '@/lib/db/scoped';
+import { dbSceneId } from '@/lib/db/schema';
 import type { Character, Sequence } from '@/lib/db/schema';
+import {
+  resolveSceneImageModel,
+  resolveSceneVideoModel,
+} from '@/lib/model/resolve-scene-model';
 import { analyzeFailures } from '@/lib/failures/failure-analysis';
 import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
@@ -142,14 +147,21 @@ export async function executeSmartRetry(context: SmartRetryContext) {
   const retried: string[] = [];
   let totalCost = ZERO_MICROS;
 
-  const imageModel = safeTextToImageModel(
-    sequence.imageModel,
-    DEFAULT_IMAGE_MODEL
-  );
-  const videoModel = safeImageToVideoModel(
-    sequence.videoModel,
-    DEFAULT_VIDEO_MODEL
-  );
+  // Model resolution is scene-level (#909): each failed shot retries with its
+  // scene's chosen model (scene → sequence default), keyed off the scene render
+  // unit rather than one sequence-wide model.
+  const scenes = await context.scopedDb.scenes.listBySequence(sequence.id);
+  const sceneById = new Map(scenes.map((s) => [s.id, s]));
+  const imageModelForFrame = (frame: (typeof frames)[number]) =>
+    resolveSceneImageModel(
+      frame.sceneId ? sceneById.get(dbSceneId(frame.sceneId)) : null,
+      sequence
+    );
+  const videoModelForFrame = (frame: (typeof frames)[number]) =>
+    resolveSceneVideoModel(
+      frame.sceneId ? sceneById.get(dbSceneId(frame.sceneId)) : null,
+      sequence
+    );
 
   // Collect failed items and estimate costs
   const failedImageFrames = frames.filter(
@@ -161,28 +173,24 @@ export async function executeSmartRetry(context: SmartRetryContext) {
   const hasMusicFailure =
     sequence.musicStatus === 'failed' && sequence.musicPrompt;
 
-  // Calculate total cost
-  if (failedImageFrames.length > 0) {
+  // Calculate total cost — each frame may use a different scene model, so sum
+  // per-frame rather than multiplying one price.
+  for (const frame of failedImageFrames) {
     totalCost = addMicros(
       totalCost,
-      estimateImageCost(
-        imageModel,
-        sequence.aspectRatio,
-        failedImageFrames.length
-      )
+      estimateImageCost(imageModelForFrame(frame), sequence.aspectRatio, 1)
     );
   }
 
   if (failedMotionFrames.length > 0) {
     const { snapDuration } = await import('@/lib/motion/motion-generation');
-    const duration = snapDuration(undefined, videoModel);
-    totalCost = addMicros(
-      totalCost,
-      multiplyMicros(
-        estimateVideoCost(videoModel, duration),
-        failedMotionFrames.length
-      )
-    );
+    for (const frame of failedMotionFrames) {
+      const model = videoModelForFrame(frame);
+      totalCost = addMicros(
+        totalCost,
+        estimateVideoCost(model, snapDuration(undefined, model))
+      );
+    }
   }
 
   // Single credit check for all retries
@@ -220,7 +228,7 @@ export async function executeSmartRetry(context: SmartRetryContext) {
         userId: user.id,
         teamId,
         prompt,
-        model: imageModel,
+        model: imageModelForFrame(frame),
         imageSize: aspectRatioToImageSize(sequence.aspectRatio),
         numImages: 1,
         shotId: frame.id,
@@ -243,14 +251,15 @@ export async function executeSmartRetry(context: SmartRetryContext) {
     for (const frame of failedMotionFrames) {
       if (!frame.thumbnailUrl) continue;
 
+      const frameVideoModel = videoModelForFrame(frame);
       const workflowInput: MotionWorkflowInput = {
         userId: user.id,
         teamId,
         shotId: frame.id,
         sequenceId: sequence.id,
         imageUrl: frame.thumbnailUrl,
-        prompt: resolveMotionPrompt(frame, videoModel),
-        model: videoModel,
+        prompt: resolveMotionPrompt(frame, frameVideoModel),
+        model: frameVideoModel,
         aspectRatio: sequence.aspectRatio,
         duration: frame.durationMs ? frame.durationMs / 1000 : undefined,
       };

--- a/src/hooks/use-scenes.ts
+++ b/src/hooks/use-scenes.ts
@@ -1,0 +1,77 @@
+/**
+ * Scene queries + the scene-model mutation (#909).
+ *
+ * Scenes own the image/video model for their shots. The list is read with
+ * Suspense (consumers wrap in `<Suspense>`); the model mutation optimistically
+ * patches the cached scene so the picker reflects the choice immediately, then
+ * reconciles with the server row on success.
+ */
+
+import { getScenesFn, updateSceneModelsFn } from '@/functions/scenes';
+import type { SceneRow } from '@/lib/db/schema';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+const sceneKeys = {
+  all: ['scenes'] as const,
+  lists: () => [...sceneKeys.all, 'list'] as const,
+  list: (sequenceId: string) => [...sceneKeys.lists(), sequenceId] as const,
+};
+
+/** All scenes for a sequence, ordered by `orderIndex`. */
+export function useScenes(sequenceId: string) {
+  return useQuery<SceneRow[]>({
+    queryKey: sceneKeys.list(sequenceId),
+    queryFn: () => getScenesFn({ data: { sequenceId } }),
+    staleTime: 30_000,
+    enabled: !!sequenceId,
+  });
+}
+
+type UpdateSceneModelsVars = {
+  sequenceId: string;
+  sceneId: string;
+  imageModel?: string | null;
+  videoModel?: string | null;
+};
+
+/** Persist a scene's image and/or video model, with optimistic cache patch. */
+export function useUpdateSceneModels() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: UpdateSceneModelsVars) =>
+      updateSceneModelsFn({ data: vars }),
+    onMutate: async (vars) => {
+      const key = sceneKeys.list(vars.sequenceId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<SceneRow[]>(key);
+      queryClient.setQueryData<SceneRow[]>(key, (old) =>
+        old?.map((scene) =>
+          scene.id === vars.sceneId
+            ? {
+                ...scene,
+                ...(vars.imageModel !== undefined
+                  ? { imageModel: vars.imageModel }
+                  : {}),
+                ...(vars.videoModel !== undefined
+                  ? { videoModel: vars.videoModel }
+                  : {}),
+              }
+            : scene
+        )
+      );
+      return { previous };
+    },
+    onError: (_error, vars, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(sceneKeys.list(vars.sequenceId), ctx.previous);
+      }
+    },
+    onSuccess: (updated, vars) => {
+      queryClient.setQueryData<SceneRow[]>(
+        sceneKeys.list(vars.sequenceId),
+        (old) =>
+          old?.map((scene) => (scene.id === updated.id ? updated : scene))
+      );
+    },
+  });
+}

--- a/src/lib/model/resolve-scene-model.test.ts
+++ b/src/lib/model/resolve-scene-model.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_IMAGE_MODEL, DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
+import {
+  resolveSceneImageModel,
+  resolveSceneVideoModel,
+} from './resolve-scene-model';
+
+/**
+ * The scene-level resolution chain (#909): scene override wins, otherwise the
+ * scene inherits the sequence default. A valid model id flows through; an
+ * unknown/retired one clamps to the global default.
+ */
+describe('resolveSceneImageModel', () => {
+  it('uses the scene override when set', () => {
+    expect(
+      resolveSceneImageModel(
+        { imageModel: 'nano_banana_pro', videoModel: null },
+        { imageModel: 'nano_banana_2', videoModel: 'seedance_v2' }
+      )
+    ).toBe('nano_banana_pro');
+  });
+
+  it('falls back to the sequence model when the scene model is null', () => {
+    expect(
+      resolveSceneImageModel(
+        { imageModel: null, videoModel: null },
+        { imageModel: 'nano_banana_pro', videoModel: 'seedance_v2' }
+      )
+    ).toBe('nano_banana_pro');
+  });
+
+  it('falls back to the global default when neither is set', () => {
+    expect(
+      resolveSceneImageModel(
+        { imageModel: null, videoModel: null },
+        { imageModel: null, videoModel: null }
+      )
+    ).toBe(DEFAULT_IMAGE_MODEL);
+  });
+
+  it('clamps a retired persisted model to the default', () => {
+    expect(
+      resolveSceneImageModel(
+        { imageModel: 'no_longer_a_real_model', videoModel: null },
+        { imageModel: 'nano_banana_2', videoModel: 'seedance_v2' }
+      )
+    ).toBe(DEFAULT_IMAGE_MODEL);
+  });
+
+  it('handles an undefined scene (not yet loaded)', () => {
+    expect(
+      resolveSceneImageModel(undefined, {
+        imageModel: 'nano_banana_pro',
+        videoModel: 'seedance_v2',
+      })
+    ).toBe('nano_banana_pro');
+  });
+});
+
+describe('resolveSceneVideoModel', () => {
+  it('uses the scene override when set', () => {
+    expect(
+      resolveSceneVideoModel(
+        { imageModel: null, videoModel: 'kling_v3_pro' },
+        { imageModel: 'nano_banana_2', videoModel: 'seedance_v2' }
+      )
+    ).toBe('kling_v3_pro');
+  });
+
+  it('falls back to the sequence model when the scene model is null', () => {
+    expect(
+      resolveSceneVideoModel(
+        { imageModel: null, videoModel: null },
+        { imageModel: 'nano_banana_2', videoModel: 'kling_v3_pro' }
+      )
+    ).toBe('kling_v3_pro');
+  });
+
+  it('falls back to the global default when neither is set', () => {
+    expect(
+      resolveSceneVideoModel(
+        { imageModel: null, videoModel: null },
+        { imageModel: null, videoModel: null }
+      )
+    ).toBe(DEFAULT_VIDEO_MODEL);
+  });
+});

--- a/src/lib/model/resolve-scene-model.ts
+++ b/src/lib/model/resolve-scene-model.ts
@@ -1,0 +1,62 @@
+/**
+ * Scene-level model resolution (#909).
+ *
+ * A scene owns one "look" (image model) and one "motion character" (video
+ * model). Both columns are nullable: NULL = inherit the sequence default. The
+ * sequence keeps non-null defaults (its own columns), so resolution is a single
+ * coalesce — the scene override wins, otherwise the sequence value applies.
+ *
+ * `safe*` clamps the resolved string to a valid model id, defaulting if a
+ * persisted value has since been retired.
+ */
+
+import {
+  DEFAULT_IMAGE_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  safeImageToVideoModel,
+  safeTextToImageModel,
+  type ImageToVideoModel,
+  type TextToImageModel,
+} from '@/lib/ai/models';
+
+// Each resolver reads only its own field, so both are independently optional —
+// callers can pass a partial row (e.g. the middleware's PartialSequence, which
+// carries videoModel but not imageModel) without widening to `unknown`.
+type SceneModelSource = {
+  imageModel?: string | null;
+  videoModel?: string | null;
+};
+
+type SequenceModelSource = {
+  imageModel?: string | null;
+  videoModel?: string | null;
+};
+
+/**
+ * Effective image model for a scene: scene override → sequence default →
+ * global default. Pass `null`/`undefined` for either source when it isn't
+ * loaded yet; the chain falls through to the next level.
+ */
+export function resolveSceneImageModel(
+  scene: SceneModelSource | null | undefined,
+  sequence: SequenceModelSource | null | undefined
+): TextToImageModel {
+  return safeTextToImageModel(
+    scene?.imageModel ?? sequence?.imageModel,
+    DEFAULT_IMAGE_MODEL
+  );
+}
+
+/**
+ * Effective video model for a scene: scene override → sequence default →
+ * global default. Mirrors {@link resolveSceneImageModel}.
+ */
+export function resolveSceneVideoModel(
+  scene: SceneModelSource | null | undefined,
+  sequence: SequenceModelSource | null | undefined
+): ImageToVideoModel {
+  return safeImageToVideoModel(
+    scene?.videoModel ?? sequence?.videoModel,
+    DEFAULT_VIDEO_MODEL
+  );
+}

--- a/src/lib/model/scene-model-status.test.ts
+++ b/src/lib/model/scene-model-status.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import type { ShotVariant } from '@/lib/db/schema';
+import { computeSceneModelStatuses } from './scene-model-status';
+
+/**
+ * Scene-granular per-model status (#909): a model covers the SCENE only when it
+ * has completed every shot in it; the scene's chosen model always reads `set`.
+ */
+
+const baseVariant: ShotVariant = {
+  id: 'v',
+  shotId: 's1',
+  sequenceId: 'seq1',
+  variantType: 'video',
+  model: 'seedance_v2',
+  url: 'https://r2/clip.mp4',
+  storagePath: 'team/seq/clip.mp4',
+  previewUrl: null,
+  shotVariantUrl: null,
+  shotVariantPath: null,
+  shotVariantStatus: null,
+  shotVariantWorkflowRunId: null,
+  status: 'completed',
+  workflowRunId: null,
+  generatedAt: null,
+  error: null,
+  promptHash: null,
+  inputHash: null,
+  divergedAt: null,
+  discardedAt: null,
+  durationMs: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+function variant(overrides: Partial<ShotVariant>): ShotVariant {
+  return { ...baseVariant, ...overrides };
+}
+
+function byFrame(variants: ShotVariant[]): Map<string, ShotVariant[]> {
+  const map = new Map<string, ShotVariant[]>();
+  for (const v of variants) {
+    const list = map.get(v.shotId) ?? [];
+    list.push(v);
+    map.set(v.shotId, list);
+  }
+  return map;
+}
+
+describe('computeSceneModelStatuses', () => {
+  it('marks the scene chosen model as set regardless of coverage', () => {
+    const statuses = computeSceneModelStatuses({
+      shots: [{ id: 's1' }],
+      variantsByFrame: byFrame([]),
+      setModel: 'seedance_v2',
+    });
+    expect(statuses.get('seedance_v2')).toBe('set');
+  });
+
+  it('reports completed only when a model covers every shot in the scene', () => {
+    const shots = [{ id: 's1' }, { id: 's2' }];
+    const statuses = computeSceneModelStatuses({
+      shots,
+      variantsByFrame: byFrame([
+        variant({ id: 'a', shotId: 's1', model: 'kling_v3_pro' }),
+        variant({ id: 'b', shotId: 's2', model: 'kling_v3_pro' }),
+      ]),
+      setModel: 'seedance_v2',
+    });
+    expect(statuses.get('kling_v3_pro')).toBe('completed');
+  });
+
+  it('reports generating for partial scene coverage', () => {
+    const shots = [{ id: 's1' }, { id: 's2' }];
+    const statuses = computeSceneModelStatuses({
+      shots,
+      variantsByFrame: byFrame([
+        // Only one of the two shots done for this model.
+        variant({ id: 'a', shotId: 's1', model: 'kling_v3_pro' }),
+      ]),
+      setModel: 'seedance_v2',
+    });
+    expect(statuses.get('kling_v3_pro')).toBe('generating');
+  });
+
+  it('reports generating when a shot row is in flight', () => {
+    const statuses = computeSceneModelStatuses({
+      shots: [{ id: 's1' }],
+      variantsByFrame: byFrame([
+        variant({
+          id: 'a',
+          shotId: 's1',
+          model: 'kling_v3_pro',
+          status: 'generating',
+        }),
+      ]),
+      setModel: 'seedance_v2',
+    });
+    expect(statuses.get('kling_v3_pro')).toBe('generating');
+  });
+
+  it('reports failed when the only row failed', () => {
+    const statuses = computeSceneModelStatuses({
+      shots: [{ id: 's1' }],
+      variantsByFrame: byFrame([
+        variant({
+          id: 'a',
+          shotId: 's1',
+          model: 'kling_v3_pro',
+          status: 'failed',
+        }),
+      ]),
+      setModel: 'seedance_v2',
+    });
+    expect(statuses.get('kling_v3_pro')).toBe('failed');
+  });
+
+  it('excludes divergent and discarded alternates', () => {
+    const statuses = computeSceneModelStatuses({
+      shots: [{ id: 's1' }],
+      variantsByFrame: byFrame([
+        variant({
+          id: 'a',
+          shotId: 's1',
+          model: 'kling_v3_pro',
+          divergedAt: new Date(),
+        }),
+        variant({
+          id: 'b',
+          shotId: 's1',
+          model: 'wan_v2_5',
+          discardedAt: new Date(),
+        }),
+      ]),
+      setModel: 'seedance_v2',
+    });
+    // Both alternates are excluded, so neither model registers a status.
+    expect(statuses.has('kling_v3_pro')).toBe(false);
+    expect(statuses.has('wan_v2_5')).toBe(false);
+  });
+});

--- a/src/lib/model/scene-model-status.ts
+++ b/src/lib/model/scene-model-status.ts
@@ -1,0 +1,101 @@
+import type { ModelGenerationStatus } from '@/components/model/base-model-selector';
+import type { ShotVariant } from '@/lib/db/schema';
+
+/**
+ * Scene-granular per-model generation status (#909).
+ *
+ * The render unit is the SCENE, so a model's marker reflects how it covered the
+ * whole scene rather than a single shot: a model reads `completed` only when it
+ * has a completed primary variant for EVERY shot in the scene, `generating`
+ * when any shot's row for it is in flight, `failed` when a shot's row failed
+ * (and nothing more advanced), else `pending`. The scene's chosen model
+ * (`setModel`) always shows the distinct `set` marker.
+ *
+ * Divergent/discarded alternates are excluded — only primary per-model rows
+ * count. With one shot per scene (today's 1:1 backfill) this degenerates to the
+ * shot's own status, and stays correct as scenes gain multiple shots (#910).
+ */
+export function computeSceneModelStatuses(opts: {
+  /** The shots that make up the scene — only their ids are read. */
+  shots: readonly { id: string }[];
+  variantsByFrame: ReadonlyMap<string, ShotVariant[]>;
+  /** The scene's chosen model — marked `set` regardless of coverage. */
+  setModel: string;
+}): Map<string, ModelGenerationStatus> {
+  const { shots, variantsByFrame, setModel } = opts;
+  const map = new Map<string, ModelGenerationStatus>();
+  const shotCount = shots.length;
+
+  // Per-model tallies across the scene's shots.
+  const completedShots = new Map<string, number>();
+  const generating = new Set<string>();
+  const failed = new Set<string>();
+
+  for (const shot of shots) {
+    const variants = (variantsByFrame.get(shot.id) ?? []).filter(
+      (v) => v.divergedAt === null && v.discardedAt === null
+    );
+    // De-dupe to one row per model per shot — prefer the most advanced status.
+    const byModel = new Map<string, ShotVariant['status']>();
+    for (const v of variants) {
+      const prev = byModel.get(v.model);
+      if (!prev || statusRank(v.status) > statusRank(prev)) {
+        byModel.set(v.model, v.status);
+      }
+    }
+    for (const [model, status] of byModel) {
+      if (status === 'completed') {
+        completedShots.set(model, (completedShots.get(model) ?? 0) + 1);
+      } else if (status === 'generating' || status === 'pending') {
+        generating.add(model);
+      } else {
+        // status === 'failed'
+        failed.add(model);
+      }
+    }
+  }
+
+  const models = new Set<string>([
+    ...completedShots.keys(),
+    ...generating,
+    ...failed,
+    setModel,
+  ]);
+
+  for (const model of models) {
+    if (model === setModel) {
+      map.set(model, 'set');
+      continue;
+    }
+    const covered = completedShots.get(model) ?? 0;
+    if (shotCount > 0 && covered === shotCount) {
+      map.set(model, 'completed');
+    } else if (generating.has(model)) {
+      map.set(model, 'generating');
+    } else if (covered > 0) {
+      // Partial coverage across the scene — still in progress conceptually.
+      map.set(model, 'generating');
+    } else if (failed.has(model)) {
+      map.set(model, 'failed');
+    } else {
+      map.set(model, 'pending');
+    }
+  }
+
+  return map;
+}
+
+// "More advanced" ordering so a per-shot model with mixed rows reports its
+// furthest-along status.
+function statusRank(status: ShotVariant['status']): number {
+  switch (status) {
+    case 'completed':
+      return 3;
+    case 'generating':
+      return 2;
+    case 'pending':
+      return 1;
+    case 'failed':
+      return 0;
+  }
+}


### PR DESCRIPTION
## Scene/Shot/Frame stage 3 — scene-level image + video model selection

Closes #909. Part of the **Scene / Shot / Frame** milestone (base: `milestone-18-scene-shot-frame`). Depends on #907 (scenes table, merged) and pairs with #908 (analysis, parallel).

Moves **both** the image model ("look") and video model ("motion character") pickers from shot/frame level up to **scene** level. The model is chosen once per scene and shared by every shot in it.

### What changed

**Model resolution chain (new, unit-tested)**
- `resolveSceneImageModel` / `resolveSceneVideoModel`: `scene.imageModel ?? sequence.imageModel` (→ global default). `null` scene columns inherit the sequence default. Sequence level stays the inherited default.
- The `scenes.imageModel` / `scenes.videoModel` columns already exist (added in #907) — **no migration**; `bun db:generate` is a no-op.

**Read/write plumbing**
- `getScenesFn` + `updateSceneModelsFn` server fns (write via `scopedDb.scenes.update`, validate the scene belongs to the sequence, validate model ids).
- `useScenes` query hook + `useUpdateSceneModels` mutation (optimistic cache patch).

**UI**
- New `SceneModelHeader` renders the two pickers ("Look" / "Motion character") above the shot prompts for the selected shot's scene. Picking a model persists it on the scene.
- **Removed** the per-shot image + video model pickers from `scene-script-prompts.tsx` (image-prompt, motion-prompt, scene-variants tabs). Generate / Regenerate / Set now read the scene's resolved model. *(This intentionally removes the previous per-shot model flexibility — the locked product decision for this milestone.)*
- Batch-motion footer (`scene-list.tsx` + `mobile-scene-drawer.tsx`) drops its motion-model picker; it's now the sequence-level **"generate all"** secondary action, with each shot rendering via its scene's model. Music picker + SFX toggle stay.

**Video comparison / coverage at scene granularity**
- New `computeSceneModelStatuses` aggregates per-model status across a scene's shots: a model reads `completed` only when it covers **every** shot in the scene, `set` for the scene's chosen model, else `generating` / `failed` / `pending`. With today's 1:1 (one shot per scene) this degenerates correctly and stays correct once #910 lands multi-shot scenes. **Image variants stay per-shot** (unchanged).

**Retries / batch key off the scene render unit (#881/#4)**
- `generateShotMotionFn`, `batchGenerateMotionFn`, and `smartRetryFn` resolve each shot's model from its scene (per-frame cost summed since shots may differ).

### Scope discipline
`git diff milestone-18-scene-shot-frame` is UI + model-resolution + the motion/retry server fns only — **no** billing, schema, migration, or analysis-workflow changes (those are #908). The sequence-header viewer "active model" pins (#545/#547 display preference) are intentionally left in place — they govern which model's output is *displayed*, separate from the scene's *generation* model.

### Gates (all green)
- `bun typecheck` — 0 errors
- `bun lint` — 0 errors (no new warnings in changed files)
- `bun run test` — 1455 passed (incl. new `resolve-scene-model` + `scene-model-status` tests and updated `smart-retry` mock)
- `bun format:check` — clean
- `bun dead-code` — clean
- `bun db:generate` — no-op (no schema change)
- `bun dev` boots; `/sequences` returns 200 with no compile/import errors.

### UX notes (scene header)
Two side-by-side dropdowns labelled **Look** (image model) and **Motion character** (video model) sit above the script/prompt tabs. Each shows the effective model (resolved through scene → sequence → default), ✓/⟳/! coverage markers computed at scene granularity, and the style "Recommended" badge. Disabled for orphan shots that have no scene yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qVHz4VNwvw4z7oit8C1Sp
