### PR TITLE
feat(#907): add scenes table with 1:1 shot backfill

### DIFF
--- a/drizzle/migrations/20260624011426_jazzy_whiplash/migration.sql
+++ b/drizzle/migrations/20260624011426_jazzy_whiplash/migration.sql
@@ -1,0 +1,58 @@
+CREATE TABLE `scenes` (
+	`id` text PRIMARY KEY,
+	`sequence_id` text NOT NULL,
+	`order_index` integer NOT NULL,
+	`location` text,
+	`time_of_day` text,
+	`story_beat` text,
+	`title` text,
+	`continuity` text,
+	`music_design` text,
+	`original_script` text,
+	`image_model` text(100),
+	`video_model` text(100),
+	`video_url` text,
+	`video_path` text,
+	`video_status` text DEFAULT 'pending',
+	`video_workflow_run_id` text,
+	`video_generated_at` integer,
+	`video_error` text,
+	`video_input_hash` text,
+	`render_strategy` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT `fk_scenes_sequence_id_sequences_id_fk` FOREIGN KEY (`sequence_id`) REFERENCES `sequences`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+ALTER TABLE `shots` ADD `scene_id` text REFERENCES scenes(id);--> statement-breakpoint
+ALTER TABLE `shots` ADD `shot_number` integer;--> statement-breakpoint
+CREATE INDEX `idx_scenes_sequence_order` ON `scenes` (`sequence_id`,`order_index`);--> statement-breakpoint
+CREATE UNIQUE INDEX `scenes_sequence_id_order_index_key` ON `scenes` (`sequence_id`,`order_index`);--> statement-breakpoint
+-- #907 backfill (1:1 expand): one scene per existing shot, splitting the
+-- scene-level slices out of the shot's `metadata` (the Scene object). The scene
+-- REUSES the shot's ULID as its id — shots↔scenes are 1:1 at this stage, so the
+-- id is already a valid ULID and no app-side minting is needed (same rule as the
+-- frames expand). Data DML, not a table rebuild: no DROP, no `__new_` shuffle,
+-- so it sidesteps the D1/Turso ON DELETE CASCADE trap (CLAUDE.md / #612).
+-- `WHERE scene_id IS NULL` keeps it safe to re-run. Touches only shots.scene_id
+-- + shot_number, never `metadata` or any `*_input_hash`, so staleness is
+-- unchanged. created_at/updated_at mirror the shot's.
+INSERT INTO `scenes` (
+	`id`, `sequence_id`, `order_index`,
+	`location`, `time_of_day`, `story_beat`, `title`,
+	`continuity`, `music_design`, `original_script`,
+	`created_at`, `updated_at`
+)
+SELECT
+	`id`, `sequence_id`, `order_index`,
+	json_extract(`metadata`, '$.metadata.location'),
+	json_extract(`metadata`, '$.metadata.timeOfDay'),
+	json_extract(`metadata`, '$.metadata.storyBeat'),
+	json_extract(`metadata`, '$.metadata.title'),
+	json_extract(`metadata`, '$.continuity'),
+	json_extract(`metadata`, '$.musicDesign'),
+	json_extract(`metadata`, '$.originalScript'),
+	`created_at`, `updated_at`
+FROM `shots`
+WHERE `scene_id` IS NULL;--> statement-breakpoint
+UPDATE `shots` SET `scene_id` = `id`, `shot_number` = 1 WHERE `scene_id` IS NULL;

--- a/drizzle/migrations/20260624011426_jazzy_whiplash/snapshot.json
+++ b/drizzle/migrations/20260624011426_jazzy_whiplash/snapshot.json
@@ -1,0 +1,7672 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "b118fee2-ab40-4bd2-bad5-beeef1bf5b42",
+  "prevIds": ["aaee1fd3-a528-488d-8f8d-0958c618f7de"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "apikey",
+      "entityType": "tables"
+    },
+    {
+      "name": "app_metadata",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "scenes",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_exports",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_prompt_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "shots",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_interval",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_amount",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_refill_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "rate_limit_enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_time_window",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_max",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "request_count",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_request",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permissions",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text(255)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "story_beat",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "continuity",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_design",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_script",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_strategy",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_shots_hash",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_music_variant_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "loudness_gain_db",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "include_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_number",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_thumbnail_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "variant_image_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "thumbnail_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sample_videos",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_image_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_video_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_aspect_ratio",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "use_cases",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_scenes_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "scenes"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_sequence_exports_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shots_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shots_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "apikey_pk",
+      "table": "apikey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["key"],
+      "nameExplicit": false,
+      "name": "app_metadata_pk",
+      "table": "app_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "scenes_pk",
+      "table": "scenes",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_exports_pk",
+      "table": "sequence_exports",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_variants_pk",
+      "table": "sequence_music_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_prompt_variants_pk",
+      "table": "shot_prompt_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_variants_pk",
+      "table": "shot_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shots_pk",
+      "table": "shots",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_referenceId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_key_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_configId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_scenes_sequence_order",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "scenes_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_sequence",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_created_at",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_prompt_variants\".\"input_hash\" IS NOT NULL AND \"sequence_music_prompt_variants\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_sequence_music_prompt_variants_sequence_hash_ai",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_prompt_variants_shot_type_created",
+      "entityType": "indexes",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_prompt_variants\".\"input_hash\" IS NOT NULL AND \"shot_prompt_variants\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_shot_prompt_variants_shot_type_hash_ai",
+      "entityType": "indexes",
+      "table": "shot_prompt_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_shot_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "shot_variants_primary_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "shot_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_order",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_sequence_id",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "shots_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"transactions\".\"idempotency_key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "idx_transactions_team_idempotency_key",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": []
+}

--- a/src/components/motion/scene-player.stories.tsx
+++ b/src/components/motion/scene-player.stories.tsx
@@ -16,6 +16,8 @@ type Story = StoryObj<typeof ScenePlayer>;
 
 const mockShotBase = {
   sequenceId: 'seq-1',
+  sceneId: null,
+  shotNumber: null,
   orderIndex: 0,
   description: 'A scene from the storyboard',
   durationMs: 5000,

--- a/src/components/scenes/divergence-compare-dialog.stories.tsx
+++ b/src/components/scenes/divergence-compare-dialog.stories.tsx
@@ -7,6 +7,8 @@ const NOW = new Date('2026-04-29T00:00:00Z');
 const baseShot: Shot = {
   id: 'shot-1',
   sequenceId: 'seq-1',
+  sceneId: null,
+  shotNumber: null,
   orderIndex: 0,
   description: 'A wide shot.',
   durationMs: 3000,

--- a/src/components/scenes/scene-list-item.stories.tsx
+++ b/src/components/scenes/scene-list-item.stories.tsx
@@ -5,6 +5,8 @@ import { SceneListItem } from './scene-list-item';
 const mockShot: Shot = {
   id: 'shot-1',
   sequenceId: 'seq-1',
+  sceneId: null,
+  shotNumber: null,
   orderIndex: 0,
   description: 'A bustling coffee shop interior during morning rush hour',
   durationMs: 3000,

--- a/src/components/scenes/scene-script-prompts.stories.tsx
+++ b/src/components/scenes/scene-script-prompts.stories.tsx
@@ -6,6 +6,8 @@ import { SceneScriptPrompts, type TabValue } from './scene-script-prompts';
 const mockShot = {
   id: 'shot-1',
   sequenceId: 'seq-1',
+  sceneId: null,
+  shotNumber: null,
   orderIndex: 0,
   description: 'A bustling coffee shop interior during morning rush hour',
   durationMs: 3000,

--- a/src/components/scenes/scenes-view.stories.tsx
+++ b/src/components/scenes/scenes-view.stories.tsx
@@ -107,6 +107,8 @@ type Story = StoryObj<typeof meta>;
 // Mock shot base — all Shot fields included
 const mockShotBase = {
   sequenceId: 'seq-1',
+  sceneId: null,
+  shotNumber: null,
   orderIndex: 0,
   description: 'A scene from the storyboard',
   durationMs: 5000,

--- a/src/functions/__tests__/sequences.test.ts
+++ b/src/functions/__tests__/sequences.test.ts
@@ -58,6 +58,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: 'seq-1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: 'A scene',
     durationMs: 3000,

--- a/src/functions/__tests__/smart-retry.test.ts
+++ b/src/functions/__tests__/smart-retry.test.ts
@@ -91,6 +91,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: 'seq_1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: 'A scene',
     durationMs: 3000,

--- a/src/lib/ai/scene-analysis.schema.ts
+++ b/src/lib/ai/scene-analysis.schema.ts
@@ -450,7 +450,7 @@ export type VisualPromptResult = z.infer<typeof visualPromptResultSchema>;
 // Original Script Schema
 // ============================================================================
 
-const originalScriptSchema = z.object({
+export const originalScriptSchema = z.object({
   extract: z
     .string()
     .meta({ description: 'Original script text for this scene' }),
@@ -463,7 +463,7 @@ const originalScriptSchema = z.object({
 // Scene Metadata Schema
 // ============================================================================
 
-const sceneMetadataSchema = z.object({
+export const sceneMetadataSchema = z.object({
   title: z.string().meta({ description: 'Short descriptive scene title' }),
   durationSeconds: z.number().meta({
     description: 'Estimated scene duration in seconds (typically 3-15)',

--- a/src/lib/ai/scene-persistence.test.ts
+++ b/src/lib/ai/scene-persistence.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { Scene } from './scene-analysis.schema';
+import { buildSceneInserts } from './scene-persistence';
+
+function makeScene(overrides: Partial<Scene> = {}): Scene {
+  return {
+    sceneId: 'analysis-scene-1',
+    sceneNumber: 1,
+    originalScript: { extract: 'A man walks in.', dialogue: [] },
+    metadata: {
+      title: 'Entrance',
+      durationSeconds: 4,
+      location: 'INT. OFFICE - DAY',
+      timeOfDay: 'day',
+      storyBeat: 'introduction',
+    },
+    continuity: {
+      characterTags: ['man'],
+      environmentTag: 'office',
+      elementTags: [],
+      colorPalette: 'warm',
+      lightingSetup: 'soft daylight',
+      styleTag: 'cinematic',
+    },
+    ...overrides,
+  };
+}
+
+describe('buildSceneInserts', () => {
+  it('maps scene-level fields onto scene rows with 0-based orderIndex', () => {
+    const rows = buildSceneInserts('seq-1', [
+      makeScene(),
+      makeScene({ sceneId: 'analysis-scene-2', sceneNumber: 2 }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      sequenceId: 'seq-1',
+      orderIndex: 0,
+      location: 'INT. OFFICE - DAY',
+      timeOfDay: 'day',
+      storyBeat: 'introduction',
+      title: 'Entrance',
+    });
+    expect(rows[1]?.orderIndex).toBe(1);
+  });
+
+  it('carries continuity and original script onto the scene row', () => {
+    const [row] = buildSceneInserts('seq-1', [makeScene()]);
+    expect(row?.continuity?.environmentTag).toBe('office');
+    expect(row?.originalScript?.extract).toBe('A man walks in.');
+  });
+
+  it('defaults missing scene metadata to null (no analysis metadata yet)', () => {
+    const [row] = buildSceneInserts('seq-1', [
+      makeScene({ metadata: undefined, continuity: undefined }),
+    ]);
+    expect(row?.location).toBeNull();
+    expect(row?.timeOfDay).toBeNull();
+    expect(row?.storyBeat).toBeNull();
+    expect(row?.title).toBeNull();
+    expect(row?.continuity).toBeNull();
+  });
+
+  it('returns an empty array for no scenes', () => {
+    expect(buildSceneInserts('seq-1', [])).toEqual([]);
+  });
+});

--- a/src/lib/ai/scene-persistence.test.ts
+++ b/src/lib/ai/scene-persistence.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { dbSceneId } from '@/lib/db/schema';
+import type { SceneRow } from '@/lib/db/schema';
 import type { Scene } from './scene-analysis.schema';
-import { buildSceneInserts } from './scene-persistence';
+import { buildSceneInserts, buildSceneShotLinks } from './scene-persistence';
 
 function makeScene(overrides: Partial<Scene> = {}): Scene {
   return {
@@ -64,5 +66,92 @@ describe('buildSceneInserts', () => {
 
   it('returns an empty array for no scenes', () => {
     expect(buildSceneInserts('seq-1', [])).toEqual([]);
+  });
+});
+
+/** Minimal scene row — only `id` + `orderIndex` drive the linking. */
+function makeSceneRow(id: string, orderIndex: number): SceneRow {
+  const now = new Date();
+  return {
+    id: dbSceneId(id),
+    sequenceId: 'seq-1',
+    orderIndex,
+    location: null,
+    timeOfDay: null,
+    storyBeat: null,
+    title: null,
+    continuity: null,
+    musicDesign: null,
+    originalScript: null,
+    imageModel: null,
+    videoModel: null,
+    videoUrl: null,
+    videoPath: null,
+    videoStatus: 'pending',
+    videoWorkflowRunId: null,
+    videoGeneratedAt: null,
+    videoError: null,
+    videoInputHash: null,
+    renderStrategy: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('buildSceneShotLinks', () => {
+  const scenes = [
+    { sceneId: 'analysis-scene-1' },
+    { sceneId: 'analysis-scene-2' },
+  ];
+  const shotMapping = [
+    { analysisSceneId: 'analysis-scene-1', shotId: 'shot-a' },
+    { analysisSceneId: 'analysis-scene-2', shotId: 'shot-b' },
+  ];
+
+  it('links each shot to its scene row at shotNumber 1 (1:1)', () => {
+    const { links, unmappedShotIds } = buildSceneShotLinks(
+      scenes,
+      [makeSceneRow('scene-row-1', 0), makeSceneRow('scene-row-2', 1)],
+      shotMapping
+    );
+    expect(unmappedShotIds).toEqual([]);
+    expect(links).toEqual([
+      { shotId: 'shot-a', sceneId: 'scene-row-1', shotNumber: 1 },
+      { shotId: 'shot-b', sceneId: 'scene-row-2', shotNumber: 1 },
+    ]);
+  });
+
+  it('keys on orderIndex, not array position (rows returned out of order)', () => {
+    // createBulk RETURNING order is not guaranteed; the link must still be
+    // correct when sceneRows come back reversed.
+    const { links, unmappedShotIds } = buildSceneShotLinks(
+      scenes,
+      [makeSceneRow('scene-row-2', 1), makeSceneRow('scene-row-1', 0)],
+      shotMapping
+    );
+    expect(unmappedShotIds).toEqual([]);
+    expect(links).toEqual([
+      { shotId: 'shot-a', sceneId: 'scene-row-1', shotNumber: 1 },
+      { shotId: 'shot-b', sceneId: 'scene-row-2', shotNumber: 1 },
+    ]);
+  });
+
+  it('surfaces a shot whose analysis scene has no row (no silent skip)', () => {
+    const { links, unmappedShotIds } = buildSceneShotLinks(
+      scenes,
+      [makeSceneRow('scene-row-1', 0)], // scene 2's row is missing
+      shotMapping
+    );
+    expect(links).toEqual([
+      { shotId: 'shot-a', sceneId: 'scene-row-1', shotNumber: 1 },
+    ]);
+    expect(unmappedShotIds).toEqual(['shot-b']);
+  });
+
+  it('returns empty plan for no shots', () => {
+    expect(buildSceneShotLinks(scenes, [], [])).toEqual({
+      links: [],
+      unmappedShotIds: [],
+    });
   });
 });

--- a/src/lib/ai/scene-persistence.ts
+++ b/src/lib/ai/scene-persistence.ts
@@ -1,0 +1,38 @@
+/**
+ * Scene-row persistence mapping (#908)
+ * ============================================================================
+ *
+ * Maps an analysis `Scene` onto the scene-level columns of the `scenes` table
+ * (#907). Scene-level shared truth — location, time of day, story beat, title,
+ * continuity, music design, original script — lives on the scene row; the
+ * shot's own `metadata` JSON keeps the full `Scene` object so existing read
+ * paths are untouched.
+ *
+ * Pulled out of the workflow so the column mapping is unit-testable without a
+ * full Cloudflare-Workflow harness.
+ */
+
+import type { NewScene } from '@/lib/db/schema';
+import type { Scene } from './scene-analysis.schema';
+
+/**
+ * Build the `scenes` insert rows for a sequence from the ordered analysis
+ * scenes. `orderIndex` is the scene's position in the analysis output (0-based),
+ * which is the unique key the `scenes` table sorts and de-duplicates on.
+ */
+export function buildSceneInserts(
+  sequenceId: string,
+  scenes: ReadonlyArray<Scene>
+): NewScene[] {
+  return scenes.map((scene, index) => ({
+    sequenceId,
+    orderIndex: index,
+    location: scene.metadata?.location ?? null,
+    timeOfDay: scene.metadata?.timeOfDay ?? null,
+    storyBeat: scene.metadata?.storyBeat ?? null,
+    title: scene.metadata?.title ?? null,
+    continuity: scene.continuity ?? null,
+    musicDesign: scene.musicDesign ?? null,
+    originalScript: scene.originalScript,
+  }));
+}

--- a/src/lib/ai/scene-persistence.ts
+++ b/src/lib/ai/scene-persistence.ts
@@ -12,7 +12,7 @@
  * full Cloudflare-Workflow harness.
  */
 
-import type { NewScene } from '@/lib/db/schema';
+import type { DbSceneId, NewScene, SceneRow } from '@/lib/db/schema';
 import type { Scene } from './scene-analysis.schema';
 
 /**
@@ -35,4 +35,66 @@ export function buildSceneInserts(
     musicDesign: scene.musicDesign ?? null,
     originalScript: scene.originalScript,
   }));
+}
+
+/** A shot→scene link to apply via `shots.update`. */
+type SceneShotLink = {
+  shotId: string;
+  sceneId: DbSceneId;
+  shotNumber: number;
+};
+
+/** Result of linking analysis shots to their persisted scene rows. */
+export type SceneShotLinkPlan = {
+  links: SceneShotLink[];
+  /**
+   * Shots whose analysis scene had no matching persisted row. An invariant
+   * violation (every mapped shot should belong to a scene), surfaced to the
+   * caller to log rather than silently dropped.
+   */
+  unmappedShotIds: string[];
+};
+
+/**
+ * Pair each analysis shot with its persisted scene row so the caller can set
+ * `shots.sceneId` / `shots.shotNumber`.
+ *
+ * Resolution goes analysisSceneId → the scene's 0-based `orderIndex` (its
+ * position in the analysis output, which `buildSceneInserts` writes) → the
+ * scene row carrying that `orderIndex`. Keying on `orderIndex` — the table's
+ * unique `(sequenceId, orderIndex)` key — rather than on the position of
+ * `sceneRows` means the link is correct even if `createBulk`'s `RETURNING`
+ * order ever diverges from insertion order.
+ *
+ * 1:1 today: analysis emits one shot per scene, so every shot links at
+ * `shotNumber` 1. When multi-shot emission lands (#910) the number comes from
+ * the shot spec.
+ */
+export function buildSceneShotLinks(
+  scenes: ReadonlyArray<Pick<Scene, 'sceneId'>>,
+  sceneRows: ReadonlyArray<SceneRow>,
+  shotMapping: ReadonlyArray<{ analysisSceneId: string; shotId: string }>
+): SceneShotLinkPlan {
+  const orderIndexByAnalysisId = new Map(
+    scenes.map((scene, index) => [scene.sceneId, index])
+  );
+  const sceneRowByOrderIndex = new Map(
+    sceneRows.map((row) => [row.orderIndex, row])
+  );
+
+  const links: SceneShotLink[] = [];
+  const unmappedShotIds: string[] = [];
+  for (const { analysisSceneId, shotId } of shotMapping) {
+    const orderIndex = orderIndexByAnalysisId.get(analysisSceneId);
+    const sceneRow =
+      orderIndex === undefined
+        ? undefined
+        : sceneRowByOrderIndex.get(orderIndex);
+    if (!sceneRow) {
+      unmappedShotIds.push(shotId);
+      continue;
+    }
+    links.push({ shotId, sceneId: sceneRow.id, shotNumber: 1 });
+  }
+  return { links, unmappedShotIds };
 }

--- a/src/lib/ai/shot-list.derive.test.ts
+++ b/src/lib/ai/shot-list.derive.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import type { StyleConfig } from '@/lib/db/schema/libraries';
+import { deriveMotionPrompt, deriveShotScenes } from './shot-list.derive';
+import type { SceneWithShots } from './shot-list.schema';
+
+const styleConfig: StyleConfig = {
+  mood: 'tense',
+  artStyle: 'neo-noir cinematic',
+  lighting: 'low key',
+  colorPalette: ['#111', '#eee'],
+  cameraWork: 'handheld',
+  referenceFilms: ['Blade Runner'],
+  colorGrading: 'teal and orange',
+};
+
+function makeScene(overrides: Partial<SceneWithShots> = {}): SceneWithShots {
+  return {
+    sceneId: 'scene-1',
+    sceneNumber: 1,
+    originalScript: {
+      extract: 'She opens the door.',
+      dialogue: [{ character: 'SARAH', line: 'Hello?', tone: 'wary' }],
+    },
+    metadata: {
+      title: 'The Doorway',
+      durationSeconds: 12,
+      location: 'INT. HALLWAY - NIGHT',
+      timeOfDay: 'night',
+      storyBeat: 'rising tension',
+    },
+    continuity: {
+      characterTags: ['sarah'],
+      environmentTag: 'dim_hallway',
+      elementTags: [],
+      colorPalette: 'cold blues',
+      lightingSetup: 'single overhead bulb',
+      styleTag: 'noir',
+    },
+    dialoguePresent: true,
+    continuousFromPrevious: false,
+    shots: [
+      {
+        shotNumber: 1,
+        framing: {
+          shotSize: 'wide',
+          angle: 'eye level',
+          composition: 'centered down the hallway',
+          subjectStartState: 'Sarah at the far end, hand on the wall',
+        },
+        action: 'Sarah walks toward the door',
+        cameraMovement: { move: 'dolly', pacing: 'slow' },
+        soundCue: 'distant hum, footsteps',
+        durationSeconds: 6,
+      },
+      {
+        shotNumber: 2,
+        framing: {
+          shotSize: 'close-up',
+          angle: 'low angle',
+          composition: 'hand on the door handle, shallow depth',
+          subjectStartState: "Sarah's fingers wrapping the handle",
+        },
+        action: 'she turns the handle and pushes',
+        cameraMovement: { move: 'push-in', pacing: 'gradual' },
+        soundCue: 'handle click, hinge creak',
+        durationSeconds: 6,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** First shot of a scene, with a guard so tests never need a `!` assertion. */
+function firstShot(scene: SceneWithShots) {
+  const [shot] = scene.shots;
+  if (!shot) throw new Error('test scene has no shots');
+  return shot;
+}
+
+describe('deriveShotScenes — single source of truth', () => {
+  it('produces one derived shot per shot, ordered by shotNumber', () => {
+    const scene = makeScene();
+    const derived = deriveShotScenes(scene, styleConfig);
+    expect(derived).toHaveLength(2);
+    expect(derived.map((d) => d.shotNumber)).toEqual([1, 2]);
+  });
+
+  it('reuses scene context verbatim across every shot (no per-shot re-derivation)', () => {
+    const derived = deriveShotScenes(makeScene(), styleConfig);
+    for (const d of derived) {
+      const visual = d.metadata.prompts?.visual?.fullPrompt ?? '';
+      // Scene-level shared truth appears in EVERY shot's visual prompt.
+      expect(visual).toContain('INT. HALLWAY - NIGHT');
+      expect(visual).toContain('dim_hallway');
+      expect(visual).toContain('single overhead bulb');
+      expect(visual).toContain('cold blues');
+      expect(visual).toContain('neo-noir cinematic');
+      // Continuity is the same object across shots.
+      expect(d.metadata.continuity).toEqual(makeScene().continuity);
+    }
+  });
+
+  it('composes start-frame visual from shot framing + scene context', () => {
+    const [first] = deriveShotScenes(makeScene(), styleConfig);
+    const visual = first?.metadata.prompts?.visual;
+    expect(visual?.fullPrompt).toContain('wide');
+    expect(visual?.fullPrompt).toContain('eye level');
+    expect(visual?.fullPrompt).toContain('Sarah at the far end');
+    expect(visual?.components.subject).toBe(
+      'Sarah at the far end, hand on the wall'
+    );
+    expect(visual?.components.lighting).toBe('single overhead bulb');
+  });
+
+  it('composes motion prompt from action + one camera move + sound cue', () => {
+    const [, second] = deriveShotScenes(makeScene(), styleConfig);
+    const motion = second?.metadata.prompts?.motion;
+    expect(motion?.fullPrompt).toContain('she turns the handle and pushes');
+    expect(motion?.fullPrompt).toContain('gradual push-in');
+    expect(motion?.components.cameraMovement).toBe('push-in');
+    expect(motion?.components.speed).toBe('gradual');
+    // Sound cue is carried into the audio channel for audio-capable models.
+    expect(motion?.audio?.ambientSound).toBe('handle click, hinge creak');
+  });
+
+  it('carries per-shot duration onto both the column and the metadata', () => {
+    const derived = deriveShotScenes(makeScene(), styleConfig);
+    expect(derived[0]?.durationMs).toBe(6000);
+    expect(derived[0]?.metadata.metadata?.durationSeconds).toBe(6);
+  });
+
+  it('keeps shotNumber OUT of the persisted Scene metadata (it is a shots column)', () => {
+    const [first] = deriveShotScenes(makeScene(), styleConfig);
+    expect(first?.metadata).not.toHaveProperty('shotNumber');
+  });
+});
+
+describe('deriveMotionPrompt — model-agnostic', () => {
+  it('emits no vendor-specific syntax (no Seedance/Kling/Veo tokens)', () => {
+    const scene = makeScene();
+    for (const shot of scene.shots) {
+      const motion = deriveMotionPrompt(scene, shot);
+      const text = JSON.stringify(motion).toLowerCase();
+      for (const vendor of [
+        'seedance',
+        'kling',
+        'veo',
+        'bytedance',
+        '--',
+        '[camera]',
+      ]) {
+        expect(text).not.toContain(vendor);
+      }
+    }
+  });
+
+  it('signals dialogue presence and omits it when the scene is silent', () => {
+    const silent = makeScene({ dialoguePresent: false });
+    const motion = deriveMotionPrompt(silent, firstShot(silent));
+    expect(motion.dialogue).toBeNull();
+
+    const spoken = makeScene({ dialoguePresent: true });
+    const m2 = deriveMotionPrompt(spoken, firstShot(spoken));
+    expect(m2.dialogue?.presence).toBe(true);
+    expect(m2.dialogue?.lines).toHaveLength(1);
+  });
+
+  it('omits audio when there is no sound cue', () => {
+    const scene = makeScene();
+    const shot = { ...firstShot(scene), soundCue: '' };
+    const motion = deriveMotionPrompt(scene, shot);
+    expect(motion.audio).toBeNull();
+  });
+});
+
+describe('deriveShotScenes — single-shot regression', () => {
+  it('returns exactly one derived shot for a short single-shot scene', () => {
+    const scene = makeScene({
+      metadata: {
+        title: 'Establishing',
+        durationSeconds: 4,
+        location: 'EXT. CITY - DAY',
+        timeOfDay: 'day',
+        storyBeat: 'opening',
+      },
+      shots: [
+        {
+          shotNumber: 1,
+          framing: {
+            shotSize: 'extreme wide',
+            angle: 'high angle',
+            composition: 'skyline fills the frame',
+            subjectStartState: 'static cityscape',
+          },
+          action: 'clouds drift over the towers',
+          cameraMovement: { move: 'static', pacing: 'slow' },
+          soundCue: 'city ambience',
+          durationSeconds: 4,
+        },
+      ],
+    });
+    const derived = deriveShotScenes(scene, styleConfig);
+    expect(derived).toHaveLength(1);
+    expect(derived[0]?.metadata.prompts?.motion?.parameters.motionAmount).toBe(
+      'low'
+    );
+  });
+});

--- a/src/lib/ai/shot-list.derive.ts
+++ b/src/lib/ai/shot-list.derive.ts
@@ -1,0 +1,210 @@
+/**
+ * Shot-list prompt derivation (#908)
+ * ============================================================================
+ *
+ * Single source of truth: a shot's start-frame visual prompt and motion prompt
+ * are ASSEMBLED from the parent scene's shared context plus the shot's own
+ * structured fields — never re-authored per shot by the LLM. Keeping the
+ * derivation here (one place) is the structural fix for adjacent-clip drift:
+ * every shot in a scene inherits the same location / lighting / cast / palette
+ * / style truth verbatim.
+ *
+ *   start-frame visual prompt = scene context + shot framing/start-state
+ *   motion prompt             = shot action + camera movement + sound cue
+ *
+ * The derived shapes are the existing `VisualPrompt` / `MotionPrompt` types so
+ * downstream image/motion workflows consume them unchanged. Each shot is
+ * persisted as a `Scene` row (shots.metadata is `$type<Scene>()`); the
+ * scene-level shared fields are persisted separately to the `scenes` table.
+ */
+
+import type { StyleConfig } from '@/lib/db/schema/libraries';
+import type {
+  MotionPrompt,
+  Scene,
+  VisualPrompt,
+} from './scene-analysis.schema';
+import type { SceneWithShots, ShotSpec } from './shot-list.schema';
+
+/** Join non-empty parts with a separator, dropping blanks. */
+function joinParts(parts: ReadonlyArray<string>, sep = ', '): string {
+  return parts
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .join(sep);
+}
+
+/**
+ * Scene-level shared truth, stated once and reused by every shot's derived
+ * prompt. Pulled from the scene's `continuity` + `metadata` + the style config
+ * so the LLM never re-derives it per shot.
+ */
+function sceneContextParts(
+  scene: SceneWithShots,
+  styleConfig: StyleConfig
+): string[] {
+  const { continuity, metadata } = scene;
+  return [
+    metadata.location,
+    metadata.timeOfDay,
+    continuity.environmentTag,
+    continuity.lightingSetup,
+    continuity.colorPalette,
+    // Cast membership is shared context; the per-shot subject state narrows it.
+    continuity.characterTags.join(', '),
+    // Style is the single look authored for the whole sequence.
+    styleConfig.artStyle,
+    continuity.styleTag,
+  ].filter((p): p is string => typeof p === 'string' && p.trim().length > 0);
+}
+
+/**
+ * Derive the start-frame visual prompt for one shot.
+ *
+ * fullPrompt = scene context (authored once) + the shot's framing/start-state.
+ * Internal building block of `deriveShotScenes` (covered through it).
+ */
+function deriveVisualPrompt(
+  scene: SceneWithShots,
+  shot: ShotSpec,
+  styleConfig: StyleConfig
+): VisualPrompt {
+  const { framing } = shot;
+  const sceneParts = sceneContextParts(scene, styleConfig);
+
+  const fullPrompt = joinParts([
+    framing.shotSize,
+    framing.angle,
+    framing.subjectStartState,
+    framing.composition,
+    ...sceneParts,
+  ]);
+
+  return {
+    fullPrompt,
+    negativePrompt: '',
+    components: {
+      sceneDescription: scene.metadata.storyBeat,
+      subject: framing.subjectStartState,
+      environment: joinParts([
+        scene.metadata.location,
+        scene.continuity.environmentTag,
+      ]),
+      lighting: scene.continuity.lightingSetup,
+      camera: joinParts([framing.shotSize, framing.angle]),
+      composition: framing.composition,
+      style: joinParts([styleConfig.artStyle, scene.continuity.styleTag]),
+      technical: '',
+      atmosphere: joinParts([
+        scene.metadata.timeOfDay,
+        scene.continuity.colorPalette,
+      ]),
+    },
+  };
+}
+
+/**
+ * Derive the motion prompt for one shot.
+ *
+ * fullPrompt = the shot's action + its single camera move (with pacing adverb)
+ * + the sound cue. Model-agnostic: no vendor syntax — `assembleMotionPrompt`
+ * adapts per model at render time.
+ */
+export function deriveMotionPrompt(
+  scene: SceneWithShots,
+  shot: ShotSpec
+): MotionPrompt {
+  const { action, cameraMovement, soundCue } = shot;
+  const cameraPhrase = joinParts(
+    [cameraMovement.pacing, cameraMovement.move],
+    ' '
+  );
+
+  const fullPrompt = joinParts([action, `Camera: ${cameraPhrase}`], '. ');
+
+  // Dialogue presence is a scene-level hint; the start-frame visual carries the
+  // performance, the motion prompt carries the move + sound. Lines themselves
+  // are sourced from originalScript downstream (audio models), so here we only
+  // signal presence and the on-screen sound cue.
+  return {
+    fullPrompt,
+    components: {
+      cameraMovement: cameraMovement.move,
+      startPosition: shot.framing.subjectStartState,
+      endPosition: '',
+      durationSeconds: shot.durationSeconds,
+      speed: cameraMovement.pacing,
+      smoothness: 'smooth',
+      subjectTracking: '',
+      equipment: '',
+    },
+    parameters: {
+      durationSeconds: shot.durationSeconds,
+      fps: 24,
+      motionAmount: cameraMovement.move === 'static' ? 'low' : 'medium',
+      cameraControl: {
+        pan: 0,
+        tilt: 0,
+        zoom: 1,
+        movement: cameraMovement.move,
+      },
+    },
+    dialogue: scene.dialoguePresent
+      ? {
+          presence: true,
+          lines: scene.originalScript.dialogue,
+        }
+      : null,
+    audio: soundCue.trim().length
+      ? { ambientSound: soundCue, soundEffects: [] }
+      : null,
+  };
+}
+
+/**
+ * A derived shot ready to persist: the per-shot `Scene` metadata object plus
+ * the shot-level columns (`shotNumber`, `durationMs`) that live on the `shots`
+ * table rather than inside the JSON. `shotNumber` stays OUT of the `Scene`
+ * metadata — it is a `shots` column (#907).
+ */
+export type DerivedShot = {
+  shotNumber: number;
+  durationMs: number;
+  metadata: Scene;
+};
+
+/**
+ * Convert one analysis scene into the per-shot rows persisted to the `shots`
+ * table. Each shot inherits the scene's shared context (so existing read paths
+ * that key off `metadata.continuity` / `metadata.metadata` keep working) and
+ * carries its own derived visual + motion prompts.
+ *
+ * Returned shots are ordered by `shotNumber`. The caller persists each with
+ * its `shotNumber` and a `sceneId` linking back to the `scenes` row.
+ */
+export function deriveShotScenes(
+  scene: SceneWithShots,
+  styleConfig: StyleConfig
+): DerivedShot[] {
+  const ordered = [...scene.shots].sort((a, b) => a.shotNumber - b.shotNumber);
+  return ordered.map((shot) => {
+    const visual = deriveVisualPrompt(scene, shot, styleConfig);
+    const motion = deriveMotionPrompt(scene, shot);
+    const metadata: Scene = {
+      sceneId: scene.sceneId,
+      sceneNumber: scene.sceneNumber,
+      originalScript: scene.originalScript,
+      metadata: {
+        ...scene.metadata,
+        durationSeconds: shot.durationSeconds,
+      },
+      continuity: scene.continuity,
+      prompts: { visual, motion },
+    };
+    return {
+      shotNumber: shot.shotNumber,
+      durationMs: Math.round(shot.durationSeconds * 1000),
+      metadata,
+    };
+  });
+}

--- a/src/lib/ai/shot-list.schema.test.ts
+++ b/src/lib/ai/shot-list.schema.test.ts
@@ -143,4 +143,31 @@ describe('shot-list schema — constraints', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('enforces the 1..MAX shots-per-scene bound at parse time', () => {
+    const validShot = {
+      shotNumber: 1,
+      framing: {
+        shotSize: 'medium',
+        angle: 'eye level',
+        composition: 'centered',
+        subjectStartState: 'standing',
+      },
+      action: 'turns',
+      cameraMovement: { move: 'pan', pacing: 'smooth' as const },
+      soundCue: '',
+      durationSeconds: 3,
+    };
+    const shots = sceneWithShotsSchema.shape.shots;
+    // Empty (zero shots) is rejected — a scene must own at least one shot.
+    expect(shots.safeParse([]).success).toBe(false);
+    // One shot is fine.
+    expect(shots.safeParse([validShot]).success).toBe(true);
+    // Over the ceiling is rejected (minItems/maxItems, still union-free).
+    const tooMany = Array.from({ length: MAX_SHOTS_PER_SCENE + 1 }, (_, i) => ({
+      ...validShot,
+      shotNumber: i + 1,
+    }));
+    expect(shots.safeParse(tooMany).success).toBe(false);
+  });
 });

--- a/src/lib/ai/shot-list.schema.test.ts
+++ b/src/lib/ai/shot-list.schema.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  MAX_SCENE_DURATION_SECONDS,
+  MAX_SHOTS_PER_SCENE,
+  MIN_SHOT_DURATION_SECONDS,
+  sceneWithShotsResultSchema,
+  sceneWithShotsSchema,
+  shotSpecSchema,
+} from './shot-list.schema';
+
+/**
+ * Count union-typed parameters in the compiled JSON Schema grammar. Anthropic
+ * caps strict structured output at 16; every `.optional()` / `.catch()` /
+ * `.nullish()` compiles to an `anyOf` ([T, null]) union. This shot-list schema
+ * MUST stay union-free so it never eats into the budget when sent to the model.
+ */
+function countUnions(schema: z.ZodType): number {
+  const json = JSON.stringify(
+    z.toJSONSchema(schema, { unrepresentable: 'any' })
+  );
+  return (json.match(/"anyOf"/g) ?? []).length;
+}
+
+describe('shot-list schema — union budget', () => {
+  it('shotSpecSchema compiles to ZERO union-typed params', () => {
+    expect(countUnions(shotSpecSchema)).toBe(0);
+  });
+
+  it('sceneWithShotsSchema compiles to ZERO union-typed params', () => {
+    expect(countUnions(sceneWithShotsSchema)).toBe(0);
+  });
+
+  it('sceneWithShotsResultSchema compiles to ZERO union-typed params (well under the 16 cap)', () => {
+    const unions = countUnions(sceneWithShotsResultSchema);
+    expect(unions).toBe(0);
+    expect(unions).toBeLessThanOrEqual(16);
+  });
+
+  it('has no optional/nullish/catch fields (all required, emptyable)', () => {
+    const json = JSON.stringify(
+      z.toJSONSchema(sceneWithShotsResultSchema, { unrepresentable: 'any' })
+    );
+    // A union-free schema never emits a "null" type branch.
+    expect(json).not.toContain('"type":"null"');
+  });
+});
+
+describe('shot-list schema — constraints', () => {
+  it('caps a scene at the multi-shot render ceiling', () => {
+    expect(MAX_SCENE_DURATION_SECONDS).toBe(15);
+    expect(MIN_SHOT_DURATION_SECONDS).toBe(3);
+    expect(MAX_SHOTS_PER_SCENE).toBe(5);
+  });
+
+  it('parses a single-shot scene (short-scene regression)', () => {
+    const result = sceneWithShotsSchema.safeParse({
+      sceneId: 's1',
+      sceneNumber: 1,
+      originalScript: { extract: 'A man walks in.', dialogue: [] },
+      metadata: {
+        title: 'Entrance',
+        durationSeconds: 4,
+        location: 'INT. OFFICE - DAY',
+        timeOfDay: 'day',
+        storyBeat: 'introduction',
+      },
+      continuity: {
+        characterTags: ['man'],
+        environmentTag: 'office',
+        elementTags: [],
+        colorPalette: 'warm',
+        lightingSetup: 'soft daylight',
+        styleTag: 'cinematic',
+      },
+      dialoguePresent: false,
+      continuousFromPrevious: false,
+      shots: [
+        {
+          shotNumber: 1,
+          framing: {
+            shotSize: 'wide',
+            angle: 'eye level',
+            composition: 'centered',
+            subjectStartState: 'man stepping through the doorway',
+          },
+          action: 'he walks toward the desk',
+          cameraMovement: { move: 'dolly', pacing: 'slow' },
+          soundCue: 'footsteps',
+          durationSeconds: 4,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.shots).toHaveLength(1);
+  });
+
+  it('parses a multi-shot scene', () => {
+    const shot = {
+      shotNumber: 1,
+      framing: {
+        shotSize: 'medium',
+        angle: 'eye level',
+        composition: 'rule of thirds',
+        subjectStartState: 'standing',
+      },
+      action: 'turns',
+      cameraMovement: { move: 'pan', pacing: 'smooth' } as const,
+      soundCue: '',
+      durationSeconds: 3,
+    };
+    const result = sceneWithShotsSchema.safeParse({
+      sceneId: 's2',
+      sceneNumber: 2,
+      originalScript: { extract: 'x', dialogue: [] },
+      metadata: {
+        title: 't',
+        durationSeconds: 9,
+        location: 'l',
+        timeOfDay: 'night',
+        storyBeat: 'b',
+      },
+      continuity: {
+        characterTags: [],
+        environmentTag: '',
+        elementTags: [],
+        colorPalette: '',
+        lightingSetup: '',
+        styleTag: '',
+      },
+      dialoguePresent: false,
+      continuousFromPrevious: true,
+      shots: [shot, { ...shot, shotNumber: 2 }, { ...shot, shotNumber: 3 }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.shots).toHaveLength(3);
+  });
+
+  it('rejects pacing adverbs outside slow/smooth/gradual', () => {
+    const result = shotSpecSchema.shape.cameraMovement.safeParse({
+      move: 'pan',
+      pacing: 'fast',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/ai/shot-list.schema.ts
+++ b/src/lib/ai/shot-list.schema.ts
@@ -1,0 +1,257 @@
+/**
+ * Shot-list analysis schema (#908)
+ * ============================================================================
+ *
+ * Stage 2 of the Scene / Shot / Frame milestone. Scene analysis stops emitting
+ * shot-sized "scenes" and instead emits **scenes containing 1..N shots**, each
+ * with a STRUCTURED shot prompt. The split is decided here — during analysis,
+ * where the script, dialogue and pacing context live — not downstream in the
+ * motion-prompt step.
+ *
+ * ## Why a separate schema (union budget isolation)
+ *
+ * Anthropic's strict structured-output grammar caps a request at 16
+ * union-typed parameters, and `convertSchemaToJsonSchema` compiles every
+ * `.optional()` / `.catch()` / `.nullish()` field into a `["T","null"]` union
+ * (an `anyOf` in the emitted JSON Schema). The existing
+ * `sceneSplittingResultSchema` already carries optionals; nesting a rich
+ * shots[] array inside it would blow that budget. This schema is authored
+ * SEPARATELY and kept STRICTLY union-free — every field is required with an
+ * emptyable default ('' / [] / sensible scalar). The
+ * `sceneWithShotsResultSchema.union-count.test.ts` asserts the compiled grammar
+ * stays at zero `anyOf` so the budget can never be silently exceeded.
+ *
+ * ## Single source of truth (derive, don't double-author)
+ *
+ * Scene-level shared truth (location, lighting, cast, palette, style) is stated
+ * ONCE per scene by the LLM and reused across every shot. The start-frame
+ * visual prompt and the motion prompt are ASSEMBLED from scene context + the
+ * shot's own structured fields (see `shot-list.derive.ts`) — never re-derived
+ * per shot by the model. This is the structural fix for adjacent-clip drift.
+ *
+ * ## Model-agnostic
+ *
+ * The analysis annotates a shot list with framing, one action, exactly one
+ * camera move (paired with a pacing adverb), a sound cue and a duration. It
+ * never emits vendor-specific syntax (Seedance/Kling/etc.) — the render layer
+ * (#910) adapts per model capability.
+ */
+
+import { z } from 'zod';
+import {
+  characterBibleEntrySchema,
+  elementBibleEntrySchema,
+  locationBibleEntrySchema,
+  originalScriptSchema,
+  projectMetadataSchema,
+  sceneMetadataSchema,
+} from './scene-analysis.schema';
+
+// ============================================================================
+// Constraints (issue #908)
+// ============================================================================
+
+/**
+ * Multi-shot render ceiling. A scene must stay renderable as ONE call on a
+ * capable model (Seedance 2.0 / Kling 3.0 cap at 15s), so the sum of its shot
+ * durations is capped here.
+ */
+export const MAX_SCENE_DURATION_SECONDS = 15;
+/** Floor on an individual shot so a scene can't degenerate into micro-cuts. */
+export const MIN_SHOT_DURATION_SECONDS = 3;
+/**
+ * Derived ceiling on shots per scene: with a 3s floor and a 15s scene cap a
+ * scene holds at most 5 shots. Richer shot lists are allowed (more shots =
+ * more image credits, documented in the PR), but never beyond what the scene
+ * can render as one call.
+ */
+export const MAX_SHOTS_PER_SCENE = Math.floor(
+  MAX_SCENE_DURATION_SECONDS / MIN_SHOT_DURATION_SECONDS
+);
+
+// ============================================================================
+// Scene-level shared continuity (strict, union-free)
+// ============================================================================
+//
+// The shared `continuitySchema` marks `elementTags` `.nullish()` (one union).
+// The shot-list pass keeps the budget at ZERO, so it declares its own
+// continuity with a REQUIRED `elementTags` array (empty when none) instead.
+// The inferred shape stays assignable to `Continuity` (empty `string[]` ⊆
+// `string[] | null`), so derived `Scene.continuity` flows downstream unchanged.
+
+const shotListContinuitySchema = z.object({
+  characterTags: z.array(z.string()).meta({
+    description:
+      "Snake_case slug of each character appearing in the scene (e.g. 'GIRL ONE' → 'girl_one'). One entry per character; empty array if none.",
+  }),
+  environmentTag: z
+    .string()
+    .meta({ description: 'Location/setting tag for environment consistency' }),
+  elementTags: z.array(z.string()).meta({
+    description:
+      'UPPERCASE tokens for elements referenced in this scene. Empty array when none.',
+  }),
+  colorPalette: z
+    .string()
+    .meta({ description: 'Dominant colors for visual continuity' }),
+  lightingSetup: z
+    .string()
+    .meta({ description: 'Lighting configuration shared across the shots' }),
+  styleTag: z
+    .string()
+    .meta({ description: 'Visual style reference for a consistent look' }),
+});
+
+// ============================================================================
+// Structured shot prompt
+// ============================================================================
+
+/**
+ * Framing / start-state — what the start frame shows. Feeds the start-frame
+ * visual prompt alongside the scene context.
+ */
+const shotFramingSchema = z.object({
+  shotSize: z.string().meta({
+    description:
+      'Shot size: extreme wide, wide, medium wide, medium, medium close-up, close-up, extreme close-up',
+  }),
+  angle: z.string().meta({
+    description:
+      'Camera angle: eye level, low angle, high angle, overhead, dutch, over-the-shoulder',
+  }),
+  composition: z.string().meta({
+    description:
+      'How the frame is composed: rule-of-thirds placement, depth, foreground/background, focal point',
+  }),
+  subjectStartState: z.string().meta({
+    description:
+      "The subject's state at the START of the shot: pose, position, expression, what they hold — the still the start frame captures",
+  }),
+});
+
+/**
+ * Camera movement — EXACTLY ONE move, paired with a pacing adverb. Never
+ * stacked (no "pan then dolly"). Feeds the motion prompt.
+ */
+const shotCameraMovementSchema = z.object({
+  move: z.string().meta({
+    description:
+      'The single primary camera move: static, pan, tilt, dolly, truck, pedestal, zoom, push-in, pull-out, orbit. Exactly one — never stacked.',
+  }),
+  pacing: z.enum(['slow', 'smooth', 'gradual']).meta({
+    description:
+      'Pacing adverb for the move: slow, smooth, or gradual. Keeps motion calm and avoids the chaotic output fast moves trigger in video models.',
+  }),
+});
+
+/**
+ * One structured shot. Carries exactly what a real shot-list entry has:
+ * framing/start-state, one primary action, one camera move, a sound cue and a
+ * duration. Visual + motion prompts are DERIVED from these fields plus the
+ * parent scene's shared context (see `shot-list.derive.ts`).
+ */
+export const shotSpecSchema = z.object({
+  shotNumber: z.number().meta({
+    description: '1-based order of this shot within its scene',
+  }),
+  framing: shotFramingSchema.meta({
+    description: 'Framing and subject start-state for the start frame',
+  }),
+  action: z.string().meta({
+    description:
+      'The ONE primary action that happens during this shot (e.g. "she turns and reaches for the door handle"). One action per shot.',
+  }),
+  cameraMovement: shotCameraMovementSchema.meta({
+    description: 'Exactly one camera move paired with a pacing adverb',
+  }),
+  soundCue: z.string().meta({
+    description:
+      'On-screen SFX / ambience hook for audio-capable models (e.g. "door creak, distant traffic"). Empty string when none.',
+  }),
+  durationSeconds: z.number().meta({
+    description: `Shot duration in seconds. At least ${MIN_SHOT_DURATION_SECONDS}; the scene's shots sum to at most ${MAX_SCENE_DURATION_SECONDS}.`,
+  }),
+});
+
+export type ShotSpec = z.infer<typeof shotSpecSchema>;
+
+// ============================================================================
+// Scene with shots
+// ============================================================================
+
+/**
+ * A scene that owns an ordered list of shots. Scene-level context (location,
+ * lighting, cast, palette, style — via `continuity` + `metadata`) is authored
+ * ONCE here and reused by every shot's derived prompts.
+ */
+export const sceneWithShotsSchema = z.object({
+  sceneId: z
+    .string()
+    .meta({ description: 'Unique identifier for this scene (required)' }),
+  sceneNumber: z
+    .number()
+    .meta({ description: 'Scene order number starting from 1 (required)' }),
+  originalScript: originalScriptSchema.meta({
+    description: 'Original (verbatim) script content for this scene',
+  }),
+  metadata: sceneMetadataSchema.meta({
+    description: 'Scene-level metadata (title, location, time of day, beat)',
+  }),
+  continuity: shotListContinuitySchema.meta({
+    description:
+      'Scene-level shared truth: cast membership, environment, palette, lighting, style — authored once, reused by every shot',
+  }),
+  dialoguePresent: z.boolean().meta({
+    description:
+      'Whether the scene contains spoken dialogue. A model-agnostic hint for the render layer (lip-sync vs silent).',
+  }),
+  continuousFromPrevious: z.boolean().meta({
+    description:
+      'Whether this scene continues directly from the previous one without a hard cut (a continuous-transition hint for the render layer). False for the first scene.',
+  }),
+  shots: z.array(shotSpecSchema).meta({
+    description: `Ordered list of 1..${MAX_SHOTS_PER_SCENE} shots. A short scene with no internal cut is a single shot.`,
+  }),
+});
+
+export type SceneWithShots = z.infer<typeof sceneWithShotsSchema>;
+
+// ============================================================================
+// Top-level shot-list analysis result
+// ============================================================================
+
+/**
+ * The full structured output of the shot-list analysis pass. Mirrors
+ * `sceneSplittingResultSchema` but with scenes that own shot lists. Kept
+ * union-free (see file header) to isolate the Anthropic 16-union budget.
+ */
+export const sceneWithShotsResultSchema = z.object({
+  status: z
+    .enum(['success', 'error', 'rejected'])
+    .meta({ description: 'Processing status: success, error, or rejected' }),
+  projectMetadata: projectMetadataSchema.meta({
+    description: 'Project-level metadata extracted from the script',
+  }),
+  scenes: z.array(sceneWithShotsSchema).meta({
+    description: 'Array of scenes, each owning an ordered list of shots',
+  }),
+  characterBible: z.array(characterBibleEntrySchema).meta({
+    description: 'Character descriptions for visual consistency',
+  }),
+  locationBible: z.array(locationBibleEntrySchema).meta({
+    description: 'Location descriptions for visual consistency',
+  }),
+  elementBible: z.array(elementBibleEntrySchema).meta({
+    description:
+      'Elements referenced by UPPERCASE token (uploaded or detected recurring products/objects)',
+  }),
+});
+
+/**
+ * Inferred result of the shot-list analysis pass. The render-layer rewire
+ * (#910) consumes this when scene-split switches to the shot-list schema; kept
+ * exported now as the published analysis contract so #910 can adopt it without
+ * a churn to this file.
+ * @public
+ */
+export type SceneWithShotsResult = z.infer<typeof sceneWithShotsResultSchema>;

--- a/src/lib/ai/shot-list.schema.ts
+++ b/src/lib/ai/shot-list.schema.ts
@@ -16,10 +16,11 @@
  * (an `anyOf` in the emitted JSON Schema). The existing
  * `sceneSplittingResultSchema` already carries optionals; nesting a rich
  * shots[] array inside it would blow that budget. This schema is authored
- * SEPARATELY and kept STRICTLY union-free — every field is required with an
- * emptyable default ('' / [] / sensible scalar). The
- * `sceneWithShotsResultSchema.union-count.test.ts` asserts the compiled grammar
- * stays at zero `anyOf` so the budget can never be silently exceeded.
+ * SEPARATELY and kept STRICTLY union-free — every field is required and
+ * emptyable by convention ('' / [] / sensible scalar), with no Zod `.default()`,
+ * so the model emits the empty value explicitly rather than the parser filling
+ * it. The union-budget block in `shot-list.schema.test.ts` asserts the compiled
+ * grammar stays at zero `anyOf` so the budget can never be silently exceeded.
  *
  * ## Single source of truth (derive, don't double-author)
  *
@@ -209,9 +210,19 @@ export const sceneWithShotsSchema = z.object({
     description:
       'Whether this scene continues directly from the previous one without a hard cut (a continuous-transition hint for the render layer). False for the first scene.',
   }),
-  shots: z.array(shotSpecSchema).meta({
-    description: `Ordered list of 1..${MAX_SHOTS_PER_SCENE} shots. A short scene with no internal cut is a single shot.`,
-  }),
+  // `.min(1).max()` compile to JSON-Schema minItems/maxItems — NOT an `anyOf`
+  // union — so the count bound is enforced at parse time without touching the
+  // zero-union budget (asserted in the union-budget test). The per-shot 3s
+  // floor and 15s scene-sum cap are cross-field and can't be expressed
+  // union-free per field; they stay prompt-only (the field descriptions) and
+  // are enforced by the #910 render-layer consumer.
+  shots: z
+    .array(shotSpecSchema)
+    .min(1)
+    .max(MAX_SHOTS_PER_SCENE)
+    .meta({
+      description: `Ordered list of 1..${MAX_SHOTS_PER_SCENE} shots. A short scene with no internal cut is a single shot.`,
+    }),
 });
 
 export type SceneWithShots = z.infer<typeof sceneWithShotsSchema>;

--- a/src/lib/api-v1/list.test.ts
+++ b/src/lib/api-v1/list.test.ts
@@ -73,6 +73,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: 'seq-1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: 'A scene',
     durationMs: 3000,

--- a/src/lib/api-v1/state.test.ts
+++ b/src/lib/api-v1/state.test.ts
@@ -49,6 +49,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: 'seq-1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: 'A scene',
     durationMs: 3000,

--- a/src/lib/db/backfill-scenes.test.ts
+++ b/src/lib/db/backfill-scenes.test.ts
@@ -1,0 +1,294 @@
+/**
+ * In-memory DB tests for the #907 scenes backfill.
+ *
+ * The backfill is a data migration (INSERT … SELECT + UPDATE) that ships inside
+ * the `…_jazzy_whiplash` migration. Because migrations run against an empty DB
+ * at setup, the in-migration backfill no-ops there — so these tests seed shots
+ * AFTER migrating, then execute the migration's own backfill statements (read
+ * verbatim from the shipped SQL file) and assert the result. Reading the real
+ * SQL keeps the test honest: it exercises exactly what runs in prod.
+ *
+ * The staleness-compat test is the milestone's #1 QA risk: a freshly-backfilled
+ * shot must still report isStale() === false.
+ */
+
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import type { NewShot } from '@/lib/db/schema';
+import {
+  dbSceneId,
+  scenes,
+  sequences,
+  shots,
+  styles,
+  teams,
+} from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { createShotsMethods } from '@/lib/db/scoped/shots';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+const MIGRATIONS_DIR = './drizzle/migrations';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let sequenceId = '';
+
+/**
+ * Pull the backfill statements straight out of the shipped migration SQL so the
+ * test runs the exact DML that prod applies. Finds the migration that contains
+ * the `INSERT INTO scenes … SELECT … FROM shots` backfill, splits on drizzle's
+ * statement breakpoint, and returns just the INSERT + UPDATE.
+ */
+function readBackfillStatements(): string[] {
+  for (const dir of readdirSync(MIGRATIONS_DIR)) {
+    const file = join(MIGRATIONS_DIR, dir, 'migration.sql');
+    let sql: string;
+    try {
+      sql = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (!sql.includes('INSERT INTO `scenes`')) continue;
+    return sql
+      .split('--> statement-breakpoint')
+      .map((s) =>
+        s
+          .split('\n')
+          .filter((line) => !line.trim().startsWith('--'))
+          .join('\n')
+          .trim()
+      )
+      .filter(
+        (s) =>
+          s.startsWith('INSERT INTO `scenes`') ||
+          s.startsWith('UPDATE `shots` SET `scene_id`')
+      );
+  }
+  throw new Error('test setup: backfill migration not found');
+}
+
+const BACKFILL_STATEMENTS = readBackfillStatements();
+
+// Fail loud if the parser extracted the wrong number of statements (e.g. a
+// future db:generate reformat that the startsWith filters no longer match).
+// Without this, a partial match — INSERT found but UPDATE missed — would let
+// the scene-only assertions pass while shot-linking goes untested.
+if (BACKFILL_STATEMENTS.length !== 2) {
+  throw new Error(
+    `test setup: expected 2 backfill statements (INSERT scenes + UPDATE shots), got ${BACKFILL_STATEMENTS.length} — migration SQL format likely changed`
+  );
+}
+
+async function runBackfill(): Promise<void> {
+  for (const stmt of BACKFILL_STATEMENTS) {
+    await client.execute(stmt);
+  }
+}
+
+function sceneFixture(overrides: Partial<Scene> = {}): Scene {
+  return {
+    sceneId: 'scene-1',
+    sceneNumber: 1,
+    originalScript: { extract: 'INT. OFFICE - DAY', dialogue: [] },
+    metadata: {
+      title: 'The meeting',
+      durationSeconds: 5,
+      location: 'INT. OFFICE - DAY',
+      timeOfDay: 'day',
+      storyBeat: 'Setup',
+    },
+    continuity: {
+      characterTags: ['sarah'],
+      environmentTag: 'office',
+      elementTags: [],
+      colorPalette: 'cool blues',
+      lightingSetup: 'overhead fluorescent',
+      styleTag: 'corporate',
+    },
+    musicDesign: {
+      presence: 'minimal',
+      style: 'ambient',
+      mood: 'tense',
+      atmosphere: 'office hum',
+    },
+    ...overrides,
+  };
+}
+
+async function seedSequence(): Promise<void> {
+  teamId = generateId();
+  sequenceId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: `t-${teamId}` });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db.insert(sequences).values({
+    id: sequenceId,
+    teamId,
+    title: 'S',
+    styleId: style.id,
+  });
+}
+
+async function insertShot(data: Partial<NewShot> & { orderIndex: number }) {
+  const [shot] = await db
+    .insert(shots)
+    .values({ sequenceId, ...data } satisfies NewShot)
+    .returning();
+  if (!shot) throw new Error('test setup: shot insert returned nothing');
+  return shot;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: MIGRATIONS_DIR });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await db.delete(shots);
+  await db.delete(scenes);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await seedSequence();
+});
+
+describe('backfill scenes migration', () => {
+  it('creates one scene per shot, reusing the shot id, linked with shotNumber=1', async () => {
+    const a = await insertShot({ orderIndex: 0, metadata: sceneFixture() });
+    const b = await insertShot({
+      orderIndex: 1,
+      metadata: sceneFixture({ sceneId: 'scene-2', sceneNumber: 2 }),
+    });
+
+    await runBackfill();
+
+    const allScenes = await db.select().from(scenes);
+    expect(allScenes).toHaveLength(2);
+
+    for (const shot of await db.select().from(shots)) {
+      // The scene REUSES the shot's ULID — the 1:1 expand rule.
+      expect(shot.sceneId).toBe(shot.id);
+      expect(shot.shotNumber).toBe(1);
+      const scene = allScenes.find((s) => s.id === shot.sceneId);
+      expect(scene?.orderIndex).toBe(shot.orderIndex);
+    }
+    // Explicit id-reuse assertion against the known shots.
+    expect(allScenes.map((s) => s.id).sort()).toEqual([a.id, b.id].sort());
+  });
+
+  it('splits scene-level fields out of the shot metadata onto the scene row', async () => {
+    const shot = await insertShot({ orderIndex: 3, metadata: sceneFixture() });
+    await runBackfill();
+
+    const [scene] = await db
+      .select()
+      .from(scenes)
+      // The scene reuses the shot's ULID (1:1 backfill), so the shot id doubles
+      // as the scene's branded id — convert it explicitly at this boundary.
+      .where(eq(scenes.id, dbSceneId(shot.id)));
+    expect(scene?.orderIndex).toBe(3);
+    expect(scene?.location).toBe('INT. OFFICE - DAY');
+    expect(scene?.timeOfDay).toBe('day');
+    expect(scene?.storyBeat).toBe('Setup');
+    expect(scene?.title).toBe('The meeting');
+    // JSON subtrees survive the json_extract round-trip with their shape intact.
+    expect(scene?.continuity?.environmentTag).toBe('office');
+    expect(scene?.continuity?.characterTags).toEqual(['sarah']);
+    expect(scene?.musicDesign?.presence).toBe('minimal');
+    expect(scene?.originalScript?.extract).toBe('INT. OFFICE - DAY');
+
+    // The shot's metadata is left intact (transitional duplicate).
+    const [reread] = await db.select().from(shots).where(eq(shots.id, shot.id));
+    expect(reread?.metadata?.metadata?.location).toBe('INT. OFFICE - DAY');
+  });
+
+  it('backfills a null-metadata shot without crashing (null scene fields)', async () => {
+    const shot = await insertShot({ orderIndex: 0, metadata: null });
+    await runBackfill();
+
+    const [scene] = await db.select().from(scenes);
+    expect(scene?.id).toBe(shot.id);
+    expect(scene?.location).toBeNull();
+    expect(scene?.title).toBeNull();
+    expect(scene?.continuity).toBeNull();
+    expect(scene?.musicDesign).toBeNull();
+    expect(scene?.originalScript).toBeNull();
+
+    const [reread] = await db.select().from(shots).where(eq(shots.id, shot.id));
+    expect(reread?.sceneId).toBe(shot.id);
+    expect(reread?.shotNumber).toBe(1);
+  });
+
+  it('is idempotent: a second run creates no duplicate scenes', async () => {
+    await insertShot({ orderIndex: 0, metadata: sceneFixture() });
+    await insertShot({
+      orderIndex: 1,
+      metadata: sceneFixture({ sceneId: 'scene-2' }),
+    });
+
+    await runBackfill();
+    expect(await db.select().from(scenes)).toHaveLength(2);
+
+    // Second run: every shot already has a scene_id, so WHERE scene_id IS NULL
+    // matches nothing — no new scenes, no constraint violation.
+    await runBackfill();
+    expect(await db.select().from(scenes)).toHaveLength(2);
+    const allShots = await db.select().from(shots);
+    expect(allShots.every((s) => s.sceneId === s.id)).toBe(true);
+  });
+
+  it('staleness compat: a freshly-backfilled shot is NOT stale', async () => {
+    // A shot whose video artifact has a recorded input hash — the real path
+    // where staleness matters. Backfill must not perturb it.
+    const knownHash = 'abc123-video-input-hash';
+    const shot = await insertShot({
+      orderIndex: 0,
+      metadata: sceneFixture(),
+      videoInputHash: knownHash,
+    });
+
+    await runBackfill();
+
+    const shotsMethods = createShotsMethods(db);
+    // Same hash → not stale. Backfill touched only sceneId + shotNumber, so the
+    // stored videoInputHash is unchanged.
+    expect(await shotsMethods.isStale(shot.id, 'video', knownHash)).toBe(false);
+
+    // Sanity: a different hash WOULD be stale, proving the check is live.
+    expect(await shotsMethods.isStale(shot.id, 'video', 'different')).toBe(
+      true
+    );
+
+    // And the stored hash itself survived the backfill untouched.
+    const [reread] = await db.select().from(shots).where(eq(shots.id, shot.id));
+    expect(reread?.videoInputHash).toBe(knownHash);
+  });
+});

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -12,6 +12,8 @@ import { teamInvitations, teamMembers, teams } from './teams';
 
 import { sequences } from './sequences';
 
+import { dbSceneId, scenes } from './scenes';
+
 import { shots } from './shots';
 
 import { shotVariants } from './shot-variants';
@@ -77,6 +79,11 @@ export { teamInvitations, teamMembers, teams };
 export { sequences };
 
 export type { NewSequence, Sequence } from './sequences';
+
+// Scenes (narrative units; each owns an ordered list of shots)
+export { dbSceneId, scenes };
+
+export type { DbSceneId, NewScene, SceneRow } from './scenes';
 
 // Shots
 export { shots };
@@ -244,6 +251,7 @@ export const schema = {
 
   // Sequences
   sequences,
+  scenes,
   shots,
   shotVariants,
   characterSheetVariants,

--- a/src/lib/db/schema/relations.ts
+++ b/src/lib/db/schema/relations.ts
@@ -51,6 +51,7 @@ export const relations = defineRelations(schema, (r) => ({
       alias: 'sequences_updatedBy_users_id',
     }),
     style: r.one.styles({ from: r.sequences.styleId, to: r.styles.id }),
+    scenes: r.many.scenes(),
     shots: r.many.shots(),
     characters: r.many.characters(),
     locations: r.many.sequenceLocations(),
@@ -58,11 +59,24 @@ export const relations = defineRelations(schema, (r) => ({
     musicPromptVariants: r.many.sequenceMusicPromptVariants(),
   },
 
+  // ---- Scenes ----
+  scenes: {
+    sequence: r.one.sequences({
+      from: r.scenes.sequenceId,
+      to: r.sequences.id,
+    }),
+    shots: r.many.shots(),
+  },
+
   // ---- Shots ----
   shots: {
     sequence: r.one.sequences({
       from: r.shots.sequenceId,
       to: r.sequences.id,
+    }),
+    scene: r.one.scenes({
+      from: r.shots.sceneId,
+      to: r.scenes.id,
     }),
     variants: r.many.shotVariants(),
     promptVariants: r.many.shotPromptVariants(),

--- a/src/lib/db/schema/scenes.ts
+++ b/src/lib/db/schema/scenes.ts
@@ -1,0 +1,131 @@
+/**
+ * Scenes Schema
+ * Narrative units within a sequence — each owns an ordered list of shots,
+ * a single look (image model) and a single motion character (video model).
+ *
+ * A scene is the render unit: capable models render all its shots in one
+ * multi-shot call, others render N per-shot calls and attach the assets here.
+ * Scene-level fields (location, time of day, story beat, continuity,
+ * music design, original script) live in dedicated columns or typed JSON so
+ * the shot's own `metadata` no longer has to be the sole source of truth.
+ *
+ * @see src/lib/ai/scene-analysis.schema.ts for the Scene metadata structure
+ * @see src/lib/db/schema/shots.ts — shots reference a scene via `shots.sceneId`
+ */
+
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import { type InferInsertModel, type InferSelectModel } from 'drizzle-orm';
+import {
+  index,
+  integer,
+  snakeCase,
+  text,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
+import { generateId } from '../id';
+import { sequences } from './sequences';
+
+/**
+ * Generation status values for the scene-level video render. Mirrors the
+ * shot-level statuses (kept as a local list per the existing per-schema
+ * convention rather than a shared import).
+ */
+const SCENE_GENERATION_STATUSES = [
+  'pending',
+  'generating',
+  'completed',
+  'failed',
+] as const;
+type SceneGenerationStatus = (typeof SCENE_GENERATION_STATUSES)[number];
+
+/**
+ * Branded id for `scenes.id` (a ULID). Distinct from the LLM-assigned
+ * `Scene.sceneId` string carried in analysis output (see `analysisSceneId` in
+ * the ShotMapping type) — both are plain strings, so this brand exists for call
+ * sites that want the compiler to keep the two apart. The `scenes.id` column is
+ * `.$type<DbSceneId>()`, so `SceneRow.id` — and any relation query that reaches
+ * a scene — carries the brand by inference. The scoped scene methods take it for
+ * their id params, so a `scene.id` flows through naturally, while a bare
+ * analysis `sceneId` string won't type-check where a `DbSceneId` is expected.
+ */
+export type DbSceneId = string & { readonly __brand: 'DbSceneId' };
+
+/**
+ * Brand a raw ULID string as a `DbSceneId` (no conversion, just a type cast).
+ * The single sanctioned place to mint the brand — mirrors `micros()` in
+ * billing/money.ts.
+ */
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- sole brand constructor for DbSceneId
+export const dbSceneId = (id: string): DbSceneId => id as DbSceneId;
+
+// Scene-level slices of the analysis `Scene` object, reused verbatim so the
+// JSON columns stay precisely typed without re-declaring the shapes. All three
+// columns are nullable (the backfill writes NULL for a null-metadata shot), so
+// `| null` is spelled out — `originalScript` is a required field on `Scene`, so
+// unlike the optional `continuity`/`musicDesign` it needs the explicit union.
+type SceneContinuity = NonNullable<Scene['continuity']>;
+type SceneMusicDesign = NonNullable<Scene['musicDesign']>;
+type SceneOriginalScript = Scene['originalScript'] | null;
+
+/**
+ * Scenes table — narrative units within a sequence.
+ */
+export const scenes = snakeCase.table(
+  'scenes',
+  {
+    id: text()
+      .$defaultFn(() => generateId())
+      .$type<DbSceneId>()
+      .primaryKey()
+      .notNull(),
+    sequenceId: text()
+      .notNull()
+      .references(() => sequences.id, { onDelete: 'cascade' }),
+    // 0-based scene order within the sequence.
+    orderIndex: integer().notNull(),
+    // Query/sort targets get dedicated columns (not buried in JSON).
+    location: text(),
+    timeOfDay: text(),
+    storyBeat: text(),
+    title: text(),
+    // Typed JSON slices of the analysis Scene object.
+    continuity: text({ mode: 'json' }).$type<SceneContinuity>(),
+    musicDesign: text({ mode: 'json' }).$type<SceneMusicDesign>(),
+    originalScript: text({ mode: 'json' }).$type<SceneOriginalScript>(),
+    // Model selection lives at scene level (one look, one motion character).
+    // NULL = inherit from the sequence default (#909 wires the UI later).
+    imageModel: text({ length: 100 }),
+    videoModel: text({ length: 100 }),
+    // Scene-render video columns — unused until #910, included now to avoid a
+    // later ALTER. All nullable.
+    videoUrl: text(),
+    videoPath: text(), // R2 storage path (not signed URL)
+    videoStatus: text().$type<SceneGenerationStatus>().default('pending'),
+    videoWorkflowRunId: text(),
+    videoGeneratedAt: integer({ mode: 'timestamp' }),
+    videoError: text(),
+    videoInputHash: text(),
+    // How the scene render is assembled (e.g. multi-shot vs per-shot). Free
+    // text until #910 defines the strategy enum.
+    renderStrategy: text(),
+    createdAt: integer({ mode: 'timestamp' })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: integer({ mode: 'timestamp' })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    index('idx_scenes_sequence_order').on(table.sequenceId, table.orderIndex),
+    uniqueIndex('scenes_sequence_id_order_index_key').on(
+      table.sequenceId,
+      table.orderIndex
+    ),
+  ]
+);
+
+// `id` carries the `DbSceneId` brand via the column's `.$type<>()`, so the
+// inferred models are branded directly — no Omit-and-re-add, and relation
+// queries / the `shots.sceneId` FK pick the brand up for free.
+export type SceneRow = InferSelectModel<typeof scenes>;
+export type NewScene = InferInsertModel<typeof scenes>;

--- a/src/lib/db/schema/shots.ts
+++ b/src/lib/db/schema/shots.ts
@@ -13,6 +13,7 @@ import {
   uniqueIndex,
 } from 'drizzle-orm/sqlite-core';
 import { generateId } from '../id';
+import { scenes } from './scenes';
 import { sequences } from './sequences';
 
 export const SHOT_GENERATION_STATUSES = [
@@ -44,6 +45,13 @@ export const shots = snakeCase.table(
     sequenceId: text()
       .notNull()
       .references(() => sequences.id, { onDelete: 'cascade' }),
+    // Parent scene (#907). NULL until backfilled. Deliberately NOT cascade —
+    // CLAUDE.md rule 3: never cascade to long-lived parents; orphaned shots
+    // null out rather than vanish if a scene is deleted.
+    sceneId: text().references(() => scenes.id, { onDelete: 'set null' }),
+    // 1-based shot order within the scene. Backfill sets this to 1 (every
+    // sequence becomes scenes-of-one-shot until multi-shot analysis lands).
+    shotNumber: integer(),
     orderIndex: integer().notNull(),
     description: text(),
     durationMs: integer().default(3000),

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -14,6 +14,7 @@ import { createApiKeysMethods } from '@/lib/db/scoped/api-keys';
 import { createBillingMethods } from '@/lib/db/scoped/billing';
 import { createCharacterSheetVariantsMethods } from '@/lib/db/scoped/character-sheet-variants';
 import { createCharactersMethods } from '@/lib/db/scoped/characters';
+import { createScenesMethods } from '@/lib/db/scoped/scenes';
 import { createShotPromptVariantsMethods } from '@/lib/db/scoped/shot-prompt-variants';
 import { createShotVariantsMethods } from '@/lib/db/scoped/shot-variants';
 import { createShotsMethods } from '@/lib/db/scoped/shots';
@@ -284,6 +285,7 @@ export function createScopedDb(teamId: string, userId: string) {
     locationSheets: createLocationSheetsMethods(db),
     library: createLibraryMethods(db, teamId),
 
+    scenes: createScenesMethods(db),
     shots: createShotsMethods(db),
     shotVariants: createShotVariantsMethods(db),
     shotPromptVariants: createShotPromptVariantsMethods(db),

--- a/src/lib/db/scoped/scenes.ts
+++ b/src/lib/db/scoped/scenes.ts
@@ -1,0 +1,125 @@
+/**
+ * Scoped Scenes Sub-module
+ * Scene CRUD and ordered listing within a sequence.
+ *
+ * Scenes are the narrative units introduced in #907. Each owns an ordered list
+ * of shots; this stage keeps every sequence as scenes-of-one-shot.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { scenes } from '@/lib/db/schema';
+import type { DbSceneId, NewScene, SceneRow } from '@/lib/db/schema';
+import { asc, desc, eq, inArray } from 'drizzle-orm';
+
+type SceneOrderBy = 'orderIndex' | 'createdAt' | 'updatedAt';
+
+type SceneFilters = {
+  orderBy?: SceneOrderBy;
+  ascending?: boolean;
+};
+
+export function createScenesMethods(db: Database) {
+  return {
+    getById: async (sceneId: DbSceneId): Promise<SceneRow | null> => {
+      const result = await db
+        .select()
+        .from(scenes)
+        .where(eq(scenes.id, sceneId));
+      return result[0] ?? null;
+    },
+
+    listBySequence: async (
+      sequenceId: string,
+      options?: SceneFilters
+    ): Promise<SceneRow[]> => {
+      const { orderBy = 'orderIndex', ascending = true } = options ?? {};
+
+      const orderColumn =
+        orderBy === 'orderIndex'
+          ? scenes.orderIndex
+          : orderBy === 'createdAt'
+            ? scenes.createdAt
+            : scenes.updatedAt;
+
+      const orderFn = ascending ? asc : desc;
+
+      return await db
+        .select()
+        .from(scenes)
+        .where(eq(scenes.sequenceId, sequenceId))
+        .orderBy(orderFn(orderColumn));
+    },
+
+    create: async (data: NewScene): Promise<SceneRow> => {
+      const [scene] = await db.insert(scenes).values(data).returning();
+      if (!scene) {
+        throw new Error(
+          `Failed to create scene for sequence ${data.sequenceId}`
+        );
+      }
+      return scene;
+    },
+
+    update: async (
+      sceneId: DbSceneId,
+      data: Partial<NewScene>,
+      options?: { throwOnMissing?: boolean }
+    ): Promise<SceneRow | undefined> => {
+      const [scene] = await db
+        .update(scenes)
+        .set({ ...data, updatedAt: new Date() })
+        .where(eq(scenes.id, sceneId))
+        .returning();
+
+      if (!scene && options?.throwOnMissing !== false) {
+        throw new Error(`Scene ${sceneId} not found`);
+      }
+
+      return scene;
+    },
+
+    delete: async (sceneId: DbSceneId): Promise<boolean> => {
+      const result = await db.delete(scenes).where(eq(scenes.id, sceneId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return (result.rowsAffected ?? 0) > 0;
+    },
+
+    deleteBySequence: async (sequenceId: string): Promise<number> => {
+      const result = await db
+        .delete(scenes)
+        .where(eq(scenes.sequenceId, sequenceId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return result.rowsAffected ?? 0;
+    },
+
+    createBulk: async (sceneData: NewScene[]): Promise<SceneRow[]> => {
+      if (sceneData.length === 0) return [];
+
+      const BATCH_SIZE = 5;
+      const results: SceneRow[] = [];
+
+      for (let i = 0; i < sceneData.length; i += BATCH_SIZE) {
+        const batch = sceneData.slice(i, i + BATCH_SIZE);
+        const batchResults = await db.insert(scenes).values(batch).returning();
+        results.push(...batchResults);
+      }
+
+      // Fail loud on a short write rather than silently returning fewer rows
+      // than requested. (Batches are not atomic across the loop — same as
+      // shots.createBulk — so a mid-loop throw can leave earlier batches
+      // committed; the count check at least surfaces a truncated success.)
+      if (results.length !== sceneData.length) {
+        throw new Error(
+          `createBulk inserted ${results.length}/${sceneData.length} scenes`
+        );
+      }
+
+      return results;
+    },
+
+    getByIds: async (sceneIds: DbSceneId[]): Promise<SceneRow[]> => {
+      if (sceneIds.length === 0) return [];
+      return await db.select().from(scenes).where(inArray(scenes.id, sceneIds));
+    },
+  };
+}

--- a/src/lib/db/scoped/shots.ts
+++ b/src/lib/db/scoped/shots.ts
@@ -137,6 +137,11 @@ export function createShotsMethods(db: Database) {
             description: sql.raw(`excluded."description"`),
             durationMs: sql.raw(`excluded."duration_ms"`),
             metadata: sql.raw(`excluded."metadata"`),
+            // #908: a replay re-derives the same shot at the same orderIndex —
+            // carry the scene link + intra-scene number through the conflict so
+            // a re-run is idempotent rather than leaving stale values.
+            sceneId: sql.raw(`excluded."scene_id"`),
+            shotNumber: sql.raw(`excluded."shot_number"`),
             updatedAt: new Date(),
           },
         })
@@ -190,6 +195,10 @@ export function createShotsMethods(db: Database) {
               description: sql.raw(`excluded."description"`),
               durationMs: sql.raw(`excluded."duration_ms"`),
               metadata: sql.raw(`excluded."metadata"`),
+              // #908: keep the scene link + intra-scene number idempotent on
+              // replay (see the matching note in `upsert`).
+              sceneId: sql.raw(`excluded."scene_id"`),
+              shotNumber: sql.raw(`excluded."shot_number"`),
               updatedAt: new Date(),
             },
           })

--- a/src/lib/failures/failure-analysis.test.ts
+++ b/src/lib/failures/failure-analysis.test.ts
@@ -7,6 +7,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: 'seq-1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: 'A scene',
     durationMs: 3000,

--- a/src/lib/image/build-shot-image-input.test.ts
+++ b/src/lib/image/build-shot-image-input.test.ts
@@ -21,6 +21,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: 'seq-1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: '',
     durationMs: 3000,

--- a/src/lib/mocks/data-generators.ts
+++ b/src/lib/mocks/data-generators.ts
@@ -18,6 +18,8 @@ const generateMockShot = (overrides?: Partial<Shot>): Shot => {
   return {
     id: faker.string.ulid(),
     sequenceId: faker.string.ulid(),
+    sceneId: null,
+    shotNumber: null,
     orderIndex: faker.number.int({ min: 1, max: 10 }),
     description: faker.lorem.paragraph(),
     thumbnailUrl: `https://picsum.photos/seed/${faker.helpers.arrayElement([

--- a/src/lib/realtime/__tests__/query-cache-updater.test.ts
+++ b/src/lib/realtime/__tests__/query-cache-updater.test.ts
@@ -23,6 +23,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   return {
     id: 'shot-1',
     sequenceId: SEQ,
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: 'A scene',
     durationMs: 3000,

--- a/src/lib/vtt/generate-chapters.test.ts
+++ b/src/lib/vtt/generate-chapters.test.ts
@@ -15,6 +15,8 @@ const createTestScene = (overrides: Partial<Scene>): Scene => ({
 const createTestShot = (overrides: Partial<Shot>): Shot => ({
   id: '1',
   sequenceId: 'seq-1',
+  sceneId: null,
+  shotNumber: null,
   orderIndex: 0,
   description: null,
   durationMs: 3000,

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -190,7 +190,7 @@ export type SceneSplitWorkflowInput = SequenceWorkflowContext & {
 export type SceneSplitWorkflowResult = {
   scenes: Scene[];
   title: string;
-  shotMapping: Array<{ sceneId: string; shotId: string }>;
+  shotMapping: ShotMapping;
   characterBible: CharacterBibleEntry[];
   locationBible: LocationBibleEntry[];
   elementBible: ElementBibleEntry[];
@@ -419,7 +419,13 @@ export interface CharacterBibleWorkflowInput extends SequenceWorkflowContext {
   styleConfig?: StyleConfig;
 }
 
-type ShotMapping = Array<{ sceneId: string; shotId: string }>;
+/**
+ * Maps each analysis scene (the LLM-assigned `Scene.sceneId` string carried in
+ * the analysis output) to the DB shot row created for it. `analysisSceneId` is
+ * deliberately NOT the new `scenes.id` ULID (see DbSceneId in schema/scenes.ts)
+ * — both are strings, so the distinct name guards against confusing them.
+ */
+type ShotMapping = Array<{ analysisSceneId: string; shotId: string }>;
 
 export interface VisualPromptWorkflowInput extends SequenceWorkflowContext {
   scenes: Scene[];

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -628,7 +628,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
         }
 
         const matchedShot = shotMapping.find(
-          (f) => f.sceneId === scene.sceneId
+          (f) => f.analysisSceneId === scene.sceneId
         );
 
         const characterTags = scene.continuity?.characterTags;

--- a/src/lib/workflows/motion-prompt-workflow.ts
+++ b/src/lib/workflows/motion-prompt-workflow.ts
@@ -102,7 +102,8 @@ export class MotionPromptWorkflow extends OpenStoryWorkflowEntrypoint<MotionProm
           teamId: input.teamId,
           userId: input.userId,
           sequenceId,
-          shotId: shotMapping?.find((f) => f.sceneId === scene.sceneId)?.shotId,
+          shotId: shotMapping?.find((f) => f.analysisSceneId === scene.sceneId)
+            ?.shotId,
           // Pass the rendered still per scene, snapshotted upstream (#929) —
           // never looked up inside the child workflow.
           startingFrameImageUrl:

--- a/src/lib/workflows/regenerate-shots-snapshot.test.ts
+++ b/src/lib/workflows/regenerate-shots-snapshot.test.ts
@@ -58,6 +58,8 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
   const shot: Shot = {
     id: 'f1',
     sequenceId: 'seq1',
+    sceneId: null,
+    shotNumber: null,
     orderIndex: 0,
     description: null,
     durationMs: 3000,

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -39,7 +39,10 @@ import {
 import type { Microdollars } from '@/lib/billing/money';
 import type { TokenUsage } from '@tanstack/ai';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
-import { buildSceneInserts } from '@/lib/ai/scene-persistence';
+import {
+  buildSceneInserts,
+  buildSceneShotLinks,
+} from '@/lib/ai/scene-persistence';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { NewShot } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
@@ -558,22 +561,35 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         const sceneInserts = buildSceneInserts(sequenceId, reconciled.scenes);
         const sceneRows = await scopedDb.scenes.createBulk(sceneInserts);
 
-        // Link each shot to its scene row by analysisSceneId → orderIndex.
-        // shotMapping is analysisSceneId-keyed; scenes are order-aligned to
-        // `reconciled.scenes`, so map analysisSceneId → its index → scene row.
-        const sceneRowByAnalysisId = new Map(
-          reconciled.scenes.map((scene, index) => [
-            scene.sceneId,
-            sceneRows[index],
-          ])
+        // Link each shot to its scene row by analysisSceneId → orderIndex →
+        // row (see buildSceneShotLinks — keyed on the unique orderIndex, not
+        // array position). A shot whose scene is missing is surfaced, not
+        // silently skipped: every mapped shot should belong to a scene.
+        const { links, unmappedShotIds } = buildSceneShotLinks(
+          reconciled.scenes,
+          sceneRows,
+          reconciled.shotMapping
         );
-        for (const { analysisSceneId, shotId } of reconciled.shotMapping) {
-          const sceneRow = sceneRowByAnalysisId.get(analysisSceneId);
-          if (!sceneRow) continue;
-          await scopedDb.shots.update(
+        if (unmappedShotIds.length > 0) {
+          logger.warn(
+            `[SceneSplitWorkflow:cf] persist-scenes: ${unmappedShotIds.length} shot(s) had no matching scene row`,
+            { sequenceId, unmappedShotIds }
+          );
+        }
+
+        const missingShotIds: string[] = [];
+        for (const { shotId, sceneId, shotNumber } of links) {
+          const updated = await scopedDb.shots.update(
             shotId,
-            { sceneId: sceneRow.id, shotNumber: 1 },
+            { sceneId, shotNumber },
             { throwOnMissing: false }
+          );
+          if (!updated) missingShotIds.push(shotId);
+        }
+        if (missingShotIds.length > 0) {
+          logger.warn(
+            `[SceneSplitWorkflow:cf] persist-scenes: ${missingShotIds.length} shot(s) missing at link time`,
+            { sequenceId, missingShotIds }
           );
         }
       });

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -77,7 +77,7 @@ const LOG_METADATA = { phase: PHASE.number, phaseName: PHASE.name };
 type StreamResult = {
   scenes: SceneSplittingResult['scenes'];
   projectMetadata: SceneSplittingResult['projectMetadata'];
-  shotMapping: Array<{ sceneId: string; shotId: string }>;
+  shotMapping: Array<{ analysisSceneId: string; shotId: string }>;
   characterBible: SceneSplittingResult['characterBible'];
   locationBible: SceneSplittingResult['locationBible'];
   elementBible: SceneSplittingResult['elementBible'];
@@ -153,7 +153,8 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         );
 
         const parser = createStreamingSceneParser();
-        const shotMapping: Array<{ sceneId: string; shotId: string }> = [];
+        const shotMapping: Array<{ analysisSceneId: string; shotId: string }> =
+          [];
         let finalText = '';
         let chunkCount = 0;
         let prevScene: SceneSplittingScene | undefined = undefined;
@@ -291,7 +292,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                 );
 
                 shotMapping.push({
-                  sceneId: ev.scene.sceneId,
+                  analysisSceneId: ev.scene.sceneId,
                   shotId: shot.id,
                 });
 
@@ -465,7 +466,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         const reconciledShots = await scopedDb.shots.bulkUpsert(shotInserts);
         const reconciledMapping = reconciledShots.map((f) => ({
           // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard: metadata is JSONB, can be null despite Drizzle types
-          sceneId: f.metadata?.sceneId || '',
+          analysisSceneId: f.metadata?.sceneId || '',
           shotId: f.id,
         }));
 
@@ -479,9 +480,9 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
 
         // Emit shot:created for any shots the streaming step didn't cover.
         const streamedSceneIds = new Set(
-          streamResult.shotMapping.map((f) => f.sceneId)
+          streamResult.shotMapping.map((f) => f.analysisSceneId)
         );
-        for (const { sceneId: sId, shotId } of reconciledMapping) {
+        for (const { analysisSceneId: sId, shotId } of reconciledMapping) {
           if (!streamedSceneIds.has(sId)) {
             const scene = scenes.find((s) => s.sceneId === sId);
             await getGenerationChannel(sequenceId).emit(

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -39,6 +39,7 @@ import {
 import type { Microdollars } from '@/lib/billing/money';
 import type { TokenUsage } from '@tanstack/ai';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
+import { buildSceneInserts } from '@/lib/ai/scene-persistence';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { NewShot } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
@@ -531,6 +532,49 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
             text: entry.firstMention.text,
             lineNumber: entry.firstMention.lineNumber,
           });
+        }
+      });
+    }
+
+    // Step 4b (#908): persist a `scenes` row per analysis scene and link each
+    // shot to it via `shots.sceneId`. Analysis currently emits shot-sized
+    // scenes (one shot per scene), so this writes a 1:1 scenes↔shots mapping —
+    // the same shape #907's backfill produced for existing sequences, now
+    // populated at analysis time for NEW sequences too. Scene-level fields
+    // (location / time of day / story beat / continuity / music design /
+    // original script) are stored on the scene row; the shot's `metadata` keeps
+    // the full Scene object unchanged so every downstream read path is
+    // untouched. The structured multi-shot shot list + per-shot prompt
+    // derivation (src/lib/ai/shot-list.{schema,derive}.ts) is wired into the
+    // render chain in #910 — this step is the additive persistence half.
+    //
+    // Idempotent on replay: delete-then-recreate within the step (scenes are
+    // only ever written here, so a full rewrite is safe and avoids the missing
+    // scenes-upsert).
+    if (sequenceId && reconciled.scenes.length > 0) {
+      await step.do('persist-scenes', async () => {
+        await scopedDb.scenes.deleteBySequence(sequenceId);
+
+        const sceneInserts = buildSceneInserts(sequenceId, reconciled.scenes);
+        const sceneRows = await scopedDb.scenes.createBulk(sceneInserts);
+
+        // Link each shot to its scene row by analysisSceneId → orderIndex.
+        // shotMapping is analysisSceneId-keyed; scenes are order-aligned to
+        // `reconciled.scenes`, so map analysisSceneId → its index → scene row.
+        const sceneRowByAnalysisId = new Map(
+          reconciled.scenes.map((scene, index) => [
+            scene.sceneId,
+            sceneRows[index],
+          ])
+        );
+        for (const { analysisSceneId, shotId } of reconciled.shotMapping) {
+          const sceneRow = sceneRowByAnalysisId.get(analysisSceneId);
+          if (!sceneRow) continue;
+          await scopedDb.shots.update(
+            shotId,
+            { sceneId: sceneRow.id, shotNumber: 1 },
+            { throwOnMissing: false }
+          );
         }
       });
     }

--- a/src/lib/workflows/shot-images-workflow.ts
+++ b/src/lib/workflows/shot-images-workflow.ts
@@ -202,7 +202,7 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
         }
 
         const matchedShot = shotMapping.find(
-          (f) => f.sceneId === scene.sceneId
+          (f) => f.analysisSceneId === scene.sceneId
         );
 
         const characterRefs = buildCharacterReferenceImages(

--- a/src/lib/workflows/visual-prompt-workflow.ts
+++ b/src/lib/workflows/visual-prompt-workflow.ts
@@ -97,7 +97,8 @@ export class VisualPromptWorkflow extends OpenStoryWorkflowEntrypoint<VisualProm
         userId: input.userId,
         sequenceId: input.sequenceId,
         // Shot id of the scene to save the visual prompt to
-        shotId: shotMapping?.find((f) => f.sceneId === scene.sceneId)?.shotId,
+        shotId: shotMapping?.find((f) => f.analysisSceneId === scene.sceneId)
+          ?.shotId,
       };
 
       const childResult = await spawnAndAwaitChild<


### PR DESCRIPTION
## Summary

Stages 1 + 2 of the Scene/Shot/Frame architecture (milestone 18), landed together so `main` never sees a state where new sequences have a `scenes` table but no scene rows.

### #907 — scenes table + 1:1 backfill

Introduces a `scenes` table — narrative units that own an ordered list of shots, one look (image model) and one motion character (video model) — and links every existing shot to a scene via a 1:1 backfill.

- **Schema**: new `scenes` table (scene-level columns: location / timeOfDay / storyBeat / title, typed-JSON `continuity` / `musicDesign` / `originalScript` slices reused from the analysis `Scene`, plus model selection and scene-render video columns reserved for #910). Adds `shots.scene_id` (`onDelete: 'set null'` — never cascade to a long-lived parent) and `shots.shot_number`.
- **Migration** (`…_jazzy_whiplash`): additive only — `CREATE TABLE scenes` + `ALTER TABLE shots ADD …`, then a data backfill that creates one scene per existing shot, **reusing the shot's ULID** as the scene id and splitting the scene-level slices out of the shot's `metadata`. No table rebuild, so it sidesteps the D1 `ON DELETE CASCADE` trap (#612). Re-runnable (`WHERE scene_id IS NULL`); touches only `scene_id` / `shot_number`, so every `*_input_hash` is untouched and staleness is preserved.
- **Brand**: `scenes.id` is `.$type<DbSceneId>()` so relation queries and the scoped scene methods keep the DB scene ULID distinct from the LLM-assigned analysis `Scene.sceneId` string.
- **Workflows**: renames the `ShotMapping` field `sceneId` → `analysisSceneId` across the analyze / scene-split / visual / motion / shot-images workflows to make the two id spaces unconfusable.
- **Scoped CRUD**: `createScenesMethods` (getById, listBySequence, create, update, delete, deleteBySequence, createBulk, getByIds).

### #908 — live scene persistence + shot-list contract

Populates scenes on the live generation path so sequences created **after** deploy get scene rows too — not just the one-time backfill.

- **Scene persistence** (`scene-persistence.ts`): the scene-split workflow now creates a scene per shot and links `shots.sceneId` + `shotNumber`, mirroring the backfill's 1:1 rule (each shot is its own scene; the shot ULID is reused as the scene id). First live consumer of `scopedDb.scenes.*` and the `DbSceneId` brand.
- **Shot-list contract** (`shot-list.schema.ts`, `shot-list.derive.ts`): structured shot-list analysis output ("richer shot lists" — more shots → more scenes-of-one-shot), with a shot-count bound enforced during persistence.
- **Cardinality is 1:1** (locked): a scene owns exactly one shot at this stage; multi-shot-per-scene stays deferred to #910 plumbing / #953 activation.

## Test plan

- `src/lib/db/backfill-scenes.test.ts` runs the **shipped migration SQL verbatim** against an in-memory DB: one-scene-per-shot + id reuse, scene-field split, null-metadata, idempotency, and the staleness-compat case (a freshly-backfilled shot is **not** stale).
- #908 adds scene-persistence + shot-list derivation tests; shot fixtures updated for the two new columns.
- `bun typecheck`, `bun lint`, and the DB + workflow suites pass; CI green (deploy-preview, test, e2e, e2e-full-pipeline, CodeQL).

Closes #907
Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)
