### PR TITLE
feat(#988): SSF redesign Phase 1 — scoped-db access layer (frames, versions, select/repoint, recordEvent)

### DIFF
--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -29,7 +29,7 @@ From your own clone, `bun setup --prod` walks through everything interactively: 
 
 ## wrangler.jsonc
 
-Bindings live in [`wrangler.jsonc`](https://github.com/anthropics/openstory/blob/main/wrangler.jsonc) at the repo root:
+Bindings live in [`wrangler.jsonc`](https://github.com/openstory-so/openstory/blob/main/wrangler.jsonc) at the repo root:
 
 - `DB` — D1 database (`openstory-prd`)
 - `R2_PUBLIC_ASSETS_BUCKET` — public assets (served via custom domain)
@@ -116,7 +116,7 @@ setup.
 
 ## Secrets
 
-Secrets are pushed to the Worker via `wrangler secret bulk`. The full list is defined in [`.github/workflows/deploy-cloudflare.yml`](https://github.com/anthropics/openstory/blob/main/.github/workflows/deploy-cloudflare.yml). Core secrets include:
+Secrets are pushed to the Worker via `wrangler secret bulk`. The full list is defined in [`.github/workflows/deploy-cloudflare.yml`](https://github.com/openstory-so/openstory/blob/main/.github/workflows/deploy-cloudflare.yml). Core secrets include:
 
 | Variable                                    | Description                                                                           |
 | ------------------------------------------- | ------------------------------------------------------------------------------------- |
@@ -185,7 +185,7 @@ reopen the PR to get a fresh, wrangler-tracked preview database.
 
 ## CI/CD
 
-Production pushes to `main` deploy via Workers Builds (see [Build & Deploy](#build--deploy) above). [`deploy-cloudflare.yml`](https://github.com/anthropics/openstory/blob/main/.github/workflows/deploy-cloudflare.yml) handles the PR previews, which stay on GitHub Actions because Workers Builds branch previews share production bindings — no per-PR D1 provisioning, no workflow-name namespacing, no teardown on close:
+Production pushes to `main` deploy via Workers Builds (see [Build & Deploy](#build--deploy) above). [`deploy-cloudflare.yml`](https://github.com/openstory-so/openstory/blob/main/.github/workflows/deploy-cloudflare.yml) handles the PR previews, which stay on GitHub Actions because Workers Builds branch previews share production bindings — no per-PR D1 provisioning, no workflow-name namespacing, no teardown on close:
 
 - **PR previews**: each PR gets its own Worker (`pr-<number>`) and D1 database (`openstory-pr-<number>`), with secrets pushed and the preview URL posted as a PR comment.
 - **Cleanup**: closing a PR deletes both the Worker and the D1 database.

--- a/drizzle/migrations/20260626023937_flaky_grey_gargoyle/migration.sql
+++ b/drizzle/migrations/20260626023937_flaky_grey_gargoyle/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `sequence_music_prompt_variants` RENAME TO `sequence_music_prompt_versions`;--> statement-breakpoint
+ALTER TABLE `shot_prompt_variants` RENAME TO `shot_prompt_versions`;--> statement-breakpoint
+ALTER TABLE `shots` ADD `selected_motion_prompt_version_id` text;

--- a/drizzle/migrations/20260626023937_flaky_grey_gargoyle/snapshot.json
+++ b/drizzle/migrations/20260626023937_flaky_grey_gargoyle/snapshot.json
@@ -1,0 +1,8589 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "b45d98c4-a6a4-457a-a1da-5a3e86dd8561",
+  "prevIds": ["4aa43531-97b8-4bdc-87f7-54898e497318"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "apikey",
+      "entityType": "tables"
+    },
+    {
+      "name": "app_metadata",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frames",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "scenes",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_exports",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "shots",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_interval",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_amount",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_refill_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "rate_limit_enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_time_window",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_max",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "request_count",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_request",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permissions",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text(255)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'model'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_variant_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'first'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'generated'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "image_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_image_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_image_prompt_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "story_beat",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "continuity",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_design",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_script",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_strategy",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_type",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'ready'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_shots_hash",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_music_variant_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "loudness_gain_db",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "include_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_number",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_thumbnail_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "variant_image_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "thumbnail_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_motion_prompt_version_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "thumbnail_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_image_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sample_videos",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_image_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_video_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_aspect_ratio",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "use_cases",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_versions_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_versions_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frames_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frames_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_scenes_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "scenes"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_events_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_events"
+    },
+    {
+      "columns": ["actor_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_events_actor_id_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_events"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_sequence_exports_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shots_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shots_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "apikey_pk",
+      "table": "apikey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["key"],
+      "nameExplicit": false,
+      "name": "app_metadata_pk",
+      "table": "app_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_prompt_versions_pk",
+      "table": "frame_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_variants_pk",
+      "table": "frame_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frames_pk",
+      "table": "frames",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "scenes_pk",
+      "table": "scenes",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_events_pk",
+      "table": "sequence_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_exports_pk",
+      "table": "sequence_exports",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_variants_pk",
+      "table": "sequence_music_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_prompt_variants_pk",
+      "table": "shot_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_variants_pk",
+      "table": "shot_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shots_pk",
+      "table": "shots",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_referenceId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_key_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_configId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_prompt_versions_frame_created",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_prompt_versions\".\"input_hash\" IS NOT NULL AND \"frame_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_frame_prompt_versions_frame_hash_ai",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "kind",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_group",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_sequence",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_shot_order",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_sequence_id",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "frames_shot_id_order_index_key",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_scenes_sequence_order",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "scenes_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_events_sequence",
+      "entityType": "indexes",
+      "table": "sequence_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "target_type",
+          "isExpression": false
+        },
+        {
+          "value": "target_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_events_target",
+      "entityType": "indexes",
+      "table": "sequence_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_sequence",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_created_at",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_exports\".\"status\" = 'processing'",
+      "origin": "manual",
+      "name": "uq_sequence_exports_one_processing",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_prompt_versions\".\"input_hash\" IS NOT NULL AND \"sequence_music_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_sequence_music_prompt_variants_sequence_hash_ai",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_prompt_variants_shot_type_created",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_prompt_versions\".\"input_hash\" IS NOT NULL AND \"shot_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_shot_prompt_variants_shot_type_hash_ai",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_shot_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "shot_variants_primary_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "shot_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_order",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_sequence_id",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "shots_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"transactions\".\"idempotency_key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "idx_transactions_team_idempotency_key",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": [
+    "sequence_music_prompt_variants->sequence_music_prompt_versions",
+    "shot_prompt_variants->shot_prompt_versions"
+  ]
+}

--- a/scripts/reorder-d1-dump.ts
+++ b/scripts/reorder-d1-dump.ts
@@ -14,7 +14,9 @@
  *   bun scripts/reorder-d1-dump.ts <input.sql> <output.sql>
  *
  * The FK edge list below is a snapshot of pragma_foreign_key_list over the
- * 2026-06 schema (one-time cutover tooling, not kept in CI sync). The script
+ * schema as of the Scene→Shot→Frame redesign (#988: scenes/shots/shot_variants/
+ * shot_prompt_versions/frames/frame_variants/frame_prompt_versions/
+ * sequence_events). One-time cutover tooling, not kept in CI sync — the script
  * fails loudly on any dump table it doesn't know about — regenerate the list
  * from a migrated DB if that happens:
  *   SELECT m.name, f."table" FROM sqlite_master m,
@@ -40,11 +42,12 @@ const EDGES: Array<[string, string]> = [
   ['credit_batches', 'teams'],
   ['credit_batches', 'transactions'],
   ['credits', 'teams'],
-  ['frame_prompt_variants', 'frames'],
-  ['frame_prompt_variants', 'user'],
+  ['frame_prompt_versions', 'frames'],
+  ['frame_prompt_versions', 'user'],
   ['frame_variants', 'frames'],
   ['frame_variants', 'sequences'],
   ['frames', 'sequences'],
+  ['frames', 'shots'],
   ['gift_token_redemptions', 'gift_tokens'],
   ['gift_token_redemptions', 'teams'],
   ['gift_token_redemptions', 'user'],
@@ -53,17 +56,26 @@ const EDGES: Array<[string, string]> = [
   ['location_library', 'user'],
   ['location_sheets', 'location_library'],
   ['passkey', 'user'],
+  ['scenes', 'sequences'],
   ['sequence_elements', 'sequences'],
+  ['sequence_events', 'sequences'],
+  ['sequence_events', 'user'],
   ['sequence_exports', 'sequences'],
   ['sequence_locations', 'location_library'],
   ['sequence_locations', 'sequences'],
-  ['sequence_music_prompt_variants', 'sequences'],
-  ['sequence_music_prompt_variants', 'user'],
+  ['sequence_music_prompt_versions', 'sequences'],
+  ['sequence_music_prompt_versions', 'user'],
   ['sequence_music_variants', 'sequences'],
   ['sequences', 'styles'],
   ['sequences', 'teams'],
   ['sequences', 'user'],
   ['session', 'user'],
+  ['shot_prompt_versions', 'shots'],
+  ['shot_prompt_versions', 'user'],
+  ['shot_variants', 'sequences'],
+  ['shot_variants', 'shots'],
+  ['shots', 'scenes'],
+  ['shots', 'sequences'],
   ['styles', 'teams'],
   ['styles', 'user'],
   ['talent_media', 'talent'],
@@ -85,10 +97,13 @@ const EDGES: Array<[string, string]> = [
 ];
 
 // Tables that genuinely carry no FK constraints in the schema snapshot.
+// `location_sheet_variants` is polymorphic (`parent_type` + `parent_id`, no FK),
+// so it carries no insert-ordering constraint.
 const KNOWN_FK_FREE = new Set([
   'apikey',
   'app_metadata',
   'd1_migrations',
+  'location_sheet_variants',
   'user',
   'teams',
   'verification',

--- a/src/components/motion/scene-player.stories.tsx
+++ b/src/components/motion/scene-player.stories.tsx
@@ -31,6 +31,7 @@ const mockShotBase = {
   videoError: null,
   motionPrompt: null,
   motionModel: 'veo3',
+  selectedMotionPromptVersionId: null,
   audioUrl: null,
   audioPath: null,
   audioStatus: 'pending' as const,

--- a/src/components/scenes/divergence-compare-dialog.stories.tsx
+++ b/src/components/scenes/divergence-compare-dialog.stories.tsx
@@ -34,6 +34,7 @@ const baseShot: Shot = {
   videoError: null,
   motionPrompt: null,
   motionModel: null,
+  selectedMotionPromptVersionId: null,
   audioUrl: null,
   audioPath: null,
   audioStatus: 'pending',

--- a/src/components/scenes/scene-list-item.stories.tsx
+++ b/src/components/scenes/scene-list-item.stories.tsx
@@ -31,6 +31,7 @@ const mockShot: Shot = {
   videoError: null,
   motionPrompt: '',
   motionModel: 'veo3',
+  selectedMotionPromptVersionId: null,
   audioUrl: null,
   audioPath: null,
   audioStatus: 'pending',

--- a/src/components/scenes/scene-script-prompts.stories.tsx
+++ b/src/components/scenes/scene-script-prompts.stories.tsx
@@ -32,6 +32,7 @@ const mockShot = {
   videoError: null,
   motionPrompt: null,
   motionModel: 'veo3',
+  selectedMotionPromptVersionId: null,
   audioUrl: null,
   audioPath: null,
   audioStatus: 'pending',

--- a/src/components/scenes/scenes-view.fixture.ts
+++ b/src/components/scenes/scenes-view.fixture.ts
@@ -392,6 +392,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       'Locked eye-level probe lens macro frame holds steady on a luminous serum droplet clinging to a glass dropper tip against a seamless warm ivory-to-blush gradient. The droplet releases and descends in ultra-slow motion, stretching into a languid weightless ribbon that narrows and falls below frame over the full duration. Soft edge light and gentle backlight keep the serum glowing translucent gold throughout the descent.',
     motionModel: 'veo3_1',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',
@@ -540,6 +541,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       'Slow macro push-in descends straight down from directly above the porcelain surface while gently rotating two degrees clockwise. A generous curl of dense cream dispenses from below frame, coiling outward in a smooth, deliberate spiral that builds ridges and peaks. The forming swirl gradually fills the frame, transforming the surface texture into an abstract landscape of peaks and valleys. The low raking key light shifts subtly across the moving ridges, accentuating depth and sheen. A faint atmospheric hum underscores the intimate, tactile motion.',
     motionModel: 'kling_v3_pro',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',
@@ -688,6 +690,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       'Low-angle macro lens positioned almost parallel to the skin surface executes an imperceptibly slow clockwise rotational drift. The fingertip presses gently downward, the cream yielding and spreading in a thin even veil while a subtle rose flush blooms outward from the contact point in extreme slow motion.',
     motionModel: 'kling_v3_pro',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',
@@ -838,6 +841,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       'Probe-lens positioned low and slightly ahead of the path, the deep brown-rose lipstick bullet glides smoothly toward camera in extreme slow motion across luminous dewy wrist skin, laying down a saturated glossy color ribbon that blooms behind it. Rack focus shifts gradually from the moving bullet tip to the settling trail. Fine hairs along the wrist catch the rear illumination. The glistening pigment settles with soft sheen.',
     motionModel: 'kling_v3_pro',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',
@@ -986,6 +990,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       "Slow barely perceptible push-in on a centered vertical portrait filling the 9:16 frame from chin to crown. The woman's face begins in complete stillness with eyes closed and lashes resting against luminous dewy skin, lips slightly parted. The eyes then open slowly and unhurriedly, the gaze turning direct, sovereign and steady toward camera. Subtle skin texture and warm gold rim light remain constant as framing tightens gently throughout the six-second shot.",
     motionModel: 'kling_v3_pro',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',
@@ -1135,6 +1140,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       'Static locked frame with the hero product perfectly centered and motionless on a pure warm-white surface. Soft glowing key light from upper left casts a discreet golden edge light along its right silhouette. Background gradient holds steady from ivory to the softest peach. No camera movement. Product remains still and inevitable throughout the shot.',
     motionModel: 'kling_v3_pro',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',
@@ -1280,6 +1286,7 @@ export const fixtureShots: Shot[] = [
     motionPrompt:
       'Camera locked in static straight-on framing on a centered white brand logo against a smooth warm ivory gradient. Logo remains perfectly still with no movement or animation. The frame holds clean and composed before a gentle fade begins at the close of the shot.',
     motionModel: 'kling_v3_pro',
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',

--- a/src/functions/__tests__/sequences.test.ts
+++ b/src/functions/__tests__/sequences.test.ts
@@ -84,6 +84,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     videoError: null,
     motionPrompt: null,
     motionModel: null,
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',

--- a/src/functions/__tests__/smart-retry.test.ts
+++ b/src/functions/__tests__/smart-retry.test.ts
@@ -119,6 +119,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     videoError: null,
     motionPrompt: 'slow pan',
     motionModel: null,
+    selectedMotionPromptVersionId: null,
     audioUrl: null,
     audioPath: null,
     audioStatus: 'pending',

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -13,8 +13,8 @@ import {
 } from '@/lib/ai/prompt-context';
 import {
   SHOT_PROMPT_TYPES,
-  type ShotPromptVariant,
-  type SequenceMusicPromptVariant,
+  type ShotPromptVersion,
+  type SequenceMusicPromptVersion,
 } from '@/lib/db/schema';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { simpleHash } from '@/lib/utils/hash';
@@ -80,12 +80,12 @@ export function isPromptUpToDate(
   return storedHash !== null && storedHash === liveHash;
 }
 
-export type ShotPromptVariantWithAuthor = ShotPromptVariant & {
+export type ShotPromptVariantWithAuthor = ShotPromptVersion & {
   createdByName: string | null;
 };
 
 export type SequenceMusicPromptVariantWithAuthor =
-  SequenceMusicPromptVariant & { createdByName: string | null };
+  SequenceMusicPromptVersion & { createdByName: string | null };
 
 const shotListInput = z.object({
   sequenceId: ulidSchema,
@@ -98,7 +98,7 @@ export const listShotPromptVariantsFn = createServerFn({ method: 'GET' })
   .inputValidator(zodValidator(shotListInput))
   .handler(
     async ({ context, data }): Promise<ShotPromptVariantWithAuthor[]> => {
-      return await context.scopedDb.shotPromptVariants.listByShotWithAuthor(
+      return await context.scopedDb.shotPromptVersions.listByShotWithAuthor(
         data.shotId,
         data.promptType
       );
@@ -117,7 +117,7 @@ export const listSequenceMusicPromptVariantsFn = createServerFn({
       context,
       data,
     }): Promise<SequenceMusicPromptVariantWithAuthor[]> => {
-      return await context.scopedDb.sequenceMusicPromptVariants.listBySequenceWithAuthor(
+      return await context.scopedDb.sequenceMusicPromptVersions.listBySequenceWithAuthor(
         data.sequenceId
       );
     }
@@ -136,7 +136,7 @@ export const restoreShotPromptVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
   .inputValidator(zodValidator(shotRestoreInput))
   .handler(async ({ context, data }) => {
-    const chosen = await context.scopedDb.shotPromptVariants.getByIdForShot(
+    const chosen = await context.scopedDb.shotPromptVersions.getByIdForShot(
       data.variantId,
       data.shotId
     );
@@ -144,7 +144,7 @@ export const restoreShotPromptVariantFn = createServerFn({ method: 'POST' })
       throw new Error('Prompt variant not found for this shot');
     }
 
-    const inserted = await context.scopedDb.shotPromptVariants.write({
+    const inserted = await context.scopedDb.shotPromptVersions.write({
       shotId: data.shotId,
       promptType: chosen.promptType,
       text: chosen.text,
@@ -170,7 +170,7 @@ export const restoreSequenceMusicPromptVariantFn = createServerFn({
   .inputValidator(zodValidator(sequenceRestoreInput))
   .handler(async ({ context, data }) => {
     const chosen =
-      await context.scopedDb.sequenceMusicPromptVariants.getByIdForSequence(
+      await context.scopedDb.sequenceMusicPromptVersions.getByIdForSequence(
         data.variantId,
         data.sequenceId
       );
@@ -178,7 +178,7 @@ export const restoreSequenceMusicPromptVariantFn = createServerFn({
       throw new Error('Music prompt variant not found for this sequence');
     }
 
-    const inserted = await context.scopedDb.sequenceMusicPromptVariants.write({
+    const inserted = await context.scopedDb.sequenceMusicPromptVersions.write({
       sequenceId: data.sequenceId,
       prompt: chosen.prompt,
       tags: chosen.tags,
@@ -373,7 +373,7 @@ export const getMusicPromptStalenessFn = createServerFn({ method: 'GET' })
       }
       const sceneSummaries = buildMusicSceneSummaries(scenes);
 
-      const latest = await scopedDb.sequenceMusicPromptVariants.getLatest(
+      const latest = await scopedDb.sequenceMusicPromptVersions.getLatest(
         sequence.id
       );
       const analysisModel =
@@ -434,7 +434,7 @@ export const getDivergentVariantPromptDiffFn = createServerFn({
 
     const promptType = variant.variantType === 'image' ? 'visual' : 'motion';
     const candidates =
-      await context.scopedDb.shotPromptVariants.listCandidatesAtOrBefore(
+      await context.scopedDb.shotPromptVersions.listCandidatesAtOrBefore(
         variant.shotId,
         promptType,
         variant.createdAt

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -867,7 +867,7 @@ export const generateMusicFn = createServerFn({ method: 'POST' })
     // revision; the variants helper updates the cached columns on `sequences`
     // alongside the row insert so a tags-only edit isn't dropped.
     if (data.prompt !== undefined || data.tags !== undefined) {
-      await context.scopedDb.sequenceMusicPromptVariants.write({
+      await context.scopedDb.sequenceMusicPromptVersions.write({
         sequenceId: sequence.id,
         prompt: effectivePrompt,
         tags: effectiveTags,

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -658,7 +658,7 @@ export const getShotStalenessFn = createServerFn({ method: 'GET' })
       let referenceHash = shot.visualPromptInputHash;
       if (!referenceHash) {
         const fallback =
-          await scopedDb.shotPromptVariants.getLatestWithInputHash(
+          await scopedDb.shotPromptVersions.getLatestWithInputHash(
             shot.id,
             'visual'
           );
@@ -666,7 +666,7 @@ export const getShotStalenessFn = createServerFn({ method: 'GET' })
       }
       if (referenceHash) {
         try {
-          const latest = await scopedDb.shotPromptVariants.getLatest(
+          const latest = await scopedDb.shotPromptVersions.getLatest(
             shot.id,
             'visual'
           );
@@ -692,7 +692,7 @@ export const getShotStalenessFn = createServerFn({ method: 'GET' })
       let referenceHash = shot.motionPromptInputHash;
       if (!referenceHash) {
         const fallback =
-          await scopedDb.shotPromptVariants.getLatestWithInputHash(
+          await scopedDb.shotPromptVersions.getLatestWithInputHash(
             shot.id,
             'motion'
           );
@@ -700,7 +700,7 @@ export const getShotStalenessFn = createServerFn({ method: 'GET' })
       }
       if (referenceHash) {
         try {
-          const latest = await scopedDb.shotPromptVariants.getLatest(
+          const latest = await scopedDb.shotPromptVersions.getLatest(
             shot.id,
             'motion'
           );

--- a/src/lib/api-v1/list.test.ts
+++ b/src/lib/api-v1/list.test.ts
@@ -112,6 +112,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     previewThumbnailUrl: null,
     metadata: null,
     createdAt: new Date(),

--- a/src/lib/api-v1/state.test.ts
+++ b/src/lib/api-v1/state.test.ts
@@ -88,6 +88,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     previewThumbnailUrl: null,
     metadata: null,
     createdAt: new Date(),

--- a/src/lib/db/schema/frame-variants.ts
+++ b/src/lib/db/schema/frame-variants.ts
@@ -81,8 +81,9 @@ export const frameVariants = snakeCase.table(
       .notNull(),
   },
   (table) => [
-    // List a variant's versions by time: filter (frameId, kind, model,
-    // sourceVariantId), order by createdAt.
+    // List a variant's versions by time: filter on (frameId, kind, model)
+    // (sourceVariantId is matched in app code, not indexed), order by id
+    // (ULID ≈ creation time).
     index('idx_frame_variants_group').on(
       table.frameId,
       table.kind,

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -30,9 +30,9 @@ import { locationSheetVariants } from './location-sheet-variants';
 
 import { talentSheetVariants } from './talent-sheet-variants';
 
-import { shotPromptVariants } from './shot-prompt-variants';
+import { shotPromptVersions } from './shot-prompt-versions';
 
-import { sequenceMusicPromptVariants } from './sequence-music-prompt-variants';
+import { sequenceMusicPromptVersions } from './sequence-music-prompt-versions';
 
 import { sequenceMusicVariants } from './sequence-music-variants';
 import { sequenceExports } from './sequence-exports';
@@ -168,22 +168,24 @@ export type {
   TalentSheetVariant,
 } from './talent-sheet-variants';
 
-// Shot Prompt Variants (visual/motion prompt history)
-export { shotPromptVariants };
+// Shot Prompt Versions (visual/motion prompt history; renamed from
+// shot_prompt_variants in #988)
+export { shotPromptVersions };
 
-export { SHOT_PROMPT_TYPES } from './shot-prompt-variants';
+export { SHOT_PROMPT_TYPES } from './shot-prompt-versions';
 
 export type {
   ShotPromptType,
-  ShotPromptVariant,
-  ShotPromptVariantComponents,
+  ShotPromptVersion,
+  ShotPromptVersionComponents,
   PromptVariantSource,
-} from './shot-prompt-variants';
+} from './shot-prompt-versions';
 
-// Sequence Music Prompt Variants (music prompt history)
-export { sequenceMusicPromptVariants };
+// Sequence Music Prompt Versions (music prompt history; renamed from
+// sequence_music_prompt_variants in #988)
+export { sequenceMusicPromptVersions };
 
-export type { SequenceMusicPromptVariant } from './sequence-music-prompt-variants';
+export type { SequenceMusicPromptVersion } from './sequence-music-prompt-versions';
 
 // Sequence-level variants (music)
 export { sequenceMusicVariants };
@@ -312,8 +314,8 @@ export const schema = {
   characterSheetVariants,
   locationSheetVariants,
   talentSheetVariants,
-  shotPromptVariants,
-  sequenceMusicPromptVariants,
+  shotPromptVersions,
+  sequenceMusicPromptVersions,
   sequenceMusicVariants,
   sequenceExports,
 

--- a/src/lib/db/schema/relations.ts
+++ b/src/lib/db/schema/relations.ts
@@ -58,7 +58,7 @@ export const relations = defineRelations(schema, (r) => ({
     characters: r.many.characters(),
     locations: r.many.sequenceLocations(),
     elements: r.many.sequenceElements(),
-    musicPromptVariants: r.many.sequenceMusicPromptVariants(),
+    musicPromptVariants: r.many.sequenceMusicPromptVersions(),
   },
 
   // ---- Scenes ----
@@ -82,7 +82,7 @@ export const relations = defineRelations(schema, (r) => ({
     }),
     frames: r.many.frames(),
     variants: r.many.shotVariants(),
-    promptVariants: r.many.shotPromptVariants(),
+    promptVariants: r.many.shotPromptVersions(),
   },
 
   // ---- Shot Variants ----
@@ -147,26 +147,26 @@ export const relations = defineRelations(schema, (r) => ({
     }),
   },
 
-  // ---- Shot Prompt Variants ----
-  shotPromptVariants: {
+  // ---- Shot Prompt Versions ----
+  shotPromptVersions: {
     shot: r.one.shots({
-      from: r.shotPromptVariants.shotId,
+      from: r.shotPromptVersions.shotId,
       to: r.shots.id,
     }),
     createdByUser: r.one.user({
-      from: r.shotPromptVariants.createdBy,
+      from: r.shotPromptVersions.createdBy,
       to: r.user.id,
     }),
   },
 
-  // ---- Sequence Music Prompt Variants ----
-  sequenceMusicPromptVariants: {
+  // ---- Sequence Music Prompt Versions ----
+  sequenceMusicPromptVersions: {
     sequence: r.one.sequences({
-      from: r.sequenceMusicPromptVariants.sequenceId,
+      from: r.sequenceMusicPromptVersions.sequenceId,
       to: r.sequences.id,
     }),
     createdByUser: r.one.user({
-      from: r.sequenceMusicPromptVariants.createdBy,
+      from: r.sequenceMusicPromptVersions.createdBy,
       to: r.user.id,
     }),
   },

--- a/src/lib/db/schema/sequence-music-prompt-versions.ts
+++ b/src/lib/db/schema/sequence-music-prompt-versions.ts
@@ -1,9 +1,12 @@
 /**
- * Sequence Music Prompt Variants Schema
+ * Sequence Music Prompt Versions Schema
  *
  * One row per revision of a sequence's music prompt + tags. The current
  * "active" prompt is mirrored on `sequences.musicPrompt` / `sequences.musicTags`
  * for read-path simplicity; this table stores the full revision history.
+ *
+ * Renamed from `sequence_music_prompt_variants` in the Scene→Shot→Frame
+ * redesign (#988) — a prompt is a *version* history, not parallel *variants*.
  *
  * See docs/architecture/workflow-snapshots-and-content-hash-staleness.md
  * § prompt versioning.
@@ -19,15 +22,15 @@ import {
 } from 'drizzle-orm/sqlite-core';
 import { generateId } from '../id';
 import { user } from './auth';
-import { type PromptVariantSource } from './shot-prompt-variants';
+import { type PromptVariantSource } from './shot-prompt-versions';
 import { sequences } from './sequences';
 
 const SEQUENCE_MUSIC_PROMPT_TYPE = 'music' as const;
 export type SequenceMusicPromptType = typeof SEQUENCE_MUSIC_PROMPT_TYPE;
 export type { PromptVariantSource };
 
-export const sequenceMusicPromptVariants = snakeCase.table(
-  'sequence_music_prompt_variants',
+export const sequenceMusicPromptVersions = snakeCase.table(
+  'sequence_music_prompt_versions',
   {
     id: text()
       .$defaultFn(() => generateId())
@@ -62,6 +65,9 @@ export const sequenceMusicPromptVariants = snakeCase.table(
       onDelete: 'set null',
     }),
   },
+  // Index names intentionally keep the `*_variants_*` spelling — see the note
+  // in shot-prompt-versions.ts: a table RENAME TO carries indexes unchanged, so
+  // renaming them would force a needless DROP/CREATE INDEX pair.
   (table) => [
     index('idx_sequence_music_prompt_variants_sequence_created').on(
       table.sequenceId,
@@ -80,6 +86,6 @@ export const sequenceMusicPromptVariants = snakeCase.table(
   ]
 );
 
-export type SequenceMusicPromptVariant = InferSelectModel<
-  typeof sequenceMusicPromptVariants
+export type SequenceMusicPromptVersion = InferSelectModel<
+  typeof sequenceMusicPromptVersions
 >;

--- a/src/lib/db/schema/shot-prompt-versions.ts
+++ b/src/lib/db/schema/shot-prompt-versions.ts
@@ -1,12 +1,19 @@
 /**
- * Shot Prompt Variants Schema
+ * Shot Prompt Versions Schema
  *
  * One row per revision of a shot's visual or motion prompt. The current
  * "active" prompt is mirrored on `shots.imagePrompt` / `shots.motionPrompt`
  * for read-path simplicity; this table stores the full revision history.
  *
+ * Renamed from `shot_prompt_variants` in the Scene→Shot→Frame redesign (#988):
+ * a prompt is a single authored input revised over time (a *version* history),
+ * not a set of parallel alternatives (*variants*). End-state role is the MOTION
+ * prompt — the image/visual prompt migrates to `frame_prompt_versions` as the
+ * image surface moves onto frames (later phases); the `promptType` column stays
+ * dual-purpose meanwhile.
+ *
  * See docs/architecture/workflow-snapshots-and-content-hash-staleness.md
- * § prompt versioning.
+ * § prompt versioning and docs/architecture/scene-shot-frame-redesign.md.
  */
 
 import type {
@@ -34,7 +41,7 @@ import { shots } from './shots';
  *     speed / ...)
  * User-edits without structured components persist `null`.
  */
-export type ShotPromptVariantComponents =
+export type ShotPromptVersionComponents =
   | VisualPromptComponents
   | MotionPromptComponents;
 
@@ -49,8 +56,8 @@ const PROMPT_VARIANT_SOURCES = [
 ] as const;
 export type PromptVariantSource = (typeof PROMPT_VARIANT_SOURCES)[number];
 
-export const shotPromptVariants = snakeCase.table(
-  'shot_prompt_variants',
+export const shotPromptVersions = snakeCase.table(
+  'shot_prompt_versions',
   {
     id: text()
       .$defaultFn(() => generateId())
@@ -67,7 +74,7 @@ export const shotPromptVariants = snakeCase.table(
     // composition / lighting / etc.; user-edits may not have components).
     components: text({
       mode: 'json',
-    }).$type<ShotPromptVariantComponents>(),
+    }).$type<ShotPromptVersionComponents>(),
     // Motion-only: timing / speed / camera parameters. Visual rows store null.
     parameters: text({
       mode: 'json',
@@ -89,6 +96,11 @@ export const shotPromptVariants = snakeCase.table(
       onDelete: 'set null',
     }),
   },
+  // Index names intentionally keep the `*_variants_*` spelling: SQLite's
+  // `ALTER TABLE … RENAME TO` carries a table's indexes across unchanged, so
+  // renaming them here would force a needless DROP/CREATE INDEX pair on top of
+  // the rename. Keep them as-is so the #988 migration is RENAME TO + ADD COLUMN
+  // only (no rebuild).
   (table) => [
     index('idx_shot_prompt_variants_shot_type_created').on(
       table.shotId,
@@ -108,4 +120,4 @@ export const shotPromptVariants = snakeCase.table(
   ]
 );
 
-export type ShotPromptVariant = InferSelectModel<typeof shotPromptVariants>;
+export type ShotPromptVersion = InferSelectModel<typeof shotPromptVersions>;

--- a/src/lib/db/schema/shots.ts
+++ b/src/lib/db/schema/shots.ts
@@ -93,7 +93,8 @@ export const shots = snakeCase.table(
     // Soft pointer (plain column, no FK — mirrors frames.selected*VersionId) to
     // the selected `shot_prompt_versions` row for the MOTION prompt. Selection
     // is a pointer, not a per-row flag: reverting / re-rolling the motion prompt
-    // repoints this. Null until a motion prompt version is written (#988).
+    // will repoint this. Additive groundwork in #988 — no write path populates
+    // it yet (it stays null), so the repoint is wired in a later phase.
     selectedMotionPromptVersionId: text(),
     motionModel: text({ length: 100 }), // Model used for motion/video generation (nullable - inherits from sequence if not set)
     // Audio/music generation status tracking

--- a/src/lib/db/schema/shots.ts
+++ b/src/lib/db/schema/shots.ts
@@ -90,6 +90,11 @@ export const shots = snakeCase.table(
     }),
     videoError: text(),
     motionPrompt: text(), // User-updated motion prompt (overrides AI-generated prompt from metadata)
+    // Soft pointer (plain column, no FK — mirrors frames.selected*VersionId) to
+    // the selected `shot_prompt_versions` row for the MOTION prompt. Selection
+    // is a pointer, not a per-row flag: reverting / re-rolling the motion prompt
+    // repoints this. Null until a motion prompt version is written (#988).
+    selectedMotionPromptVersionId: text(),
     motionModel: text({ length: 100 }), // Model used for motion/video generation (nullable - inherits from sequence if not set)
     // Audio/music generation status tracking
     audioUrl: text(),

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -14,8 +14,12 @@ import { createApiKeysMethods } from '@/lib/db/scoped/api-keys';
 import { createBillingMethods } from '@/lib/db/scoped/billing';
 import { createCharacterSheetVariantsMethods } from '@/lib/db/scoped/character-sheet-variants';
 import { createCharactersMethods } from '@/lib/db/scoped/characters';
+import { createFramePromptVersionsMethods } from '@/lib/db/scoped/frame-prompt-versions';
+import { createFrameVariantsMethods } from '@/lib/db/scoped/frame-variants';
+import { createFramesMethods } from '@/lib/db/scoped/frames';
 import { createScenesMethods } from '@/lib/db/scoped/scenes';
-import { createShotPromptVariantsMethods } from '@/lib/db/scoped/shot-prompt-variants';
+import { createSequenceEventsMethods } from '@/lib/db/scoped/sequence-events';
+import { createShotPromptVersionsMethods } from '@/lib/db/scoped/shot-prompt-versions';
 import { createShotVariantsMethods } from '@/lib/db/scoped/shot-variants';
 import { createShotsMethods } from '@/lib/db/scoped/shots';
 import { createLibraryMethods } from '@/lib/db/scoped/library';
@@ -29,7 +33,7 @@ import { createLocationSheetVariantsMethods } from '@/lib/db/scoped/location-she
 import { createSequenceElementsMethods } from '@/lib/db/scoped/sequence-elements';
 import { createSequenceExportsMethods } from '@/lib/db/scoped/sequence-exports';
 import { createSequenceLocationsMethods } from '@/lib/db/scoped/sequence-locations';
-import { createSequenceMusicPromptVariantsMethods } from '@/lib/db/scoped/sequence-music-prompt-variants';
+import { createSequenceMusicPromptVersionsMethods } from '@/lib/db/scoped/sequence-music-prompt-versions';
 import { createSequenceVariantsMethods } from '@/lib/db/scoped/sequence-variants';
 import {
   createSequenceMethods,
@@ -288,11 +292,18 @@ export function createScopedDb(teamId: string, userId: string) {
     scenes: createScenesMethods(db),
     shots: createShotsMethods(db),
     shotVariants: createShotVariantsMethods(db),
-    shotPromptVariants: createShotPromptVariantsMethods(db),
+    shotPromptVersions: createShotPromptVersionsMethods(db),
+    // SSF redesign (#988) — frames are the IMAGE unit (still keyframes per
+    // shot); frame_variants the flat image versions; frame_prompt_versions the
+    // visual-prompt history; sequence_events the append-only activity log.
+    frames: createFramesMethods(db),
+    frameVariants: createFrameVariantsMethods(db),
+    framePromptVersions: createFramePromptVersionsMethods(db),
+    sequenceEvents: createSequenceEventsMethods(db),
     characterSheetVariants: createCharacterSheetVariantsMethods(db),
     locationSheetVariants: createLocationSheetVariantsMethods(db),
     talentSheetVariants: createTalentSheetVariantsMethods(db),
-    sequenceMusicPromptVariants: createSequenceMusicPromptVariantsMethods(db),
+    sequenceMusicPromptVersions: createSequenceMusicPromptVersionsMethods(db),
     sequenceVariants: createSequenceVariantsMethods(db),
     sequenceExports: createSequenceExportsMethods(db),
 

--- a/src/lib/db/scoped/frame-prompt-versions.test.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Acceptance tests for the frame prompt-versions helper (image / visual prompt
+ * history). Exercised against an in-memory libSQL database with the real
+ * migrations applied — the same harness as shot-prompt-versions.test.ts.
+ *
+ * Covers the write dedupe / force-regen contract (including the regression
+ * where a user-edit whose hash collides with an existing row silently dropped
+ * the edit), the restore (`select`) repoint + atomic `prompt.selected` event,
+ * and the cross-frame ownership guard.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import {
+  framePromptVersions,
+  frames,
+  sequenceEvents,
+  sequences,
+  shots,
+  styles,
+  teams,
+  user,
+} from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createFramePromptVersionsMethods } from './frame-prompt-versions';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let sequenceId = '';
+let shotId = '';
+let frameId = '';
+
+async function seed() {
+  await db.delete(sequenceEvents);
+  await db.delete(framePromptVersions);
+  await db.delete(frames);
+  await db.delete(shots);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await db.delete(user);
+
+  teamId = generateId();
+  sequenceId = generateId();
+
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db
+    .insert(sequences)
+    .values({ id: sequenceId, teamId, title: 'S', styleId: style.id });
+  const [shot] = await db
+    .insert(shots)
+    .values({ sequenceId, orderIndex: 0 })
+    .returning();
+  if (!shot) throw new Error('test setup: shot insert returned nothing');
+  shotId = shot.id;
+  const [frame] = await db
+    .insert(frames)
+    .values({ shotId, sequenceId, orderIndex: 0, role: 'first' })
+    .returning();
+  if (!frame) throw new Error('test setup: frame insert returned nothing');
+  frameId = frame.id;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+const HAIKU = 'anthropic/claude-haiku-4.5';
+
+describe('framePromptVersions.write', () => {
+  it('mirrors the version onto the frame (text, hash, selected pointer)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+
+    const version = await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('AI prompt v1');
+    expect(frame.visualPromptInputHash).toBe('hash-1');
+    expect(frame.selectedImagePromptVersionId).toBe(version.id);
+  });
+
+  it('AI write is idempotent on (frame, input_hash) — a retry returns the existing row', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const first = await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    const retried = await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    expect(retried.id).toBe(first.id);
+    expect(await m.listByFrame(frameId)).toHaveLength(1);
+  });
+
+  it('force-regen at the same hash appends a null-hash row and keeps the cached hash tracking live context', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const first = await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    const forced = await m.write({
+      frameId,
+      text: 'Fresh completion against same inputs',
+      source: 'regenerated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    expect(forced.id).not.toBe(first.id);
+    expect(forced.inputHash).toBeNull();
+    expect(forced.text).toBe('Fresh completion against same inputs');
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Fresh completion against same inputs');
+    // Cached hash still tracks the live upstream so staleness doesn't fire.
+    expect(frame.visualPromptInputHash).toBe('hash-1');
+    expect(frame.selectedImagePromptVersionId).toBe(forced.id);
+  });
+
+  it('user-edit whose hash collides with an existing row STILL records the edit (regression)', async () => {
+    // The bug: a user-edit carries the live upstream hash captured at edit
+    // time. When the text was edited but upstream context is unchanged, that
+    // hash matches the existing AI row, so the unique-index insert no-ops. The
+    // helper previously fell through to `version = existing` (the OLD row) while
+    // mirroring the NEW text onto the frame — the edit vanished from history and
+    // the pointer disagreed with the cached prompt. It must append instead.
+    const m = createFramePromptVersionsMethods(db);
+    const ai = await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+
+    const edit = await m.write({
+      frameId,
+      text: 'Hand-edited prompt',
+      source: 'user-edit',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+
+    // A distinct row was appended, carrying the new text.
+    expect(edit.id).not.toBe(ai.id);
+    expect(edit.source).toBe('user-edit');
+    expect(edit.text).toBe('Hand-edited prompt');
+    // Bypasses the partial unique index via null input_hash.
+    expect(edit.inputHash).toBeNull();
+
+    const history = await m.listByFrame(frameId);
+    expect(history).toHaveLength(2);
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    // The pointer references the row whose text is mirrored — no divergence.
+    expect(frame.imagePrompt).toBe('Hand-edited prompt');
+    expect(frame.selectedImagePromptVersionId).toBe(edit.id);
+    // Cached hash still tracks the live upstream context.
+    expect(frame.visualPromptInputHash).toBe('hash-1');
+  });
+
+  it('idempotent retry of the same text at the same hash de-dupes (no spurious null-hash row)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'regenerated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    expect(await m.listByFrame(frameId)).toHaveLength(1);
+  });
+
+  it('user-edit with null hash clears the cached hash', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    await m.write({
+      frameId,
+      text: 'Hand-typed prompt',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Hand-typed prompt');
+    expect(frame.visualPromptInputHash).toBeNull();
+  });
+});
+
+describe('framePromptVersions.select (restore)', () => {
+  it('repoints the frame and appends a prompt.selected event with prevVersionId in one batch', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const v1 = await m.write({
+      frameId,
+      text: 'AI prompt v1',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    const v2 = await m.write({
+      frameId,
+      text: 'AI prompt v2',
+      source: 'regenerated',
+      inputHash: 'hash-2',
+      analysisModel: HAIKU,
+    });
+    // Frame now points at v2; restore v1.
+    const actorId = generateId();
+    await db.insert(user).values({ id: actorId, name: 'U', email: 'u@e.com' });
+
+    const restored = await m.select(frameId, v1.id, { actorId });
+    expect(restored.id).toBe(v1.id);
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('AI prompt v1');
+    expect(frame.selectedImagePromptVersionId).toBe(v1.id);
+
+    const events = await db
+      .select()
+      .from(sequenceEvents)
+      .where(eq(sequenceEvents.kind, 'prompt.selected'));
+    expect(events).toHaveLength(1);
+    const [evt] = events;
+    if (!evt) throw new Error('event missing');
+    expect(evt.targetId).toBe(frameId);
+    expect(evt.actorId).toBe(actorId);
+    expect(evt.data).toMatchObject({ versionId: v1.id, prevVersionId: v2.id });
+  });
+
+  it('throws for a version that belongs to another frame (cross-frame guard)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const [sibling] = await db
+      .insert(frames)
+      .values({ shotId, sequenceId, orderIndex: 1, role: 'last' })
+      .returning();
+    if (!sibling) throw new Error('test setup: sibling frame missing');
+    const siblingVersion = await m.write({
+      frameId: sibling.id,
+      text: 'belongs to sibling',
+      source: 'ai-generated',
+      inputHash: 'hash-s',
+      analysisModel: HAIKU,
+    });
+
+    await expect(
+      m.select(frameId, siblingVersion.id, { actorId: null })
+    ).rejects.toThrow(/not found for frame/);
+  });
+});
+
+describe('framePromptVersions.getByIdForFrame', () => {
+  it('refuses to return a sibling frame version (cross-frame guard)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const [sibling] = await db
+      .insert(frames)
+      .values({ shotId, sequenceId, orderIndex: 1, role: 'last' })
+      .returning();
+    if (!sibling) throw new Error('test setup: sibling frame missing');
+    const own = await m.write({
+      frameId,
+      text: 'belongs to frame A',
+      source: 'ai-generated',
+      inputHash: 'hash-A',
+      analysisModel: HAIKU,
+    });
+
+    expect(await m.getByIdForFrame(own.id, sibling.id)).toBeNull();
+    expect((await m.getByIdForFrame(own.id, frameId))?.id).toBe(own.id);
+  });
+});
+
+describe('framePromptVersions.getLatestWithInputHash', () => {
+  it('skips null-hash user-edits and returns the most recent hashed row', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const ai = await m.write({
+      frameId,
+      text: 'AI prompt',
+      source: 'ai-generated',
+      inputHash: 'ai-hash',
+      analysisModel: HAIKU,
+    });
+    await m.write({
+      frameId,
+      text: 'Hand-typed',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+    expect((await m.getLatest(frameId))?.inputHash).toBeNull();
+    const hashed = await m.getLatestWithInputHash(frameId);
+    expect(hashed?.id).toBe(ai.id);
+    expect(hashed?.inputHash).toBe('ai-hash');
+  });
+});

--- a/src/lib/db/scoped/frame-prompt-versions.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.ts
@@ -1,0 +1,285 @@
+/**
+ * Scoped Frame Prompt Versions Sub-module (image / visual prompt history).
+ *
+ * Appends a revision to `frame_prompt_versions` and mirrors the current value
+ * onto the frame: `frames.imagePrompt` (text), `frames.visualPromptInputHash`
+ * (staleness), and the `frames.selectedImagePromptVersionId` pointer. The
+ * frame-side sibling of `shot_prompt_versions` (motion prompt).
+ *
+ * Like the shot-prompt path, the append + mirror pair is sequential, not
+ * transactional: the version row is the source of truth and the cached columns
+ * are a read-path optimization. AI rows dedupe on the partial unique index
+ * `(frame_id, input_hash) WHERE input_hash IS NOT NULL AND source != 'restored'`
+ * so workflow retries don't double-append; a force-regen against unchanged
+ * inputs falls back to a null-hash row so the new text still lands in history.
+ *
+ * See docs/architecture/workflow-snapshots-and-content-hash-staleness.md
+ * § prompt versioning and docs/architecture/scene-shot-frame-redesign.md.
+ */
+
+import type { VisualPromptComponents } from '@/lib/ai/scene-analysis.schema';
+import type { Database } from '@/lib/db/client';
+import { framePromptVersions, frames, user } from '@/lib/db/schema';
+import type { FramePromptVersion } from '@/lib/db/schema';
+import { and, desc, eq, isNotNull } from 'drizzle-orm';
+import { buildEventInsert } from './sequence-events';
+
+type WriteFramePromptVersionBase = {
+  frameId: string;
+  text: string;
+  components?: VisualPromptComponents | null;
+  createdBy?: string | null;
+};
+
+/**
+ * `inputHash` is the upstream context (scene + style + narrowed bibles +
+ * aspectRatio + analysisModel) the prompt aligns with. AI / regenerated rows
+ * must carry a real hash + analysis model so the cached
+ * `visual_prompt_input_hash` keeps staleness detection alive; user-edits and
+ * restores may carry null when context was uncomputable. Restores carry the
+ * source version's hash + model verbatim so restoring an old AI prompt does
+ * not silently disable staleness.
+ */
+export type WriteFramePromptVersionInput = WriteFramePromptVersionBase &
+  (
+    | {
+        source: 'ai-generated' | 'regenerated';
+        inputHash: string;
+        analysisModel: string;
+      }
+    | {
+        source: 'user-edit';
+        inputHash: string | null;
+        analysisModel: string | null;
+      }
+    | {
+        source: 'restored';
+        inputHash: string | null;
+        analysisModel: string | null;
+      }
+  );
+
+export function createFramePromptVersionsMethods(db: Database) {
+  /** Point the frame at `version` and mirror its text/hash onto the frame. */
+  const mirrorOntoFrame = (frameId: string, version: FramePromptVersion) =>
+    db
+      .update(frames)
+      .set({
+        imagePrompt: version.text,
+        visualPromptInputHash: version.inputHash,
+        selectedImagePromptVersionId: version.id,
+        updatedAt: new Date(),
+      })
+      .where(eq(frames.id, frameId));
+
+  return {
+    /**
+     * Append a prompt version and mirror it onto the frame (text, hash, and
+     * the selected-pointer). Returns the inserted (or pre-existing matching)
+     * row. See the module docstring for the dedupe / force-regen contract.
+     */
+    write: async (
+      input: WriteFramePromptVersionInput
+    ): Promise<FramePromptVersion> => {
+      const nextHash = input.inputHash;
+      const analysisModel = input.analysisModel;
+
+      const [inserted] = await db
+        .insert(framePromptVersions)
+        .values({
+          frameId: input.frameId,
+          text: input.text,
+          components: input.components,
+          source: input.source,
+          inputHash: nextHash,
+          analysisModel,
+          createdBy: input.createdBy ?? null,
+        })
+        .onConflictDoNothing()
+        .returning();
+
+      let version: FramePromptVersion | undefined = inserted;
+      if (!version && nextHash !== null) {
+        const [existing] = await db
+          .select()
+          .from(framePromptVersions)
+          .where(
+            and(
+              eq(framePromptVersions.frameId, input.frameId),
+              eq(framePromptVersions.inputHash, nextHash)
+            )
+          )
+          .limit(1);
+
+        if (
+          existing &&
+          existing.text !== input.text &&
+          (input.source === 'ai-generated' || input.source === 'regenerated')
+        ) {
+          // Force-regen: same upstream hash, fresh completion. Bypass the
+          // partial unique index with a null input_hash so the new text is
+          // recorded; the cached hash below still tracks the real context.
+          const [forced] = await db
+            .insert(framePromptVersions)
+            .values({
+              frameId: input.frameId,
+              text: input.text,
+              components: input.components,
+              source: input.source,
+              inputHash: null,
+              analysisModel,
+              createdBy: input.createdBy ?? null,
+            })
+            .returning();
+          version = forced;
+        } else {
+          version = existing;
+        }
+      }
+
+      if (!version) {
+        throw new Error('Failed to insert frame prompt version');
+      }
+
+      await db
+        .update(frames)
+        .set({
+          imagePrompt: input.text,
+          visualPromptInputHash: nextHash,
+          selectedImagePromptVersionId: version.id,
+          updatedAt: new Date(),
+        })
+        .where(eq(frames.id, input.frameId));
+
+      return version;
+    },
+
+    /**
+     * Repoint the frame at an existing prompt version (a restore) and mirror
+     * it onto the frame, committing the change and a `prompt.selected` event
+     * in one batch. Returns the selected version.
+     */
+    select: async (
+      frameId: string,
+      versionId: string,
+      opts: { actorId: string | null }
+    ): Promise<FramePromptVersion> => {
+      const [version] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.id, versionId),
+            eq(framePromptVersions.frameId, frameId)
+          )
+        );
+      if (!version) {
+        throw new Error(
+          `FramePromptVersion ${versionId} not found for frame ${frameId}`
+        );
+      }
+      const [frame] = await db
+        .select({
+          sequenceId: frames.sequenceId,
+          prev: frames.selectedImagePromptVersionId,
+        })
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      if (!frame) {
+        throw new Error(`Frame ${frameId} not found`);
+      }
+
+      await db.batch([
+        mirrorOntoFrame(frameId, version),
+        buildEventInsert(db, {
+          sequenceId: frame.sequenceId,
+          actorId: opts.actorId,
+          kind: 'prompt.selected',
+          targetType: 'frame',
+          targetId: frameId,
+          summary: 'Restored image prompt',
+          data: { versionId, prevVersionId: frame.prev ?? null },
+        }),
+      ]);
+      return version;
+    },
+
+    /** Revision history for a frame's image prompt, newest first. */
+    listByFrame: async (frameId: string): Promise<FramePromptVersion[]> => {
+      return await db
+        .select()
+        .from(framePromptVersions)
+        .where(eq(framePromptVersions.frameId, frameId))
+        .orderBy(desc(framePromptVersions.createdAt));
+    },
+
+    /** History list for the UI — joins author name. Newest first. */
+    listByFrameWithAuthor: async (
+      frameId: string
+    ): Promise<
+      Array<FramePromptVersion & { createdByName: string | null }>
+    > => {
+      const rows = await db
+        .select({ version: framePromptVersions, createdByName: user.name })
+        .from(framePromptVersions)
+        .leftJoin(user, eq(framePromptVersions.createdBy, user.id))
+        .where(eq(framePromptVersions.frameId, frameId))
+        .orderBy(desc(framePromptVersions.createdAt));
+      return rows.map((r) => ({
+        ...r.version,
+        createdByName: r.createdByName,
+      }));
+    },
+
+    /** Fetch a single version scoped to its frame. */
+    getByIdForFrame: async (
+      versionId: string,
+      frameId: string
+    ): Promise<FramePromptVersion | null> => {
+      const [row] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.id, versionId),
+            eq(framePromptVersions.frameId, frameId)
+          )
+        )
+        .limit(1);
+      return row ?? null;
+    },
+
+    /** Most recent version, or null. */
+    getLatest: async (frameId: string): Promise<FramePromptVersion | null> => {
+      const [row] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(eq(framePromptVersions.frameId, frameId))
+        .orderBy(desc(framePromptVersions.createdAt))
+        .limit(1);
+      return row ?? null;
+    },
+
+    /**
+     * Most recent version with a non-null `inputHash` — the staleness path's
+     * reference for frames whose cached hash was nulled by a context-less
+     * user-edit. Mirrors `shotPromptVersions.getLatestWithInputHash`.
+     */
+    getLatestWithInputHash: async (
+      frameId: string
+    ): Promise<FramePromptVersion | null> => {
+      const [row] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.frameId, frameId),
+            isNotNull(framePromptVersions.inputHash)
+          )
+        )
+        .orderBy(desc(framePromptVersions.createdAt))
+        .limit(1);
+      return row ?? null;
+    },
+  };
+}

--- a/src/lib/db/scoped/frame-prompt-versions.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.ts
@@ -111,14 +111,14 @@ export function createFramePromptVersionsMethods(db: Database) {
           )
           .limit(1);
 
-        if (
-          existing &&
-          existing.text !== input.text &&
-          (input.source === 'ai-generated' || input.source === 'regenerated')
-        ) {
-          // Force-regen: same upstream hash, fresh completion. Bypass the
-          // partial unique index with a null input_hash so the new text is
-          // recorded; the cached hash below still tracks the real context.
+        if (existing && existing.text !== input.text) {
+          // Same upstream hash, genuinely new text. Two ways to get here: a
+          // force-regen (AI runs against unchanged inputs) or a user-edit whose
+          // live hash matches the row it edits. Either way the new text must
+          // land in history, so bypass the partial unique index with a null
+          // input_hash; the cached hash below still tracks the real context.
+          // (`restored` rows never reach this branch — the index excludes them,
+          // so their insert never conflicts.)
           const [forced] = await db
             .insert(framePromptVersions)
             .values({

--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Acceptance tests for the frame-variants helper (flat, append-only image
+ * versions + pointer selection). In-memory libSQL with the real migrations.
+ *
+ * Covers the core of the redesign: `select` repoints the frame's primary still
+ * by mirroring a version's image fields and appending an `image.selected` event
+ * atomically (one `db.batch`), the completed-only selection guard, the
+ * cross-frame ownership guard, discard/undiscard, listByGroup source matching,
+ * and isStale null-hash semantics.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import {
+  frameVariants,
+  frames,
+  sequenceEvents,
+  sequences,
+  shots,
+  styles,
+  teams,
+  user,
+} from '@/lib/db/schema';
+import type { NewFrameVariant } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createFrameVariantsMethods } from './frame-variants';
+
+let client: Client;
+let db: Database;
+let sequenceId = '';
+let shotId = '';
+let frameId = '';
+
+async function seed() {
+  await db.delete(sequenceEvents);
+  await db.delete(frameVariants);
+  await db.delete(frames);
+  await db.delete(shots);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await db.delete(user);
+
+  const teamId = generateId();
+  sequenceId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db
+    .insert(sequences)
+    .values({ id: sequenceId, teamId, title: 'S', styleId: style.id });
+  const [shot] = await db
+    .insert(shots)
+    .values({ sequenceId, orderIndex: 0 })
+    .returning();
+  if (!shot) throw new Error('test setup: shot insert returned nothing');
+  shotId = shot.id;
+  const [frame] = await db
+    .insert(frames)
+    .values({ shotId, sequenceId, orderIndex: 0, role: 'first' })
+    .returning();
+  if (!frame) throw new Error('test setup: frame insert returned nothing');
+  frameId = frame.id;
+}
+
+function variantInput(
+  overrides: Partial<NewFrameVariant> = {}
+): NewFrameVariant {
+  return {
+    frameId,
+    sequenceId,
+    kind: 'model',
+    model: 'nano_banana_2',
+    status: 'completed',
+    url: 'https://cdn/img.png',
+    storagePath: 'r2/img.png',
+    previewUrl: 'https://cdn/preview.png',
+    generatedAt: new Date('2026-06-26T00:00:00Z'),
+    inputHash: 'hash-1',
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('frameVariants.appendVersion', () => {
+  it('appends accumulating rows even for matching inputs (re-roll)', async () => {
+    const m = createFrameVariantsMethods(db);
+    const a = await m.appendVersion(variantInput());
+    const b = await m.appendVersion(variantInput());
+    expect(a.id).not.toBe(b.id);
+    expect(await m.listByFrame(frameId)).toHaveLength(2);
+  });
+});
+
+describe('frameVariants.select', () => {
+  it('mirrors the version onto the frame and appends an atomic image.selected event', async () => {
+    const m = createFrameVariantsMethods(db);
+    const v1 = await m.appendVersion(variantInput({ model: 'm1' }));
+    const v2 = await m.appendVersion(
+      variantInput({
+        model: 'm2',
+        url: 'https://cdn/v2.png',
+        storagePath: 'r2/v2.png',
+        previewUrl: 'https://cdn/v2-preview.png',
+        inputHash: 'hash-2',
+      })
+    );
+    const actorId = generateId();
+    await db.insert(user).values({ id: actorId, name: 'U', email: 'u@e.com' });
+
+    // Select v1 first so v2 select has a non-null prev pointer.
+    await m.select(frameId, v1.id, { actorId: null });
+    await m.select(frameId, v2.id, { actorId });
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.selectedImageVersionId).toBe(v2.id);
+    expect(frame.imageUrl).toBe('https://cdn/v2.png');
+    expect(frame.imagePath).toBe('r2/v2.png');
+    expect(frame.previewImageUrl).toBe('https://cdn/v2-preview.png');
+    expect(frame.imageStatus).toBe('completed');
+    expect(frame.imageModel).toBe('m2');
+    expect(frame.imageInputHash).toBe('hash-2');
+
+    const events = await db
+      .select()
+      .from(sequenceEvents)
+      .where(eq(sequenceEvents.kind, 'image.selected'));
+    expect(events).toHaveLength(2);
+    const latest = events.find((e) => e.actorId === actorId);
+    if (!latest) throw new Error('expected actor event');
+    expect(latest.targetId).toBe(frameId);
+    expect(latest.data).toMatchObject({
+      versionId: v2.id,
+      model: 'm2',
+      prevVersionId: v1.id,
+    });
+  });
+
+  it('refuses to select a non-completed version (would blank the frame)', async () => {
+    const m = createFrameVariantsMethods(db);
+    const pending = await m.appendVersion(
+      variantInput({ status: 'pending', url: null })
+    );
+    await expect(
+      m.select(frameId, pending.id, { actorId: null })
+    ).rejects.toThrow(/not 'completed'/);
+
+    // The frame's pointer was never touched.
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.selectedImageVersionId).toBeNull();
+    // And no event leaked out of the rejected batch.
+    expect(
+      await db
+        .select()
+        .from(sequenceEvents)
+        .where(eq(sequenceEvents.sequenceId, sequenceId))
+    ).toHaveLength(0);
+  });
+
+  it('throws for a version that belongs to another frame (cross-frame guard)', async () => {
+    const m = createFrameVariantsMethods(db);
+    const [sibling] = await db
+      .insert(frames)
+      .values({ shotId, sequenceId, orderIndex: 1, role: 'last' })
+      .returning();
+    if (!sibling) throw new Error('test setup: sibling frame missing');
+    const siblingVersion = await m.appendVersion(
+      variantInput({ frameId: sibling.id })
+    );
+    await expect(
+      m.select(frameId, siblingVersion.id, { actorId: null })
+    ).rejects.toThrow(/not found for frame/);
+  });
+});
+
+describe('frameVariants.discard / undiscard', () => {
+  it('soft-hides then restores a version, with matching events, in atomic batches', async () => {
+    const m = createFrameVariantsMethods(db);
+    const v = await m.appendVersion(variantInput());
+
+    const discardedAt = await m.discard(v.id, { actorId: null });
+    expect(discardedAt).toBeInstanceOf(Date);
+    expect(await m.listByFrame(frameId)).toHaveLength(0);
+    expect(
+      await m.listByFrame(frameId, { includeDiscarded: true })
+    ).toHaveLength(1);
+
+    await m.undiscard(v.id, { actorId: null });
+    expect(await m.listByFrame(frameId)).toHaveLength(1);
+
+    const kinds = (
+      await db
+        .select()
+        .from(sequenceEvents)
+        .where(eq(sequenceEvents.targetId, v.id))
+    ).map((e) => e.kind);
+    expect(kinds).toContain('image.discarded');
+    expect(kinds).toContain('image.undiscarded');
+  });
+});
+
+describe('frameVariants.listByGroup', () => {
+  it('matches null sourceVariantId explicitly so model groups do not collide with framing picks', async () => {
+    const m = createFrameVariantsMethods(db);
+    const modelVersion = await m.appendVersion(
+      variantInput({ kind: 'model', model: 'm1' })
+    );
+    await m.appendVersion(
+      variantInput({
+        kind: 'framing',
+        model: 'm1',
+        sourceVariantId: modelVersion.id,
+      })
+    );
+
+    const modelGroup = await m.listByGroup({
+      frameId,
+      kind: 'model',
+      model: 'm1',
+    });
+    expect(modelGroup).toHaveLength(1);
+    expect(modelGroup[0]?.id).toBe(modelVersion.id);
+
+    const framingGroup = await m.listByGroup({
+      frameId,
+      kind: 'framing',
+      model: 'm1',
+      sourceVariantId: modelVersion.id,
+    });
+    expect(framingGroup).toHaveLength(1);
+    expect(framingGroup[0]?.kind).toBe('framing');
+  });
+});
+
+describe('frameVariants.isStale', () => {
+  it('throws when the version does not exist', () => {
+    const m = createFrameVariantsMethods(db);
+    expect(m.isStale(generateId(), 'h')).rejects.toThrow(/not found/);
+  });
+
+  it('null stored hash → not stale; match → not stale; differ → stale', async () => {
+    const m = createFrameVariantsMethods(db);
+    const noHash = await m.appendVersion(variantInput({ inputHash: null }));
+    expect(await m.isStale(noHash.id, 'anything')).toBe(false);
+
+    const hashed = await m.appendVersion(
+      variantInput({ inputHash: 'h-match' })
+    );
+    expect(await m.isStale(hashed.id, 'h-match')).toBe(false);
+    expect(await m.isStale(hashed.id, 'h-new')).toBe(true);
+  });
+});

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -1,0 +1,299 @@
+/**
+ * Scoped Frame Variants Sub-module (flat, append-only image versions).
+ *
+ * Each row is ONE image generation — a *version*. A "variant" is the emergent
+ * group of rows sharing `(frameId, kind, model, sourceVariantId)`; its
+ * "versions" are those rows ordered by time (ULID). Re-rolls **accumulate** —
+ * append never overwrites, so a video render manifest can reference a version
+ * id as a stable snapshot.
+ *
+ * **Selection is a pointer, not a per-row flag.** The frame's current image is
+ * whichever version `frames.selectedImageVersionId` points at; revert /
+ * switch-model is a {@link select} repoint. `discardedAt` soft-hides a version
+ * (undoable); there is no `divergedAt` (retired in the redesign).
+ *
+ * Every selection / discard repoint commits its frame-state change and its
+ * `sequence_events` row in the SAME `db.batch()` (see {@link buildEventInsert}),
+ * so the change and its activity entry are atomic.
+ *
+ * See docs/architecture/scene-shot-frame-redesign.md.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { frameVariants, frames } from '@/lib/db/schema';
+import type { FrameVariant, NewFrameVariant } from '@/lib/db/schema';
+import type { FrameVariantKind } from '@/lib/db/schema/frame-variants';
+import { and, asc, eq, isNull } from 'drizzle-orm';
+import { buildFrameImageMirror } from './frames';
+import { buildEventInsert } from './sequence-events';
+
+/** The grouping key that makes a flat row set read as a "variant". */
+type VariantGroup = {
+  frameId: string;
+  kind: FrameVariantKind;
+  model: string;
+  /** Only for `kind: 'framing'` rows — the model image the 3×3 came from. */
+  sourceVariantId?: string | null;
+};
+
+export function createFrameVariantsMethods(db: Database) {
+  return {
+    getById: async (versionId: string): Promise<FrameVariant | null> => {
+      const result = await db
+        .select()
+        .from(frameVariants)
+        .where(eq(frameVariants.id, versionId));
+      return result[0] ?? null;
+    },
+
+    /**
+     * Append a new version row. Pure append — even when the inputs match an
+     * existing version (a deliberate re-roll), a fresh row is created so the
+     * history accumulates. Idempotency for workflow retries is the caller's
+     * concern (Phase 2), not enforced here.
+     */
+    appendVersion: async (data: NewFrameVariant): Promise<FrameVariant> => {
+      const [version] = await db.insert(frameVariants).values(data).returning();
+      if (!version) {
+        throw new Error(
+          `Failed to append frame variant for frame ${data.frameId}`
+        );
+      }
+      return version;
+    },
+
+    /** Update generation tracking on an in-flight version (status/url/error/…). */
+    update: async (
+      versionId: string,
+      data: Partial<NewFrameVariant>
+    ): Promise<FrameVariant> => {
+      const [version] = await db
+        .update(frameVariants)
+        .set({ ...data, updatedAt: new Date() })
+        .where(eq(frameVariants.id, versionId))
+        .returning();
+      if (!version) {
+        throw new Error(`FrameVariant ${versionId} not found`);
+      }
+      return version;
+    },
+
+    /**
+     * The versions of one variant group, oldest-first so a per-model ordinal
+     * label ("v1, v2, …") derives from position. Discarded rows are excluded
+     * unless `includeDiscarded`.
+     */
+    listByGroup: async (
+      group: VariantGroup,
+      options?: { includeDiscarded?: boolean }
+    ): Promise<FrameVariant[]> => {
+      const conditions = [
+        eq(frameVariants.frameId, group.frameId),
+        eq(frameVariants.kind, group.kind),
+        eq(frameVariants.model, group.model),
+      ];
+      // sourceVariantId distinguishes framing groups; match null explicitly so
+      // model groups (null source) don't collide with framing picks.
+      conditions.push(
+        group.sourceVariantId == null
+          ? isNull(frameVariants.sourceVariantId)
+          : eq(frameVariants.sourceVariantId, group.sourceVariantId)
+      );
+      if (!options?.includeDiscarded) {
+        conditions.push(isNull(frameVariants.discardedAt));
+      }
+      return await db
+        .select()
+        .from(frameVariants)
+        .where(and(...conditions))
+        .orderBy(asc(frameVariants.id));
+    },
+
+    /** All versions for a frame, oldest-first. Excludes discarded by default. */
+    listByFrame: async (
+      frameId: string,
+      options?: { includeDiscarded?: boolean }
+    ): Promise<FrameVariant[]> => {
+      const conditions = [eq(frameVariants.frameId, frameId)];
+      if (!options?.includeDiscarded) {
+        conditions.push(isNull(frameVariants.discardedAt));
+      }
+      return await db
+        .select()
+        .from(frameVariants)
+        .where(and(...conditions))
+        .orderBy(asc(frameVariants.id));
+    },
+
+    /** The version the frame currently points at, or null if unset/dangling. */
+    getSelected: async (frameId: string): Promise<FrameVariant | null> => {
+      const [frame] = await db
+        .select({ selected: frames.selectedImageVersionId })
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      if (!frame?.selected) return null;
+      const [version] = await db
+        .select()
+        .from(frameVariants)
+        .where(eq(frameVariants.id, frame.selected));
+      return version ?? null;
+    },
+
+    /**
+     * Repoint the frame's selection at `versionId`: set
+     * `frames.selectedImageVersionId`, mirror the version's image fields onto
+     * the frame, and append an `image.selected` activity event — all in one
+     * `db.batch()` so the pointer move and its event are atomic. The event's
+     * `data` carries the previous pointer so the change is undoable. Returns
+     * the selected version.
+     */
+    select: async (
+      frameId: string,
+      versionId: string,
+      opts: { actorId: string | null }
+    ): Promise<FrameVariant> => {
+      const [version] = await db
+        .select()
+        .from(frameVariants)
+        .where(
+          and(
+            eq(frameVariants.id, versionId),
+            eq(frameVariants.frameId, frameId)
+          )
+        );
+      if (!version) {
+        throw new Error(
+          `FrameVariant ${versionId} not found for frame ${frameId}`
+        );
+      }
+      const [frame] = await db
+        .select({
+          sequenceId: frames.sequenceId,
+          prev: frames.selectedImageVersionId,
+        })
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      if (!frame) {
+        throw new Error(`Frame ${frameId} not found`);
+      }
+
+      await db.batch([
+        buildFrameImageMirror(db, frameId, version),
+        buildEventInsert(db, {
+          sequenceId: frame.sequenceId,
+          actorId: opts.actorId,
+          kind: 'image.selected',
+          targetType: 'frame',
+          targetId: frameId,
+          summary: `Selected ${version.model} image`,
+          data: {
+            versionId,
+            model: version.model,
+            prevVersionId: frame.prev ?? null,
+          },
+        }),
+      ]);
+      return version;
+    },
+
+    /**
+     * Soft-hide a version (undoable). Commits the `discardedAt` write and an
+     * `image.discarded` event in one batch. Returns the timestamp for an Undo.
+     */
+    discard: async (
+      versionId: string,
+      opts: { actorId: string | null }
+    ): Promise<Date> => {
+      const [version] = await db
+        .select({ sequenceId: frameVariants.sequenceId })
+        .from(frameVariants)
+        .where(eq(frameVariants.id, versionId));
+      if (!version) {
+        throw new Error(`FrameVariant ${versionId} not found`);
+      }
+      const discardedAt = new Date();
+      await db.batch([
+        db
+          .update(frameVariants)
+          .set({ discardedAt, updatedAt: discardedAt })
+          .where(eq(frameVariants.id, versionId)),
+        buildEventInsert(db, {
+          sequenceId: version.sequenceId,
+          actorId: opts.actorId,
+          kind: 'image.discarded',
+          targetType: 'variant',
+          targetId: versionId,
+          data: { versionId },
+        }),
+      ]);
+      return discardedAt;
+    },
+
+    /** Undo a discard (clears `discardedAt`), with a matching event. */
+    undiscard: async (
+      versionId: string,
+      opts: { actorId: string | null }
+    ): Promise<void> => {
+      const [version] = await db
+        .select({ sequenceId: frameVariants.sequenceId })
+        .from(frameVariants)
+        .where(eq(frameVariants.id, versionId));
+      if (!version) {
+        throw new Error(`FrameVariant ${versionId} not found`);
+      }
+      const now = new Date();
+      await db.batch([
+        db
+          .update(frameVariants)
+          .set({ discardedAt: null, updatedAt: now })
+          .where(eq(frameVariants.id, versionId)),
+        buildEventInsert(db, {
+          sequenceId: version.sequenceId,
+          actorId: opts.actorId,
+          kind: 'image.undiscarded',
+          targetType: 'variant',
+          targetId: versionId,
+          data: { versionId },
+        }),
+      ]);
+    },
+
+    /**
+     * Staleness of a single version: stored `inputHash` vs a fresh hash. Null
+     * stored hash (legacy / in-flight) is "unknown, not stale". Throws when the
+     * version is missing. Mirrors `shotVariants.isStale`.
+     */
+    isStale: async (
+      versionId: string,
+      currentHash: string
+    ): Promise<boolean> => {
+      const result = await db
+        .select({ hash: frameVariants.inputHash })
+        .from(frameVariants)
+        .where(eq(frameVariants.id, versionId));
+      const row = result[0];
+      if (!row) {
+        throw new Error(`FrameVariant ${versionId} not found`);
+      }
+      const stored = row.hash;
+      if (stored === null) return false;
+      return currentHash !== stored;
+    },
+
+    deleteByFrame: async (frameId: string): Promise<number> => {
+      const result = await db
+        .delete(frameVariants)
+        .where(eq(frameVariants.frameId, frameId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return result.rowsAffected ?? 0;
+    },
+
+    deleteBySequence: async (sequenceId: string): Promise<number> => {
+      const result = await db
+        .delete(frameVariants)
+        .where(eq(frameVariants.sequenceId, sequenceId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return result.rowsAffected ?? 0;
+    },
+  };
+}

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -12,9 +12,10 @@
  * switch-model is a {@link select} repoint. `discardedAt` soft-hides a version
  * (undoable); there is no `divergedAt` (retired in the redesign).
  *
- * Every selection / discard repoint commits its frame-state change and its
- * `sequence_events` row in the SAME `db.batch()` (see {@link buildEventInsert}),
- * so the change and its activity entry are atomic.
+ * Every mutation commits its state change (the frame mirror for {@link select},
+ * the `discardedAt` write for discard / undiscard) and its `sequence_events`
+ * row in the SAME `db.batch()` (see {@link buildEventInsert}), so the change and
+ * its activity entry are atomic.
  *
  * See docs/architecture/scene-shot-frame-redesign.md.
  */
@@ -164,6 +165,14 @@ export function createFrameVariantsMethods(db: Database) {
       if (!version) {
         throw new Error(
           `FrameVariant ${versionId} not found for frame ${frameId}`
+        );
+      }
+      // Only a finished image may become the frame's primary still. Selecting a
+      // pending/failed version would mirror its null url + failed status onto
+      // the frame, silently blanking a good image.
+      if (version.status !== 'completed') {
+        throw new Error(
+          `FrameVariant ${versionId} is '${version.status}', not 'completed' — cannot select an unfinished image`
         );
       }
       const [frame] = await db

--- a/src/lib/db/scoped/frames.test.ts
+++ b/src/lib/db/scoped/frames.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Acceptance tests for the frames helper. In-memory libSQL with the real
+ * migrations. Covers upsert idempotency (workflow-replay safety), isStale
+ * null-hash semantics, resolveCurrent, and that the generic `update` path does
+ * not move the selection pointer / mirror columns (drift prevention — those
+ * live on `frameVariants.select` / `framePromptVersions`).
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import {
+  frameVariants,
+  frames,
+  sequences,
+  shots,
+  styles,
+  teams,
+  user,
+} from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createFramesMethods } from './frames';
+
+let client: Client;
+let db: Database;
+let sequenceId = '';
+let shotId = '';
+
+async function seed() {
+  await db.delete(frameVariants);
+  await db.delete(frames);
+  await db.delete(shots);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await db.delete(user);
+
+  const teamId = generateId();
+  sequenceId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db
+    .insert(sequences)
+    .values({ id: sequenceId, teamId, title: 'S', styleId: style.id });
+  const [shot] = await db
+    .insert(shots)
+    .values({ sequenceId, orderIndex: 0 })
+    .returning();
+  if (!shot) throw new Error('test setup: shot insert returned nothing');
+  shotId = shot.id;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('frames.upsert', () => {
+  it('is idempotent on (shotId, orderIndex) — a replay updates in place', async () => {
+    const m = createFramesMethods(db);
+    const first = await m.upsert({
+      shotId,
+      sequenceId,
+      orderIndex: 0,
+      role: 'first',
+    });
+    const replay = await m.upsert({
+      shotId,
+      sequenceId,
+      orderIndex: 0,
+      role: 'first',
+    });
+    expect(replay.id).toBe(first.id);
+    expect(await m.listByShot(shotId)).toHaveLength(1);
+  });
+});
+
+describe('frames.update', () => {
+  it('updates non-mirror fields without disturbing the selection pointer', async () => {
+    const m = createFramesMethods(db);
+    const frame = await m.create({
+      shotId,
+      sequenceId,
+      orderIndex: 0,
+      role: 'first',
+    });
+    // Seed a pointer + mirror as the select path would.
+    await db
+      .update(frames)
+      .set({
+        selectedImageVersionId: 'ver-1',
+        imageUrl: 'https://cdn/keep.png',
+        imageInputHash: 'keep-hash',
+      })
+      .where(eq(frames.id, frame.id));
+
+    await m.update(frame.id, { orderIndex: 2, role: 'key' });
+
+    const [refreshed] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frame.id));
+    if (!refreshed) throw new Error('test setup: refresh failed');
+    expect(refreshed.orderIndex).toBe(2);
+    expect(refreshed.role).toBe('key');
+    // Mirror columns untouched.
+    expect(refreshed.selectedImageVersionId).toBe('ver-1');
+    expect(refreshed.imageUrl).toBe('https://cdn/keep.png');
+    expect(refreshed.imageInputHash).toBe('keep-hash');
+  });
+
+  it('throws on a missing frame by default, returns undefined when opted out', async () => {
+    const m = createFramesMethods(db);
+    await expect(m.update(generateId(), { orderIndex: 1 })).rejects.toThrow(
+      /not found/
+    );
+    expect(
+      await m.update(generateId(), { orderIndex: 1 }, { throwOnMissing: false })
+    ).toBeUndefined();
+  });
+});
+
+describe('frames.resolveCurrent', () => {
+  it('returns the frame with a null selectedVersion when unselected', async () => {
+    const m = createFramesMethods(db);
+    const frame = await m.create({
+      shotId,
+      sequenceId,
+      orderIndex: 0,
+      role: 'first',
+    });
+    const resolved = await m.resolveCurrent(frame.id);
+    expect(resolved?.frame.id).toBe(frame.id);
+    expect(resolved?.selectedVersion).toBeNull();
+  });
+
+  it('returns null for a missing frame', async () => {
+    const m = createFramesMethods(db);
+    expect(await m.resolveCurrent(generateId())).toBeNull();
+  });
+
+  it('resolves the pointed-at version', async () => {
+    const m = createFramesMethods(db);
+    const frame = await m.create({
+      shotId,
+      sequenceId,
+      orderIndex: 0,
+      role: 'first',
+    });
+    const [version] = await db
+      .insert(frameVariants)
+      .values({
+        frameId: frame.id,
+        sequenceId,
+        kind: 'model',
+        model: 'm1',
+        status: 'completed',
+      })
+      .returning();
+    if (!version)
+      throw new Error('test setup: version insert returned nothing');
+    await db
+      .update(frames)
+      .set({ selectedImageVersionId: version.id })
+      .where(eq(frames.id, frame.id));
+
+    const resolved = await m.resolveCurrent(frame.id);
+    expect(resolved?.selectedVersion?.id).toBe(version.id);
+  });
+});
+
+describe('frames.isStale', () => {
+  it('throws when the frame does not exist', () => {
+    const m = createFramesMethods(db);
+    expect(m.isStale(generateId(), 'h')).rejects.toThrow(/not found/);
+  });
+
+  it('null stored hash → not stale; match → not stale; differ → stale', async () => {
+    const m = createFramesMethods(db);
+    const a = await m.create({ shotId, sequenceId, orderIndex: 0 });
+    expect(await m.isStale(a.id, 'anything')).toBe(false);
+
+    await db
+      .update(frames)
+      .set({ imageInputHash: 'h-match' })
+      .where(eq(frames.id, a.id));
+    expect(await m.isStale(a.id, 'h-match')).toBe(false);
+    expect(await m.isStale(a.id, 'h-new')).toBe(true);
+  });
+});

--- a/src/lib/db/scoped/frames.ts
+++ b/src/lib/db/scoped/frames.ts
@@ -1,0 +1,214 @@
+/**
+ * Scoped Frames Sub-module
+ *
+ * A frame is the IMAGE unit — one still keyframe within a shot (1 frame = 1
+ * image). A shot owns 1..N frames (role first|last|key). The frame's primary
+ * still is a cached MIRROR of whichever `frame_variants` version
+ * `frames.selectedImageVersionId` points at; the model alternates live in
+ * `frame_variants` and the visual-prompt history in `frame_prompt_versions`.
+ *
+ * The mirror columns (`imageUrl`, `imagePath`, …) are written here via
+ * {@link buildFrameImageMirror} so the "which columns mirror a selected
+ * version" knowledge lives with the frame; `frame_variants.select` composes
+ * that statement into its repoint batch.
+ *
+ * See docs/architecture/scene-shot-frame-redesign.md.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { frameVariants, frames } from '@/lib/db/schema';
+import type { Frame, FrameVariant, NewFrame } from '@/lib/db/schema';
+import { asc, desc, eq, inArray } from 'drizzle-orm';
+
+/** A frame plus the `frame_variants` version it currently points at (if any). */
+export type ResolvedFrame = {
+  frame: Frame;
+  selectedVersion: FrameVariant | null;
+};
+
+/**
+ * Build (without executing) the UPDATE that mirrors a selected version's image
+ * fields onto its frame, so a caller can compose it into the same `db.batch()`
+ * as the selection-pointer write and the activity event. Returns the drizzle
+ * statement; the caller owns execution.
+ *
+ * Mirrors the output fields only — `role` / `source` / `orderIndex` are frame
+ * identity and never change on a selection repoint.
+ */
+export function buildFrameImageMirror(
+  db: Database,
+  frameId: string,
+  version: FrameVariant
+) {
+  return db
+    .update(frames)
+    .set({
+      selectedImageVersionId: version.id,
+      imageUrl: version.url,
+      imagePath: version.storagePath,
+      previewImageUrl: version.previewUrl,
+      imageStatus: version.status,
+      imageGeneratedAt: version.generatedAt,
+      imageError: version.error,
+      imageModel: version.model,
+      imageInputHash: version.inputHash,
+      updatedAt: new Date(),
+    })
+    .where(eq(frames.id, frameId));
+}
+
+type FrameOrderBy = 'orderIndex' | 'createdAt' | 'updatedAt';
+
+export function createFramesMethods(db: Database) {
+  return {
+    getById: async (frameId: string): Promise<Frame | null> => {
+      const result = await db
+        .select()
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      return result[0] ?? null;
+    },
+
+    getByIds: async (frameIds: string[]): Promise<Frame[]> => {
+      if (frameIds.length === 0) return [];
+      return await db.select().from(frames).where(inArray(frames.id, frameIds));
+    },
+
+    /** Frames of a shot, ordered (0 = first/anchor by default). */
+    listByShot: async (shotId: string): Promise<Frame[]> => {
+      return await db
+        .select()
+        .from(frames)
+        .where(eq(frames.shotId, shotId))
+        .orderBy(asc(frames.orderIndex));
+    },
+
+    listBySequence: async (
+      sequenceId: string,
+      options?: { orderBy?: FrameOrderBy; ascending?: boolean }
+    ): Promise<Frame[]> => {
+      const { orderBy = 'createdAt', ascending = true } = options ?? {};
+      const orderColumn =
+        orderBy === 'orderIndex'
+          ? frames.orderIndex
+          : orderBy === 'updatedAt'
+            ? frames.updatedAt
+            : frames.createdAt;
+      const orderFn = ascending ? asc : desc;
+      return await db
+        .select()
+        .from(frames)
+        .where(eq(frames.sequenceId, sequenceId))
+        .orderBy(orderFn(orderColumn));
+    },
+
+    create: async (data: NewFrame): Promise<Frame> => {
+      const [frame] = await db.insert(frames).values(data).returning();
+      if (!frame) {
+        throw new Error(`Failed to create frame for shot ${data.shotId}`);
+      }
+      return frame;
+    },
+
+    /**
+     * Idempotent insert keyed on the `(shot_id, order_index)` unique index —
+     * a replay re-deriving the same frame slot updates in place rather than
+     * colliding. Identity columns (role/source) and the image mirror are left
+     * to dedicated paths.
+     */
+    upsert: async (data: NewFrame): Promise<Frame> => {
+      const [frame] = await db
+        .insert(frames)
+        .values(data)
+        .onConflictDoUpdate({
+          target: [frames.shotId, frames.orderIndex],
+          set: { role: data.role, updatedAt: new Date() },
+        })
+        .returning();
+      if (!frame) {
+        throw new Error(
+          `Failed to upsert frame for shot ${data.shotId} at orderIndex ${data.orderIndex}`
+        );
+      }
+      return frame;
+    },
+
+    update: async (
+      frameId: string,
+      data: Partial<NewFrame>,
+      options?: { throwOnMissing?: boolean }
+    ): Promise<Frame | undefined> => {
+      const [frame] = await db
+        .update(frames)
+        .set({ ...data, updatedAt: new Date() })
+        .where(eq(frames.id, frameId))
+        .returning();
+      if (!frame && options?.throwOnMissing !== false) {
+        throw new Error(`Frame ${frameId} not found`);
+      }
+      return frame;
+    },
+
+    delete: async (frameId: string): Promise<boolean> => {
+      const result = await db.delete(frames).where(eq(frames.id, frameId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return (result.rowsAffected ?? 0) > 0;
+    },
+
+    deleteByShot: async (shotId: string): Promise<number> => {
+      const result = await db.delete(frames).where(eq(frames.shotId, shotId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return result.rowsAffected ?? 0;
+    },
+
+    deleteBySequence: async (sequenceId: string): Promise<number> => {
+      const result = await db
+        .delete(frames)
+        .where(eq(frames.sequenceId, sequenceId));
+      // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- DB result may be undefined at runtime
+      return result.rowsAffected ?? 0;
+    },
+
+    /**
+     * The frame plus its currently-selected image version. After a select the
+     * frame's mirror columns already equal the version's, so reads can use
+     * either; this exposes the underlying version row for callers that need
+     * its provenance (model, hashes). Returns null if the frame is missing.
+     */
+    resolveCurrent: async (frameId: string): Promise<ResolvedFrame | null> => {
+      const [frame] = await db
+        .select()
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      if (!frame) return null;
+      if (!frame.selectedImageVersionId) {
+        return { frame, selectedVersion: null };
+      }
+      const [version] = await db
+        .select()
+        .from(frameVariants)
+        .where(eq(frameVariants.id, frame.selectedImageVersionId));
+      return { frame, selectedVersion: version ?? null };
+    },
+
+    /**
+     * Compare the stored `imageInputHash` against a fresh hash. A null stored
+     * hash (legacy / never generated) is treated as "unknown, not stale"
+     * rather than forcing regeneration. Throws when the frame is missing.
+     * Mirrors `shots.isStale`.
+     */
+    isStale: async (frameId: string, currentHash: string): Promise<boolean> => {
+      const result = await db
+        .select({ hash: frames.imageInputHash })
+        .from(frames)
+        .where(eq(frames.id, frameId));
+      const row = result[0];
+      if (!row) {
+        throw new Error(`Frame ${frameId} not found`);
+      }
+      const stored = row.hash;
+      if (stored === null) return false;
+      return currentHash !== stored;
+    },
+  };
+}

--- a/src/lib/db/scoped/frames.ts
+++ b/src/lib/db/scoped/frames.ts
@@ -59,6 +59,31 @@ export function buildFrameImageMirror(
 
 type FrameOrderBy = 'orderIndex' | 'createdAt' | 'updatedAt';
 
+/**
+ * Columns owned by the selection / mirror paths ({@link buildFrameImageMirror}
+ * via `frameVariants.select`, and `framePromptVersions.write`/`select`). They
+ * are excluded from the generic `update` input so a partial write can never
+ * leave the selection pointer and its mirrored columns diverged — the only way
+ * to move a selection is through those methods, which repoint + mirror (and log
+ * the event) atomically.
+ */
+type FrameMirrorColumn =
+  | 'selectedImageVersionId'
+  | 'imageUrl'
+  | 'imagePath'
+  | 'previewImageUrl'
+  | 'imageStatus'
+  | 'imageGeneratedAt'
+  | 'imageError'
+  | 'imageModel'
+  | 'imageInputHash'
+  | 'selectedImagePromptVersionId'
+  | 'imagePrompt'
+  | 'visualPromptInputHash';
+
+/** Fields `update` accepts — everything on a frame except the mirror columns. */
+export type FrameUpdateInput = Omit<Partial<NewFrame>, FrameMirrorColumn>;
+
 export function createFramesMethods(db: Database) {
   return {
     getById: async (frameId: string): Promise<Frame | null> => {
@@ -133,9 +158,15 @@ export function createFramesMethods(db: Database) {
       return frame;
     },
 
+    /**
+     * Update non-mirror frame fields. Selection pointers and their mirrored
+     * image / prompt columns are intentionally excluded (see
+     * {@link FrameUpdateInput}); move a selection via `frameVariants.select` or
+     * `framePromptVersions.write`/`select` instead.
+     */
     update: async (
       frameId: string,
-      data: Partial<NewFrame>,
+      data: FrameUpdateInput,
       options?: { throwOnMissing?: boolean }
     ): Promise<Frame | undefined> => {
       const [frame] = await db

--- a/src/lib/db/scoped/sequence-events.test.ts
+++ b/src/lib/db/scoped/sequence-events.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Acceptance tests for the sequence-events helper (append-only activity log).
+ * In-memory libSQL with the real migrations. Covers record persistence,
+ * buildEventInsert composing into a caller's batch (atomic with its mutation),
+ * and the timeline / by-target read ordering (newest-first, ULID order).
+ */
+
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import {
+  frames,
+  sequenceEvents,
+  sequences,
+  shots,
+  styles,
+  teams,
+  user,
+} from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  buildEventInsert,
+  createSequenceEventsMethods,
+} from './sequence-events';
+
+let client: Client;
+let db: Database;
+let sequenceId = '';
+let shotId = '';
+
+async function seed() {
+  await db.delete(sequenceEvents);
+  await db.delete(frames);
+  await db.delete(shots);
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await db.delete(user);
+
+  const teamId = generateId();
+  sequenceId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  await db
+    .insert(sequences)
+    .values({ id: sequenceId, teamId, title: 'S', styleId: style.id });
+  const [shot] = await db
+    .insert(shots)
+    .values({ sequenceId, orderIndex: 0 })
+    .returning();
+  if (!shot) throw new Error('test setup: shot insert returned nothing');
+  shotId = shot.id;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('sequenceEvents.record', () => {
+  it('persists a standalone event with its data payload', async () => {
+    const m = createSequenceEventsMethods(db);
+    const row = await m.record({
+      sequenceId,
+      actorId: null,
+      kind: 'shot.added',
+      targetType: 'shot',
+      targetId: shotId,
+      summary: 'Added a shot',
+      data: { orderIndex: 0 },
+    });
+    expect(row.kind).toBe('shot.added');
+    expect(row.summary).toBe('Added a shot');
+    expect(row.data).toMatchObject({ orderIndex: 0 });
+  });
+});
+
+describe('buildEventInsert', () => {
+  it('composes into a caller batch so the mutation and its event are atomic', async () => {
+    const m = createSequenceEventsMethods(db);
+    await db.batch([
+      db.update(shots).set({ orderIndex: 5 }).where(eq(shots.id, shotId)),
+      buildEventInsert(db, {
+        sequenceId,
+        actorId: null,
+        kind: 'shots.reordered',
+        targetType: 'shot',
+        targetId: shotId,
+        data: { to: 5 },
+      }),
+    ]);
+
+    const [shot] = await db.select().from(shots).where(eq(shots.id, shotId));
+    if (!shot) throw new Error('test setup: refresh failed');
+    expect(shot.orderIndex).toBe(5);
+    const events = await m.listByTarget('shot', shotId);
+    expect(events).toHaveLength(1);
+    expect(events[0]?.kind).toBe('shots.reordered');
+  });
+});
+
+describe('sequenceEvents reads', () => {
+  it('listBySequence returns the timeline newest-first', async () => {
+    const m = createSequenceEventsMethods(db);
+    await m.record({
+      sequenceId,
+      actorId: null,
+      kind: 'a.first',
+      targetType: 'sequence',
+      targetId: sequenceId,
+    });
+    await m.record({
+      sequenceId,
+      actorId: null,
+      kind: 'b.second',
+      targetType: 'sequence',
+      targetId: sequenceId,
+    });
+    const timeline = await m.listBySequence(sequenceId);
+    expect(timeline.map((e) => e.kind)).toEqual(['b.second', 'a.first']);
+    expect(await m.listBySequence(sequenceId, { limit: 1 })).toHaveLength(1);
+  });
+
+  it('listByTarget filters by (targetType, targetId)', async () => {
+    const m = createSequenceEventsMethods(db);
+    await m.record({
+      sequenceId,
+      actorId: null,
+      kind: 'shot.added',
+      targetType: 'shot',
+      targetId: shotId,
+    });
+    await m.record({
+      sequenceId,
+      actorId: null,
+      kind: 'sequence.touched',
+      targetType: 'sequence',
+      targetId: sequenceId,
+    });
+    const shotEvents = await m.listByTarget('shot', shotId);
+    expect(shotEvents).toHaveLength(1);
+    expect(shotEvents[0]?.targetType).toBe('shot');
+  });
+});

--- a/src/lib/db/scoped/sequence-events.ts
+++ b/src/lib/db/scoped/sequence-events.ts
@@ -1,0 +1,114 @@
+/**
+ * Scoped Sequence Events Sub-module — the append-only activity log.
+ *
+ * `sequence_events` narrates every change to a sequence (image generated,
+ * selection repointed, prompt edited, shot added/reordered, …). It is
+ * **log-over-truth**: the domain tables stay authoritative and an event merely
+ * references the row it describes (e.g. an `image.selected` event carries the
+ * new `frame_variants` version id in `data`).
+ *
+ * The drift-prevention rule (design doc § Sequence activity log): an event is
+ * appended in the **same `db.batch()`** as the mutation it narrates, so the
+ * change and its event commit together or not at all. Write methods elsewhere
+ * compose {@link buildEventInsert} into their own batch; {@link
+ * createSequenceEventsMethods.record} is the convenience for a standalone event.
+ *
+ * See docs/architecture/scene-shot-frame-redesign.md.
+ */
+
+import type { Database } from '@/lib/db/client';
+import { sequenceEvents } from '@/lib/db/schema';
+import type {
+  SequenceEvent,
+  SequenceEventData,
+  SequenceEventTargetType,
+} from '@/lib/db/schema';
+import { and, desc, eq } from 'drizzle-orm';
+
+/**
+ * One activity-log entry. `actorId` is null for system / AI / workflow-driven
+ * changes; a user id when a person triggered it. `kind` is an open-ended dotted
+ * string (e.g. `'image.generated'`, `'image.selected'`, `'prompt.edited'`) —
+ * not an enum, so new kinds need no migration.
+ */
+export type RecordEventInput = {
+  sequenceId: string;
+  actorId: string | null;
+  kind: string;
+  targetType: SequenceEventTargetType;
+  targetId: string;
+  summary?: string | null;
+  /** Specifics: model, versionId, from→to, prevPointer (enables undo), … */
+  data?: SequenceEventData | null;
+};
+
+/**
+ * Build the `sequence_events` insert statement WITHOUT executing it, so a
+ * caller can append it to its own `db.batch([...mutations, eventInsert])` and
+ * have the change + its event commit atomically. The row id / createdAt are
+ * filled by the schema `$defaultFn`s.
+ */
+export function buildEventInsert(db: Database, input: RecordEventInput) {
+  return db.insert(sequenceEvents).values({
+    sequenceId: input.sequenceId,
+    actorId: input.actorId,
+    kind: input.kind,
+    targetType: input.targetType,
+    targetId: input.targetId,
+    summary: input.summary ?? null,
+    data: input.data ?? null,
+  });
+}
+
+export function createSequenceEventsMethods(db: Database) {
+  return {
+    /**
+     * Append a standalone event (no accompanying domain mutation). When the
+     * event narrates a mutation, prefer composing {@link buildEventInsert} into
+     * the mutation's own `db.batch()` so they commit together.
+     */
+    record: async (input: RecordEventInput): Promise<SequenceEvent> => {
+      const [row] = await buildEventInsert(db, input).returning();
+      if (!row) {
+        throw new Error(
+          `Failed to record event ${input.kind} for sequence ${input.sequenceId}`
+        );
+      }
+      return row;
+    },
+
+    /** The timeline: every event for a sequence, newest first (ULID order). */
+    listBySequence: async (
+      sequenceId: string,
+      options?: { limit?: number }
+    ): Promise<SequenceEvent[]> => {
+      let query = db
+        .select()
+        .from(sequenceEvents)
+        .where(eq(sequenceEvents.sequenceId, sequenceId))
+        .orderBy(desc(sequenceEvents.id))
+        .$dynamic();
+      if (options?.limit) {
+        query = query.limit(options.limit);
+      }
+      return await query;
+    },
+
+    /** "What happened to this entity": events targeting one frame/shot/scene. */
+    listByTarget: async (
+      targetType: SequenceEventTargetType,
+      targetId: string
+    ): Promise<SequenceEvent[]> => {
+      return await db
+        .select()
+        .from(sequenceEvents)
+        .where(
+          and(
+            eq(sequenceEvents.targetType, targetType),
+            eq(sequenceEvents.targetId, targetId)
+          )
+        )
+        .orderBy(desc(sequenceEvents.id));
+    },
+  };
+}

--- a/src/lib/db/scoped/sequence-music-prompt-versions.ts
+++ b/src/lib/db/scoped/sequence-music-prompt-versions.ts
@@ -1,22 +1,22 @@
 /**
- * Scoped Sequence Music Prompt Variants Sub-module
+ * Scoped Sequence Music Prompt Versions Sub-module
  *
- * Appends a new revision row to `sequence_music_prompt_variants` and
+ * Appends a new revision row to `sequence_music_prompt_versions` and
  * updates the cached `musicPrompt` / `musicTags` / `musicPromptInputHash`
  * columns on `sequences`. Sequential, not transactional — see the
- * equivalent docstring in `shot-prompt-variants.ts` for the durability
- * story.
+ * equivalent docstring in `shot-prompt-versions.ts` for the durability
+ * story. Renamed from `sequence-music-prompt-variants` in #988.
  *
  * See docs/architecture/workflow-snapshots-and-content-hash-staleness.md
  * § prompt versioning.
  */
 
 import type { Database } from '@/lib/db/client';
-import { sequenceMusicPromptVariants, sequences, user } from '@/lib/db/schema';
-import type { SequenceMusicPromptVariant } from '@/lib/db/schema';
+import { sequenceMusicPromptVersions, sequences, user } from '@/lib/db/schema';
+import type { SequenceMusicPromptVersion } from '@/lib/db/schema';
 import { and, desc, eq } from 'drizzle-orm';
 
-type WriteSequenceMusicPromptVariantBase = {
+type WriteSequenceMusicPromptVersionBase = {
   sequenceId: string;
   prompt: string;
   tags?: string | null;
@@ -30,14 +30,14 @@ type WriteSequenceMusicPromptVariantBase = {
  * detection silently breaks. User-edits forbid both fields so they cannot be
  * set by mistake.
  *
- * Restored rows carry the source variant's hash + analysisModel verbatim so
+ * Restored rows carry the source version's hash + analysisModel verbatim so
  * the cached `musicPromptInputHash` column keeps tracking the upstream
  * context that originally produced the prompt — restoring an old AI prompt
  * must NOT silently disable staleness detection. Both fields can be null
  * when the source is itself a user-edit (which never had a hash).
  */
-export type WriteSequenceMusicPromptVariantInput =
-  WriteSequenceMusicPromptVariantBase &
+export type WriteSequenceMusicPromptVersionInput =
+  WriteSequenceMusicPromptVersionBase &
     (
       | {
           source: 'ai-generated' | 'regenerated';
@@ -56,10 +56,10 @@ export type WriteSequenceMusicPromptVariantInput =
         }
     );
 
-export function createSequenceMusicPromptVariantsMethods(db: Database) {
+export function createSequenceMusicPromptVersionsMethods(db: Database) {
   return {
     /**
-     * Append a music prompt variant row and update the cached
+     * Append a music prompt version row and update the cached
      * `musicPrompt` / `musicTags` / `musicPromptInputHash` columns on
      * `sequences`. Returns the inserted (or pre-existing matching) row.
      *
@@ -68,14 +68,14 @@ export function createSequenceMusicPromptVariantsMethods(db: Database) {
      * retries don't append duplicate history.
      */
     write: async (
-      input: WriteSequenceMusicPromptVariantInput
-    ): Promise<SequenceMusicPromptVariant> => {
+      input: WriteSequenceMusicPromptVersionInput
+    ): Promise<SequenceMusicPromptVersion> => {
       const nextHash = input.source === 'user-edit' ? null : input.inputHash;
       const analysisModel =
         input.source === 'user-edit' ? null : input.analysisModel;
 
       const [inserted] = await db
-        .insert(sequenceMusicPromptVariants)
+        .insert(sequenceMusicPromptVersions)
         .values({
           sequenceId: input.sequenceId,
           prompt: input.prompt,
@@ -88,23 +88,23 @@ export function createSequenceMusicPromptVariantsMethods(db: Database) {
         .onConflictDoNothing()
         .returning();
 
-      let variant: SequenceMusicPromptVariant | undefined = inserted;
-      if (!variant && nextHash !== null) {
+      let version: SequenceMusicPromptVersion | undefined = inserted;
+      if (!version && nextHash !== null) {
         const [existing] = await db
           .select()
-          .from(sequenceMusicPromptVariants)
+          .from(sequenceMusicPromptVersions)
           .where(
             and(
-              eq(sequenceMusicPromptVariants.sequenceId, input.sequenceId),
-              eq(sequenceMusicPromptVariants.inputHash, nextHash)
+              eq(sequenceMusicPromptVersions.sequenceId, input.sequenceId),
+              eq(sequenceMusicPromptVersions.inputHash, nextHash)
             )
           )
           .limit(1);
-        variant = existing;
+        version = existing;
       }
 
-      if (!variant) {
-        throw new Error('Failed to insert sequence music prompt variant');
+      if (!version) {
+        throw new Error('Failed to insert sequence music prompt version');
       }
 
       await db
@@ -117,29 +117,29 @@ export function createSequenceMusicPromptVariantsMethods(db: Database) {
         })
         .where(eq(sequences.id, input.sequenceId));
 
-      return variant;
+      return version;
     },
 
     /** Revision history for a sequence's music prompt, newest first. */
     listBySequence: async (
       sequenceId: string
-    ): Promise<SequenceMusicPromptVariant[]> => {
+    ): Promise<SequenceMusicPromptVersion[]> => {
       return await db
         .select()
-        .from(sequenceMusicPromptVariants)
-        .where(eq(sequenceMusicPromptVariants.sequenceId, sequenceId))
-        .orderBy(desc(sequenceMusicPromptVariants.createdAt));
+        .from(sequenceMusicPromptVersions)
+        .where(eq(sequenceMusicPromptVersions.sequenceId, sequenceId))
+        .orderBy(desc(sequenceMusicPromptVersions.createdAt));
     },
 
-    /** Most recent music prompt variant, or null if none exists. */
+    /** Most recent music prompt version, or null if none exists. */
     getLatest: async (
       sequenceId: string
-    ): Promise<SequenceMusicPromptVariant | null> => {
+    ): Promise<SequenceMusicPromptVersion | null> => {
       const [row] = await db
         .select()
-        .from(sequenceMusicPromptVariants)
-        .where(eq(sequenceMusicPromptVariants.sequenceId, sequenceId))
-        .orderBy(desc(sequenceMusicPromptVariants.createdAt))
+        .from(sequenceMusicPromptVersions)
+        .where(eq(sequenceMusicPromptVersions.sequenceId, sequenceId))
+        .orderBy(desc(sequenceMusicPromptVersions.createdAt))
         .limit(1);
       return row ?? null;
     },
@@ -148,35 +148,35 @@ export function createSequenceMusicPromptVariantsMethods(db: Database) {
     listBySequenceWithAuthor: async (
       sequenceId: string
     ): Promise<
-      Array<SequenceMusicPromptVariant & { createdByName: string | null }>
+      Array<SequenceMusicPromptVersion & { createdByName: string | null }>
     > => {
       const rows = await db
         .select({
-          variant: sequenceMusicPromptVariants,
+          version: sequenceMusicPromptVersions,
           createdByName: user.name,
         })
-        .from(sequenceMusicPromptVariants)
-        .leftJoin(user, eq(sequenceMusicPromptVariants.createdBy, user.id))
-        .where(eq(sequenceMusicPromptVariants.sequenceId, sequenceId))
-        .orderBy(desc(sequenceMusicPromptVariants.createdAt));
+        .from(sequenceMusicPromptVersions)
+        .leftJoin(user, eq(sequenceMusicPromptVersions.createdBy, user.id))
+        .where(eq(sequenceMusicPromptVersions.sequenceId, sequenceId))
+        .orderBy(desc(sequenceMusicPromptVersions.createdAt));
       return rows.map((r) => ({
-        ...r.variant,
+        ...r.version,
         createdByName: r.createdByName,
       }));
     },
 
-    /** Fetch a single music prompt variant scoped to its sequence. */
+    /** Fetch a single music prompt version scoped to its sequence. */
     getByIdForSequence: async (
-      variantId: string,
+      versionId: string,
       sequenceId: string
-    ): Promise<SequenceMusicPromptVariant | null> => {
+    ): Promise<SequenceMusicPromptVersion | null> => {
       const [row] = await db
         .select()
-        .from(sequenceMusicPromptVariants)
+        .from(sequenceMusicPromptVersions)
         .where(
           and(
-            eq(sequenceMusicPromptVariants.id, variantId),
-            eq(sequenceMusicPromptVariants.sequenceId, sequenceId)
+            eq(sequenceMusicPromptVersions.id, versionId),
+            eq(sequenceMusicPromptVersions.sequenceId, sequenceId)
           )
         )
         .limit(1);

--- a/src/lib/db/scoped/sequence-music-prompt-versions.ts
+++ b/src/lib/db/scoped/sequence-music-prompt-versions.ts
@@ -64,8 +64,10 @@ export function createSequenceMusicPromptVersionsMethods(db: Database) {
      * `sequences`. Returns the inserted (or pre-existing matching) row.
      *
      * AI-generated rows are deduped on a unique partial index
-     * `(sequence_id, input_hash) WHERE input_hash IS NOT NULL` so QStash
-     * retries don't append duplicate history.
+     * `(sequence_id, input_hash) WHERE input_hash IS NOT NULL AND
+     * source != 'restored'` so workflow retries don't append duplicate history
+     * (the `source != 'restored'` clause lets a restore still append an audit
+     * row even when its hash matches an existing one).
      */
     write: async (
       input: WriteSequenceMusicPromptVersionInput

--- a/src/lib/db/scoped/shot-prompt-versions.test.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.test.ts
@@ -16,9 +16,9 @@
 import type { Database } from '@/lib/db/client';
 import { generateId } from '@/lib/db/id';
 import {
-  shotPromptVariants,
+  shotPromptVersions,
   shots,
-  sequenceMusicPromptVariants,
+  sequenceMusicPromptVersions,
   sequences,
   styles,
   teams,
@@ -30,8 +30,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
-import { createShotPromptVariantsMethods } from './shot-prompt-variants';
-import { createSequenceMusicPromptVariantsMethods } from './sequence-music-prompt-variants';
+import { createShotPromptVersionsMethods } from './shot-prompt-versions';
+import { createSequenceMusicPromptVersionsMethods } from './sequence-music-prompt-versions';
 
 let client: Client;
 let db: Database;
@@ -40,8 +40,8 @@ let sequenceId = '';
 let shotId = '';
 
 async function seed() {
-  await db.delete(shotPromptVariants);
-  await db.delete(sequenceMusicPromptVariants);
+  await db.delete(shotPromptVersions);
+  await db.delete(sequenceMusicPromptVersions);
   await db.delete(shots);
   await db.delete(sequences);
   await db.delete(styles);
@@ -99,7 +99,7 @@ beforeEach(async () => {
 
 describe('shot_prompt_variants helper', () => {
   it('user-edit with null inputHash appends a row and clears the cached hash', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     // Seed the cached column to mimic an existing AI-generated prompt.
     await db
@@ -135,7 +135,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('user-edit with a real inputHash stamps both the row and the cached column', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     await db
       .update(shots)
@@ -167,7 +167,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('regenerated prompt populates input_hash on both the row and the cached column', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const variant = await methods.write({
       shotId,
@@ -191,7 +191,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('preserves prior AI text in the variant chain after a user edit (recoverable history)', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     await methods.write({
       shotId,
@@ -226,7 +226,7 @@ describe('shot_prompt_variants helper', () => {
     // 'regenerated' : 'ai-generated'. A regression that swaps the two would
     // mislabel every regeneration as a first generation (or vice versa) and
     // corrupt prompt history.
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const previousBeforeFirst = await methods.getLatest(shotId, 'visual');
     expect(previousBeforeFirst).toBeNull();
@@ -282,7 +282,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('AI write is idempotent on (shot, type, input_hash) — a retry returns the existing row', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const first = await methods.write({
       shotId,
@@ -315,7 +315,7 @@ describe('shot_prompt_variants helper', () => {
     // text in history (otherwise the user's regenerated prompt would be
     // silently lost) while keeping the cached `*_prompt_input_hash` column
     // tracking the real upstream hash so staleness detection stays correct.
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const first = await methods.write({
       shotId,
@@ -366,7 +366,7 @@ describe('shot_prompt_variants helper', () => {
     // Regression guard for the force-regen branch: it must only fire when
     // `existing.text !== input.text`. A genuine workflow step retry submits
     // the same text + same hash and should still collapse to one row.
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     await methods.write({
       shotId,
@@ -391,7 +391,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('a different input_hash produces a new row for the same shot+type', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     await methods.write({
       shotId,
@@ -415,7 +415,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('motion prompts use the motionPrompt cached column independently of visual', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     await methods.write({
       shotId,
@@ -450,7 +450,7 @@ describe('shot_prompt_variants helper', () => {
     // belongs to a different shot in the same sequence — without it, a
     // user could restore shot A's prompt onto shot B by passing the wrong
     // variantId. The shot-access middleware only checks the parent shot.
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const [siblingShot] = await db
       .insert(shots)
@@ -481,7 +481,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('restored row carries the source variant input_hash so staleness keeps tracking the original upstream context', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     // Original AI-generated prompt with a stored hash.
     const original = await methods.write({
@@ -547,7 +547,7 @@ describe('shot_prompt_variants helper', () => {
   it('restoring an AI prompt that is currently live still appends a restored row (audit trail)', async () => {
     // Without the partial-index `source != 'restored'` exclusion, this case
     // hit onConflictDoNothing and silently returned the original AI row.
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const original = await methods.write({
       shotId,
@@ -578,7 +578,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('restored row from a user-edit source carries null hash (no staleness opinion to forward)', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     const userEdit = await methods.write({
       shotId,
@@ -606,7 +606,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('getLatestWithInputHash skips null-hash user-edits and returns the most recent hashed row', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     // 1) An AI prompt with a real hash.
     const ai = await methods.write({
@@ -638,7 +638,7 @@ describe('shot_prompt_variants helper', () => {
   });
 
   it('getLatestWithInputHash isolates by promptType (visual vs motion)', async () => {
-    const methods = createShotPromptVariantsMethods(db);
+    const methods = createShotPromptVersionsMethods(db);
 
     await methods.write({
       shotId,
@@ -656,7 +656,7 @@ describe('shot_prompt_variants helper', () => {
 
 describe('sequence_music_prompt_variants helper', () => {
   it('user-edit clears musicPromptInputHash and overwrites the cached prompt/tags', async () => {
-    const methods = createSequenceMusicPromptVariantsMethods(db);
+    const methods = createSequenceMusicPromptVersionsMethods(db);
 
     await db
       .update(sequences)
@@ -687,7 +687,7 @@ describe('sequence_music_prompt_variants helper', () => {
   });
 
   it('ai-generated → regenerated chain on music variants mirrors the music-prompt workflow flow', async () => {
-    const methods = createSequenceMusicPromptVariantsMethods(db);
+    const methods = createSequenceMusicPromptVersionsMethods(db);
 
     const previousBeforeFirst = await methods.getLatest(sequenceId);
     expect(previousBeforeFirst).toBeNull();
@@ -731,7 +731,7 @@ describe('sequence_music_prompt_variants helper', () => {
   });
 
   it('AI music write is idempotent on (sequence, input_hash) — a retry returns the existing row', async () => {
-    const methods = createSequenceMusicPromptVariantsMethods(db);
+    const methods = createSequenceMusicPromptVersionsMethods(db);
 
     const first = await methods.write({
       sequenceId,
@@ -758,7 +758,7 @@ describe('sequence_music_prompt_variants helper', () => {
   });
 
   it('regenerated music prompt populates the input hash on the sequence row', async () => {
-    const methods = createSequenceMusicPromptVariantsMethods(db);
+    const methods = createSequenceMusicPromptVersionsMethods(db);
 
     await methods.write({
       sequenceId,
@@ -779,7 +779,7 @@ describe('sequence_music_prompt_variants helper', () => {
   });
 
   it('getByIdForSequence refuses to return a sibling sequence variant (cross-sequence guard)', async () => {
-    const methods = createSequenceMusicPromptVariantsMethods(db);
+    const methods = createSequenceMusicPromptVersionsMethods(db);
 
     // Reuse the seeded style so we can satisfy the not-null styleId on
     // sequences without duplicating the style fixture here.
@@ -820,7 +820,7 @@ describe('sequence_music_prompt_variants helper', () => {
   });
 
   it('restored music row carries the source variant input_hash so sequence staleness keeps tracking upstream context', async () => {
-    const methods = createSequenceMusicPromptVariantsMethods(db);
+    const methods = createSequenceMusicPromptVersionsMethods(db);
 
     const original = await methods.write({
       sequenceId,

--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -1,7 +1,7 @@
 /**
- * Scoped Shot Prompt Variants Sub-module
+ * Scoped Shot Prompt Versions Sub-module
  *
- * Appends a new revision row to `shot_prompt_variants` and updates the
+ * Appends a new revision row to `shot_prompt_versions` and updates the
  * cached pointer column on `shots` (`imagePrompt` for visual prompts,
  * `motionPrompt` for motion prompts) plus the matching
  * `*_prompt_input_hash` column. The two writes are sequential, not
@@ -9,7 +9,7 @@
  *
  * Callers go through these helpers instead of writing the cached column
  * directly so prompt history is never lost. Read-path (read the cached
- * column) is unchanged.
+ * column) is unchanged. Renamed from `shot-prompt-variants` in #988.
  *
  * See docs/architecture/workflow-snapshots-and-content-hash-staleness.md
  * § prompt versioning.
@@ -17,19 +17,19 @@
 
 import type { MotionPromptParameters } from '@/lib/ai/scene-analysis.schema';
 import type { Database } from '@/lib/db/client';
-import { shotPromptVariants, shots, user } from '@/lib/db/schema';
+import { shotPromptVersions, shots, user } from '@/lib/db/schema';
 import type {
   ShotPromptType,
-  ShotPromptVariant,
-  ShotPromptVariantComponents,
+  ShotPromptVersion,
+  ShotPromptVersionComponents,
 } from '@/lib/db/schema';
 import { and, desc, eq, isNotNull, lte } from 'drizzle-orm';
 
-type WriteShotPromptVariantBase = {
+type WriteShotPromptVersionBase = {
   shotId: string;
   promptType: ShotPromptType;
   text: string;
-  components?: ShotPromptVariantComponents | null;
+  components?: ShotPromptVersionComponents | null;
   parameters?: MotionPromptParameters | null;
   createdBy?: string | null;
 };
@@ -46,14 +46,14 @@ type WriteShotPromptVariantBase = {
  * upstream context was uncomputable at write time (e.g. style deleted), in
  * which case the staleness function falls back to an earlier non-null row.
  *
- * Restored rows carry the source variant's hash + analysisModel verbatim so
+ * Restored rows carry the source version's hash + analysisModel verbatim so
  * the cached `*_prompt_input_hash` column keeps tracking the upstream context
  * that originally produced the prompt — restoring an old AI prompt must NOT
  * silently disable staleness detection. Both fields stay nullable for restored
- * rows to accommodate legacy user-edit variants written before this contract
+ * rows to accommodate legacy user-edit rows written before this contract
  * landed (they have null hashes that we can't retroactively recompute).
  */
-export type WriteShotPromptVariantInput = WriteShotPromptVariantBase &
+export type WriteShotPromptVersionInput = WriteShotPromptVersionBase &
   (
     | {
         source: 'ai-generated' | 'regenerated';
@@ -87,14 +87,14 @@ const cachedColumnsForType = (promptType: ShotPromptType) =>
         hashKey: 'motionPromptInputHash' as const,
       };
 
-export function createShotPromptVariantsMethods(db: Database) {
+export function createShotPromptVersionsMethods(db: Database) {
   return {
     /**
-     * Append a new prompt variant row and update the cached pointer on
+     * Append a new prompt version row and update the cached pointer on
      * `shots`. Returns the inserted (or pre-existing matching) row.
      *
      * Durability: the insert + update pair is sequential, not transactional.
-     * The variant row is the source of truth; the cached column on `shots`
+     * The version row is the source of truth; the cached column on `shots`
      * is a read-path optimization. To make retries safe, AI-generated
      * rows are deduped by the unique partial index on
      * `(shot_id, prompt_type, input_hash) WHERE input_hash IS NOT NULL`:
@@ -110,8 +110,8 @@ export function createShotPromptVariantsMethods(db: Database) {
      * `liveHash` so staleness detection stays correct.
      */
     write: async (
-      input: WriteShotPromptVariantInput
-    ): Promise<ShotPromptVariant> => {
+      input: WriteShotPromptVersionInput
+    ): Promise<ShotPromptVersion> => {
       const cached = cachedColumnsForType(input.promptType);
 
       const nextHash = input.inputHash;
@@ -120,7 +120,7 @@ export function createShotPromptVariantsMethods(db: Database) {
       // Append first so a crash can't leave a stale pointer with no row
       // behind it. The reverse order would be unrecoverable.
       const [inserted] = await db
-        .insert(shotPromptVariants)
+        .insert(shotPromptVersions)
         .values({
           shotId: input.shotId,
           promptType: input.promptType,
@@ -135,16 +135,16 @@ export function createShotPromptVariantsMethods(db: Database) {
         .onConflictDoNothing()
         .returning();
 
-      let variant: ShotPromptVariant | undefined = inserted;
-      if (!variant && nextHash !== null) {
+      let version: ShotPromptVersion | undefined = inserted;
+      if (!version && nextHash !== null) {
         const [existing] = await db
           .select()
-          .from(shotPromptVariants)
+          .from(shotPromptVersions)
           .where(
             and(
-              eq(shotPromptVariants.shotId, input.shotId),
-              eq(shotPromptVariants.promptType, input.promptType),
-              eq(shotPromptVariants.inputHash, nextHash)
+              eq(shotPromptVersions.shotId, input.shotId),
+              eq(shotPromptVersions.promptType, input.promptType),
+              eq(shotPromptVersions.inputHash, nextHash)
             )
           )
           .limit(1);
@@ -159,7 +159,7 @@ export function createShotPromptVariantsMethods(db: Database) {
           // new text lands in history. Restore/user-edit paths never reach
           // this branch — they don't carry a non-null `inputHash` here.
           const [forced] = await db
-            .insert(shotPromptVariants)
+            .insert(shotPromptVersions)
             .values({
               shotId: input.shotId,
               promptType: input.promptType,
@@ -172,14 +172,14 @@ export function createShotPromptVariantsMethods(db: Database) {
               createdBy: input.createdBy ?? null,
             })
             .returning();
-          variant = forced;
+          version = forced;
         } else {
-          variant = existing;
+          version = existing;
         }
       }
 
-      if (!variant) {
-        throw new Error('Failed to insert shot prompt variant');
+      if (!version) {
+        throw new Error('Failed to insert shot prompt version');
       }
 
       await db
@@ -191,24 +191,24 @@ export function createShotPromptVariantsMethods(db: Database) {
         })
         .where(eq(shots.id, input.shotId));
 
-      return variant;
+      return version;
     },
 
     /** List the revision history for a shot's prompt, newest first. */
     listByShot: async (
       shotId: string,
       promptType: ShotPromptType
-    ): Promise<ShotPromptVariant[]> => {
+    ): Promise<ShotPromptVersion[]> => {
       return await db
         .select()
-        .from(shotPromptVariants)
+        .from(shotPromptVersions)
         .where(
           and(
-            eq(shotPromptVariants.shotId, shotId),
-            eq(shotPromptVariants.promptType, promptType)
+            eq(shotPromptVersions.shotId, shotId),
+            eq(shotPromptVersions.promptType, promptType)
           )
         )
-        .orderBy(desc(shotPromptVariants.createdAt));
+        .orderBy(desc(shotPromptVersions.createdAt));
     },
 
     /**
@@ -217,36 +217,36 @@ export function createShotPromptVariantsMethods(db: Database) {
     listByShotWithAuthor: async (
       shotId: string,
       promptType: ShotPromptType
-    ): Promise<Array<ShotPromptVariant & { createdByName: string | null }>> => {
+    ): Promise<Array<ShotPromptVersion & { createdByName: string | null }>> => {
       const rows = await db
-        .select({ variant: shotPromptVariants, createdByName: user.name })
-        .from(shotPromptVariants)
-        .leftJoin(user, eq(shotPromptVariants.createdBy, user.id))
+        .select({ version: shotPromptVersions, createdByName: user.name })
+        .from(shotPromptVersions)
+        .leftJoin(user, eq(shotPromptVersions.createdBy, user.id))
         .where(
           and(
-            eq(shotPromptVariants.shotId, shotId),
-            eq(shotPromptVariants.promptType, promptType)
+            eq(shotPromptVersions.shotId, shotId),
+            eq(shotPromptVersions.promptType, promptType)
           )
         )
-        .orderBy(desc(shotPromptVariants.createdAt));
+        .orderBy(desc(shotPromptVersions.createdAt));
       return rows.map((r) => ({
-        ...r.variant,
+        ...r.version,
         createdByName: r.createdByName,
       }));
     },
 
-    /** Fetch a single variant scoped to its shot. */
+    /** Fetch a single version scoped to its shot. */
     getByIdForShot: async (
-      variantId: string,
+      versionId: string,
       shotId: string
-    ): Promise<ShotPromptVariant | null> => {
+    ): Promise<ShotPromptVersion | null> => {
       const [row] = await db
         .select()
-        .from(shotPromptVariants)
+        .from(shotPromptVersions)
         .where(
           and(
-            eq(shotPromptVariants.id, variantId),
-            eq(shotPromptVariants.shotId, shotId)
+            eq(shotPromptVersions.id, versionId),
+            eq(shotPromptVersions.shotId, shotId)
           )
         )
         .limit(1);
@@ -255,7 +255,7 @@ export function createShotPromptVariantsMethods(db: Database) {
 
     /**
      * Candidates for matching a `shot_variants.promptHash` (`simpleHash` of
-     * the prompt text) — pulls prompt variants of the right type that existed
+     * the prompt text) — pulls prompt versions of the right type that existed
      * at or before `cutoff`, newest first. Caller filters by simpleHash.
      */
     listCandidatesAtOrBefore: async (
@@ -263,42 +263,42 @@ export function createShotPromptVariantsMethods(db: Database) {
       promptType: ShotPromptType,
       cutoff: Date,
       limit = 50
-    ): Promise<ShotPromptVariant[]> => {
+    ): Promise<ShotPromptVersion[]> => {
       return await db
         .select()
-        .from(shotPromptVariants)
+        .from(shotPromptVersions)
         .where(
           and(
-            eq(shotPromptVariants.shotId, shotId),
-            eq(shotPromptVariants.promptType, promptType),
-            lte(shotPromptVariants.createdAt, cutoff)
+            eq(shotPromptVersions.shotId, shotId),
+            eq(shotPromptVersions.promptType, promptType),
+            lte(shotPromptVersions.createdAt, cutoff)
           )
         )
-        .orderBy(desc(shotPromptVariants.createdAt))
+        .orderBy(desc(shotPromptVersions.createdAt))
         .limit(limit);
     },
 
-    /** Most recent variant of a given type, or null if none exists. */
+    /** Most recent version of a given type, or null if none exists. */
     getLatest: async (
       shotId: string,
       promptType: ShotPromptType
-    ): Promise<ShotPromptVariant | null> => {
+    ): Promise<ShotPromptVersion | null> => {
       const [row] = await db
         .select()
-        .from(shotPromptVariants)
+        .from(shotPromptVersions)
         .where(
           and(
-            eq(shotPromptVariants.shotId, shotId),
-            eq(shotPromptVariants.promptType, promptType)
+            eq(shotPromptVersions.shotId, shotId),
+            eq(shotPromptVersions.promptType, promptType)
           )
         )
-        .orderBy(desc(shotPromptVariants.createdAt))
+        .orderBy(desc(shotPromptVersions.createdAt))
         .limit(1);
       return row ?? null;
     },
 
     /**
-     * Most recent variant of a given type whose `inputHash` is non-null.
+     * Most recent version of a given type whose `inputHash` is non-null.
      * Used by the staleness path to find a reference hash for legacy shots
      * whose cached `*_prompt_input_hash` column was nulled out by a
      * pre-fix user-edit. Skips user-edit rows that fell back to null when
@@ -307,18 +307,18 @@ export function createShotPromptVariantsMethods(db: Database) {
     getLatestWithInputHash: async (
       shotId: string,
       promptType: ShotPromptType
-    ): Promise<ShotPromptVariant | null> => {
+    ): Promise<ShotPromptVersion | null> => {
       const [row] = await db
         .select()
-        .from(shotPromptVariants)
+        .from(shotPromptVersions)
         .where(
           and(
-            eq(shotPromptVariants.shotId, shotId),
-            eq(shotPromptVariants.promptType, promptType),
-            isNotNull(shotPromptVariants.inputHash)
+            eq(shotPromptVersions.shotId, shotId),
+            eq(shotPromptVersions.promptType, promptType),
+            isNotNull(shotPromptVersions.inputHash)
           )
         )
-        .orderBy(desc(shotPromptVariants.createdAt))
+        .orderBy(desc(shotPromptVersions.createdAt))
         .limit(1);
       return row ?? null;
     },

--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -97,9 +97,11 @@ export function createShotPromptVersionsMethods(db: Database) {
      * The version row is the source of truth; the cached column on `shots`
      * is a read-path optimization. To make retries safe, AI-generated
      * rows are deduped by the unique partial index on
-     * `(shot_id, prompt_type, input_hash) WHERE input_hash IS NOT NULL`:
-     * an insert that conflicts with an existing row no-ops, the existing row
-     * is fetched, and the cached pointer is updated as normal.
+     * `(shot_id, prompt_type, input_hash) WHERE input_hash IS NOT NULL AND
+     * source != 'restored'`: an insert that conflicts with an existing row
+     * no-ops, the existing row is fetched, and the cached pointer is updated as
+     * normal. (The `source != 'restored'` clause is load-bearing — it lets a
+     * restore append an audit row even when its hash matches an existing one.)
      *
      * Force-regeneration corner case: an explicit user-triggered regen runs
      * the LLM against unchanged upstream inputs. The new completion's hash
@@ -149,15 +151,15 @@ export function createShotPromptVersionsMethods(db: Database) {
           )
           .limit(1);
 
-        if (
-          existing &&
-          existing.text !== input.text &&
-          (input.source === 'ai-generated' || input.source === 'regenerated')
-        ) {
-          // Force-regen path: same upstream hash but a fresh LLM completion.
-          // Bypass the partial unique index with a null `input_hash` so the
-          // new text lands in history. Restore/user-edit paths never reach
-          // this branch — they don't carry a non-null `inputHash` here.
+        if (existing && existing.text !== input.text) {
+          // Same upstream hash but genuinely new text. Two ways to get here: a
+          // force-regen (AI runs against unchanged inputs) or a user-edit whose
+          // live hash matches the row it edits. Either way the new text must
+          // land in history, so bypass the partial unique index with a null
+          // `input_hash`; the cached hash below still tracks the real `liveHash`
+          // so staleness detection stays correct. (`restored` rows never reach
+          // this branch — the partial index excludes them, so they never
+          // conflict on insert.)
           const [forced] = await db
             .insert(shotPromptVersions)
             .values({

--- a/src/lib/failures/failure-analysis.test.ts
+++ b/src/lib/failures/failure-analysis.test.ts
@@ -46,6 +46,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     previewThumbnailUrl: null,
     metadata: null,
     createdAt: new Date(),

--- a/src/lib/image/build-shot-image-input.test.ts
+++ b/src/lib/image/build-shot-image-input.test.ts
@@ -60,6 +60,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     previewThumbnailUrl: null,
     metadata: null,
     createdAt: NOW,

--- a/src/lib/mocks/data-generators.ts
+++ b/src/lib/mocks/data-generators.ts
@@ -88,6 +88,7 @@ const generateMockShot = (overrides?: Partial<Shot>): Shot => {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     previewThumbnailUrl: null,
     createdAt: faker.date.past(),
     updatedAt: faker.date.recent(),

--- a/src/lib/realtime/__tests__/query-cache-updater.test.ts
+++ b/src/lib/realtime/__tests__/query-cache-updater.test.ts
@@ -62,6 +62,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     previewThumbnailUrl: null,
     metadata: null,
     createdAt: new Date(),

--- a/src/lib/vtt/generate-chapters.test.ts
+++ b/src/lib/vtt/generate-chapters.test.ts
@@ -57,6 +57,7 @@ const createTestShot = (overrides: Partial<Shot>): Shot => ({
   audioInputHash: null,
   visualPromptInputHash: null,
   motionPromptInputHash: null,
+  selectedMotionPromptVersionId: null,
   previewThumbnailUrl: null,
   ...overrides,
 });

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -168,7 +168,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
               );
             }
 
-            await scopedDb.shotPromptVariants.write({
+            await scopedDb.shotPromptVersions.write({
               shotId: input.shotId,
               promptType: 'visual',
               text: input.prompt,

--- a/src/lib/workflows/motion-prompt-scene-workflow.ts
+++ b/src/lib/workflows/motion-prompt-scene-workflow.ts
@@ -159,7 +159,7 @@ export class MotionPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Motio
       };
 
       await step.do('save-motion-prompt-to-db', async () => {
-        const previous = await scopedDb.shotPromptVariants.getLatest(
+        const previous = await scopedDb.shotPromptVersions.getLatest(
           shotId,
           'motion'
         );
@@ -174,7 +174,7 @@ export class MotionPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Motio
           motionPrompt: null,
         });
 
-        await scopedDb.shotPromptVariants.write({
+        await scopedDb.shotPromptVersions.write({
           shotId,
           promptType: 'motion',
           text: motionPrompt.fullPrompt,

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -252,7 +252,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           );
         }
 
-        await scopedDb.shotPromptVariants.write({
+        await scopedDb.shotPromptVersions.write({
           shotId: input.shotId,
           promptType: 'motion',
           text: input.prompt,

--- a/src/lib/workflows/music-prompt-workflow.ts
+++ b/src/lib/workflows/music-prompt-workflow.ts
@@ -85,10 +85,10 @@ export class MusicPromptWorkflow extends OpenStoryWorkflowEntrypoint<MusicPrompt
         );
 
         const previous =
-          await scopedDb.sequenceMusicPromptVariants.getLatest(sequenceId);
+          await scopedDb.sequenceMusicPromptVersions.getLatest(sequenceId);
         const source = previous ? 'regenerated' : 'ai-generated';
 
-        await scopedDb.sequenceMusicPromptVariants.write({
+        await scopedDb.sequenceMusicPromptVersions.write({
           sequenceId,
           prompt: musicDesignResult.prompt,
           tags: reinforcedTags,

--- a/src/lib/workflows/regenerate-shots-snapshot.test.ts
+++ b/src/lib/workflows/regenerate-shots-snapshot.test.ts
@@ -98,6 +98,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     audioInputHash: null,
     visualPromptInputHash: null,
     motionPromptInputHash: null,
+    selectedMotionPromptVersionId: null,
     metadata: {
       sceneId: 's1',
       sceneNumber: 1,

--- a/src/lib/workflows/visual-prompt-scene-workflow.ts
+++ b/src/lib/workflows/visual-prompt-scene-workflow.ts
@@ -369,7 +369,7 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
       const inputHash = await computeVisualPromptInputHash(narrowed);
 
       await step.do('save-visual-prompt-to-db', async () => {
-        const previous = await scopedDb.shotPromptVariants.getLatest(
+        const previous = await scopedDb.shotPromptVersions.getLatest(
           shotId,
           'visual'
         );
@@ -387,7 +387,7 @@ export class VisualPromptSceneWorkflow extends OpenStoryWorkflowEntrypoint<Visua
           imagePrompt: null,
         });
 
-        await scopedDb.shotPromptVariants.write({
+        await scopedDb.shotPromptVersions.write({
           shotId,
           promptType: 'visual',
           text: result.visual.fullPrompt,


### PR DESCRIPTION
## Phase 1 — Scoped-db access layer (the frozen contract)

Part of the Scene -> Shot -> Frame redesign (#987–#993). Design:
`docs/architecture/scene-shot-frame-redesign.md`.

This phase ships the team-scoped access layer Phases 2-5 build on — ~900 lines
of new scoped modules — plus the additive schema renames that were deferred out
of the additive-only Phase 0 (#987).

### New scoped modules (wired into `createScopedDb`)
- **`frames`** — CRUD + `upsert`, `resolveCurrent`, `isStale`, and
  `buildFrameImageMirror` (mirrors a selected version's image fields onto the
  frame).
- **`frame-variants`** — flat append-only image versions: `appendVersion`,
  `listByGroup`/`listByFrame`, `getSelected`, **`select`/repoint**,
  `discard`/`undiscard`, `isStale`. Selection is a pointer
  (`frames.selectedImageVersionId`); `select` repoints + mirrors + appends an
  `image.selected` event in **one `db.batch()`**.
- **`frame-prompt-versions`** — visual-prompt history: `write` (append + mirror
  + pointer, with the dedupe / force-regen contract), `select`/repoint, reads.
- **`sequence-events`** — the `recordEvent` helper: `buildEventInsert` composes
  into a mutation's batch so the change and its activity event commit together
  or not at all.

### Schema renames + column (additive)
- `shot_prompt_variants -> shot_prompt_versions`,
  `sequence_music_prompt_variants -> sequence_music_prompt_versions` — land here
  with their scoped-layer readers so the build never goes red.
- New `shots.selectedMotionPromptVersionId` (soft pointer -> `shot_prompt_versions.id`).
- Migration is **`ALTER TABLE ... RENAME TO` x2 + `ADD COLUMN`** — no table
  rebuild. Index names keep the `*_variants_*` spelling on purpose (a
  `RENAME TO` carries indexes; renaming them would add a needless DROP/CREATE).

### Out-of-scope tidy-ups found along the way
- `scripts/reorder-d1-dump.ts` `EDGES` regenerated to the current schema (it
  predated milestone-18): adds `scenes`/`shots`/`shot_variants`/
  `shot_prompt_versions`/`sequence_events`, the `frames -> shots` edge, and
  `location_sheet_variants` as FK-free. Verified: all 44 schema tables covered,
  no FK cycle.
- Fixed wrong-org GitHub links (`anthropics -> openstory-so`) in
  `docs/deployment/cloudflare.md`.

### Notes
- "Trim image bits out of `scoped/shots.ts`" is intentionally deferred to Phase
  2 — the `shots` image columns and their accessors still have live consumers
  until the image read/write path moves to frames; removing them now would
  break the build.
- Gates: typecheck + knip + lint + build green.

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
