### PR TITLE
Fix model-update checker to handle TLS-intercepting proxies

### DIFF
--- a/.claude/skills/update-model-versions/SKILL.md
+++ b/.claude/skills/update-model-versions/SKILL.md
@@ -28,16 +28,23 @@ open a focused PR that bumps it → leave everything green.
 
 ```bash
 bun models:check          # human-readable report
-bun models:check --json   # { hasUpdates, models[], packages[] } for scripting
+bun models:check --json   # { ok, errorCount, hasUpdates, models[], packages[] }
 ```
 
 `scripts/check-model-updates.ts` reads the registries and queries public,
 unauthenticated catalogs (fal.ai `/api/models`, OpenRouter `/api/v1/models`, npm
 registry). It is HTTP-only so it runs anywhere — no `FAL_KEY` or MCP needed.
+Behind a proxy it routes through `curl` (Bun's fetch can't traverse a
+TLS-intercepting proxy), so `curl` must be on PATH in that case.
 
 Candidates are **heuristic** (same brand, higher version number, same modality,
-not already adopted). Treat them as leads to verify, not facts. If
-`hasUpdates` is `false`, stop — nothing to do.
+not already adopted). Treat them as leads to verify, not facts.
+
+**Check `ok` before trusting the result.** `ok: false` (equivalently, a non-zero
+exit code or `errorCount > 0`) means one or more lookups FAILED — the report is
+INCOMPLETE, not "all current". Do not treat a failed run as "nothing to do":
+fix connectivity and re-run. Only when `ok` is `true` does `hasUpdates: false`
+genuinely mean every model is current — in that case, stop.
 
 ## 2. Verify each candidate is a genuine successor
 

--- a/scripts/check-model-updates.ts
+++ b/scripts/check-model-updates.ts
@@ -13,16 +13,30 @@
  * applying the bump is the skill's job. HTTP-only by design so it runs anywhere
  * (local, CI, or a headless cron agent) without genmedia/fal-MCP/FAL_KEY.
  *
+ * Proxy handling: the agent/CI sandboxes route outbound HTTPS through a
+ * TLS-intercepting proxy (HTTPS_PROXY). Bun's fetch cannot complete the
+ * handshake through such a proxy, which silently turned every lookup into an
+ * error on the cloud routine. So when a proxy is configured we make requests
+ * via `curl` (a system tool, not an npm dep) — it honors HTTPS_PROXY, NO_PROXY,
+ * and the system CA bundle on every runtime. Without a proxy, the built-in
+ * fetch is used directly. `curl` must be on PATH behind a proxy (it is in CI,
+ * cloud sandboxes, and standard dev machines).
+ *
  * Usage:
  *   bun scripts/check-model-updates.ts            # human-readable report
  *   bun scripts/check-model-updates.ts --json     # machine-readable JSON
  *
- * Exit code is 0 even when updates are found (it is a report, not a gate);
- * use the JSON `hasUpdates` field to branch in automation.
+ * Exit code is 0 when every lookup succeeded — whether or not updates were
+ * found (it is a report, not a gate). It is NON-ZERO when one or more lookups
+ * FAILED, so automation never mistakes a network outage for "all models
+ * current". Branch on the JSON `ok` / `hasUpdates` fields (`ok: false` means
+ * the report is incomplete — investigate connectivity, do not stop).
  */
 
