### PR TITLE
feat(#908): scene analysis shot-list contract + scene-row persistence

### DIFF
--- a/src/lib/ai/scene-analysis.schema.ts
+++ b/src/lib/ai/scene-analysis.schema.ts
@@ -450,7 +450,7 @@ export type VisualPromptResult = z.infer<typeof visualPromptResultSchema>;
 // Original Script Schema
 // ============================================================================
 
-const originalScriptSchema = z.object({
+export const originalScriptSchema = z.object({
   extract: z
     .string()
     .meta({ description: 'Original script text for this scene' }),
@@ -463,7 +463,7 @@ const originalScriptSchema = z.object({
 // Scene Metadata Schema
 // ============================================================================
 
-const sceneMetadataSchema = z.object({
+export const sceneMetadataSchema = z.object({
   title: z.string().meta({ description: 'Short descriptive scene title' }),
   durationSeconds: z.number().meta({
     description: 'Estimated scene duration in seconds (typically 3-15)',

--- a/src/lib/ai/scene-persistence.test.ts
+++ b/src/lib/ai/scene-persistence.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { Scene } from './scene-analysis.schema';
+import { buildSceneInserts } from './scene-persistence';
+
+function makeScene(overrides: Partial<Scene> = {}): Scene {
+  return {
+    sceneId: 'analysis-scene-1',
+    sceneNumber: 1,
+    originalScript: { extract: 'A man walks in.', dialogue: [] },
+    metadata: {
+      title: 'Entrance',
+      durationSeconds: 4,
+      location: 'INT. OFFICE - DAY',
+      timeOfDay: 'day',
+      storyBeat: 'introduction',
+    },
+    continuity: {
+      characterTags: ['man'],
+      environmentTag: 'office',
+      elementTags: [],
+      colorPalette: 'warm',
+      lightingSetup: 'soft daylight',
+      styleTag: 'cinematic',
+    },
+    ...overrides,
+  };
+}
+
+describe('buildSceneInserts', () => {
+  it('maps scene-level fields onto scene rows with 0-based orderIndex', () => {
+    const rows = buildSceneInserts('seq-1', [
+      makeScene(),
+      makeScene({ sceneId: 'analysis-scene-2', sceneNumber: 2 }),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      sequenceId: 'seq-1',
+      orderIndex: 0,
+      location: 'INT. OFFICE - DAY',
+      timeOfDay: 'day',
+      storyBeat: 'introduction',
+      title: 'Entrance',
+    });
+    expect(rows[1]?.orderIndex).toBe(1);
+  });
+
+  it('carries continuity and original script onto the scene row', () => {
+    const [row] = buildSceneInserts('seq-1', [makeScene()]);
+    expect(row?.continuity?.environmentTag).toBe('office');
+    expect(row?.originalScript?.extract).toBe('A man walks in.');
+  });
+
+  it('defaults missing scene metadata to null (no analysis metadata yet)', () => {
+    const [row] = buildSceneInserts('seq-1', [
+      makeScene({ metadata: undefined, continuity: undefined }),
+    ]);
+    expect(row?.location).toBeNull();
+    expect(row?.timeOfDay).toBeNull();
+    expect(row?.storyBeat).toBeNull();
+    expect(row?.title).toBeNull();
+    expect(row?.continuity).toBeNull();
+  });
+
+  it('returns an empty array for no scenes', () => {
+    expect(buildSceneInserts('seq-1', [])).toEqual([]);
+  });
+});

--- a/src/lib/ai/scene-persistence.test.ts
+++ b/src/lib/ai/scene-persistence.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { dbSceneId } from '@/lib/db/schema';
+import type { SceneRow } from '@/lib/db/schema';
 import type { Scene } from './scene-analysis.schema';
-import { buildSceneInserts } from './scene-persistence';
+import { buildSceneInserts, buildSceneShotLinks } from './scene-persistence';
 
 function makeScene(overrides: Partial<Scene> = {}): Scene {
   return {
@@ -64,5 +66,92 @@ describe('buildSceneInserts', () => {
 
   it('returns an empty array for no scenes', () => {
     expect(buildSceneInserts('seq-1', [])).toEqual([]);
+  });
+});
+
+/** Minimal scene row — only `id` + `orderIndex` drive the linking. */
+function makeSceneRow(id: string, orderIndex: number): SceneRow {
+  const now = new Date();
+  return {
+    id: dbSceneId(id),
+    sequenceId: 'seq-1',
+    orderIndex,
+    location: null,
+    timeOfDay: null,
+    storyBeat: null,
+    title: null,
+    continuity: null,
+    musicDesign: null,
+    originalScript: null,
+    imageModel: null,
+    videoModel: null,
+    videoUrl: null,
+    videoPath: null,
+    videoStatus: 'pending',
+    videoWorkflowRunId: null,
+    videoGeneratedAt: null,
+    videoError: null,
+    videoInputHash: null,
+    renderStrategy: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+describe('buildSceneShotLinks', () => {
+  const scenes = [
+    { sceneId: 'analysis-scene-1' },
+    { sceneId: 'analysis-scene-2' },
+  ];
+  const shotMapping = [
+    { analysisSceneId: 'analysis-scene-1', shotId: 'shot-a' },
+    { analysisSceneId: 'analysis-scene-2', shotId: 'shot-b' },
+  ];
+
+  it('links each shot to its scene row at shotNumber 1 (1:1)', () => {
+    const { links, unmappedShotIds } = buildSceneShotLinks(
+      scenes,
+      [makeSceneRow('scene-row-1', 0), makeSceneRow('scene-row-2', 1)],
+      shotMapping
+    );
+    expect(unmappedShotIds).toEqual([]);
+    expect(links).toEqual([
+      { shotId: 'shot-a', sceneId: 'scene-row-1', shotNumber: 1 },
+      { shotId: 'shot-b', sceneId: 'scene-row-2', shotNumber: 1 },
+    ]);
+  });
+
+  it('keys on orderIndex, not array position (rows returned out of order)', () => {
+    // createBulk RETURNING order is not guaranteed; the link must still be
+    // correct when sceneRows come back reversed.
+    const { links, unmappedShotIds } = buildSceneShotLinks(
+      scenes,
+      [makeSceneRow('scene-row-2', 1), makeSceneRow('scene-row-1', 0)],
+      shotMapping
+    );
+    expect(unmappedShotIds).toEqual([]);
+    expect(links).toEqual([
+      { shotId: 'shot-a', sceneId: 'scene-row-1', shotNumber: 1 },
+      { shotId: 'shot-b', sceneId: 'scene-row-2', shotNumber: 1 },
+    ]);
+  });
+
+  it('surfaces a shot whose analysis scene has no row (no silent skip)', () => {
+    const { links, unmappedShotIds } = buildSceneShotLinks(
+      scenes,
+      [makeSceneRow('scene-row-1', 0)], // scene 2's row is missing
+      shotMapping
+    );
+    expect(links).toEqual([
+      { shotId: 'shot-a', sceneId: 'scene-row-1', shotNumber: 1 },
+    ]);
+    expect(unmappedShotIds).toEqual(['shot-b']);
+  });
+
+  it('returns empty plan for no shots', () => {
+    expect(buildSceneShotLinks(scenes, [], [])).toEqual({
+      links: [],
+      unmappedShotIds: [],
+    });
   });
 });

--- a/src/lib/ai/scene-persistence.ts
+++ b/src/lib/ai/scene-persistence.ts
@@ -1,0 +1,38 @@
+/**
+ * Scene-row persistence mapping (#908)
+ * ============================================================================
+ *
+ * Maps an analysis `Scene` onto the scene-level columns of the `scenes` table
+ * (#907). Scene-level shared truth — location, time of day, story beat, title,
+ * continuity, music design, original script — lives on the scene row; the
+ * shot's own `metadata` JSON keeps the full `Scene` object so existing read
+ * paths are untouched.
+ *
+ * Pulled out of the workflow so the column mapping is unit-testable without a
+ * full Cloudflare-Workflow harness.
+ */
+
+import type { NewScene } from '@/lib/db/schema';
+import type { Scene } from './scene-analysis.schema';
+
+/**
+ * Build the `scenes` insert rows for a sequence from the ordered analysis
+ * scenes. `orderIndex` is the scene's position in the analysis output (0-based),
+ * which is the unique key the `scenes` table sorts and de-duplicates on.
+ */
+export function buildSceneInserts(
+  sequenceId: string,
+  scenes: ReadonlyArray<Scene>
+): NewScene[] {
+  return scenes.map((scene, index) => ({
+    sequenceId,
+    orderIndex: index,
+    location: scene.metadata?.location ?? null,
+    timeOfDay: scene.metadata?.timeOfDay ?? null,
+    storyBeat: scene.metadata?.storyBeat ?? null,
+    title: scene.metadata?.title ?? null,
+    continuity: scene.continuity ?? null,
+    musicDesign: scene.musicDesign ?? null,
+    originalScript: scene.originalScript,
+  }));
+}

--- a/src/lib/ai/scene-persistence.ts
+++ b/src/lib/ai/scene-persistence.ts
@@ -12,7 +12,7 @@
  * full Cloudflare-Workflow harness.
  */
 
-import type { NewScene } from '@/lib/db/schema';
+import type { DbSceneId, NewScene, SceneRow } from '@/lib/db/schema';
 import type { Scene } from './scene-analysis.schema';
 
 /**
@@ -35,4 +35,66 @@ export function buildSceneInserts(
     musicDesign: scene.musicDesign ?? null,
     originalScript: scene.originalScript,
   }));
+}
+
+/** A shot→scene link to apply via `shots.update`. */
+type SceneShotLink = {
+  shotId: string;
+  sceneId: DbSceneId;
+  shotNumber: number;
+};
+
+/** Result of linking analysis shots to their persisted scene rows. */
+export type SceneShotLinkPlan = {
+  links: SceneShotLink[];
+  /**
+   * Shots whose analysis scene had no matching persisted row. An invariant
+   * violation (every mapped shot should belong to a scene), surfaced to the
+   * caller to log rather than silently dropped.
+   */
+  unmappedShotIds: string[];
+};
+
+/**
+ * Pair each analysis shot with its persisted scene row so the caller can set
+ * `shots.sceneId` / `shots.shotNumber`.
+ *
+ * Resolution goes analysisSceneId → the scene's 0-based `orderIndex` (its
+ * position in the analysis output, which `buildSceneInserts` writes) → the
+ * scene row carrying that `orderIndex`. Keying on `orderIndex` — the table's
+ * unique `(sequenceId, orderIndex)` key — rather than on the position of
+ * `sceneRows` means the link is correct even if `createBulk`'s `RETURNING`
+ * order ever diverges from insertion order.
+ *
+ * 1:1 today: analysis emits one shot per scene, so every shot links at
+ * `shotNumber` 1. When multi-shot emission lands (#910) the number comes from
+ * the shot spec.
+ */
+export function buildSceneShotLinks(
+  scenes: ReadonlyArray<Pick<Scene, 'sceneId'>>,
+  sceneRows: ReadonlyArray<SceneRow>,
+  shotMapping: ReadonlyArray<{ analysisSceneId: string; shotId: string }>
+): SceneShotLinkPlan {
+  const orderIndexByAnalysisId = new Map(
+    scenes.map((scene, index) => [scene.sceneId, index])
+  );
+  const sceneRowByOrderIndex = new Map(
+    sceneRows.map((row) => [row.orderIndex, row])
+  );
+
+  const links: SceneShotLink[] = [];
+  const unmappedShotIds: string[] = [];
+  for (const { analysisSceneId, shotId } of shotMapping) {
+    const orderIndex = orderIndexByAnalysisId.get(analysisSceneId);
+    const sceneRow =
+      orderIndex === undefined
+        ? undefined
+        : sceneRowByOrderIndex.get(orderIndex);
+    if (!sceneRow) {
+      unmappedShotIds.push(shotId);
+      continue;
+    }
+    links.push({ shotId, sceneId: sceneRow.id, shotNumber: 1 });
+  }
+  return { links, unmappedShotIds };
 }

--- a/src/lib/ai/shot-list.derive.test.ts
+++ b/src/lib/ai/shot-list.derive.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import type { StyleConfig } from '@/lib/db/schema/libraries';
+import { deriveMotionPrompt, deriveShotScenes } from './shot-list.derive';
+import type { SceneWithShots } from './shot-list.schema';
+
+const styleConfig: StyleConfig = {
+  mood: 'tense',
+  artStyle: 'neo-noir cinematic',
+  lighting: 'low key',
+  colorPalette: ['#111', '#eee'],
+  cameraWork: 'handheld',
+  referenceFilms: ['Blade Runner'],
+  colorGrading: 'teal and orange',
+};
+
+function makeScene(overrides: Partial<SceneWithShots> = {}): SceneWithShots {
+  return {
+    sceneId: 'scene-1',
+    sceneNumber: 1,
+    originalScript: {
+      extract: 'She opens the door.',
+      dialogue: [{ character: 'SARAH', line: 'Hello?', tone: 'wary' }],
+    },
+    metadata: {
+      title: 'The Doorway',
+      durationSeconds: 12,
+      location: 'INT. HALLWAY - NIGHT',
+      timeOfDay: 'night',
+      storyBeat: 'rising tension',
+    },
+    continuity: {
+      characterTags: ['sarah'],
+      environmentTag: 'dim_hallway',
+      elementTags: [],
+      colorPalette: 'cold blues',
+      lightingSetup: 'single overhead bulb',
+      styleTag: 'noir',
+    },
+    dialoguePresent: true,
+    continuousFromPrevious: false,
+    shots: [
+      {
+        shotNumber: 1,
+        framing: {
+          shotSize: 'wide',
+          angle: 'eye level',
+          composition: 'centered down the hallway',
+          subjectStartState: 'Sarah at the far end, hand on the wall',
+        },
+        action: 'Sarah walks toward the door',
+        cameraMovement: { move: 'dolly', pacing: 'slow' },
+        soundCue: 'distant hum, footsteps',
+        durationSeconds: 6,
+      },
+      {
+        shotNumber: 2,
+        framing: {
+          shotSize: 'close-up',
+          angle: 'low angle',
+          composition: 'hand on the door handle, shallow depth',
+          subjectStartState: "Sarah's fingers wrapping the handle",
+        },
+        action: 'she turns the handle and pushes',
+        cameraMovement: { move: 'push-in', pacing: 'gradual' },
+        soundCue: 'handle click, hinge creak',
+        durationSeconds: 6,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+/** First shot of a scene, with a guard so tests never need a `!` assertion. */
+function firstShot(scene: SceneWithShots) {
+  const [shot] = scene.shots;
+  if (!shot) throw new Error('test scene has no shots');
+  return shot;
+}
+
+describe('deriveShotScenes — single source of truth', () => {
+  it('produces one derived shot per shot, ordered by shotNumber', () => {
+    const scene = makeScene();
+    const derived = deriveShotScenes(scene, styleConfig);
+    expect(derived).toHaveLength(2);
+    expect(derived.map((d) => d.shotNumber)).toEqual([1, 2]);
+  });
+
+  it('reuses scene context verbatim across every shot (no per-shot re-derivation)', () => {
+    const derived = deriveShotScenes(makeScene(), styleConfig);
+    for (const d of derived) {
+      const visual = d.metadata.prompts?.visual?.fullPrompt ?? '';
+      // Scene-level shared truth appears in EVERY shot's visual prompt.
+      expect(visual).toContain('INT. HALLWAY - NIGHT');
+      expect(visual).toContain('dim_hallway');
+      expect(visual).toContain('single overhead bulb');
+      expect(visual).toContain('cold blues');
+      expect(visual).toContain('neo-noir cinematic');
+      // Continuity is the same object across shots.
+      expect(d.metadata.continuity).toEqual(makeScene().continuity);
+    }
+  });
+
+  it('composes start-frame visual from shot framing + scene context', () => {
+    const [first] = deriveShotScenes(makeScene(), styleConfig);
+    const visual = first?.metadata.prompts?.visual;
+    expect(visual?.fullPrompt).toContain('wide');
+    expect(visual?.fullPrompt).toContain('eye level');
+    expect(visual?.fullPrompt).toContain('Sarah at the far end');
+    expect(visual?.components.subject).toBe(
+      'Sarah at the far end, hand on the wall'
+    );
+    expect(visual?.components.lighting).toBe('single overhead bulb');
+  });
+
+  it('composes motion prompt from action + one camera move + sound cue', () => {
+    const [, second] = deriveShotScenes(makeScene(), styleConfig);
+    const motion = second?.metadata.prompts?.motion;
+    expect(motion?.fullPrompt).toContain('she turns the handle and pushes');
+    expect(motion?.fullPrompt).toContain('gradual push-in');
+    expect(motion?.components.cameraMovement).toBe('push-in');
+    expect(motion?.components.speed).toBe('gradual');
+    // Sound cue is carried into the audio channel for audio-capable models.
+    expect(motion?.audio?.ambientSound).toBe('handle click, hinge creak');
+  });
+
+  it('carries per-shot duration onto both the column and the metadata', () => {
+    const derived = deriveShotScenes(makeScene(), styleConfig);
+    expect(derived[0]?.durationMs).toBe(6000);
+    expect(derived[0]?.metadata.metadata?.durationSeconds).toBe(6);
+  });
+
+  it('keeps shotNumber OUT of the persisted Scene metadata (it is a shots column)', () => {
+    const [first] = deriveShotScenes(makeScene(), styleConfig);
+    expect(first?.metadata).not.toHaveProperty('shotNumber');
+  });
+});
+
+describe('deriveMotionPrompt — model-agnostic', () => {
+  it('emits no vendor-specific syntax (no Seedance/Kling/Veo tokens)', () => {
+    const scene = makeScene();
+    for (const shot of scene.shots) {
+      const motion = deriveMotionPrompt(scene, shot);
+      const text = JSON.stringify(motion).toLowerCase();
+      for (const vendor of [
+        'seedance',
+        'kling',
+        'veo',
+        'bytedance',
+        '--',
+        '[camera]',
+      ]) {
+        expect(text).not.toContain(vendor);
+      }
+    }
+  });
+
+  it('signals dialogue presence and omits it when the scene is silent', () => {
+    const silent = makeScene({ dialoguePresent: false });
+    const motion = deriveMotionPrompt(silent, firstShot(silent));
+    expect(motion.dialogue).toBeNull();
+
+    const spoken = makeScene({ dialoguePresent: true });
+    const m2 = deriveMotionPrompt(spoken, firstShot(spoken));
+    expect(m2.dialogue?.presence).toBe(true);
+    expect(m2.dialogue?.lines).toHaveLength(1);
+  });
+
+  it('omits audio when there is no sound cue', () => {
+    const scene = makeScene();
+    const shot = { ...firstShot(scene), soundCue: '' };
+    const motion = deriveMotionPrompt(scene, shot);
+    expect(motion.audio).toBeNull();
+  });
+});
+
+describe('deriveShotScenes — single-shot regression', () => {
+  it('returns exactly one derived shot for a short single-shot scene', () => {
+    const scene = makeScene({
+      metadata: {
+        title: 'Establishing',
+        durationSeconds: 4,
+        location: 'EXT. CITY - DAY',
+        timeOfDay: 'day',
+        storyBeat: 'opening',
+      },
+      shots: [
+        {
+          shotNumber: 1,
+          framing: {
+            shotSize: 'extreme wide',
+            angle: 'high angle',
+            composition: 'skyline fills the frame',
+            subjectStartState: 'static cityscape',
+          },
+          action: 'clouds drift over the towers',
+          cameraMovement: { move: 'static', pacing: 'slow' },
+          soundCue: 'city ambience',
+          durationSeconds: 4,
+        },
+      ],
+    });
+    const derived = deriveShotScenes(scene, styleConfig);
+    expect(derived).toHaveLength(1);
+    expect(derived[0]?.metadata.prompts?.motion?.parameters.motionAmount).toBe(
+      'low'
+    );
+  });
+});

--- a/src/lib/ai/shot-list.derive.ts
+++ b/src/lib/ai/shot-list.derive.ts
@@ -1,0 +1,210 @@
+/**
+ * Shot-list prompt derivation (#908)
+ * ============================================================================
+ *
+ * Single source of truth: a shot's start-frame visual prompt and motion prompt
+ * are ASSEMBLED from the parent scene's shared context plus the shot's own
+ * structured fields — never re-authored per shot by the LLM. Keeping the
+ * derivation here (one place) is the structural fix for adjacent-clip drift:
+ * every shot in a scene inherits the same location / lighting / cast / palette
+ * / style truth verbatim.
+ *
+ *   start-frame visual prompt = scene context + shot framing/start-state
+ *   motion prompt             = shot action + camera movement + sound cue
+ *
+ * The derived shapes are the existing `VisualPrompt` / `MotionPrompt` types so
+ * downstream image/motion workflows consume them unchanged. Each shot is
+ * persisted as a `Scene` row (shots.metadata is `$type<Scene>()`); the
+ * scene-level shared fields are persisted separately to the `scenes` table.
+ */
+
+import type { StyleConfig } from '@/lib/db/schema/libraries';
+import type {
+  MotionPrompt,
+  Scene,
+  VisualPrompt,
+} from './scene-analysis.schema';
+import type { SceneWithShots, ShotSpec } from './shot-list.schema';
+
+/** Join non-empty parts with a separator, dropping blanks. */
+function joinParts(parts: ReadonlyArray<string>, sep = ', '): string {
+  return parts
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
+    .join(sep);
+}
+
+/**
+ * Scene-level shared truth, stated once and reused by every shot's derived
+ * prompt. Pulled from the scene's `continuity` + `metadata` + the style config
+ * so the LLM never re-derives it per shot.
+ */
+function sceneContextParts(
+  scene: SceneWithShots,
+  styleConfig: StyleConfig
+): string[] {
+  const { continuity, metadata } = scene;
+  return [
+    metadata.location,
+    metadata.timeOfDay,
+    continuity.environmentTag,
+    continuity.lightingSetup,
+    continuity.colorPalette,
+    // Cast membership is shared context; the per-shot subject state narrows it.
+    continuity.characterTags.join(', '),
+    // Style is the single look authored for the whole sequence.
+    styleConfig.artStyle,
+    continuity.styleTag,
+  ].filter((p): p is string => typeof p === 'string' && p.trim().length > 0);
+}
+
+/**
+ * Derive the start-frame visual prompt for one shot.
+ *
+ * fullPrompt = scene context (authored once) + the shot's framing/start-state.
+ * Internal building block of `deriveShotScenes` (covered through it).
+ */
+function deriveVisualPrompt(
+  scene: SceneWithShots,
+  shot: ShotSpec,
+  styleConfig: StyleConfig
+): VisualPrompt {
+  const { framing } = shot;
+  const sceneParts = sceneContextParts(scene, styleConfig);
+
+  const fullPrompt = joinParts([
+    framing.shotSize,
+    framing.angle,
+    framing.subjectStartState,
+    framing.composition,
+    ...sceneParts,
+  ]);
+
+  return {
+    fullPrompt,
+    negativePrompt: '',
+    components: {
+      sceneDescription: scene.metadata.storyBeat,
+      subject: framing.subjectStartState,
+      environment: joinParts([
+        scene.metadata.location,
+        scene.continuity.environmentTag,
+      ]),
+      lighting: scene.continuity.lightingSetup,
+      camera: joinParts([framing.shotSize, framing.angle]),
+      composition: framing.composition,
+      style: joinParts([styleConfig.artStyle, scene.continuity.styleTag]),
+      technical: '',
+      atmosphere: joinParts([
+        scene.metadata.timeOfDay,
+        scene.continuity.colorPalette,
+      ]),
+    },
+  };
+}
+
+/**
+ * Derive the motion prompt for one shot.
+ *
+ * fullPrompt = the shot's action + its single camera move (with pacing adverb)
+ * + the sound cue. Model-agnostic: no vendor syntax — `assembleMotionPrompt`
+ * adapts per model at render time.
+ */
+export function deriveMotionPrompt(
+  scene: SceneWithShots,
+  shot: ShotSpec
+): MotionPrompt {
+  const { action, cameraMovement, soundCue } = shot;
+  const cameraPhrase = joinParts(
+    [cameraMovement.pacing, cameraMovement.move],
+    ' '
+  );
+
+  const fullPrompt = joinParts([action, `Camera: ${cameraPhrase}`], '. ');
+
+  // Dialogue presence is a scene-level hint; the start-frame visual carries the
+  // performance, the motion prompt carries the move + sound. Lines themselves
+  // are sourced from originalScript downstream (audio models), so here we only
+  // signal presence and the on-screen sound cue.
+  return {
+    fullPrompt,
+    components: {
+      cameraMovement: cameraMovement.move,
+      startPosition: shot.framing.subjectStartState,
+      endPosition: '',
+      durationSeconds: shot.durationSeconds,
+      speed: cameraMovement.pacing,
+      smoothness: 'smooth',
+      subjectTracking: '',
+      equipment: '',
+    },
+    parameters: {
+      durationSeconds: shot.durationSeconds,
+      fps: 24,
+      motionAmount: cameraMovement.move === 'static' ? 'low' : 'medium',
+      cameraControl: {
+        pan: 0,
+        tilt: 0,
+        zoom: 1,
+        movement: cameraMovement.move,
+      },
+    },
+    dialogue: scene.dialoguePresent
+      ? {
+          presence: true,
+          lines: scene.originalScript.dialogue,
+        }
+      : null,
+    audio: soundCue.trim().length
+      ? { ambientSound: soundCue, soundEffects: [] }
+      : null,
+  };
+}
+
+/**
+ * A derived shot ready to persist: the per-shot `Scene` metadata object plus
+ * the shot-level columns (`shotNumber`, `durationMs`) that live on the `shots`
+ * table rather than inside the JSON. `shotNumber` stays OUT of the `Scene`
+ * metadata — it is a `shots` column (#907).
+ */
+export type DerivedShot = {
+  shotNumber: number;
+  durationMs: number;
+  metadata: Scene;
+};
+
+/**
+ * Convert one analysis scene into the per-shot rows persisted to the `shots`
+ * table. Each shot inherits the scene's shared context (so existing read paths
+ * that key off `metadata.continuity` / `metadata.metadata` keep working) and
+ * carries its own derived visual + motion prompts.
+ *
+ * Returned shots are ordered by `shotNumber`. The caller persists each with
+ * its `shotNumber` and a `sceneId` linking back to the `scenes` row.
+ */
+export function deriveShotScenes(
+  scene: SceneWithShots,
+  styleConfig: StyleConfig
+): DerivedShot[] {
+  const ordered = [...scene.shots].sort((a, b) => a.shotNumber - b.shotNumber);
+  return ordered.map((shot) => {
+    const visual = deriveVisualPrompt(scene, shot, styleConfig);
+    const motion = deriveMotionPrompt(scene, shot);
+    const metadata: Scene = {
+      sceneId: scene.sceneId,
+      sceneNumber: scene.sceneNumber,
+      originalScript: scene.originalScript,
+      metadata: {
+        ...scene.metadata,
+        durationSeconds: shot.durationSeconds,
+      },
+      continuity: scene.continuity,
+      prompts: { visual, motion },
+    };
+    return {
+      shotNumber: shot.shotNumber,
+      durationMs: Math.round(shot.durationSeconds * 1000),
+      metadata,
+    };
+  });
+}

--- a/src/lib/ai/shot-list.schema.test.ts
+++ b/src/lib/ai/shot-list.schema.test.ts
@@ -143,4 +143,31 @@ describe('shot-list schema — constraints', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('enforces the 1..MAX shots-per-scene bound at parse time', () => {
+    const validShot = {
+      shotNumber: 1,
+      framing: {
+        shotSize: 'medium',
+        angle: 'eye level',
+        composition: 'centered',
+        subjectStartState: 'standing',
+      },
+      action: 'turns',
+      cameraMovement: { move: 'pan', pacing: 'smooth' as const },
+      soundCue: '',
+      durationSeconds: 3,
+    };
+    const shots = sceneWithShotsSchema.shape.shots;
+    // Empty (zero shots) is rejected — a scene must own at least one shot.
+    expect(shots.safeParse([]).success).toBe(false);
+    // One shot is fine.
+    expect(shots.safeParse([validShot]).success).toBe(true);
+    // Over the ceiling is rejected (minItems/maxItems, still union-free).
+    const tooMany = Array.from({ length: MAX_SHOTS_PER_SCENE + 1 }, (_, i) => ({
+      ...validShot,
+      shotNumber: i + 1,
+    }));
+    expect(shots.safeParse(tooMany).success).toBe(false);
+  });
 });

--- a/src/lib/ai/shot-list.schema.test.ts
+++ b/src/lib/ai/shot-list.schema.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import {
+  MAX_SCENE_DURATION_SECONDS,
+  MAX_SHOTS_PER_SCENE,
+  MIN_SHOT_DURATION_SECONDS,
+  sceneWithShotsResultSchema,
+  sceneWithShotsSchema,
+  shotSpecSchema,
+} from './shot-list.schema';
+
+/**
+ * Count union-typed parameters in the compiled JSON Schema grammar. Anthropic
+ * caps strict structured output at 16; every `.optional()` / `.catch()` /
+ * `.nullish()` compiles to an `anyOf` ([T, null]) union. This shot-list schema
+ * MUST stay union-free so it never eats into the budget when sent to the model.
+ */
+function countUnions(schema: z.ZodType): number {
+  const json = JSON.stringify(
+    z.toJSONSchema(schema, { unrepresentable: 'any' })
+  );
+  return (json.match(/"anyOf"/g) ?? []).length;
+}
+
+describe('shot-list schema — union budget', () => {
+  it('shotSpecSchema compiles to ZERO union-typed params', () => {
+    expect(countUnions(shotSpecSchema)).toBe(0);
+  });
+
+  it('sceneWithShotsSchema compiles to ZERO union-typed params', () => {
+    expect(countUnions(sceneWithShotsSchema)).toBe(0);
+  });
+
+  it('sceneWithShotsResultSchema compiles to ZERO union-typed params (well under the 16 cap)', () => {
+    const unions = countUnions(sceneWithShotsResultSchema);
+    expect(unions).toBe(0);
+    expect(unions).toBeLessThanOrEqual(16);
+  });
+
+  it('has no optional/nullish/catch fields (all required, emptyable)', () => {
+    const json = JSON.stringify(
+      z.toJSONSchema(sceneWithShotsResultSchema, { unrepresentable: 'any' })
+    );
+    // A union-free schema never emits a "null" type branch.
+    expect(json).not.toContain('"type":"null"');
+  });
+});
+
+describe('shot-list schema — constraints', () => {
+  it('caps a scene at the multi-shot render ceiling', () => {
+    expect(MAX_SCENE_DURATION_SECONDS).toBe(15);
+    expect(MIN_SHOT_DURATION_SECONDS).toBe(3);
+    expect(MAX_SHOTS_PER_SCENE).toBe(5);
+  });
+
+  it('parses a single-shot scene (short-scene regression)', () => {
+    const result = sceneWithShotsSchema.safeParse({
+      sceneId: 's1',
+      sceneNumber: 1,
+      originalScript: { extract: 'A man walks in.', dialogue: [] },
+      metadata: {
+        title: 'Entrance',
+        durationSeconds: 4,
+        location: 'INT. OFFICE - DAY',
+        timeOfDay: 'day',
+        storyBeat: 'introduction',
+      },
+      continuity: {
+        characterTags: ['man'],
+        environmentTag: 'office',
+        elementTags: [],
+        colorPalette: 'warm',
+        lightingSetup: 'soft daylight',
+        styleTag: 'cinematic',
+      },
+      dialoguePresent: false,
+      continuousFromPrevious: false,
+      shots: [
+        {
+          shotNumber: 1,
+          framing: {
+            shotSize: 'wide',
+            angle: 'eye level',
+            composition: 'centered',
+            subjectStartState: 'man stepping through the doorway',
+          },
+          action: 'he walks toward the desk',
+          cameraMovement: { move: 'dolly', pacing: 'slow' },
+          soundCue: 'footsteps',
+          durationSeconds: 4,
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.shots).toHaveLength(1);
+  });
+
+  it('parses a multi-shot scene', () => {
+    const shot = {
+      shotNumber: 1,
+      framing: {
+        shotSize: 'medium',
+        angle: 'eye level',
+        composition: 'rule of thirds',
+        subjectStartState: 'standing',
+      },
+      action: 'turns',
+      cameraMovement: { move: 'pan', pacing: 'smooth' } as const,
+      soundCue: '',
+      durationSeconds: 3,
+    };
+    const result = sceneWithShotsSchema.safeParse({
+      sceneId: 's2',
+      sceneNumber: 2,
+      originalScript: { extract: 'x', dialogue: [] },
+      metadata: {
+        title: 't',
+        durationSeconds: 9,
+        location: 'l',
+        timeOfDay: 'night',
+        storyBeat: 'b',
+      },
+      continuity: {
+        characterTags: [],
+        environmentTag: '',
+        elementTags: [],
+        colorPalette: '',
+        lightingSetup: '',
+        styleTag: '',
+      },
+      dialoguePresent: false,
+      continuousFromPrevious: true,
+      shots: [shot, { ...shot, shotNumber: 2 }, { ...shot, shotNumber: 3 }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.shots).toHaveLength(3);
+  });
+
+  it('rejects pacing adverbs outside slow/smooth/gradual', () => {
+    const result = shotSpecSchema.shape.cameraMovement.safeParse({
+      move: 'pan',
+      pacing: 'fast',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/lib/ai/shot-list.schema.ts
+++ b/src/lib/ai/shot-list.schema.ts
@@ -1,0 +1,257 @@
+/**
+ * Shot-list analysis schema (#908)
+ * ============================================================================
+ *
+ * Stage 2 of the Scene / Shot / Frame milestone. Scene analysis stops emitting
+ * shot-sized "scenes" and instead emits **scenes containing 1..N shots**, each
+ * with a STRUCTURED shot prompt. The split is decided here — during analysis,
+ * where the script, dialogue and pacing context live — not downstream in the
+ * motion-prompt step.
+ *
+ * ## Why a separate schema (union budget isolation)
+ *
+ * Anthropic's strict structured-output grammar caps a request at 16
+ * union-typed parameters, and `convertSchemaToJsonSchema` compiles every
+ * `.optional()` / `.catch()` / `.nullish()` field into a `["T","null"]` union
+ * (an `anyOf` in the emitted JSON Schema). The existing
+ * `sceneSplittingResultSchema` already carries optionals; nesting a rich
+ * shots[] array inside it would blow that budget. This schema is authored
+ * SEPARATELY and kept STRICTLY union-free — every field is required with an
+ * emptyable default ('' / [] / sensible scalar). The
+ * `sceneWithShotsResultSchema.union-count.test.ts` asserts the compiled grammar
+ * stays at zero `anyOf` so the budget can never be silently exceeded.
+ *
+ * ## Single source of truth (derive, don't double-author)
+ *
+ * Scene-level shared truth (location, lighting, cast, palette, style) is stated
+ * ONCE per scene by the LLM and reused across every shot. The start-frame
+ * visual prompt and the motion prompt are ASSEMBLED from scene context + the
+ * shot's own structured fields (see `shot-list.derive.ts`) — never re-derived
+ * per shot by the model. This is the structural fix for adjacent-clip drift.
+ *
+ * ## Model-agnostic
+ *
+ * The analysis annotates a shot list with framing, one action, exactly one
+ * camera move (paired with a pacing adverb), a sound cue and a duration. It
+ * never emits vendor-specific syntax (Seedance/Kling/etc.) — the render layer
+ * (#910) adapts per model capability.
+ */
+
+import { z } from 'zod';
+import {
+  characterBibleEntrySchema,
+  elementBibleEntrySchema,
+  locationBibleEntrySchema,
+  originalScriptSchema,
+  projectMetadataSchema,
+  sceneMetadataSchema,
+} from './scene-analysis.schema';
+
+// ============================================================================
+// Constraints (issue #908)
+// ============================================================================
+
+/**
+ * Multi-shot render ceiling. A scene must stay renderable as ONE call on a
+ * capable model (Seedance 2.0 / Kling 3.0 cap at 15s), so the sum of its shot
+ * durations is capped here.
+ */
+export const MAX_SCENE_DURATION_SECONDS = 15;
+/** Floor on an individual shot so a scene can't degenerate into micro-cuts. */
+export const MIN_SHOT_DURATION_SECONDS = 3;
+/**
+ * Derived ceiling on shots per scene: with a 3s floor and a 15s scene cap a
+ * scene holds at most 5 shots. Richer shot lists are allowed (more shots =
+ * more image credits, documented in the PR), but never beyond what the scene
+ * can render as one call.
+ */
+export const MAX_SHOTS_PER_SCENE = Math.floor(
+  MAX_SCENE_DURATION_SECONDS / MIN_SHOT_DURATION_SECONDS
+);
+
+// ============================================================================
+// Scene-level shared continuity (strict, union-free)
+// ============================================================================
+//
+// The shared `continuitySchema` marks `elementTags` `.nullish()` (one union).
+// The shot-list pass keeps the budget at ZERO, so it declares its own
+// continuity with a REQUIRED `elementTags` array (empty when none) instead.
+// The inferred shape stays assignable to `Continuity` (empty `string[]` ⊆
+// `string[] | null`), so derived `Scene.continuity` flows downstream unchanged.
+
+const shotListContinuitySchema = z.object({
+  characterTags: z.array(z.string()).meta({
+    description:
+      "Snake_case slug of each character appearing in the scene (e.g. 'GIRL ONE' → 'girl_one'). One entry per character; empty array if none.",
+  }),
+  environmentTag: z
+    .string()
+    .meta({ description: 'Location/setting tag for environment consistency' }),
+  elementTags: z.array(z.string()).meta({
+    description:
+      'UPPERCASE tokens for elements referenced in this scene. Empty array when none.',
+  }),
+  colorPalette: z
+    .string()
+    .meta({ description: 'Dominant colors for visual continuity' }),
+  lightingSetup: z
+    .string()
+    .meta({ description: 'Lighting configuration shared across the shots' }),
+  styleTag: z
+    .string()
+    .meta({ description: 'Visual style reference for a consistent look' }),
+});
+
+// ============================================================================
+// Structured shot prompt
+// ============================================================================
+
+/**
+ * Framing / start-state — what the start frame shows. Feeds the start-frame
+ * visual prompt alongside the scene context.
+ */
+const shotFramingSchema = z.object({
+  shotSize: z.string().meta({
+    description:
+      'Shot size: extreme wide, wide, medium wide, medium, medium close-up, close-up, extreme close-up',
+  }),
+  angle: z.string().meta({
+    description:
+      'Camera angle: eye level, low angle, high angle, overhead, dutch, over-the-shoulder',
+  }),
+  composition: z.string().meta({
+    description:
+      'How the frame is composed: rule-of-thirds placement, depth, foreground/background, focal point',
+  }),
+  subjectStartState: z.string().meta({
+    description:
+      "The subject's state at the START of the shot: pose, position, expression, what they hold — the still the start frame captures",
+  }),
+});
+
+/**
+ * Camera movement — EXACTLY ONE move, paired with a pacing adverb. Never
+ * stacked (no "pan then dolly"). Feeds the motion prompt.
+ */
+const shotCameraMovementSchema = z.object({
+  move: z.string().meta({
+    description:
+      'The single primary camera move: static, pan, tilt, dolly, truck, pedestal, zoom, push-in, pull-out, orbit. Exactly one — never stacked.',
+  }),
+  pacing: z.enum(['slow', 'smooth', 'gradual']).meta({
+    description:
+      'Pacing adverb for the move: slow, smooth, or gradual. Keeps motion calm and avoids the chaotic output fast moves trigger in video models.',
+  }),
+});
+
+/**
+ * One structured shot. Carries exactly what a real shot-list entry has:
+ * framing/start-state, one primary action, one camera move, a sound cue and a
+ * duration. Visual + motion prompts are DERIVED from these fields plus the
+ * parent scene's shared context (see `shot-list.derive.ts`).
+ */
+export const shotSpecSchema = z.object({
+  shotNumber: z.number().meta({
+    description: '1-based order of this shot within its scene',
+  }),
+  framing: shotFramingSchema.meta({
+    description: 'Framing and subject start-state for the start frame',
+  }),
+  action: z.string().meta({
+    description:
+      'The ONE primary action that happens during this shot (e.g. "she turns and reaches for the door handle"). One action per shot.',
+  }),
+  cameraMovement: shotCameraMovementSchema.meta({
+    description: 'Exactly one camera move paired with a pacing adverb',
+  }),
+  soundCue: z.string().meta({
+    description:
+      'On-screen SFX / ambience hook for audio-capable models (e.g. "door creak, distant traffic"). Empty string when none.',
+  }),
+  durationSeconds: z.number().meta({
+    description: `Shot duration in seconds. At least ${MIN_SHOT_DURATION_SECONDS}; the scene's shots sum to at most ${MAX_SCENE_DURATION_SECONDS}.`,
+  }),
+});
+
+export type ShotSpec = z.infer<typeof shotSpecSchema>;
+
+// ============================================================================
+// Scene with shots
+// ============================================================================
+
+/**
+ * A scene that owns an ordered list of shots. Scene-level context (location,
+ * lighting, cast, palette, style — via `continuity` + `metadata`) is authored
+ * ONCE here and reused by every shot's derived prompts.
+ */
+export const sceneWithShotsSchema = z.object({
+  sceneId: z
+    .string()
+    .meta({ description: 'Unique identifier for this scene (required)' }),
+  sceneNumber: z
+    .number()
+    .meta({ description: 'Scene order number starting from 1 (required)' }),
+  originalScript: originalScriptSchema.meta({
+    description: 'Original (verbatim) script content for this scene',
+  }),
+  metadata: sceneMetadataSchema.meta({
+    description: 'Scene-level metadata (title, location, time of day, beat)',
+  }),
+  continuity: shotListContinuitySchema.meta({
+    description:
+      'Scene-level shared truth: cast membership, environment, palette, lighting, style — authored once, reused by every shot',
+  }),
+  dialoguePresent: z.boolean().meta({
+    description:
+      'Whether the scene contains spoken dialogue. A model-agnostic hint for the render layer (lip-sync vs silent).',
+  }),
+  continuousFromPrevious: z.boolean().meta({
+    description:
+      'Whether this scene continues directly from the previous one without a hard cut (a continuous-transition hint for the render layer). False for the first scene.',
+  }),
+  shots: z.array(shotSpecSchema).meta({
+    description: `Ordered list of 1..${MAX_SHOTS_PER_SCENE} shots. A short scene with no internal cut is a single shot.`,
+  }),
+});
+
+export type SceneWithShots = z.infer<typeof sceneWithShotsSchema>;
+
+// ============================================================================
+// Top-level shot-list analysis result
+// ============================================================================
+
+/**
+ * The full structured output of the shot-list analysis pass. Mirrors
+ * `sceneSplittingResultSchema` but with scenes that own shot lists. Kept
+ * union-free (see file header) to isolate the Anthropic 16-union budget.
+ */
+export const sceneWithShotsResultSchema = z.object({
+  status: z
+    .enum(['success', 'error', 'rejected'])
+    .meta({ description: 'Processing status: success, error, or rejected' }),
+  projectMetadata: projectMetadataSchema.meta({
+    description: 'Project-level metadata extracted from the script',
+  }),
+  scenes: z.array(sceneWithShotsSchema).meta({
+    description: 'Array of scenes, each owning an ordered list of shots',
+  }),
+  characterBible: z.array(characterBibleEntrySchema).meta({
+    description: 'Character descriptions for visual consistency',
+  }),
+  locationBible: z.array(locationBibleEntrySchema).meta({
+    description: 'Location descriptions for visual consistency',
+  }),
+  elementBible: z.array(elementBibleEntrySchema).meta({
+    description:
+      'Elements referenced by UPPERCASE token (uploaded or detected recurring products/objects)',
+  }),
+});
+
+/**
+ * Inferred result of the shot-list analysis pass. The render-layer rewire
+ * (#910) consumes this when scene-split switches to the shot-list schema; kept
+ * exported now as the published analysis contract so #910 can adopt it without
+ * a churn to this file.
+ * @public
+ */
+export type SceneWithShotsResult = z.infer<typeof sceneWithShotsResultSchema>;

--- a/src/lib/ai/shot-list.schema.ts
+++ b/src/lib/ai/shot-list.schema.ts
@@ -16,10 +16,11 @@
  * (an `anyOf` in the emitted JSON Schema). The existing
  * `sceneSplittingResultSchema` already carries optionals; nesting a rich
  * shots[] array inside it would blow that budget. This schema is authored
- * SEPARATELY and kept STRICTLY union-free — every field is required with an
- * emptyable default ('' / [] / sensible scalar). The
- * `sceneWithShotsResultSchema.union-count.test.ts` asserts the compiled grammar
- * stays at zero `anyOf` so the budget can never be silently exceeded.
+ * SEPARATELY and kept STRICTLY union-free — every field is required and
+ * emptyable by convention ('' / [] / sensible scalar), with no Zod `.default()`,
+ * so the model emits the empty value explicitly rather than the parser filling
+ * it. The union-budget block in `shot-list.schema.test.ts` asserts the compiled
+ * grammar stays at zero `anyOf` so the budget can never be silently exceeded.
  *
  * ## Single source of truth (derive, don't double-author)
  *
@@ -209,9 +210,19 @@ export const sceneWithShotsSchema = z.object({
     description:
       'Whether this scene continues directly from the previous one without a hard cut (a continuous-transition hint for the render layer). False for the first scene.',
   }),
-  shots: z.array(shotSpecSchema).meta({
-    description: `Ordered list of 1..${MAX_SHOTS_PER_SCENE} shots. A short scene with no internal cut is a single shot.`,
-  }),
+  // `.min(1).max()` compile to JSON-Schema minItems/maxItems — NOT an `anyOf`
+  // union — so the count bound is enforced at parse time without touching the
+  // zero-union budget (asserted in the union-budget test). The per-shot 3s
+  // floor and 15s scene-sum cap are cross-field and can't be expressed
+  // union-free per field; they stay prompt-only (the field descriptions) and
+  // are enforced by the #910 render-layer consumer.
+  shots: z
+    .array(shotSpecSchema)
+    .min(1)
+    .max(MAX_SHOTS_PER_SCENE)
+    .meta({
+      description: `Ordered list of 1..${MAX_SHOTS_PER_SCENE} shots. A short scene with no internal cut is a single shot.`,
+    }),
 });
 
 export type SceneWithShots = z.infer<typeof sceneWithShotsSchema>;

--- a/src/lib/db/scoped/shots.ts
+++ b/src/lib/db/scoped/shots.ts
@@ -137,6 +137,11 @@ export function createShotsMethods(db: Database) {
             description: sql.raw(`excluded."description"`),
             durationMs: sql.raw(`excluded."duration_ms"`),
             metadata: sql.raw(`excluded."metadata"`),
+            // #908: a replay re-derives the same shot at the same orderIndex —
+            // carry the scene link + intra-scene number through the conflict so
+            // a re-run is idempotent rather than leaving stale values.
+            sceneId: sql.raw(`excluded."scene_id"`),
+            shotNumber: sql.raw(`excluded."shot_number"`),
             updatedAt: new Date(),
           },
         })
@@ -190,6 +195,10 @@ export function createShotsMethods(db: Database) {
               description: sql.raw(`excluded."description"`),
               durationMs: sql.raw(`excluded."duration_ms"`),
               metadata: sql.raw(`excluded."metadata"`),
+              // #908: keep the scene link + intra-scene number idempotent on
+              // replay (see the matching note in `upsert`).
+              sceneId: sql.raw(`excluded."scene_id"`),
+              shotNumber: sql.raw(`excluded."shot_number"`),
               updatedAt: new Date(),
             },
           })

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -39,7 +39,10 @@ import {
 import type { Microdollars } from '@/lib/billing/money';
 import type { TokenUsage } from '@tanstack/ai';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
-import { buildSceneInserts } from '@/lib/ai/scene-persistence';
+import {
+  buildSceneInserts,
+  buildSceneShotLinks,
+} from '@/lib/ai/scene-persistence';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { NewShot } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
@@ -558,22 +561,35 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         const sceneInserts = buildSceneInserts(sequenceId, reconciled.scenes);
         const sceneRows = await scopedDb.scenes.createBulk(sceneInserts);
 
-        // Link each shot to its scene row by analysisSceneId → orderIndex.
-        // shotMapping is analysisSceneId-keyed; scenes are order-aligned to
-        // `reconciled.scenes`, so map analysisSceneId → its index → scene row.
-        const sceneRowByAnalysisId = new Map(
-          reconciled.scenes.map((scene, index) => [
-            scene.sceneId,
-            sceneRows[index],
-          ])
+        // Link each shot to its scene row by analysisSceneId → orderIndex →
+        // row (see buildSceneShotLinks — keyed on the unique orderIndex, not
+        // array position). A shot whose scene is missing is surfaced, not
+        // silently skipped: every mapped shot should belong to a scene.
+        const { links, unmappedShotIds } = buildSceneShotLinks(
+          reconciled.scenes,
+          sceneRows,
+          reconciled.shotMapping
         );
-        for (const { analysisSceneId, shotId } of reconciled.shotMapping) {
-          const sceneRow = sceneRowByAnalysisId.get(analysisSceneId);
-          if (!sceneRow) continue;
-          await scopedDb.shots.update(
+        if (unmappedShotIds.length > 0) {
+          logger.warn(
+            `[SceneSplitWorkflow:cf] persist-scenes: ${unmappedShotIds.length} shot(s) had no matching scene row`,
+            { sequenceId, unmappedShotIds }
+          );
+        }
+
+        const missingShotIds: string[] = [];
+        for (const { shotId, sceneId, shotNumber } of links) {
+          const updated = await scopedDb.shots.update(
             shotId,
-            { sceneId: sceneRow.id, shotNumber: 1 },
+            { sceneId, shotNumber },
             { throwOnMissing: false }
+          );
+          if (!updated) missingShotIds.push(shotId);
+        }
+        if (missingShotIds.length > 0) {
+          logger.warn(
+            `[SceneSplitWorkflow:cf] persist-scenes: ${missingShotIds.length} shot(s) missing at link time`,
+            { sequenceId, missingShotIds }
           );
         }
       });

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -39,6 +39,7 @@ import {
 import type { Microdollars } from '@/lib/billing/money';
 import type { TokenUsage } from '@tanstack/ai';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
+import { buildSceneInserts } from '@/lib/ai/scene-persistence';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { NewShot } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
@@ -531,6 +532,49 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
             text: entry.firstMention.text,
             lineNumber: entry.firstMention.lineNumber,
           });
+        }
+      });
+    }
+
+    // Step 4b (#908): persist a `scenes` row per analysis scene and link each
+    // shot to it via `shots.sceneId`. Analysis currently emits shot-sized
+    // scenes (one shot per scene), so this writes a 1:1 scenes↔shots mapping —
+    // the same shape #907's backfill produced for existing sequences, now
+    // populated at analysis time for NEW sequences too. Scene-level fields
+    // (location / time of day / story beat / continuity / music design /
+    // original script) are stored on the scene row; the shot's `metadata` keeps
+    // the full Scene object unchanged so every downstream read path is
+    // untouched. The structured multi-shot shot list + per-shot prompt
+    // derivation (src/lib/ai/shot-list.{schema,derive}.ts) is wired into the
+    // render chain in #910 — this step is the additive persistence half.
+    //
+    // Idempotent on replay: delete-then-recreate within the step (scenes are
+    // only ever written here, so a full rewrite is safe and avoids the missing
+    // scenes-upsert).
+    if (sequenceId && reconciled.scenes.length > 0) {
+      await step.do('persist-scenes', async () => {
+        await scopedDb.scenes.deleteBySequence(sequenceId);
+
+        const sceneInserts = buildSceneInserts(sequenceId, reconciled.scenes);
+        const sceneRows = await scopedDb.scenes.createBulk(sceneInserts);
+
+        // Link each shot to its scene row by analysisSceneId → orderIndex.
+        // shotMapping is analysisSceneId-keyed; scenes are order-aligned to
+        // `reconciled.scenes`, so map analysisSceneId → its index → scene row.
+        const sceneRowByAnalysisId = new Map(
+          reconciled.scenes.map((scene, index) => [
+            scene.sceneId,
+            sceneRows[index],
+          ])
+        );
+        for (const { analysisSceneId, shotId } of reconciled.shotMapping) {
+          const sceneRow = sceneRowByAnalysisId.get(analysisSceneId);
+          if (!sceneRow) continue;
+          await scopedDb.shots.update(
+            shotId,
+            { sceneId: sceneRow.id, shotNumber: 1 },
+            { throwOnMissing: false }
+          );
         }
       });
     }


### PR DESCRIPTION
Closes #908

Stage 2 of the **Scene / Shot / Frame** milestone (stacked on #907 / PR #979 — **base is the #907 branch, not main**).

## What this delivers

The **analysis-contract layer** plus **additive scene-row persistence**. Per the locked **"1:1 now, contract lands"** decision, the live scene-split LLM call stays on the existing 1-scene-per-shot schema; the multi-shot-capable schema + derivation land tested-but-not-live and are consumed when the render chain is rewired (#910 / #953).

### `shot-list.schema.ts` (new)
`SceneWithShots` / `shotSpec` / `sceneWithShotsResult`. Each shot carries the structured shot-prompt fields: framing/start-state, one primary action, **exactly one** camera move paired with a pacing adverb (slow/smooth/gradual), a sound cue, and a duration.
- Authored **separately** from `sceneSplittingResultSchema` to isolate Anthropic's 16-union strict-output budget; the compiled grammar has **zero** `anyOf` unions (asserted in test).
- Constraints: **15s** scene cap (multi-shot render ceiling), **3s** shot floor, **max 5 shots/scene**.

### `shot-list.derive.ts` (new) — single source of truth
- start-frame **visual prompt** = scene context (location, lighting, cast, palette, style — authored once per scene) + the shot's framing/start-state
- **motion prompt** = the shot's action + its one camera move + sound cue

Scene-level shared truth is stated once instead of re-derived per shot — the structural fix for adjacent-clip drift. Emits the existing `VisualPrompt`/`MotionPrompt` shapes so downstream image/motion workflows consume them unchanged. Model-agnostic (no Seedance/Kling/Veo syntax — the render layer adapts per model in #910).

### `scene-persistence.ts` + `persist-scenes` workflow step
`buildSceneInserts` maps an analysis `Scene` onto the `scenes`-table columns (#907). The scene-split workflow writes one scene row per analysis scene and links `shots.sceneId` (1:1 today, matching the #907 backfill). **Additive** — columns already exist from #907, so no migration; every downstream read path is untouched.

### `shots.upsert` / `bulkUpsert`
Carry `sceneId` + `shotNumber` through the conflict-set so a workflow replay is idempotent rather than leaving stale values.

## Scope / non-goals

- The live render-chain rewire (switching analysis to emit multi-shot scenes, per-scene-N-shot rendering) is **deferred to #910**. This PR is the analysis + persistence half.
- Existing sequences are unaffected (all scenes-of-one-shot from the #907 backfill); no behaviour change for current analyses.
- Because live emission stays 1:1, **no analysis-prompt rewrite and no aimock fixture re-record** are needed in this PR — that bites when multi-shot emission flips on (#953).

## Tests / gates

- 22 new tests: shot-list schema (union budget + constraints), prompt derivation (single source of truth, model-agnostic, single-shot regression), and scene-row mapping.
- Green locally: `bun typecheck`, `bun run test` (ai/workflow/scoped suites), `bun lint` (0 errors), `bun dead-code` (knip exit 0), `bun format:check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
