### PR TITLE
fix(#980): restore Cloudflare mode=frame for gallery poster URLs

### DIFF
--- a/src/lib/media/cloudflare-video.test.ts
+++ b/src/lib/media/cloudflare-video.test.ts
@@ -25,9 +25,9 @@ describe('isTransformableVideoUrl', () => {
 });
 
 describe('videoPosterUrl', () => {
-  it('builds a shot-extraction URL for transformable sources', () => {
+  it('builds a frame-extraction URL for transformable sources', () => {
     expect(videoPosterUrl(SRC, 480)).toBe(
-      `https://assets.openstory.so/cdn-cgi/media/mode=shot,time=0s,format=jpg,width=480/${SRC}`
+      `https://assets.openstory.so/cdn-cgi/media/mode=frame,time=0s,format=jpg,width=480/${SRC}`
     );
   });
 

--- a/src/lib/media/cloudflare-video.ts
+++ b/src/lib/media/cloudflare-video.ts
@@ -49,11 +49,13 @@ function buildMediaUrl(options: string, src: string): string {
 /**
  * A still-frame poster (jpg) extracted from the first frame of the video, sized
  * to `width`. Returns `undefined` for non-transformable sources so the caller
- * can fall back to the browser's own first-shot render.
+ * can fall back to the browser's own first-frame render.
  */
 export function videoPosterUrl(src: string, width = 640): string | undefined {
   if (!isTransformableVideoUrl(src)) return undefined;
-  return buildMediaUrl(`mode=shot,time=0s,format=jpg,width=${width}`, src);
+  // `mode=frame` is Cloudflare's Media Transformations literal for still-image
+  // extraction (video still frame, NOT our domain Shot) — do not rename.
+  return buildMediaUrl(`mode=frame,time=0s,format=jpg,width=${width}`, src);
 }
 
 /**


### PR DESCRIPTION
## Problem

The #906 "frames → shots" blanket rename mangled a **Cloudflare Media Transformations** API literal, breaking the gallery/showcase poster (still-frame) images.

`videoPosterUrl()` in `src/lib/media/cloudflare-video.ts` builds a `cdn-cgi/media/` URL to extract a still image from a sample video. Cloudflare's API uses `mode=frame` for still-image extraction (valid output modes: `video`, `frame`, `spritesheet`, `audio` — see https://developers.cloudflare.com/stream/transform-videos/bindings/). The rename changed it to `mode=shot`, which is not a valid mode, so the edge returned no usable poster.

The accompanying test was updated to expect the broken `mode=shot` value, so it never caught the regression.

## Fix

- Revert `mode=shot` → `mode=frame` in `videoPosterUrl()`.
- Restore the test expectation to `mode=frame`.
- Restore frame-vocabulary wording in the nearby comment/test name, and add a comment marking the literal so the next rename sweep leaves it alone.

`mode=frame` here refers to a *video still frame* (Cloudflare's vocabulary), not our domain Shot concept.

## Verification

- `bun run test src/lib/media/cloudflare-video.test.ts` — 6 passing
- `bun typecheck` — clean
- Grepped `src/` for other `mode=shot` regressions from the rename — none

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)