+import { execFile } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { promisify } from 'node:util';
 
 import {
   AUDIO_MODELS,
@@ -182,13 +196,25 @@ function brandStem(id: string): string {
 // Network helpers
 // ---------------------------------------------------------------------------
 
-async function fetchJson<T>(url: string, timeoutMs = 20_000): Promise<T> {
+const USER_AGENT = 'openstory-model-update-checker';
+
+const execFileAsync = promisify(execFile);
+
+/** True when outbound HTTPS is routed through a proxy (agent/CI sandboxes). */
+const PROXIED = Boolean(
+  process.env.HTTPS_PROXY ??
+  process.env.https_proxy ??
+  process.env.HTTP_PROXY ??
+  process.env.http_proxy
+);
+
+async function fetchJsonNative<T>(url: string, timeoutMs: number): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch(url, {
       signal: controller.signal,
-      headers: { 'user-agent': 'openstory-model-update-checker' },
+      headers: { 'user-agent': USER_AGENT },
     });
     if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`);
     const data: T = await res.json();
@@ -196,6 +222,45 @@ async function fetchJson<T>(url: string, timeoutMs = 20_000): Promise<T> {
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function fetchJsonViaCurl<T>(url: string, timeoutMs: number): Promise<T> {
+  // -f → non-2xx exits non-zero (mirrors res.ok); -sS → quiet but show errors;
+  // -L → follow redirects. curl reads HTTPS_PROXY/NO_PROXY and the system CA
+  // bundle itself, which is why it traverses the proxy where Bun's fetch can't.
+  try {
+    const { stdout } = await execFileAsync(
+      'curl',
+      [
+        '-fsSL',
+        '--max-time',
+        String(Math.ceil(timeoutMs / 1000)),
+        '-H',
+        `user-agent: ${USER_AGENT}`,
+        url,
+      ],
+      { timeout: timeoutMs + 2_000, maxBuffer: 64 * 1024 * 1024 }
+    );
+    const data: T = JSON.parse(stdout);
+    return data;
+  } catch (error) {
+    const stderr =
+      error && typeof error === 'object' && 'stderr' in error
+        ? String((error as { stderr?: unknown }).stderr).trim()
+        : '';
+    throw new Error(`curl failed for ${url}${stderr ? `: ${stderr}` : ''}`);
+  }
+}
+
+/**
+ * Fetch + parse JSON. Routes through curl when an HTTPS proxy is configured
+ * (Bun's fetch cannot traverse the agent/CI proxy's TLS interception); uses the
+ * built-in fetch for direct, proxy-free environments.
+ */
+async function fetchJson<T>(url: string, timeoutMs = 20_000): Promise<T> {
+  return PROXIED
+    ? fetchJsonViaCurl<T>(url, timeoutMs)
+    : fetchJsonNative<T>(url, timeoutMs);
 }
 
 type FalCatalogResponse = {
@@ -414,10 +479,26 @@ async function main() {
   const hasUpdates =
     modelsWithUpdates.length > 0 || packagesWithUpdates.length > 0;
 
+  // A failed lookup is NOT "no update". Count failures so neither a human nor
+  // automation can read a network/proxy outage as "all models current" — the
+  // exact silent false-negative that hid behind `hasUpdates: false` when every
+  // fetch errored. `ok: false` ⇒ the report is incomplete; exit non-zero too.
+  const errorCount =
+    modelReports.filter((r) => r.error).length +
+    packageReports.filter((r) => r.error).length;
+  const ok = errorCount === 0;
+  if (!ok) process.exitCode = 1;
+
   if (jsonOutput) {
     console.log(
       JSON.stringify(
-        { hasUpdates, models: modelReports, packages: packageReports },
+        {
+          ok,
+          errorCount,
+          hasUpdates,
+          models: modelReports,
+          packages: packageReports,
+        },
         null,
         2
       )
@@ -425,13 +506,14 @@ async function main() {
     return;
   }
 
-  printReport(modelReports, packageReports, hasUpdates);
+  printReport(modelReports, packageReports, hasUpdates, errorCount);
 }
 
 function printReport(
   modelReports: ModelReport[],
   packageReports: PackageReport[],
-  hasUpdates: boolean
+  hasUpdates: boolean,
+  errorCount: number
 ) {
   const SOURCE_LABEL: Record<ModelReport['source'], string> = {
     'fal-image': 'Image (fal.ai)',
@@ -482,9 +564,18 @@ function printReport(
     }
   }
 
-  console.log(
-    `\n=== ${hasUpdates ? 'UPDATES AVAILABLE — review candidates above' : 'Everything is up to date'} ===\n`
-  );
+  if (errorCount > 0) {
+    console.log(
+      `\n=== ⚠️  ${errorCount} lookup(s) FAILED — report is INCOMPLETE ===\n` +
+        'Do NOT treat this as "all models current". A failed lookup means we could\n' +
+        'not check that model, not that it is up to date. Fix connectivity (behind\n' +
+        'a proxy this needs `curl` on PATH — see the header) and re-run.\n'
+    );
+  } else {
+    console.log(
+      `\n=== ${hasUpdates ? 'UPDATES AVAILABLE — review candidates above' : 'Everything is up to date'} ===\n`
+    );
+  }
   console.log(
     'Candidates are heuristic (same brand, higher version number). Verify each\n' +
       'is a genuine successor before bumping — see the update-model-versions skill.\n'


### PR DESCRIPTION
## Related Issue

Closes #966 

## Summary of Changes

The `check-model-updates.ts` script was silently failing when run in CI/cloud sandboxes that route HTTPS through a TLS-intercepting proxy. Bun's `fetch` cannot complete the TLS handshake through such proxies, causing every model lookup to fail without visible error reporting.

**Changes:**

1. **Proxy detection:** Added `PROXIED` constant that checks for `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, or `http_proxy` environment variables.

2. **Dual fetch strategy:**
   - `fetchJsonNative()`: Uses Bun's built-in `fetch` for direct, proxy-free environments
   - `fetchJsonViaCurl()`: Routes through `curl` (system tool) when a proxy is detected, since `curl` properly honors proxy environment variables and system CA bundles
   - `fetchJson()`: Dispatcher that chooses the appropriate strategy

3. **Exit code semantics:** Changed exit code behavior:
   - Exit 0 when all lookups succeed (whether or not updates were found)
   - Exit 1 when one or more lookups fail, preventing automation from mistaking network outages for "all models current"

4. **JSON output enhancement:** Added `ok` and `errorCount` fields to JSON output:
   - `ok: false` indicates the report is incomplete due to failed lookups
   - `errorCount` shows how many lookups failed
   - Automation can now distinguish between "no updates found" and "couldn't check"

5. **Human-readable reporting:** Updated console output to clearly warn when lookups failed, preventing silent false negatives.

6. **Documentation:** Updated script header and skill documentation to explain proxy handling and the new `ok` field semantics.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

The changes are backward-compatible for direct (non-proxied) environments and only add new behavior for proxied scenarios that were previously broken. The script already runs in CI and cloud sandboxes; this fix makes it work correctly in those environments. Exit code changes are intentional and improve automation reliability.

## Additional Notes

- `curl` must be on PATH when running behind a proxy (it is in CI, cloud sandboxes, and standard dev machines)
- Without a proxy, the built-in `fetch` is used directly with no performance impact
- The `ok` field in JSON output is the primary signal for automation; `hasUpdates` should only be trusted when `ok: true`

https://claude.ai/code/session_01GW6X6q9zX4mZsoQnor6JUt