### PR TITLE
feat(api-v1): add GET /api/v1/sequences list endpoint

### DIFF
--- a/src/lib/api-v1/discovery.test.ts
+++ b/src/lib/api-v1/discovery.test.ts
@@ -37,6 +37,11 @@ describe('buildRootDocument', () => {
     const enhance = _links['enhance-script'];
     expect(enhance?.method).toBe('POST');
     expect(enhance?.href).toBe('/api/v1/scripts/enhance');
+
+    const list = _links['list-sequences'];
+    expect(list?.method).toBe('GET');
+    expect(list?.templated).toBe(true);
+    expect(list?.href).toBe('/api/v1/sequences{?limit,cursor}');
   });
 
   it('documents the streaming enhance endpoint in the narrative', () => {

--- a/src/lib/api-v1/discovery.ts
+++ b/src/lib/api-v1/discovery.ts
@@ -25,6 +25,13 @@ Workflow:
      status + URLs, music, poster, and ready counts. Status is derived from the
      database, so it is always correct even if you reconnect later.
 
+List your sequences:
+  GET /api/v1/sequences returns your team's sequences, most recent first. Each
+  entry is a compact summary (status, aspect ratio, poster, music, and ready/
+  failed counts) with a 'self' link to its full status document. Page with
+  ?limit (default 20, max 100) and the opaque ?cursor from the response's
+  'next' link.
+
 Enhance only (no sequence):
   POST /api/v1/scripts/enhance to expand/polish a script without generating a
   video. Takes the enhancement-relevant inputs (style, aspectRatio, targetSeconds,
@@ -129,6 +136,13 @@ export function buildRootDocument(): RootDocument {
         title: 'API root / instructions',
       },
       'create-sequence': createSequenceLink(),
+      'list-sequences': {
+        href: `${API_V1_BASE}/sequences{?limit,cursor}`,
+        method: 'GET',
+        templated: true,
+        title:
+          "List your team's sequences (most recent first; cursor-paginated)",
+      },
       'enhance-script': enhanceScriptLink(),
       'sequence-status': {
         href: `${API_V1_BASE}/sequences/{id}{?wait}`,

--- a/src/lib/api-v1/list.test.ts
+++ b/src/lib/api-v1/list.test.ts
@@ -1,0 +1,254 @@
+import type { Frame } from '@/lib/db/schema/frames';
+import type { Sequence } from '@/lib/db/schema/sequences';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  buildSequenceListPage,
+  decodeCursor,
+  encodeCursor,
+  parseLimitParam,
+} from './list';
+
+// toShareableUrl reads R2_PUBLIC_STORAGE_DOMAIN; pin local serving so the
+// origin-fallback assertions are environment-independent (see state.test.ts).
+beforeAll(() => {
+  vi.stubEnv('R2_PUBLIC_STORAGE_DOMAIN', undefined);
+});
+
+const TEST_ORIGIN = 'https://api.example.com';
+
+function makeSequence(overrides: Partial<Sequence> = {}): Sequence {
+  return {
+    id: 'seq-1',
+    teamId: 'team-1',
+    title: 'Test Sequence',
+    script: 'A test script',
+    status: 'processing',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-02T00:00:00Z'),
+    createdBy: null,
+    updatedBy: null,
+    styleId: 'style-1',
+    aspectRatio: '16:9',
+    analysisModel: 'anthropic/claude-haiku-4.5',
+    analysisDurationMs: 0,
+    imageModel: 'nano_banana_2',
+    videoModel: 'wan_i2v',
+    workflow: null,
+    musicUrl: null,
+    musicPath: null,
+    musicStatus: 'pending',
+    musicGeneratedAt: null,
+    musicError: null,
+    musicModel: null,
+    musicPrompt: null,
+    musicTags: null,
+    musicPromptInputHash: null,
+    includeMusic: true,
+    statusError: null,
+    workflowRunId: null,
+    posterUrl: null,
+    autoGenerateMotion: false,
+    autoGenerateMusic: false,
+    suggestedTalentIds: null,
+    suggestedLocationIds: null,
+    ...overrides,
+  };
+}
+
+function makeFrame(overrides: Partial<Frame> = {}): Frame {
+  return {
+    id: 'frame-1',
+    sequenceId: 'seq-1',
+    orderIndex: 0,
+    description: 'A scene',
+    durationMs: 3000,
+    thumbnailUrl: null,
+    thumbnailPath: null,
+    thumbnailStatus: 'pending',
+    thumbnailWorkflowRunId: null,
+    thumbnailGeneratedAt: null,
+    thumbnailError: null,
+    imageModel: 'nano_banana_2',
+    imagePrompt: null,
+    variantImageUrl: null,
+    variantImageStatus: 'pending',
+    variantWorkflowRunId: null,
+    variantImageGeneratedAt: null,
+    variantImageError: null,
+    videoUrl: null,
+    videoPath: null,
+    videoStatus: 'pending',
+    videoWorkflowRunId: null,
+    videoGeneratedAt: null,
+    videoError: null,
+    motionPrompt: null,
+    motionModel: null,
+    audioUrl: null,
+    audioPath: null,
+    audioStatus: 'pending',
+    audioWorkflowRunId: null,
+    audioGeneratedAt: null,
+    audioError: null,
+    audioModel: null,
+    thumbnailInputHash: null,
+    variantImageInputHash: null,
+    videoInputHash: null,
+    audioInputHash: null,
+    visualPromptInputHash: null,
+    motionPromptInputHash: null,
+    previewThumbnailUrl: null,
+    metadata: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  };
+}
+
+/** A scopedDb stub exposing only the batched frame fetch the builder uses. */
+function depsWithFrames(frames: Frame[]) {
+  return { sequences: { listFramesByIds: async () => frames } };
+}
+
+describe('cursor encode/decode', () => {
+  it('round-trips an (updatedAt, id) position', () => {
+    const cursor = { updatedAt: new Date('2026-01-02T00:00:00Z'), id: 'seq-9' };
+    const decoded = decodeCursor(encodeCursor(cursor));
+    expect(decoded.id).toBe('seq-9');
+    expect(decoded.updatedAt.getTime()).toBe(cursor.updatedAt.getTime());
+  });
+
+  it('emits a URL-safe token (no +, /, or = padding)', () => {
+    const token = encodeCursor({
+      updatedAt: new Date('2026-06-21T12:34:56Z'),
+      id: '01JABCDEF0123456789XYZWVUT',
+    });
+    expect(token).not.toMatch(/[+/=]/);
+  });
+
+  it('rejects a malformed cursor with a 400 ValidationError', () => {
+    // Not base64, no separator, and a non-numeric timestamp all fail.
+    expect(() => decodeCursor('!!!not-base64!!!')).toThrow();
+    expect(() => decodeCursor(btoa('no-separator'))).toThrow();
+    expect(() => decodeCursor(btoa('notanumber:seq-1'))).toThrow();
+  });
+});
+
+describe('parseLimitParam', () => {
+  it('defaults to 20 when absent or empty', () => {
+    expect(parseLimitParam(null)).toBe(20);
+    expect(parseLimitParam('  ')).toBe(20);
+  });
+
+  it('clamps to [1, 100]', () => {
+    expect(parseLimitParam('0')).toBe(1);
+    expect(parseLimitParam('500')).toBe(100);
+    expect(parseLimitParam('20')).toBe(20);
+  });
+
+  it('rejects a non-integer limit', () => {
+    expect(() => parseLimitParam('abc')).toThrow();
+    expect(() => parseLimitParam('1.5')).toThrow();
+  });
+});
+
+describe('buildSequenceListPage', () => {
+  it('summarizes each sequence with counts and a self link', async () => {
+    const sequence = makeSequence({
+      posterUrl: 'https://cdn/poster.png',
+      musicStatus: 'completed',
+      musicUrl: 'https://cdn/music.mp3',
+    });
+    const frames = [
+      makeFrame({ id: 'f1', thumbnailUrl: 'https://cdn/f1.png' }),
+      makeFrame({ id: 'f2', videoStatus: 'completed' }),
+      makeFrame({ id: 'f3', videoStatus: 'failed' }),
+    ];
+
+    const page = await buildSequenceListPage({
+      scopedDb: depsWithFrames(frames),
+      sequences: [sequence],
+      hasMore: false,
+      limit: 20,
+      origin: TEST_ORIGIN,
+    });
+
+    expect(page.sequences).toHaveLength(1);
+    const [item] = page.sequences;
+    expect(item).toMatchObject({
+      id: 'seq-1',
+      title: 'Test Sequence',
+      status: 'processing',
+      aspectRatio: '16:9',
+      poster: { url: 'https://cdn/poster.png' },
+      music: { status: 'completed', url: 'https://cdn/music.mp3' },
+      counts: { frames: 3, imagesReady: 1, videosReady: 1, videosFailed: 1 },
+    });
+    // No per-frame array on the summary.
+    expect(item).not.toHaveProperty('frames');
+    expect(item?._links.self?.href).toBe('/api/v1/sequences/seq-1');
+  });
+
+  it('groups batched frames back to their own sequences', async () => {
+    const a = makeSequence({ id: 'seq-a' });
+    const b = makeSequence({ id: 'seq-b' });
+    const frames = [
+      makeFrame({ id: 'fa1', sequenceId: 'seq-a', videoStatus: 'completed' }),
+      makeFrame({ id: 'fb1', sequenceId: 'seq-b' }),
+      makeFrame({ id: 'fb2', sequenceId: 'seq-b' }),
+    ];
+
+    const page = await buildSequenceListPage({
+      scopedDb: depsWithFrames(frames),
+      sequences: [a, b],
+      hasMore: false,
+      limit: 20,
+      origin: TEST_ORIGIN,
+    });
+
+    const byId = new Map(page.sequences.map((s) => [s.id, s]));
+    expect(byId.get('seq-a')?.counts).toMatchObject({
+      frames: 1,
+      videosReady: 1,
+    });
+    expect(byId.get('seq-b')?.counts).toMatchObject({
+      frames: 2,
+      videosReady: 0,
+    });
+  });
+
+  it('omits next when no further page, includes it (with a cursor) when hasMore', async () => {
+    const last = makeSequence({
+      id: 'seq-last',
+      updatedAt: new Date('2026-01-02T00:00:00Z'),
+    });
+
+    const noMore = await buildSequenceListPage({
+      scopedDb: depsWithFrames([]),
+      sequences: [last],
+      hasMore: false,
+      limit: 5,
+      origin: TEST_ORIGIN,
+    });
+    expect(noMore._links.next).toBeUndefined();
+    expect(noMore._links.self?.href).toBe('/api/v1/sequences?limit=5');
+    expect(noMore._links['create-sequence']?.method).toBe('POST');
+
+    const more = await buildSequenceListPage({
+      scopedDb: depsWithFrames([]),
+      sequences: [last],
+      hasMore: true,
+      limit: 5,
+      origin: TEST_ORIGIN,
+    });
+    const nextHref = more._links.next?.href;
+    expect(nextHref).toBeDefined();
+    // The next link's cursor must point back at the last entry.
+    const cursorParam = new URL(nextHref ?? '', TEST_ORIGIN).searchParams.get(
+      'cursor'
+    );
+    expect(cursorParam).not.toBeNull();
+    const decoded = decodeCursor(cursorParam ?? '');
+    expect(decoded.id).toBe('seq-last');
+    expect(decoded.updatedAt.getTime()).toBe(last.updatedAt.getTime());
+  });
+});

--- a/src/lib/api-v1/list.ts
+++ b/src/lib/api-v1/list.ts
@@ -1,0 +1,186 @@
+/**
+ * The list document for `GET /api/v1/sequences` — a cursor-paginated, most-
+ * recent-first page of the team's sequences.
+ *
+ * Each entry is a compact *summary* (the same scalar fields as the single-
+ * sequence status document, minus the per-frame array) plus a `counts` block
+ * and a HAL `self` link to its full status document. Counts are derived from a
+ * single batched frame query across the whole page, so listing N sequences
+ * costs one frames round-trip rather than N (see `listFramesByIds`).
+ */
+
+import type { ScopedDb } from '@/lib/db/scoped';
+import type { Frame } from '@/lib/db/schema/frames';
+import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
+import { ValidationError } from '@/lib/errors';
+import { toShareableUrl } from '@/lib/storage/buckets';
+import type { Sequence } from '@/types/database';
+import { createSequenceLink } from './discovery';
+import { API_V1_BASE, getLink, type HalResource, withLinks } from './hal';
+import { type SequenceCounts, summarizeFrameCounts } from './state';
+
+/** A compact list entry — status-document scalars without the frame array. */
+type SequenceListItem = {
+  id: string;
+  title: string;
+  status: SequenceStatus;
+  statusError: string | null;
+  aspectRatio: string;
+  createdAt: string;
+  updatedAt: string;
+  poster: { url: string } | null;
+  music: { status: MusicStatus; url: string | null };
+  counts: SequenceCounts;
+};
+
+export type SequenceListPage = HalResource<{
+  sequences: HalResource<SequenceListItem>[];
+}>;
+
+/** Keyset position: a sequence's `(updatedAt, id)`, encoded into the cursor. */
+export type SequenceCursor = { updatedAt: Date; id: string };
+
+// URL-safe base64 so the cursor drops straight into a `?cursor=` value with no
+// percent-encoding. The encoded payload is `<updatedAtMs>:<ulid>` — an opaque
+// token to callers, who only ever echo back the `next` link we hand them.
+function toBase64Url(input: string): string {
+  return btoa(input).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function fromBase64Url(input: string): string {
+  const padded = input.padEnd(
+    input.length + ((4 - (input.length % 4)) % 4),
+    '='
+  );
+  return atob(padded.replace(/-/g, '+').replace(/_/g, '/'));
+}
+
+export function encodeCursor(cursor: SequenceCursor): string {
+  return toBase64Url(`${cursor.updatedAt.getTime()}:${cursor.id}`);
+}
+
+/**
+ * Decode a `?cursor=` token, throwing a 400 `ValidationError` if it's malformed
+ * (rather than silently restarting from the first page, which would loop an
+ * agent forever). Only ever called with a token this API minted.
+ */
+export function decodeCursor(raw: string): SequenceCursor {
+  let decoded: string;
+  try {
+    decoded = fromBase64Url(raw);
+  } catch {
+    throw new ValidationError('Invalid "cursor" parameter.');
+  }
+  const sep = decoded.indexOf(':');
+  if (sep <= 0) {
+    throw new ValidationError('Invalid "cursor" parameter.');
+  }
+  const ms = Number(decoded.slice(0, sep));
+  const id = decoded.slice(sep + 1);
+  if (!Number.isSafeInteger(ms) || id === '') {
+    throw new ValidationError('Invalid "cursor" parameter.');
+  }
+  return { updatedAt: new Date(ms), id };
+}
+
+function buildListItem(
+  sequence: Sequence,
+  frames: Frame[],
+  origin: string
+): HalResource<SequenceListItem> {
+  const item: SequenceListItem = {
+    id: sequence.id,
+    title: sequence.title,
+    status: sequence.status,
+    statusError: sequence.statusError ?? null,
+    aspectRatio: sequence.aspectRatio,
+    createdAt: sequence.createdAt.toISOString(),
+    updatedAt: sequence.updatedAt.toISOString(),
+    poster: sequence.posterUrl
+      ? { url: toShareableUrl(sequence.posterUrl, origin) }
+      : null,
+    music: {
+      status: sequence.musicStatus ?? 'pending',
+      url:
+        sequence.musicUrl == null
+          ? null
+          : toShareableUrl(sequence.musicUrl, origin),
+    },
+    counts: summarizeFrameCounts(frames),
+  };
+  return withLinks(item, {
+    self: getLink(`${API_V1_BASE}/sequences/${item.id}`, 'Sequence status'),
+  });
+}
+
+/**
+ * Build the `GET /api/v1/sequences` page document for the already-fetched page
+ * of `sequences` (most recent first). `hasMore` reflects whether a further page
+ * exists — when true, a `next` HAL link carries the keyset cursor of the last
+ * entry. `origin` absolutizes stored media URLs (see `buildSequenceState`).
+ */
+export async function buildSequenceListPage(params: {
+  scopedDb: { sequences: Pick<ScopedDb['sequences'], 'listFramesByIds'> };
+  sequences: Sequence[];
+  hasMore: boolean;
+  limit: number;
+  origin: string;
+}): Promise<SequenceListPage> {
+  const { scopedDb, sequences, hasMore, limit, origin } = params;
+
+  const framesById = new Map<string, Frame[]>();
+  const allFrames = await scopedDb.sequences.listFramesByIds(
+    sequences.map((s) => s.id)
+  );
+  for (const frame of allFrames) {
+    const bucket = framesById.get(frame.sequenceId);
+    if (bucket) bucket.push(frame);
+    else framesById.set(frame.sequenceId, [frame]);
+  }
+
+  const items = sequences.map((sequence) =>
+    buildListItem(sequence, framesById.get(sequence.id) ?? [], origin)
+  );
+
+  const last = sequences.at(-1);
+  const nextHref =
+    hasMore && last
+      ? `${API_V1_BASE}/sequences?limit=${limit}&cursor=${encodeCursor({
+          updatedAt: last.updatedAt,
+          id: last.id,
+        })}`
+      : null;
+
+  return withLinks(
+    { sequences: items },
+    {
+      self: getLink(
+        `${API_V1_BASE}/sequences?limit=${limit}`,
+        'List sequences'
+      ),
+      'create-sequence': createSequenceLink(),
+      ...(nextHref
+        ? { next: getLink(nextHref, 'Next page of sequences') }
+        : {}),
+    }
+  );
+}
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+/**
+ * Parse the `?limit` query param: absent → 20; clamped to [1, 100]; present but
+ * non-integer → 400 (so a mistyped value fails loudly rather than silently
+ * snapping to a default).
+ */
+export function parseLimitParam(raw: string | null): number {
+  if (raw === null || raw.trim() === '') return DEFAULT_LIMIT;
+  const value = Number(raw);
+  if (!Number.isInteger(value)) {
+    throw new ValidationError(
+      'Invalid "limit" parameter. Use an integer between 1 and 100.'
+    );
+  }
+  return Math.min(Math.max(value, 1), MAX_LIMIT);
+}

--- a/src/lib/api-v1/openapi.test.ts
+++ b/src/lib/api-v1/openapi.test.ts
@@ -27,10 +27,22 @@ describe('buildOpenApiDocument', () => {
 
   it('documents the operations', () => {
     expect(doc.paths['/api/v1'].get).toBeDefined();
+    expect(doc.paths['/api/v1/sequences'].get).toBeDefined();
     expect(doc.paths['/api/v1/sequences'].post).toBeDefined();
     expect(doc.paths['/api/v1/sequences/{id}'].get).toBeDefined();
     expect(doc.paths['/api/v1/openapi.json'].get).toBeDefined();
     expect(doc.paths['/api/v1/scripts/enhance'].post).toBeDefined();
+  });
+
+  it('documents the list endpoint with limit/cursor params and a result schema', () => {
+    const op = doc.paths['/api/v1/sequences'].get;
+    const paramNames = op.parameters.map((p: { name: string }) => p.name);
+    expect(paramNames).toEqual(expect.arrayContaining(['limit', 'cursor']));
+    expect(op.responses['200'].content['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/SequenceListResult',
+    });
+    expect(doc.components.schemas).toHaveProperty('SequenceListItem');
+    expect(doc.components.schemas).toHaveProperty('SequenceListResult');
   });
 
   it('documents the enhance endpoint as an SSE stream with a valid example', () => {

--- a/src/lib/api-v1/openapi.ts
+++ b/src/lib/api-v1/openapi.ts
@@ -108,6 +108,25 @@ const genStatusObject: JsonObject = {
   required: ['status', 'url'],
   properties: { status: statusEnum(GEN_STATUSES), url: nullableString },
 };
+const countsObject: JsonObject = {
+  type: 'object',
+  required: ['frames', 'imagesReady', 'videosReady', 'videosFailed'],
+  properties: {
+    frames: { type: 'integer' },
+    imagesReady: { type: 'integer' },
+    videosReady: { type: 'integer' },
+    videosFailed: {
+      type: 'integer',
+      description:
+        'Frames whose video generation failed. Can be > 0 even when `status` is "completed".',
+    },
+  },
+};
+const posterObject: JsonObject = {
+  type: ['object', 'null'],
+  required: ['url'],
+  properties: { url: { type: 'string' } },
+};
 
 /** Shared error-envelope reference for 4xx/5xx responses. */
 function errorResponse(description: string): JsonObject {
@@ -190,6 +209,45 @@ export function buildOpenApiDocument(): JsonObject {
         },
       },
       [`${API_V1_BASE}/sequences`]: {
+        get: {
+          tags: ['sequences'],
+          summary: "List this team's sequences",
+          description:
+            "List the API key team's sequences, most recent first (by updatedAt). Each entry is a compact summary — status-document scalars plus a `counts` block, without the per-frame array — and carries a HAL `self` link to its full status document. Archived sequences are excluded. Page with ?limit (default 20, max 100) and the opaque ?cursor returned in the response's `next` link.",
+          parameters: [
+            {
+              name: 'limit',
+              in: 'query',
+              required: false,
+              description: 'Max sequences to return (1–100). Default 20.',
+              schema: { type: 'integer', minimum: 1, maximum: 100 },
+              example: 20,
+            },
+            {
+              name: 'cursor',
+              in: 'query',
+              required: false,
+              description:
+                "Opaque pagination cursor. Echo back the value from the response's `next` link to fetch the following page.",
+              schema: { type: 'string' },
+            },
+          ],
+          responses: {
+            '200': {
+              description:
+                'A page of sequence summaries with a HAL `_links` catalog (`self`, `create-sequence`, and `next` when more remain).',
+              content: {
+                'application/json': {
+                  schema: { $ref: '#/components/schemas/SequenceListResult' },
+                },
+              },
+            },
+            '400': errorResponse('Invalid limit or cursor.'),
+            '401': errorResponse('Missing or invalid API key.'),
+            '403': errorResponse('No team associated with the key.'),
+            '429': errorResponse('Per-key rate limit exceeded (10 req/s).'),
+          },
+        },
         post: {
           tags: ['sequences'],
           summary: 'Create a video sequence (one-shot)',
@@ -392,34 +450,56 @@ export function buildOpenApiDocument(): JsonObject {
             aspectRatio: { type: 'string' },
             createdAt: { type: 'string', format: 'date-time' },
             updatedAt: { type: 'string', format: 'date-time' },
-            poster: {
-              type: ['object', 'null'],
-              required: ['url'],
-              properties: { url: { type: 'string' } },
-            },
+            poster: posterObject,
             music: genStatusObject,
             frames: {
               type: 'array',
               items: { $ref: '#/components/schemas/SequenceStateFrame' },
             },
-            counts: {
-              type: 'object',
-              required: [
-                'frames',
-                'imagesReady',
-                'videosReady',
-                'videosFailed',
-              ],
-              properties: {
-                frames: { type: 'integer' },
-                imagesReady: { type: 'integer' },
-                videosReady: { type: 'integer' },
-                videosFailed: {
-                  type: 'integer',
-                  description:
-                    'Frames whose video generation failed. Can be > 0 even when `status` is "completed".',
-                },
-              },
+            counts: countsObject,
+            _links: { $ref: '#/components/schemas/HalLinks' },
+          },
+        },
+        SequenceListItem: {
+          type: 'object',
+          description:
+            'A compact sequence summary (status-document scalars + counts, without the frame array) as returned in a list page.',
+          required: [
+            'id',
+            'title',
+            'status',
+            'statusError',
+            'aspectRatio',
+            'createdAt',
+            'updatedAt',
+            'poster',
+            'music',
+            'counts',
+            '_links',
+          ],
+          properties: {
+            id: { type: 'string' },
+            title: { type: 'string' },
+            status: statusEnum(SEQUENCE_STATUSES),
+            statusError: nullableString,
+            aspectRatio: { type: 'string' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+            poster: posterObject,
+            music: genStatusObject,
+            counts: countsObject,
+            _links: { $ref: '#/components/schemas/HalLinks' },
+          },
+        },
+        SequenceListResult: {
+          type: 'object',
+          description:
+            'A page of sequence summaries, most recent first. `_links.next` is present only when a further page exists.',
+          required: ['sequences', '_links'],
+          properties: {
+            sequences: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/SequenceListItem' },
             },
             _links: { $ref: '#/components/schemas/HalLinks' },
           },

--- a/src/lib/api-v1/state.ts
+++ b/src/lib/api-v1/state.ts
@@ -8,6 +8,7 @@
  */
 
 import type { ScopedDb } from '@/lib/db/scoped';
+import type { Frame } from '@/lib/db/schema/frames';
 import { FRAME_GENERATION_STATUSES } from '@/lib/db/schema/frames';
 import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
 import { toShareableUrl } from '@/lib/storage/buckets';
@@ -31,6 +32,19 @@ type SequenceStateFrame = {
   video: { status: FrameGenStatus; url: string | null };
 };
 
+export type SequenceCounts = {
+  frames: number;
+  imagesReady: number;
+  videosReady: number;
+  /**
+   * Frames whose video generation failed. A sequence can reach the terminal
+   * `completed` status with `videosFailed > 0` (per-frame motion failures
+   * don't fail the run), so an agent must check this to know a terminal
+   * result actually succeeded end-to-end.
+   */
+  videosFailed: number;
+};
+
 export type SequenceState = {
   id: string;
   title: string;
@@ -42,19 +56,32 @@ export type SequenceState = {
   poster: { url: string } | null;
   music: { status: MusicStatus; url: string | null };
   frames: SequenceStateFrame[];
-  counts: {
-    frames: number;
-    imagesReady: number;
-    videosReady: number;
-    /**
-     * Frames whose video generation failed. A sequence can reach the terminal
-     * `completed` status with `videosFailed > 0` (per-frame motion failures
-     * don't fail the run), so an agent must check this to know a terminal
-     * result actually succeeded end-to-end.
-     */
-    videosFailed: number;
-  };
+  counts: SequenceCounts;
 };
+
+/** The image URL a frame exposes once its still is ready (else null). */
+function frameImageUrl(frame: Frame): string | null {
+  // Frames track video status explicitly; image readiness is signalled by the
+  // presence of a thumbnail URL (the stored R2 url, else the fast preview CDN
+  // url).
+  return frame.thumbnailUrl ?? frame.previewThumbnailUrl ?? null;
+}
+
+/**
+ * Readiness tallies over a sequence's frames — the single source of truth for
+ * the `counts` block shared by the status document and the list summary.
+ */
+export function summarizeFrameCounts(frames: Frame[]): SequenceCounts {
+  let imagesReady = 0;
+  let videosReady = 0;
+  let videosFailed = 0;
+  for (const frame of frames) {
+    if (frameImageUrl(frame) !== null) imagesReady += 1;
+    if (frame.videoStatus === 'completed') videosReady += 1;
+    if (frame.videoStatus === 'failed') videosFailed += 1;
+  }
+  return { frames: frames.length, imagesReady, videosReady, videosFailed };
+}
 
 export async function buildSequenceState(
   scopedDb: { frames: Pick<ScopedDb['frames'], 'listBySequence'> },
@@ -71,14 +98,12 @@ export async function buildSequenceState(
     url === null ? null : toShareableUrl(url, origin);
 
   const stateFrames: SequenceStateFrame[] = ordered.map((frame) => {
-    const imageUrl = frame.thumbnailUrl ?? frame.previewThumbnailUrl ?? null;
+    const imageUrl = frameImageUrl(frame);
     return {
       id: frame.id,
       orderIndex: frame.orderIndex,
       title: frame.metadata?.metadata?.title ?? null,
       image: {
-        // Frames track video status explicitly; image readiness is signalled by
-        // the presence of a thumbnail URL.
         status: imageUrl ? 'completed' : 'pending',
         url: share(imageUrl),
       },
@@ -105,15 +130,7 @@ export async function buildSequenceState(
       url: share(sequence.musicUrl ?? null),
     },
     frames: stateFrames,
-    counts: {
-      frames: stateFrames.length,
-      imagesReady: stateFrames.filter((f) => f.image.status === 'completed')
-        .length,
-      videosReady: stateFrames.filter((f) => f.video.status === 'completed')
-        .length,
-      videosFailed: stateFrames.filter((f) => f.video.status === 'failed')
-        .length,
-    },
+    counts: summarizeFrameCounts(ordered),
   };
 }
 

--- a/src/lib/db/scoped/sequences.ts
+++ b/src/lib/db/scoped/sequences.ts
@@ -13,7 +13,7 @@ import { frames, sequences } from '@/lib/db/schema';
 import type { Frame, NewSequence, Sequence, Style } from '@/lib/db/schema';
 import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
 import { ValidationError } from '@/lib/errors';
-import { and, asc, desc, eq, inArray, isNull, not } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNull, lt, not, or } from 'drizzle-orm';
 
 export type MusicFieldsUpdate = {
   musicStatus?: MusicStatus;
@@ -49,6 +49,42 @@ function createSequencesReadMethods(db: Database, teamId: string) {
           )
         )
         .orderBy(desc(sequences.updatedAt));
+    },
+
+    /**
+     * Keyset-paginated, most-recent-first page of the team's non-archived
+     * sequences — backs the public `GET /api/v1/sequences` list. Ordered by
+     * `(updatedAt, id)` descending so the `id` tiebreaker keeps the order total
+     * even when several rows share an `updatedAt` second. Pass the last row's
+     * `(updatedAt, id)` as `cursor` to fetch the next page. Fetches `limit + 1`
+     * rows so the caller can tell whether a further page exists without a second
+     * query.
+     */
+    listPage: async (params: {
+      limit: number;
+      cursor: { updatedAt: Date; id: string } | null;
+    }): Promise<Sequence[]> => {
+      const { limit, cursor } = params;
+      return await db
+        .select()
+        .from(sequences)
+        .where(
+          and(
+            eq(sequences.teamId, teamId),
+            not(eq(sequences.status, 'archived')),
+            cursor
+              ? or(
+                  lt(sequences.updatedAt, cursor.updatedAt),
+                  and(
+                    eq(sequences.updatedAt, cursor.updatedAt),
+                    lt(sequences.id, cursor.id)
+                  )
+                )
+              : undefined
+          )
+        )
+        .orderBy(desc(sequences.updatedAt), desc(sequences.id))
+        .limit(limit + 1);
     },
 
     getById: async (sequenceId: string): Promise<Sequence | null> => {

--- a/src/routes/api/v1/sequences.ts
+++ b/src/routes/api/v1/sequences.ts
@@ -1,23 +1,38 @@
 /**
- * POST /api/v1/sequences — public "one-shot" sequence creation.
+ * /api/v1/sequences — public sequence collection.
+ *
+ *   GET  — list this team's sequences (most recent first, cursor-paginated).
+ *   POST — one-shot sequence creation.
  *
  * Authenticated via `authWithTeamRequestMiddleware`: an API key
  * (`Authorization: Bearer <key>` or `x-api-key`, resolved to its owner by the
- * Better Auth apiKey plugin) or, equivalently, a dashboard session cookie.
- * Optionally enhances the script, resolves a style + cast + locations +
+ * Better Auth apiKey plugin) or, equivalently, a dashboard session cookie. Both
+ * verbs are team-scoped, so a key only ever sees its own team's sequences.
+ *
+ * GET returns a compact summary per sequence (status-document scalars + a
+ * `counts` block, but not the full per-frame array) with a HAL `self` link to
+ * each sequence's full status document. `?limit` (default 20, cap 100) and an
+ * opaque `?cursor` page through the results; a `next` link appears while more
+ * remain. Archived sequences are excluded.
+ *
+ * POST optionally enhances the script, resolves a style + cast + locations +
  * elements, then triggers generation. Generation is async: responds 202 with
  * the created sequence id(s), workflow run id(s), a status URL to poll, and a
- * HAL `_links` catalog of next actions.
- *
- * Pass `?wait=60s` to additionally block until each new sequence shows its first
- * progress (or a terminal state) and embed that snapshot in the response — handy
- * for agents that have no sleep tool of their own.
+ * HAL `_links` catalog of next actions. Pass `?wait=60s` to additionally block
+ * until each new sequence shows its first progress (or a terminal state) and
+ * embed that snapshot in the response — handy for agents that have no sleep
+ * tool of their own.
  */
 
 import { authWithTeamRequestMiddleware } from '@/functions/middleware';
 import { type OneShotWaitResult, runOneShotCreate } from '@/lib/api-v1/create';
 import { apiJsonError, runApiV1Handler } from '@/lib/api-v1/errors';
 import { apiCreateSequenceSchema } from '@/lib/api-v1/input-schema';
+import {
+  buildSequenceListPage,
+  decodeCursor,
+  parseLimitParam,
+} from '@/lib/api-v1/list';
 import {
   buildSequenceState,
   isTerminalSequenceState,
@@ -34,6 +49,31 @@ export const Route = createFileRoute('/api/v1/sequences')({
   server: {
     middleware: [authWithTeamRequestMiddleware],
     handlers: {
+      GET: async ({ request, context }) =>
+        runApiV1Handler(async () => {
+          const url = new URL(request.url);
+          const limit = parseLimitParam(url.searchParams.get('limit'));
+          const cursorRaw = url.searchParams.get('cursor');
+          const cursor = cursorRaw ? decodeCursor(cursorRaw) : null;
+
+          // Fetch limit+1 to detect a further page without a second query.
+          const rows = await context.scopedDb.sequences.listPage({
+            limit,
+            cursor,
+          });
+          const hasMore = rows.length > limit;
+          const page = hasMore ? rows.slice(0, limit) : rows;
+
+          const document = await buildSequenceListPage({
+            scopedDb: context.scopedDb,
+            sequences: page,
+            hasMore,
+            limit,
+            origin: url.origin,
+          });
+          return Response.json(document);
+        }),
+
       POST: async ({ request, context }) =>
         runApiV1Handler(async () => {
           let body: unknown;


### PR DESCRIPTION
## Summary

Adds `GET /api/v1/sequences` to the public API so an API-key holder can list their team's sequences, complementing the existing `GET /api/v1/sequences/{id}` status endpoint.

Per the agreed scope on the issue:

- **Response — summary + counts.** Each entry is a compact summary (status-document scalars: `id`, `title`, `status`, `statusError`, `aspectRatio`, `createdAt`, `updatedAt`, `poster`, `music`, plus a `counts` block) with a HAL `self` link to its full status document. The per-frame array is **not** included. Counts come from a single batched `listFramesByIds` query across the whole page — one frames round-trip, not N.
- **Pagination — cursor.** Most-recent-first; keyset on `(updatedAt, id)`. `?limit` (default 20, cap 100) and an opaque URL-safe `?cursor`; a HAL `next` link appears while more pages remain.
- **Archived excluded** (matches `scopedDb.sequences.list()`).

Team-scoped via the API key, same auth as the rest of `/api/v1`. No `?wait` long-poll on the list (it fits a single resource, not a collection).

## Changes

- `src/lib/db/scoped/sequences.ts` — new `listPage({ limit, cursor })` keyset read (fetches `limit + 1` to detect a further page in one query).
- `src/lib/api-v1/list.ts` *(new)* — list-document builder, opaque base64url cursor encode/decode (400s on malformed), `parseLimitParam`.
- `src/lib/api-v1/state.ts` — extracted `summarizeFrameCounts` as the single source of truth for the `counts` block, reused by the status doc and the list summary.
- `src/routes/api/v1/sequences.ts` — added the `GET` handler.
- `src/lib/api-v1/discovery.ts` / `openapi.ts` — advertise a `list-sequences` affordance and document the operation (new `SequenceListItem` / `SequenceListResult` schemas, named distinctly from the create-time `SequenceSummary`).

## Testing

- New `list.test.ts`: cursor round-trip + URL-safety + malformed rejection, limit clamping, builder + batched-frame grouping + next-link cursor. Assertions added to `discovery.test.ts` and `openapi.test.ts`.
- `bun typecheck`, `bun lint` (0 errors), `bun format:check`, and **89 api-v1 + 44 scoped-db tests** all green.

Not yet exercised against a live server for this branch (the local `:3000` dev server belongs to a different worktree); the handler is thin glue over the unit-tested functions.

Closes #964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
