### PR TITLE
fix(sequences): chunk frames-by-ids query to fix array-too-big at scale

### DIFF
--- a/src/functions/frames.ts
+++ b/src/functions/frames.ts
@@ -53,13 +53,17 @@ export const getFramesFn = createServerFn({ method: 'GET' })
  *
  * Team scoping is enforced by the join inside `sequences.listFramesByIds`,
  * so caller-supplied ids from another team return nothing rather than leak.
+ * `listFramesByIds` chunks the ids to respect D1's bound-parameter limit, so
+ * the cap here is only an abuse guard on request size — a team's full sequence
+ * list (which the sequences/eval pages send) used to overflow the old 500 cap
+ * once it grew past 500 sequences (#957).
  */
 export const getFramesForSequencesFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
   .inputValidator(
     zodValidator(
       z.object({
-        sequenceIds: z.array(ulidSchema).max(500),
+        sequenceIds: z.array(ulidSchema).max(5000),
       })
     )
   )

--- a/src/lib/db/scoped/frames-by-ids.test.ts
+++ b/src/lib/db/scoped/frames-by-ids.test.ts
@@ -1,0 +1,162 @@
+/**
+ * In-memory DB tests for `sequences.listFramesByIds` (#957).
+ *
+ * The sequences/eval list pages fetch frames for every sequence on a team in
+ * one batched call. Once a team grew past ~500 sequences the request tripped a
+ * `z.array().max(500)` cap, and the underlying `inArray` would overflow D1's
+ * 100-bound-parameter limit. `listFramesByIds` now chunks the ids; these tests
+ * cover a list larger than the chunk size to prove every frame still comes back
+ * grouped and in per-sequence order.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import { frames, sequences, styles, teams } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createSequencesMethods } from './sequences';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+
+async function seed() {
+  await db.delete(frames);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+
+  teamId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  return style.id;
+}
+
+/** Insert `count` sequences, each with 3 frames; returns the sequence ids. */
+async function seedSequences(
+  styleId: string,
+  count: number
+): Promise<string[]> {
+  const seqIds: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const seqId = generateId();
+    seqIds.push(seqId);
+    await db.insert(sequences).values({
+      id: seqId,
+      teamId,
+      title: `S${i}`,
+      styleId,
+    });
+    await db.insert(frames).values([
+      { sequenceId: seqId, orderIndex: 0 },
+      { sequenceId: seqId, orderIndex: 1 },
+      { sequenceId: seqId, orderIndex: 2 },
+    ]);
+  }
+  return seqIds;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+let styleId = '';
+beforeEach(async () => {
+  styleId = await seed();
+});
+
+describe('listFramesByIds', () => {
+  it('returns [] for an empty input', async () => {
+    const methods = createSequencesMethods(db, teamId, generateId());
+    await expect(methods.listFramesByIds([])).resolves.toEqual([]);
+  });
+
+  it('returns every frame when the id list spans multiple chunks', async () => {
+    // 250 sequences > the 90-id chunk size, so the query fans out across 3
+    // batches. The old single-query path would also blow past D1's 100-param
+    // limit here.
+    const seqIds = await seedSequences(styleId, 250);
+    const methods = createSequencesMethods(db, teamId, generateId());
+
+    const result = await methods.listFramesByIds(seqIds);
+
+    expect(result).toHaveLength(250 * 3);
+    // Every requested sequence is represented with all 3 of its frames.
+    const bySeq = new Map<string, number[]>();
+    for (const frame of result) {
+      const existing = bySeq.get(frame.sequenceId) ?? [];
+      existing.push(frame.orderIndex);
+      bySeq.set(frame.sequenceId, existing);
+    }
+    expect(bySeq.size).toBe(250);
+    for (const seqId of seqIds) {
+      expect(bySeq.get(seqId)).toEqual([0, 1, 2]);
+    }
+  });
+
+  it('never leaks frames from another team', async () => {
+    const mySeqIds = await seedSequences(styleId, 2);
+
+    // A second team with its own sequence — its id is requested but must not
+    // resolve, because the join filters on teamId.
+    const otherTeamId = generateId();
+    await db.insert(teams).values({ id: otherTeamId, name: 'O', slug: 'o' });
+    const [otherStyle] = await db
+      .insert(styles)
+      .values({
+        teamId: otherTeamId,
+        name: 'default',
+        config: {
+          mood: 'neutral',
+          artStyle: 'cinematic',
+          lighting: 'natural',
+          colorPalette: ['#000', '#fff'],
+          cameraWork: 'static',
+          referenceFilms: [],
+          colorGrading: 'neutral',
+        },
+      })
+      .returning();
+    if (!otherStyle)
+      throw new Error('test setup: style insert returned nothing');
+    const otherSeqId = generateId();
+    await db.insert(sequences).values({
+      id: otherSeqId,
+      teamId: otherTeamId,
+      title: 'X',
+      styleId: otherStyle.id,
+    });
+    await db.insert(frames).values({ sequenceId: otherSeqId, orderIndex: 0 });
+
+    const methods = createSequencesMethods(db, teamId, generateId());
+    const result = await methods.listFramesByIds([...mySeqIds, otherSeqId]);
+
+    expect(result).toHaveLength(2 * 3);
+    expect(result.every((f) => f.sequenceId !== otherSeqId)).toBe(true);
+  });
+});

--- a/src/lib/db/scoped/sequences.ts
+++ b/src/lib/db/scoped/sequences.ts
@@ -29,6 +29,13 @@ type SequenceWithFrames = Sequence & {
   style: Style | null;
 };
 
+// D1 caps a single query at 100 bound parameters. `listFramesByIds` binds one
+// param per sequence id plus the teamId filter, so each query must stay under
+// that ceiling. We chunk the ids well below 100 and union the results; without
+// this a team with enough sequences overflows the limit (and previously tripped
+// the 500-item request cap on `getFramesForSequencesFn` — see #957).
+const FRAMES_BY_IDS_BATCH = 90;
+
 function createSequencesReadMethods(db: Database, teamId: string) {
   return {
     list: async (): Promise<Sequence[]> => {
@@ -91,18 +98,31 @@ function createSequencesReadMethods(db: Database, teamId: string) {
      */
     listFramesByIds: async (sequenceIds: string[]): Promise<Frame[]> => {
       if (sequenceIds.length === 0) return [];
-      return await db
-        .select()
-        .from(frames)
-        .innerJoin(sequences, eq(frames.sequenceId, sequences.id))
-        .where(
-          and(
-            inArray(frames.sequenceId, sequenceIds),
-            eq(sequences.teamId, teamId)
-          )
+      // Chunk the ids to stay under D1's bound-parameter ceiling. Each chunk
+      // holds all of a sequence's frames (we split on sequence boundaries), so
+      // per-sequence orderIndex ordering is preserved; cross-sequence ordering
+      // is irrelevant — callers regroup by sequence id.
+      const batches: string[][] = [];
+      for (let i = 0; i < sequenceIds.length; i += FRAMES_BY_IDS_BATCH) {
+        batches.push(sequenceIds.slice(i, i + FRAMES_BY_IDS_BATCH));
+      }
+      const results = await Promise.all(
+        batches.map((batch) =>
+          db
+            .select()
+            .from(frames)
+            .innerJoin(sequences, eq(frames.sequenceId, sequences.id))
+            .where(
+              and(
+                inArray(frames.sequenceId, batch),
+                eq(sequences.teamId, teamId)
+              )
+            )
+            .orderBy(asc(frames.sequenceId), asc(frames.orderIndex))
+            .then((rows) => rows.map((row) => row.frames))
         )
-        .orderBy(asc(frames.sequenceId), asc(frames.orderIndex))
-        .then((rows) => rows.map((row) => row.frames));
+      );
+      return results.flat();
     },
   };
 }


### PR DESCRIPTION
## Problem

The eval/sequences page failed to load for an account with many sample-video sequences:

```
Failed to load sequences: [{ "origin":"array", "code":"too_big", "maximum":500, "path":["sequenceIds"], "message":"Too big: expected array to have <=500 items" }]
```

`useSequencesWithFrames` fetches frames for **every** sequence on the team in one batched call (`getFramesForSequencesFn`), whose validator capped `sequenceIds` at `.max(500)`. The account had **>500 sequences**, so validation failed before the handler ran and the whole page errored.

A latent second bug sat underneath: the handler's `inArray(frames.sequenceId, sequenceIds)` binds one parameter per id, and **D1 caps a query at 100 bound parameters** — so raising the cap alone would have traded the Zod error for a D1 error at scale.

## Fix

- **Chunked the query** — `listFramesByIds` now splits ids into batches of 90 (safely under D1's 100-param ceiling, +1 for the teamId filter) and unions the results via `Promise.all`. Chunking on sequence boundaries keeps each sequence's frames together, so per-sequence `orderIndex` ordering is preserved; callers regroup by id, so cross-sequence order is irrelevant.
- **Raised the request cap** from `.max(500)` to `.max(5000)` — now just an abuse guard on request size, since the DB-limit concern is handled by chunking.

## Tests

Added `src/lib/db/scoped/frames-by-ids.test.ts` (in-memory libsql): empty input, a 250-sequence list spanning multiple chunks (all 750 frames returned, grouped, in order), and cross-team isolation (the teamId join still prevents leaks across chunks).

`bun run test`, `bun typecheck`, `bun lint` all pass.

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
