### PR TITLE
feat(#1000): paste markdown-only into script + bound logged-out composer height

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -94,6 +94,10 @@ export const ScriptView: FC<{
   teamId?: string;
   sequence?: Sequence;
   flat?: boolean;
+  /** Extra classes merged onto the outer card — e.g. a height bound on the
+   *  logged-out new-sequence page so a large paste scrolls instead of growing
+   *  the page (#1000). */
+  className?: string;
   loading?: boolean;
   onSuccess?: (sequenceIds: string[]) => void;
   onCancel?: () => void;
@@ -108,6 +112,7 @@ export const ScriptView: FC<{
   loading = false,
   onSuccess,
   flat,
+  className,
   onCancel,
   initialScript,
   initialStyleId,
@@ -735,7 +740,8 @@ export const ScriptView: FC<{
     <PremiumCard
       className={cn(
         'relative flex flex-col min-h-0 max-h-full',
-        flat && 'border-none'
+        flat && 'border-none',
+        className
       )}
       onDragEnter={handleDragEnter}
       onDragLeave={handleDragLeave}

--- a/src/components/text-editor/markdown-editor.test.ts
+++ b/src/components/text-editor/markdown-editor.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  plainTextPasteAsMarkdown,
+  toHardBreakMarkdown,
+} from './markdown-editor';
+
+describe('toHardBreakMarkdown', () => {
+  it('converts single newlines to markdown hard breaks', () => {
+    expect(toHardBreakMarkdown('INT. ROOM\nA man enters.')).toBe(
+      'INT. ROOM  \nA man enters.'
+    );
+  });
+
+  it('leaves paragraph-separating blank lines intact', () => {
+    expect(toHardBreakMarkdown('Scene one.\n\nScene two.')).toBe(
+      'Scene one.\n\nScene two.'
+    );
+  });
+
+  it('handles mixed single and double newlines', () => {
+    expect(toHardBreakMarkdown('a\nb\n\nc')).toBe('a  \nb\n\nc');
+  });
+});
+
+describe('plainTextPasteAsMarkdown', () => {
+  it('coerces rich (text/html) paste to its plain-text markdown form', () => {
+    const html = '<p style="color:red"><b>Bold</b> line</p>';
+    expect(plainTextPasteAsMarkdown(html, 'Bold line')).toBe('Bold line');
+  });
+
+  it('strips styling but preserves multi-line structure as hard breaks', () => {
+    const html = '<h1>Title</h1><p>Body</p>';
+    expect(plainTextPasteAsMarkdown(html, 'Title\nBody')).toBe('Title  \nBody');
+  });
+
+  it('defers plain-text-only paste to the markdown clipboard parser', () => {
+    expect(plainTextPasteAsMarkdown('', '# Heading')).toBeNull();
+  });
+
+  it('defers image-only / non-text paste to the default handler', () => {
+    expect(plainTextPasteAsMarkdown('<img src="x">', '')).toBeNull();
+  });
+});

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -1,6 +1,6 @@
 import HardBreak from '@tiptap/extension-hard-break';
 import { Placeholder } from '@tiptap/extensions/placeholder';
-import { EditorContent, useEditor } from '@tiptap/react';
+import { type Editor, EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import {
   Markdown,
@@ -15,6 +15,29 @@ import type { MentionItem } from '@/components/scenes/prompt-mention/mention-ite
 import { PromptMention } from './mention/mention-extension';
 
 type MentionConfigure = Partial<MentionOptions>;
+
+// markdown-it parses two trailing spaces + `\n` as a hard break, so converting
+// single newlines (but not paragraph-separating blank lines) keeps a pasted
+// multi-line screenplay block in one paragraph instead of shredding each line
+// into its own paragraph. Exported for unit testing.
+export const toHardBreakMarkdown = (text: string): string =>
+  text.replace(/(?<!\n)\n(?!\n)/g, '  \n');
+
+// Decide what to insert for a paste. The script editor must only ever ingest
+// markdown — never the arbitrary inline styling (fonts, colours, sizes) that
+// rich `text/html` clipboard payloads from Word / Google Docs / web pages
+// carry. When HTML is present we ignore it and insert the clipboard's
+// plain-text representation parsed as markdown; a plain-text-only paste returns
+// null so tiptap-markdown's own `clipboardTextParser` handles it. Exported for
+// unit testing.
+export const plainTextPasteAsMarkdown = (
+  html: string,
+  text: string
+): string | null => {
+  if (!html) return null; // plain text paste — handled as markdown already
+  if (!text) return null; // image-only / non-text paste — leave to default
+  return toHardBreakMarkdown(text);
+};
 import { createMentionSuggestion } from './mention/mention-suggestion';
 import { tagifyMarkdown } from './mention/tagify';
 
@@ -101,6 +124,10 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   // handler reads the freshest callback without needing to recreate the editor.
   const onKeyDownRef = useRef(onKeyDown);
   onKeyDownRef.current = onKeyDown;
+
+  // handlePaste is captured at editor init (before `editor` is assigned), so it
+  // reads the live instance through this ref to insert markdown at the caret.
+  const editorRef = useRef<Editor | null>(null);
 
   // The suggestion plugin fires on every `@` keystroke; the items it pulls
   // must reflect the parent's latest list (it grows as the user adds cast /
@@ -195,15 +222,32 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           return true;
         },
       },
-      // Same treatment for actual paste events — markdown-it parses two
+      // Strip styling from rich (text/html) paste: insert only the plain-text
+      // representation, parsed as markdown, so the script never accepts fonts,
+      // colours, or other inline styling. Plain-text paste falls through to
+      // tiptap-markdown's clipboardTextParser (transformPastedText below).
+      handlePaste: (_view, event) => {
+        const clipboard = event.clipboardData;
+        if (!clipboard) return false;
+        const markdown = plainTextPasteAsMarkdown(
+          clipboard.getData('text/html'),
+          clipboard.getData('text/plain')
+        );
+        if (markdown === null) return false;
+        event.preventDefault();
+        editorRef.current?.commands.insertContent(markdown);
+        return true;
+      },
+      // Same treatment for actual plain-text paste — markdown-it parses two
       // trailing spaces + \n as a hard break, so the pasted block stays in
       // one paragraph instead of splitting.
-      transformPastedText: (text) => text.replace(/(?<!\n)\n(?!\n)/g, '  \n'),
+      transformPastedText: (text) => toHardBreakMarkdown(text),
     },
     onUpdate: ({ editor: e }) => {
       onValueChange(e.storage.markdown.getMarkdown());
     },
   });
