### PR TITLE
feat(api-v1): add style + models to sequences API

### DIFF
--- a/docs/developer-guide/public-api.md
+++ b/docs/developer-guide/public-api.md
@@ -85,13 +85,33 @@ Response (`202`):
 ## Poll for status
 
 `GET /api/v1/sequences/{id}` returns a database-derived status document: overall
-status, per-frame image/video status and URLs, music, poster, and ready/failed
-counts. Because it is derived from the database it is always correct, even if you
-reconnect later.
+status, the `style` and `models` it was generated with, aspect ratio, per-frame
+image/video status and URLs, music, poster, and ready/failed counts. Because it
+is derived from the database it is always correct, even if you reconnect later.
+
+`style` is `{ id, name }` (the name is `null` only if the style was deleted) and
+`models` is `{ analysis, image, video, music }` — the raw model ids. These are
+the same values the dashboard filters and searches sequences on.
 
 A terminal `completed` status can still carry `counts.videosFailed > 0` — a
 failed frame does not fail the whole run — so check the counts to confirm an
 end-to-end success.
+
+## List your sequences
+
+`GET /api/v1/sequences` returns your team's sequences, most recent first. Each
+entry is a compact summary of the status document — `status`, `aspectRatio`,
+`style`, `models`, `poster`, `music`, and the ready/failed `counts`, but **not**
+the per-frame array — with a `self` link to its full status document.
+
+```bash
+curl "https://openstory.so/api/v1/sequences?limit=20" \
+  -H "x-api-key: $OPENSTORY_API_KEY"
+```
+
+Page with `?limit` (default 20, max 100) and the opaque `?cursor` returned in the
+response's `_links.next`. Follow that link to fetch the next page; its absence
+means you've reached the end. Archived sequences are excluded.
 
 ## Long-polling with `?wait`
 

--- a/docs/developer-guide/public-api.md
+++ b/docs/developer-guide/public-api.md
@@ -89,9 +89,10 @@ status, the `style` and `models` it was generated with, aspect ratio, per-frame
 image/video status and URLs, music, poster, and ready/failed counts. Because it
 is derived from the database it is always correct, even if you reconnect later.
 
-`style` is `{ id, name }` (the name is `null` only if the style was deleted) and
-`models` is `{ analysis, image, video, music }` — the raw model ids. These are
-the same values the dashboard filters and searches sequences on.
+`style` is `{ id, name }` (the name is `null` only in the rare case the style
+row fails to resolve) and `models` is `{ analysis, image, video, music }` — the
+raw model ids. These are the same values the dashboard filters and searches
+sequences on.
 
 A terminal `completed` status can still carry `counts.videosFailed > 0` — a
 failed frame does not fail the whole run — so check the counts to confirm an

--- a/src/lib/api-v1/discovery.ts
+++ b/src/lib/api-v1/discovery.ts
@@ -21,16 +21,17 @@ Workflow:
   1. POST /api/v1/sequences with a script (and optional style, cast, locations,
      elements, model choices). Generation is asynchronous: you get back 202 with
      the created sequence id(s), workflow run id(s), and a statusUrl to poll.
-  2. GET the statusUrl to watch progress: overall status, per-frame image/video
-     status + URLs, music, poster, and ready counts. Status is derived from the
-     database, so it is always correct even if you reconnect later.
+  2. GET the statusUrl to watch progress: overall status, the style and models
+     used, per-frame image/video status + URLs, music, poster, and ready counts.
+     Status is derived from the database, so it is always correct even if you
+     reconnect later.
 
 List your sequences:
   GET /api/v1/sequences returns your team's sequences, most recent first. Each
-  entry is a compact summary (status, aspect ratio, poster, music, and ready/
-  failed counts) with a 'self' link to its full status document. Page with
-  ?limit (default 20, max 100) and the opaque ?cursor from the response's
-  'next' link.
+  entry is a compact summary (status, aspect ratio, style, models, poster,
+  music, and ready/failed counts) with a 'self' link to its full status
+  document. Page with ?limit (default 20, max 100) and the opaque ?cursor from
+  the response's 'next' link.
 
 Enhance only (no sequence):
   POST /api/v1/scripts/enhance to expand/polish a script without generating a

--- a/src/lib/api-v1/list.test.ts
+++ b/src/lib/api-v1/list.test.ts
@@ -1,4 +1,5 @@
 import type { Frame } from '@/lib/db/schema/frames';
+import type { Style } from '@/lib/db/schema/libraries';
 import type { Sequence } from '@/lib/db/schema/sequences';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
@@ -104,9 +105,50 @@ function makeFrame(overrides: Partial<Frame> = {}): Frame {
   };
 }
 
