### PR TITLE
Use string paths for router links

### DIFF
--- a/src/components/eval/eval-matrix.tsx
+++ b/src/components/eval/eval-matrix.tsx
@@ -7,7 +7,6 @@ import { EvalSequenceRow } from './eval-sequence-row';
 import type { SequenceWithShots } from '@/hooks/use-sequences-with-shots';
 import type { ViewMode } from './eval-view';
 import type { DialogTab } from './eval-cell-dialog';
-import { Route as sequencesTheatreRoute } from '@/routes/_app/sequences/$id/theatre';
 
 const ROW_HEIGHT = 240;
 const METADATA_WIDTH = 280;
@@ -82,7 +81,7 @@ export const EvalMatrix: React.FC<EvalMatrixProps> = ({
     const sequence = sequences[sequenceIndex];
     if (!sequence) return;
     void navigate({
-      to: sequencesTheatreRoute.fullPath,
+      to: '/sequences/$id/theatre',
       params: { id: sequence.id },
     });
   };

--- a/src/components/eval/eval-sequence-metadata.tsx
+++ b/src/components/eval/eval-sequence-metadata.tsx
@@ -6,7 +6,6 @@ import type { SequenceWithShots } from '@/hooks/use-sequences-with-shots';
 import { getImageModelById } from '@/lib/ai/models';
 import { getAspectRatioData } from '@/lib/constants/aspect-ratios';
 import { formatDistanceToNow } from '@/lib/format-date';
-import { Route as sequencesScenesRoute } from '@/routes/_app/sequences/$id/scenes';
 import { Link } from '@tanstack/react-router';
 import { AlertTriangle, Calendar, ImageIcon, Mail, User } from 'lucide-react';
 import { getCreatorIdentity } from './creator-identity';
@@ -37,7 +36,7 @@ export const EvalSequenceMetadata: React.FC<EvalSequenceMetadataProps> = ({
         />
       )}
       <Link
-        to={sequencesScenesRoute.fullPath}
+        to="/sequences/$id/scenes"
         params={{ id: sequence.id }}
         className="font-medium text-sm text-foreground line-clamp-2 hover:underline shrink-0 pr-4"
         title={sequence.title || 'Untitled Sequence'}

--- a/src/components/eval/eval-sequences-mobile.tsx
+++ b/src/components/eval/eval-sequences-mobile.tsx
@@ -10,7 +10,6 @@ import type { SequenceWithShots } from '@/hooks/use-sequences-with-shots';
 import type { ViewMode } from './eval-view';
 import { getAspectRatioData } from '@/lib/constants/aspect-ratios';
 import { getAnalysisModelById } from '@/lib/ai/models.config';
-import { Route as sequencesScenesRoute } from '@/routes/_app/sequences/$id/scenes';
 import { Link } from '@tanstack/react-router';
 import { ChevronRight, Mail, User } from 'lucide-react';
 import { getCreatorIdentity } from './creator-identity';
@@ -168,7 +167,7 @@ const MobileReelRow: React.FC<MobileReelRowProps> = ({
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <Link
-            to={sequencesScenesRoute.fullPath}
+            to="/sequences/$id/scenes"
             params={{ id: sequence.id }}
             className="font-medium text-sm text-foreground line-clamp-1 hover:underline"
             title={sequence.title || 'Untitled Sequence'}
@@ -192,10 +191,7 @@ const MobileReelRow: React.FC<MobileReelRowProps> = ({
             className="h-8 w-8"
             aria-label="Open sequence"
           >
-            <Link
-              to={sequencesScenesRoute.fullPath}
-              params={{ id: sequence.id }}
-            >
+            <Link to="/sequences/$id/scenes" params={{ id: sequence.id }}>
               <ChevronRight className="h-4 w-4" />
             </Link>
           </Button>
@@ -330,7 +326,7 @@ const SequencePosterCell: React.FC<SequencePosterCellProps> = ({
   );
 
   const linkProps = {
-    to: sequencesScenesRoute.fullPath,
+    to: '/sequences/$id/scenes',
     params: { id: sequence.id },
     'aria-label': `Open ${sequence.title || 'sequence'}`,
   } as const;

--- a/src/components/eval/eval-view.tsx
+++ b/src/components/eval/eval-view.tsx
@@ -18,7 +18,6 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { VideoIcon } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
-import { Route as sequencesNewRoute } from '@/routes/_app/sequences/new';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { getCreatorIdentity } from './creator-identity';
 
@@ -245,9 +244,7 @@ export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
           action={
             !filters.search && !supportMode ? (
               <Button asChild size="lg">
-                <Link to={sequencesNewRoute.fullPath}>
-                  Create Your First Sequence
-                </Link>
+                <Link to="/sequences/new">Create Your First Sequence</Link>
               </Button>
             ) : undefined
           }

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -18,12 +18,6 @@ import {
 } from '@/components/ui/sidebar';
 import { useLowBalanceWarning } from '@/hooks/use-low-balance-warning';
 import { SITE_CONFIG } from '@/lib/marketing/constants';
-import { Route as galleryRoute } from '@/routes/_app/gallery/index';
-import { Route as locationsRoute } from '@/routes/_app/locations/index';
-import { Route as sequencesRoute } from '@/routes/_app/sequences/index';
-import { Route as sequencesNewRoute } from '@/routes/_app/sequences/new';
-import { Route as stylesRoute } from '@/routes/_app/styles/index';
-import { Route as talentRoute } from '@/routes/_app/talent/index';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { useEffect } from 'react';
 import {
@@ -39,11 +33,11 @@ import { CreditBalancePill } from './credit-balance-pill';
 import { UserSidebarFooter } from './user-sidebar-footer';
 
 const navLinks = [
-  { to: sequencesRoute.to, label: 'Sequences', icon: Video },
-  { to: stylesRoute.to, label: 'Styles', icon: Palette },
-  { to: talentRoute.to, label: 'Talent', icon: Users },
-  { to: locationsRoute.to, label: 'Locations', icon: MapPin },
-  { to: galleryRoute.to, label: 'Gallery', icon: Clapperboard },
+  { to: '/sequences', label: 'Sequences', icon: Video },
+  { to: '/styles', label: 'Styles', icon: Palette },
+  { to: '/talent', label: 'Talent', icon: Users },
+  { to: '/locations', label: 'Locations', icon: MapPin },
+  { to: '/gallery', label: 'Gallery', icon: Clapperboard },
 ] as const;
 
 export function AppSidebar() {
@@ -60,7 +54,7 @@ export function AppSidebar() {
     <Sidebar collapsible="icon">
       <SidebarHeader>
         <Link
-          to={sequencesRoute.to}
+          to="/sequences"
           className="flex h-10 items-center px-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
         >
           <OpenStoryLogo
@@ -79,7 +73,7 @@ export function AppSidebar() {
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton asChild tooltip="New sequence">
-                  <Link to={sequencesNewRoute.to}>
+                  <Link to="/sequences/new">
                     <Plus />
                     <span>New sequence</span>
                   </Link>

--- a/src/components/style/sample-video-showcase.tsx
+++ b/src/components/style/sample-video-showcase.tsx
@@ -19,8 +19,6 @@ import {
   type SampleEntry,
 } from '@/lib/style/sample-entries';
 import { cn } from '@/lib/utils';
-import { Route as GalleryRoute } from '@/routes/_app/gallery/index';
-import { Route as NewSequenceRoute } from '@/routes/_app/sequences/new';
 import { Link } from '@tanstack/react-router';
 import { ArrowRight, Wand2 } from 'lucide-react';
 import { useCallback, useRef, useState } from 'react';
@@ -59,7 +57,7 @@ export const SampleVideoShowcase: React.FC = () => {
     <section className="flex flex-col gap-4">
       <ShowcaseHeading />
       <Link
-        to={GalleryRoute.to}
+        to="/gallery"
         className="inline-flex items-center justify-center gap-1 self-center text-sm font-medium text-muted-foreground hover:text-foreground"
       >
         Browse the full gallery
@@ -158,7 +156,7 @@ export const SampleVideoCard: React.FC<{ entry: SampleEntry }> = ({
             className="absolute bottom-2 right-2 gap-1.5 opacity-90 backdrop-blur-sm transition-opacity group-hover:opacity-100"
           >
             <Link
-              to={NewSequenceRoute.to}
+              to="/sequences/new"
               search={{ style: entry.slug }}
               hash="compose"
               aria-label={`Try the ${entry.styleName} style`}
@@ -194,7 +192,7 @@ export const SampleVideoCard: React.FC<{ entry: SampleEntry }> = ({
         {entry.hasBrief && (
           <Button asChild className="gap-1.5">
             <Link
-              to={NewSequenceRoute.to}
+              to="/sequences/new"
               search={{ style: entry.slug }}
               hash="compose"
             >

--- a/src/components/style/style-detail-dialog.tsx
+++ b/src/components/style/style-detail-dialog.tsx
@@ -21,7 +21,6 @@ import {
   stylePreviewImageUrls,
 } from '@/lib/style/style-assets';
 import { styleSlug } from '@/lib/style/style-slug';
-import { Route as NewSequenceRoute } from '@/routes/_app/sequences/new';
 import type { Style } from '@/types/database';
 import { Link } from '@tanstack/react-router';
 import { Wand2 } from 'lucide-react';
@@ -90,7 +89,7 @@ const SampleClip: FC<{
           className="absolute right-2 top-2 gap-1.5 opacity-90 backdrop-blur-sm transition-opacity hover:opacity-100"
         >
           <Link
-            to={NewSequenceRoute.to}
+            to="/sequences/new"
             search={{ style: slug }}
             hash="compose"
             aria-label={`Try the ${styleName} style`}
@@ -281,7 +280,7 @@ const StyleDetailContent: FC<{ style: Style }> = ({ style }) => {
             from the video's "Try", which also seeds the sample brief. */}
         <Button asChild>
           <Link
-            to={NewSequenceRoute.to}
+            to="/sequences/new"
             search={{ style: styleSlug(style.name), prefill: 'style' }}
             hash="compose"
             aria-label={`Use the ${style.name} style`}

--- a/src/lib/auth/navigation.ts
+++ b/src/lib/auth/navigation.ts
@@ -3,8 +3,6 @@
  * Helpers for navigating to auth pages with redirect preservation
  */
 
-import { Route as loginRoute } from '@/routes/_auth/login';
-
 /**
  * Get the redirect URL from query params
  * For use in auth pages to read the intended destination
@@ -28,7 +26,7 @@ export function getRedirectFromParams(
     // Only allow relative URLs (starting with /)
     if (redirectTo.startsWith('/') && !redirectTo.startsWith('//')) {
       // Prevent redirecting back to auth pages
-      if (!redirectTo.startsWith(loginRoute.fullPath)) {
+      if (!redirectTo.startsWith('/login')) {
         return redirectTo;
       }
     }

--- a/src/routes/_app/sequences/new.tsx
+++ b/src/routes/_app/sequences/new.tsx
@@ -11,7 +11,6 @@ import { styleSlug } from '@/lib/style/style-slug';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useCallback, useEffect, useState } from 'react';
 import { z } from 'zod';
-import { Route as ScenesRoute } from '@/routes/_app/sequences/$id/scenes';
 
 const BILLING_PROMPT_KEY = 'openstory:billing-prompt-dismissed';
 const BILLING_PROMPT_EXPIRY_DAYS = 1;
@@ -115,7 +114,7 @@ function NewSequencePage() {
       if (firstId) {
         // Navigate to storyboard page after successful generation
         void navigate({
-          to: ScenesRoute.to,
+          to: '/sequences/$id/scenes',
           params: { id: firstId },
         });
       }


### PR DESCRIPTION
## Summary

Closes #812

- Replaced route object path references with typed TanStack Router string paths
- Removed route module imports that were only used for .to or .fullPath
- Kept existing params, search, and hash behavior unchanged

## Testing

- bun typecheck
- bun format:check
- bun lint: 0 errors; existing unrelated warnings remain

Pre-commit also passed: dead-code, format, lint, typecheck.