+  editorRef.current = editor;
 
   // Canonical Tiptap external-value sync (mirrors the Vue v-model example in
   // their docs): only setContent if the editor's current markdown differs

--- a/src/routes/_app/sequences/new.tsx
+++ b/src/routes/_app/sequences/new.tsx
@@ -168,10 +168,15 @@ function NewSequencePage() {
           </h1>
         </div>
         {/* `#compose` target: the "Try" links navigate here so the router
-            scrolls the composer into view (scrollRestoration handles it). */}
+            scrolls the composer into view (scrollRestoration handles it). The
+            card grows with its content but is capped (`max-h-[70dvh]` overrides
+            the default `max-h-full`, which can't bound here — no definite-height
+            ancestor like the signed-in `fullHeight` layout) so a large paste
+            scrolls inside the editor instead of growing the page (#1000). */}
         <div id="compose" className="scroll-mt-4">
           <ScriptView
             key={composerKey}
+            className="max-h-[70dvh]"
             loading={false}
             onSuccess={handleSuccess}
             initialScript={seedScript}


### PR DESCRIPTION
## Summary

Fixes two script-editor issues on the new-sequence composer (#1000):

1. **Paste markdown only.** The editor accepted arbitrary styling on paste. Now a rich `text/html` paste (Word, Google Docs, web pages) inserts only the clipboard's **plain-text** representation, parsed as markdown — so the script never ingests fonts, colours, sizes, or other inline styling. A plain-text-only paste still falls through to tiptap-markdown's own `clipboardTextParser` unchanged. The newline→hard-break transform is shared between the paste path and `transformPastedText` via a small exported helper.

2. **Bound the logged-out composer height.** The pre-sign-in composer had no height restriction, so a large paste grew the page unboundedly. The signed-in view is bounded because `PageContainer fullHeight` gives a definite-height ancestor; the logged-out view has none. Capping the card with `max-h-[70dvh]` (which overrides the default `max-h-full` via `tailwind-merge`) makes it grow with content and then scroll internally — matching the signed-in behavior.

## Changes

- `markdown-editor.tsx` — `handlePaste` coerces rich paste to plain-text-as-markdown; extracted pure `toHardBreakMarkdown` / `plainTextPasteAsMarkdown` helpers; added an `editorRef` (handlePaste is captured before `editor` is assigned).
- `script-view.tsx` — new optional `className` prop merged onto the outer card.
- `routes/_app/sequences/new.tsx` — logged-out branch passes `className="max-h-[70dvh]"`.
- `markdown-editor.test.ts` — 7 unit tests for the helpers.

## Testing

- `bun typecheck`, `bun lint` (0 errors), `bun dead-code`, 7 new unit tests — all green.
- Browser-verified: empty composer stays compact; a 30-line block caps at 70dvh and scrolls inside the editor instead of expanding the page.

Closes #1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)