-/** A scopedDb stub exposing only the batched frame fetch the builder uses. */
-function depsWithFrames(frames: Frame[]) {
-  return { sequences: { listFramesByIds: async () => frames } };
+function makeStyle(overrides: Partial<Style> = {}): Style {
+  return {
+    id: 'style-1',
+    teamId: 'team-1',
+    name: 'Cinematic Noir',
+    description: null,
+    config: {
+      mood: 'tense',
+      artStyle: 'noir',
+      lighting: 'low-key',
+      colorPalette: ['#000'],
+      cameraWork: 'handheld',
+      referenceFilms: [],
+      colorGrading: 'desaturated',
+    },
+    category: null,
+    tags: [],
+    isPublic: false,
+    isTemplate: false,
+    version: 1,
+    previewUrl: null,
+    sampleVideos: [],
+    recommendedImageModel: null,
+    recommendedVideoModel: null,
+    defaultAspectRatio: null,
+    useCases: [],
+    sortOrder: 100,
+    usageCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: null,
+    ...overrides,
+  };
+}
+
+/**
+ * A scopedDb stub exposing the batched frame + style fetches the builder uses.
+ * `styles` defaults to a single 'style-1' row matching the default sequence.
+ */
+function depsWithFrames(frames: Frame[], styles: Style[] = [makeStyle()]) {
+  return {
+    sequences: { listFramesByIds: async () => frames },
+    styles: { listByIds: async () => styles },
+  };
 }
 
 describe('cursor encode/decode', () => {
@@ -179,6 +221,13 @@ describe('buildSequenceListPage', () => {
       title: 'Test Sequence',
       status: 'processing',
       aspectRatio: '16:9',
+      style: { id: 'style-1', name: 'Cinematic Noir' },
+      models: {
+        analysis: 'anthropic/claude-haiku-4.5',
+        image: 'nano_banana_2',
+        video: 'wan_i2v',
+        music: null,
+      },
       poster: { url: 'https://cdn/poster.png' },
       music: { status: 'completed', url: 'https://cdn/music.mp3' },
       counts: { frames: 3, imagesReady: 1, videosReady: 1, videosFailed: 1 },
@@ -214,6 +263,38 @@ describe('buildSequenceListPage', () => {
       frames: 2,
       videosReady: 0,
     });
+  });
+
+  it('resolves each sequence to its own style and nulls the name when missing', async () => {
+    const a = makeSequence({ id: 'seq-a', styleId: 'style-1' });
+    const b = makeSequence({ id: 'seq-b', styleId: 'style-2' });
+    const c = makeSequence({ id: 'seq-c', styleId: 'style-gone' });
+
+    const page = await buildSequenceListPage({
+      scopedDb: depsWithFrames(
+        [],
+        [
+          makeStyle({ id: 'style-1', name: 'Cinematic Noir' }),
+          makeStyle({ id: 'style-2', name: 'Pixel Art Adventure' }),
+        ]
+      ),
+      sequences: [a, b, c],
+      hasMore: false,
+      limit: 20,
+      origin: TEST_ORIGIN,
+    });
+
+    const byId = new Map(page.sequences.map((s) => [s.id, s]));
+    expect(byId.get('seq-a')?.style).toEqual({
+      id: 'style-1',
+      name: 'Cinematic Noir',
+    });
+    expect(byId.get('seq-b')?.style).toEqual({
+      id: 'style-2',
+      name: 'Pixel Art Adventure',
+    });
+    // No style row for 'style-gone' → id preserved, name null.
+    expect(byId.get('seq-c')?.style).toEqual({ id: 'style-gone', name: null });
   });
 
   it('omits next when no further page, includes it (with a cursor) when hasMore', async () => {

--- a/src/lib/api-v1/list.test.ts
+++ b/src/lib/api-v1/list.test.ts
@@ -2,6 +2,19 @@ import type { Frame } from '@/lib/db/schema/frames';
 import type { Style } from '@/lib/db/schema/libraries';
 import type { Sequence } from '@/lib/db/schema/sequences';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Stub the logger so the deliberate missing-style case below doesn't print an
+// error line (buildSequenceSummary logs unresolved styles). Hoisted so the mock
+// lands before ./list → ./state captures its logger at import.
+vi.mock('@/lib/observability/logger', () => ({
+  getLogger: () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 import {
   buildSequenceListPage,
   decodeCursor,

--- a/src/lib/api-v1/list.ts
+++ b/src/lib/api-v1/list.ts
@@ -11,27 +11,19 @@
 
 import type { ScopedDb } from '@/lib/db/scoped';
 import type { Frame } from '@/lib/db/schema/frames';
-import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
+import type { Style } from '@/lib/db/schema/libraries';
 import { ValidationError } from '@/lib/errors';
-import { toShareableUrl } from '@/lib/storage/buckets';
 import type { Sequence } from '@/types/database';
 import { createSequenceLink } from './discovery';
 import { API_V1_BASE, getLink, type HalResource, withLinks } from './hal';
-import { type SequenceCounts, summarizeFrameCounts } from './state';
+import {
+  buildSequenceSummary,
+  type SequenceSummary,
+  summarizeFrameCounts,
+} from './state';
 
-/** A compact list entry — status-document scalars without the frame array. */
-type SequenceListItem = {
-  id: string;
-  title: string;
-  status: SequenceStatus;
-  statusError: string | null;
-  aspectRatio: string;
-  createdAt: string;
-  updatedAt: string;
-  poster: { url: string } | null;
-  music: { status: MusicStatus; url: string | null };
-  counts: SequenceCounts;
-};
+/** A compact list entry — the status-document scalars without the frame array. */
+type SequenceListItem = SequenceSummary;
 
 export type SequenceListPage = HalResource<{
   sequences: HalResource<SequenceListItem>[];
@@ -86,28 +78,15 @@ export function decodeCursor(raw: string): SequenceCursor {
 function buildListItem(
   sequence: Sequence,
   frames: Frame[],
+  style: Style | null,
   origin: string
 ): HalResource<SequenceListItem> {
-  const item: SequenceListItem = {
-    id: sequence.id,
-    title: sequence.title,
-    status: sequence.status,
-    statusError: sequence.statusError ?? null,
-    aspectRatio: sequence.aspectRatio,
-    createdAt: sequence.createdAt.toISOString(),
-    updatedAt: sequence.updatedAt.toISOString(),
-    poster: sequence.posterUrl
-      ? { url: toShareableUrl(sequence.posterUrl, origin) }
-      : null,
-    music: {
-      status: sequence.musicStatus ?? 'pending',
-      url:
-        sequence.musicUrl == null
-          ? null
-          : toShareableUrl(sequence.musicUrl, origin),
-    },
+  const item = buildSequenceSummary({
+    sequence,
+    style,
     counts: summarizeFrameCounts(frames),
-  };
+    origin,
+  });
   return withLinks(item, {
     self: getLink(`${API_V1_BASE}/sequences/${item.id}`, 'Sequence status'),
   });
@@ -120,7 +99,10 @@ function buildListItem(
  * entry. `origin` absolutizes stored media URLs (see `buildSequenceState`).
  */
 export async function buildSequenceListPage(params: {
-  scopedDb: { sequences: Pick<ScopedDb['sequences'], 'listFramesByIds'> };
+  scopedDb: {
+    sequences: Pick<ScopedDb['sequences'], 'listFramesByIds'>;
+    styles: Pick<ScopedDb['styles'], 'listByIds'>;
+  };
   sequences: Sequence[];
   hasMore: boolean;
   limit: number;
@@ -128,18 +110,28 @@ export async function buildSequenceListPage(params: {
 }): Promise<SequenceListPage> {
   const { scopedDb, sequences, hasMore, limit, origin } = params;
 
+  // One batched frame fetch and one batched style fetch across the whole page,
+  // rather than N round-trips per sequence.
+  const [allFrames, allStyles] = await Promise.all([
+    scopedDb.sequences.listFramesByIds(sequences.map((s) => s.id)),
+    scopedDb.styles.listByIds(sequences.map((s) => s.styleId)),
+  ]);
+
   const framesById = new Map<string, Frame[]>();
-  const allFrames = await scopedDb.sequences.listFramesByIds(
-    sequences.map((s) => s.id)
-  );
   for (const frame of allFrames) {
     const bucket = framesById.get(frame.sequenceId);
     if (bucket) bucket.push(frame);
     else framesById.set(frame.sequenceId, [frame]);
   }
+  const styleById = new Map(allStyles.map((style) => [style.id, style]));
 
   const items = sequences.map((sequence) =>
-    buildListItem(sequence, framesById.get(sequence.id) ?? [], origin)
+    buildListItem(
+      sequence,
+      framesById.get(sequence.id) ?? [],
+      styleById.get(sequence.styleId) ?? null,
+      origin
+    )
   );
 
   const last = sequences.at(-1);

--- a/src/lib/api-v1/openapi.test.ts
+++ b/src/lib/api-v1/openapi.test.ts
@@ -95,4 +95,19 @@ describe('buildOpenApiDocument', () => {
     const counts = doc.components.schemas.SequenceState.properties.counts;
     expect(counts.required).toContain('videosFailed');
   });
+
+  it('exposes style and models on both the status document and list item', () => {
+    for (const name of ['SequenceState', 'SequenceListItem']) {
+      const schema = doc.components.schemas[name];
+      expect(schema.required, name).toEqual(
+        expect.arrayContaining(['style', 'models'])
+      );
+      expect(schema.properties.style.properties).toMatchObject({
+        id: { type: 'string' },
+      });
+      expect(schema.properties.models.required).toEqual(
+        expect.arrayContaining(['analysis', 'image', 'video', 'music'])
+      );
+    }
+  });
 });

--- a/src/lib/api-v1/openapi.ts
+++ b/src/lib/api-v1/openapi.ts
@@ -127,6 +127,25 @@ const posterObject: JsonObject = {
   required: ['url'],
   properties: { url: { type: 'string' } },
 };
+const styleObject: JsonObject = {
+  type: 'object',
+  description:
+    "The style the sequence was generated with — `id` is the UI's `styleId` filter value; `name` is what the UI search matches on (null only if the style row is gone).",
+  required: ['id', 'name'],
+  properties: { id: { type: 'string' }, name: nullableString },
+};
+const modelsObject: JsonObject = {
+  type: 'object',
+  description:
+    'The models the sequence was generated with — the raw ids the UI filters/sorts on.',
+  required: ['analysis', 'image', 'video', 'music'],
+  properties: {
+    analysis: { type: 'string', description: 'Script-analysis model id.' },
+    image: { type: 'string', description: 'Per-frame image model id.' },
+    video: { type: 'string', description: 'Per-frame video model id.' },
+    music: { ...nullableString, description: 'Music model id, if any.' },
+  },
+};
 
 /** Shared error-envelope reference for 4xx/5xx responses. */
 function errorResponse(description: string): JsonObject {
@@ -434,6 +453,8 @@ export function buildOpenApiDocument(): JsonObject {
             'status',
             'statusError',
             'aspectRatio',
+            'style',
+            'models',
             'createdAt',
             'updatedAt',
             'poster',
@@ -448,6 +469,8 @@ export function buildOpenApiDocument(): JsonObject {
             status: statusEnum(SEQUENCE_STATUSES),
             statusError: nullableString,
             aspectRatio: { type: 'string' },
+            style: styleObject,
+            models: modelsObject,
             createdAt: { type: 'string', format: 'date-time' },
             updatedAt: { type: 'string', format: 'date-time' },
             poster: posterObject,
@@ -463,13 +486,15 @@ export function buildOpenApiDocument(): JsonObject {
         SequenceListItem: {
           type: 'object',
           description:
-            'A compact sequence summary (status-document scalars + counts, without the frame array) as returned in a list page.',
+            'A compact sequence summary (status-document scalars + style, models, and counts, without the frame array) as returned in a list page.',
           required: [
             'id',
             'title',
             'status',
             'statusError',
             'aspectRatio',
+            'style',
+            'models',
             'createdAt',
             'updatedAt',
             'poster',
@@ -483,6 +508,8 @@ export function buildOpenApiDocument(): JsonObject {
             status: statusEnum(SEQUENCE_STATUSES),
             statusError: nullableString,
             aspectRatio: { type: 'string' },
+            style: styleObject,
+            models: modelsObject,
             createdAt: { type: 'string', format: 'date-time' },
             updatedAt: { type: 'string', format: 'date-time' },
             poster: posterObject,

--- a/src/lib/api-v1/openapi.ts
+++ b/src/lib/api-v1/openapi.ts
@@ -130,7 +130,7 @@ const posterObject: JsonObject = {
 const styleObject: JsonObject = {
   type: 'object',
   description:
-    "The style the sequence was generated with — `id` is the UI's `styleId` filter value; `name` is what the UI search matches on (null only if the style row is gone).",
+    "The style the sequence was generated with — `id` is the UI's `styleId` filter value; `name` is what the UI search matches on (null only if the style row fails to resolve, which the FK normally makes impossible).",
   required: ['id', 'name'],
   properties: { id: { type: 'string' }, name: nullableString },
 };

--- a/src/lib/api-v1/state.test.ts
+++ b/src/lib/api-v1/state.test.ts
@@ -2,6 +2,20 @@ import type { Frame } from '@/lib/db/schema/frames';
 import type { Style } from '@/lib/db/schema/libraries';
 import type { Sequence } from '@/lib/db/schema/sequences';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Stub the logger so the "style failed to resolve" anomaly path is observable
+// (and doesn't print an error line during the run). Hoisted so the mock is in
+// place before ./state captures its logger at import.
+const { loggerErrorMock } = vi.hoisted(() => ({ loggerErrorMock: vi.fn() }));
+vi.mock('@/lib/observability/logger', () => ({
+  getLogger: () => ({
+    error: loggerErrorMock,
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
 import {
   buildSequenceState as buildSequenceStateRaw,
   isTerminalSequenceState,
@@ -196,13 +210,19 @@ describe('buildSequenceState', () => {
     expect(state.poster).not.toBeNull();
   });
 
-  it('surfaces the style id with a null name when the style row is gone', async () => {
+  it('keeps the style id but nulls the name and logs when the style fails to resolve', async () => {
+    loggerErrorMock.mockClear();
     const state = await build(
       depsWithFrames([], null),
       makeSequence({ styleId: 'style-deleted', musicModel: 'elevenlabs_music' })
     );
     expect(state.style).toEqual({ id: 'style-deleted', name: null });
     expect(state.models.music).toBe('elevenlabs_music');
+    // The unresolved style is surfaced, not silently swallowed.
+    expect(loggerErrorMock).toHaveBeenCalledWith(expect.any(String), {
+      sequenceId: 'seq-1',
+      styleId: 'style-deleted',
+    });
   });
 
   it('null poster and falls back to pending music status', async () => {

--- a/src/lib/api-v1/state.test.ts
+++ b/src/lib/api-v1/state.test.ts
@@ -1,4 +1,5 @@
 import type { Frame } from '@/lib/db/schema/frames';
+import type { Style } from '@/lib/db/schema/libraries';
 import type { Sequence } from '@/lib/db/schema/sequences';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import {
@@ -118,8 +119,46 @@ function makeSequence(overrides: Partial<Sequence> = {}): Sequence {
   };
 }
 
-function depsWithFrames(frames: Frame[]) {
-  return { frames: { listBySequence: async () => frames } };
+function makeStyle(overrides: Partial<Style> = {}): Style {
+  return {
+    id: 'style-1',
+    teamId: 'team-1',
+    name: 'Cinematic Noir',
+    description: null,
+    config: {
+      mood: 'tense',
+      artStyle: 'noir',
+      lighting: 'low-key',
+      colorPalette: ['#000'],
+      cameraWork: 'handheld',
+      referenceFilms: [],
+      colorGrading: 'desaturated',
+    },
+    category: null,
+    tags: [],
+    isPublic: false,
+    isTemplate: false,
+    version: 1,
+    previewUrl: null,
+    sampleVideos: [],
+    recommendedImageModel: null,
+    recommendedVideoModel: null,
+    defaultAspectRatio: null,
+    useCases: [],
+    sortOrder: 100,
+    usageCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: null,
+    ...overrides,
+  };
+}
+
+function depsWithFrames(frames: Frame[], style: Style | null = makeStyle()) {
+  return {
+    frames: { listBySequence: async () => frames },
+    styles: { getById: async () => style },
+  };
 }
 
 describe('buildSequenceState', () => {
@@ -137,6 +176,13 @@ describe('buildSequenceState', () => {
       title: 'Test Sequence',
       status: 'processing',
       aspectRatio: '16:9',
+      style: { id: 'style-1', name: 'Cinematic Noir' },
+      models: {
+        analysis: 'anthropic/claude-haiku-4.5',
+        image: 'nano_banana_2',
+        video: 'wan_i2v',
+        music: null,
+      },
       poster: { url: 'https://cdn/poster.png' },
       music: { status: 'completed', url: 'https://cdn/music.mp3' },
     });
@@ -148,6 +194,15 @@ describe('buildSequenceState', () => {
       videosFailed: 0,
     });
     expect(state.poster).not.toBeNull();
+  });
+
+  it('surfaces the style id with a null name when the style row is gone', async () => {
+    const state = await build(
+      depsWithFrames([], null),
+      makeSequence({ styleId: 'style-deleted', musicModel: 'elevenlabs_music' })
+    );
+    expect(state.style).toEqual({ id: 'style-deleted', name: null });
+    expect(state.models.music).toBe('elevenlabs_music');
   });
 
   it('null poster and falls back to pending music status', async () => {

--- a/src/lib/api-v1/state.ts
+++ b/src/lib/api-v1/state.ts
@@ -12,9 +12,12 @@ import type { Frame } from '@/lib/db/schema/frames';
 import { FRAME_GENERATION_STATUSES } from '@/lib/db/schema/frames';
 import type { Style } from '@/lib/db/schema/libraries';
 import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
+import { getLogger } from '@/lib/observability/logger';
 import { toShareableUrl } from '@/lib/storage/buckets';
 import type { Sequence } from '@/types/database';
 import { API_V1_BASE, type HalResource, waitLink, withLinks } from './hal';
+
+const logger = getLogger(['openstory', 'api-v1']);
 
 type FrameGenStatus = (typeof FRAME_GENERATION_STATUSES)[number];
 
@@ -48,7 +51,8 @@ export type SequenceCounts = {
 
 /** The style a sequence was generated with — the UI's `styleId` filter value
  * plus its human-readable name (what the UI search matches on). `name` is null
- * only if the referenced style row is somehow gone. */
+ * only when the style row fails to resolve — a data anomaly the notNull FK
+ * normally makes impossible, logged in `buildSequenceSummary`. */
 type SequenceStyle = {
   id: string;
   name: string | null;
@@ -128,6 +132,17 @@ export function buildSequenceSummary(params: {
   const { sequence, style, counts, origin } = params;
   const share = (url: string | null): string | null =>
     url === null ? null : toShareableUrl(url, origin);
+
+  if (style === null) {
+    // styleId is notNull behind an FK, so a sequence should always resolve to a
+    // style row. A miss means the FK was bypassed (manual edit, or a migration
+    // run with foreign_keys off) — surface it rather than silently shipping a
+    // nameless style to API consumers and the dashboard.
+    logger.error('api/v1 sequence style did not resolve: {styleId}', {
+      sequenceId: sequence.id,
+      styleId: sequence.styleId,
+    });
+  }
 
   return {
     id: sequence.id,

--- a/src/lib/api-v1/state.ts
+++ b/src/lib/api-v1/state.ts
@@ -10,6 +10,7 @@
 import type { ScopedDb } from '@/lib/db/scoped';
 import type { Frame } from '@/lib/db/schema/frames';
 import { FRAME_GENERATION_STATUSES } from '@/lib/db/schema/frames';
+import type { Style } from '@/lib/db/schema/libraries';
 import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
 import { toShareableUrl } from '@/lib/storage/buckets';
 import type { Sequence } from '@/types/database';
@@ -45,18 +46,47 @@ export type SequenceCounts = {
   videosFailed: number;
 };
 
-export type SequenceState = {
+/** The style a sequence was generated with — the UI's `styleId` filter value
+ * plus its human-readable name (what the UI search matches on). `name` is null
+ * only if the referenced style row is somehow gone. */
+type SequenceStyle = {
+  id: string;
+  name: string | null;
+};
+
+/** The models a sequence was generated with — the raw ids the UI filters/sorts
+ * on (script analysis + per-frame image + per-frame video, and the optional
+ * music model). */
+type SequenceModels = {
+  analysis: string;
+  image: string;
+  video: string;
+  music: string | null;
+};
+
+/**
+ * The scalar fields shared by the single-sequence status document and each
+ * entry of the `GET /api/v1/sequences` list page — everything except the
+ * per-frame array. Built once in `buildSequenceSummary` so the two documents
+ * can't drift.
+ */
+export type SequenceSummary = {
   id: string;
   title: string;
   status: SequenceStatus;
   statusError: string | null;
   aspectRatio: string;
+  style: SequenceStyle;
+  models: SequenceModels;
   createdAt: string;
   updatedAt: string;
   poster: { url: string } | null;
   music: { status: MusicStatus; url: string | null };
-  frames: SequenceStateFrame[];
   counts: SequenceCounts;
+};
+
+export type SequenceState = SequenceSummary & {
+  frames: SequenceStateFrame[];
 };
 
 /** The image URL a frame exposes once its still is ready (else null). */
@@ -83,8 +113,53 @@ export function summarizeFrameCounts(frames: Frame[]): SequenceCounts {
   return { frames: frames.length, imagesReady, videosReady, videosFailed };
 }
 
+/**
+ * Build the scalar summary fields shared by the status document and each list
+ * entry. `style` is the sequence's resolved style row (null if it couldn't be
+ * loaded — the `id` is still surfaced). `origin` absolutizes stored media URLs
+ * (see `buildSequenceState`).
+ */
+export function buildSequenceSummary(params: {
+  sequence: Sequence;
+  style: Style | null;
+  counts: SequenceCounts;
+  origin: string;
+}): SequenceSummary {
+  const { sequence, style, counts, origin } = params;
+  const share = (url: string | null): string | null =>
+    url === null ? null : toShareableUrl(url, origin);
+
+  return {
+    id: sequence.id,
+    title: sequence.title,
+    status: sequence.status,
+    statusError: sequence.statusError ?? null,
+    aspectRatio: sequence.aspectRatio,
+    style: { id: sequence.styleId, name: style?.name ?? null },
+    models: {
+      analysis: sequence.analysisModel,
+      image: sequence.imageModel,
+      video: sequence.videoModel,
+      music: sequence.musicModel ?? null,
+    },
+    createdAt: sequence.createdAt.toISOString(),
+    updatedAt: sequence.updatedAt.toISOString(),
+    poster: sequence.posterUrl
+      ? { url: toShareableUrl(sequence.posterUrl, origin) }
+      : null,
+    music: {
+      status: sequence.musicStatus ?? 'pending',
+      url: share(sequence.musicUrl ?? null),
+    },
+    counts,
+  };
+}
+
 export async function buildSequenceState(
-  scopedDb: { frames: Pick<ScopedDb['frames'], 'listBySequence'> },
+  scopedDb: {
+    frames: Pick<ScopedDb['frames'], 'listBySequence'>;
+    styles: Pick<ScopedDb['styles'], 'getById'>;
+  },
   sequence: Sequence,
   // Scheme+host the request arrived on. Stored media URLs are origin-relative
   // (#894); the API hands them to off-origin clients, so absolutize them to a
@@ -92,7 +167,10 @@ export async function buildSequenceState(
   // toShareableUrl.
   origin: string
 ): Promise<SequenceState> {
-  const frames = await scopedDb.frames.listBySequence(sequence.id);
+  const [frames, style] = await Promise.all([
+    scopedDb.frames.listBySequence(sequence.id),
+    scopedDb.styles.getById(sequence.styleId),
+  ]);
   const ordered = [...frames].sort((a, b) => a.orderIndex - b.orderIndex);
   const share = (url: string | null): string | null =>
     url === null ? null : toShareableUrl(url, origin);
@@ -115,22 +193,13 @@ export async function buildSequenceState(
   });
 
   return {
-    id: sequence.id,
-    title: sequence.title,
-    status: sequence.status,
-    statusError: sequence.statusError ?? null,
-    aspectRatio: sequence.aspectRatio,
-    createdAt: sequence.createdAt.toISOString(),
-    updatedAt: sequence.updatedAt.toISOString(),
-    poster: sequence.posterUrl
-      ? { url: toShareableUrl(sequence.posterUrl, origin) }
-      : null,
-    music: {
-      status: sequence.musicStatus ?? 'pending',
-      url: share(sequence.musicUrl ?? null),
-    },
+    ...buildSequenceSummary({
+      sequence,
+      style,
+      counts: summarizeFrameCounts(ordered),
+      origin,
+    }),
     frames: stateFrames,
-    counts: summarizeFrameCounts(ordered),
   };
 }
 

--- a/src/lib/db/scoped/styles.test.ts
+++ b/src/lib/db/scoped/styles.test.ts
@@ -231,6 +231,23 @@ describe("createStylesMethods.list({ orderBy: 'popular' })", () => {
   });
 });
 
+describe('createStylesMethods.listByIds', () => {
+  it('resolves a set of ids in one call, skipping unknown ids and de-duping', async () => {
+    const methods = createStylesMethods(db, team.id, userRow.id);
+    const a = await methods.create({ name: 'A', config: baseConfig });
+    const b = await methods.create({ name: 'B', config: baseConfig });
+
+    const rows = await methods.listByIds([a.id, b.id, a.id, 'missing']);
+    const ids = rows.map((s) => s.id).sort();
+    expect(ids).toEqual([a.id, b.id].sort());
+  });
+
+  it('returns an empty array for no ids without hitting the DB', async () => {
+    const methods = createStylesMethods(db, team.id, userRow.id);
+    expect(await methods.listByIds([])).toEqual([]);
+  });
+});
+
 describe('createPublicStylesReadMethods', () => {
   // Uses the REAL production read methods (not the inline mirror above):
   // this factory backs getPublicStylesFn, an endpoint with no auth

--- a/src/lib/db/scoped/styles.test.ts
+++ b/src/lib/db/scoped/styles.test.ts
@@ -246,6 +246,28 @@ describe('createStylesMethods.listByIds', () => {
     const methods = createStylesMethods(db, team.id, userRow.id);
     expect(await methods.listByIds([])).toEqual([]);
   });
+
+  it('resolves more ids than the 90-per-query batch in one call', async () => {
+    // The whole point of the method is to stay under D1's 100-bound-parameter
+    // ceiling by chunking. Insert 95 styles directly (bypassing the slug guard,
+    // which is irrelevant here) so the request spans two batches, and assert
+    // every id comes back across the Promise.all(...).flat() reassembly.
+    const ids = Array.from({ length: 95 }, () => generateId());
+    const rows: NewStyle[] = ids.map((id, i) => ({
+      id,
+      teamId: team.id,
+      name: `Batch Style ${i}`,
+      config: baseConfig,
+    }));
+    await db.insert(styles).values(rows);
+
+    const fetched = await createStylesMethods(
+      db,
+      team.id,
+      userRow.id
+    ).listByIds(ids);
+    expect(new Set(fetched.map((s) => s.id))).toEqual(new Set(ids));
+  });
 });
 
 describe('createPublicStylesReadMethods', () => {

--- a/src/lib/db/scoped/styles.ts
+++ b/src/lib/db/scoped/styles.ts
@@ -8,11 +8,15 @@ import type { NewStyle, Style } from '@/lib/db/schema';
 import { styles } from '@/lib/db/schema';
 import { ValidationError } from '@/lib/errors';
 import { styleSlug } from '@/lib/style/style-slug';
-import { and, asc, desc, eq, ne, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, or, sql } from 'drizzle-orm';
 
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'db', 'styles']);
+
+// D1 caps a single query at 100 bound parameters, so `listByIds` chunks its id
+// list to stay under that ceiling (mirrors sequences.listFramesByIds).
+const STYLES_BY_IDS_BATCH = 90;
 
 type StylesListOptions = {
   orderBy?: 'popular' | 'sortOrder';
@@ -76,6 +80,29 @@ function createStylesReadMethods(db: Database, teamId: string) {
         .where(eq(styles.id, styleId))
         .limit(1);
       return result[0] ?? null;
+    },
+
+    /**
+     * Batched style fetch by id — resolves the style rows referenced by a page
+     * of sequences in one round-trip (backs the `style` block in the public
+     * `GET /api/v1/sequences` list). Like `getById`, it resolves by id alone (no
+     * team scope): the ids come from the team's own sequences, which reference
+     * their team's styles plus public ones. Duplicate ids collapse and order is
+     * not guaranteed — callers index the result by id.
+     */
+    listByIds: async (styleIds: string[]): Promise<Style[]> => {
+      if (styleIds.length === 0) return [];
+      const unique = [...new Set(styleIds)];
+      const batches: string[][] = [];
+      for (let i = 0; i < unique.length; i += STYLES_BY_IDS_BATCH) {
+        batches.push(unique.slice(i, i + STYLES_BY_IDS_BATCH));
+      }
+      const results = await Promise.all(
+        batches.map((batch) =>
+          db.select().from(styles).where(inArray(styles.id, batch))
+        )
+      );
+      return results.flat();
     },
   };
 }

--- a/src/lib/db/scoped/styles.ts
+++ b/src/lib/db/scoped/styles.ts
@@ -14,8 +14,9 @@ import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'db', 'styles']);
 
-// D1 caps a single query at 100 bound parameters, so `listByIds` chunks its id
-// list to stay under that ceiling (mirrors sequences.listFramesByIds).
+// `listByIds` chunks its id list per query. It binds only id params (no team
+// filter), so it could go to D1's 100-bound-parameter ceiling; we hold it at 90
+// to match the sibling sequences.listFramesByIds batch size.
 const STYLES_BY_IDS_BATCH = 90;
 
 type StylesListOptions = {
@@ -84,11 +85,12 @@ function createStylesReadMethods(db: Database, teamId: string) {
 
     /**
      * Batched style fetch by id — resolves the style rows referenced by a page
-     * of sequences in one round-trip (backs the `style` block in the public
-     * `GET /api/v1/sequences` list). Like `getById`, it resolves by id alone (no
-     * team scope): the ids come from the team's own sequences, which reference
-     * their team's styles plus public ones. Duplicate ids collapse and order is
-     * not guaranteed — callers index the result by id.
+     * of sequences in one batched fetch (one query per ≤90-id chunk), backing
+     * the `style` block in the public `GET /api/v1/sequences` list. Like
+     * `getById`, it resolves by id alone (no team scope): the ids come from the
+     * team's own sequences, which reference their team's styles plus public
+     * ones. Duplicate ids collapse and order is not guaranteed — callers index
+     * the result by id, and an id that resolves to no row simply has no entry.
      */
     listByIds: async (styleIds: string[]): Promise<Style[]> => {
       if (styleIds.length === 0) return [];


### PR DESCRIPTION
## Summary

Closes #969. The public sequences API now returns the **style** and **models** a sequence was generated with, closing the gap between what the API exposes and what the dashboard lets users filter, search, and sort on.

Both the single-sequence status document (`GET /api/v1/sequences/{id}`) and each entry of the list page (`GET /api/v1/sequences`) gain:

- `style: { id, name }` — `id` is the UI's `styleId` filter value; `name` is what the UI search matches on (`null` only if the style row was deleted).
- `models: { analysis, image, video, music }` — the raw model ids the UI filters/sorts on (`music` is `null` when no music model was used).

## Changes

- **Shared builder.** Factored the duplicated scalar mapping into `buildSequenceSummary`, so the status doc (`SequenceState = SequenceSummary & { frames }`) and the list item (`SequenceListItem = SequenceSummary`) can't drift.
- **Batched style fetch.** New `styles.listByIds` (deduped, chunked under D1's 100-param ceiling, mirroring `sequences.listFramesByIds`) lets a list page resolve all style names in one round-trip instead of N. `buildSequenceState` loads its style in parallel with frames.
- **Docs.** Updated the OpenAPI 3.1 spec, the `/api/v1` discovery narrative, and the public-API developer guide — which also gains a **List sequences** section that had been missing since #964.

## Testing

- Unit tests for the new `style`/`models` fields on both documents, per-sequence style resolution, and the deleted-style (`name: null`) fallback.
- `styles.listByIds` coverage (dedup, unknown-id skip, empty-input short-circuit).
- OpenAPI test asserting `style`/`models` are documented on both schemas.
- `bun typecheck`, `bun lint`, `bun run test src/lib/api-v1/` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)