### PR TITLE
Update workflow docs for Cloudflare Workflows

### DIFF
--- a/docs/architecture/staleness-and-divergence-ux.md
+++ b/docs/architecture/staleness-and-divergence-ux.md
@@ -1,5 +1,7 @@
 # Staleness and divergence UX
 
+> **Scene → Shot → Frame.** Image selection is a pointer repoint on `frame_variants` (#989) — there is no divergent-image `stale:detected` path. See [scene-shot-frame-redesign.md](./scene-shot-frame-redesign.md).
+
 Companion to [workflow-snapshots-and-content-hash-staleness.md](./workflow-snapshots-and-content-hash-staleness.md). The architecture doc is intentionally backend-heavy — it specifies hashes, snapshots, and divergence routing but punts on what the user sees. This is the answer.
 
 The architecture surfaces two new states through a single realtime event (`generation.stale:detected`) and a derived `isStale(entity, artifact)` reader. Both states need UI, but they're meaningfully different — and conflating them is the most likely way the UX fails.
@@ -8,14 +10,15 @@ The architecture surfaces two new states through a single realtime event (`gener
 
 We use two names, deliberately. Treat them as load-bearing — copy in the UI sticks to these terms.
 
-| Term                    | When it applies                                                                                                                                        | What it means to the user                                                                                                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Stale**               | `computeInputHash(entity) !== entity.<artifact>_input_hash`, derived at read time.                                                                     | "What you're looking at was generated from inputs that have since changed. The image / video / sheet itself is fine, but it's no longer the answer to the question you're asking."              |
-| **Divergent alternate** | A `frame_variants` row (or stage 2 sheet variant) with `diverged_at IS NOT NULL`, produced when a workflow finished but its inputs changed mid-flight. | "You started a regeneration. While it was running, you (or your collaborator) edited an upstream input. Rather than overwrite the new inputs with old work, we set this aside as an alternate." |
+| Term                         | When it applies                                                                                                                                                              | What it means to the user                                                                                                                                                                       |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Stale**                    | Fresh hash ≠ stored `*InputHash` on the parent row (caller computes fresh hash; scoped `isStale` compares). Derived at read time.                                            | "What you're looking at was generated from inputs that have since changed. The image / video / sheet itself is fine, but it's no longer the answer to the question you're asking."              |
+| **Divergent alternate**      | A `*_variants` row with `divergedAt IS NOT NULL` (sheets, music, shot video/audio) — **not** images (#989). Produced when a workflow finished but inputs changed mid-flight. | "You started a regeneration. While it was running, you (or your collaborator) edited an upstream input. Rather than overwrite the new inputs with old work, we set this aside as an alternate." |
+| **Unselected image version** | A `frame_variants` row that exists but is not pointed to by `frames.selectedImageVersionId` — includes mid-flight drift (#989) and explicit model compares.                  | "Another still exists for this shot. Pick it from the version picker / model compare UI." — no `stale:detected` toast; selection is `frameVariants.select`.                                     |
 
-A single artifact can be **stale**, **have a divergent alternate**, both, or neither. The UI handles them as distinct, composable states.
+A single shot can be **stale**, **have a divergent alternate** (sheet/music/video), **have unselected image versions**, any combination, or none. The UI handles staleness and divergent alternates as distinct, composable states.
 
-A frame can also have **per-model alternates** — that's the existing `frame_variants` rows generated when the user explicitly tries a different model. Those are _not_ divergent alternates and don't surface either of the new affordances. The `diverged_at` column is what distinguishes the two.
+**Per-model image versions** (`frame_variants`, `kind: 'model'`) from explicit "try another model" are neither stale nor divergent alternates — they're normal version history. **`divergedAt`** on `shot_variants` / sheet variants marks workflow-time divergence; `frame_variants` has no `divergedAt`.
 
 ## Two new shared primitives
 
@@ -30,7 +33,7 @@ Both are slim, non-modal, sit inline with the artifact they describe, and reuse 
 Props:
 
 - `artifact: 'thumbnail' | 'video' | 'audio' | 'sheet' | 'visual-prompt' | 'motion-prompt' | 'music-prompt'`
-- `entityType: 'frame' | 'character' | 'location' | 'library-location' | 'talent' | 'sequence'`
+- `entityType: 'shot' | 'character' | 'location' | 'library-location' | 'talent' | 'sequence'` (matches `StalenessEntityType` in `staleness-indicator.tsx` and `realtimeSchema.generation['stale:detected']`)
 - `onRegenerate: () => void`
 - `onDismiss?: () => void` — soft-dismiss for this session only; doesn't change DB state.
 - `density?: 'inline' | 'corner-dot'` — `inline` for detail views, `corner-dot` for cards / lists.
@@ -60,12 +63,14 @@ When both states apply at once (the live primary is stale **and** there's a dive
 
 ## Divergence resolution flow
 
-The default flow:
+The default flow (**sheets / music / shot video-audio only** — not images):
 
-1. Workflow finishes, recomputes `currentInputHash`, finds it diverges from `snapshotInputHash`. Writes to `frame_variants` with `diverged_at = now()`. Emits `stale:detected` with the new `divergedVariantId`.
-2. Sonner toast on the affected sequence's view: _"An alternate version is available for Scene 4."_ Click → focuses the frame detail.
-3. `<DivergentAlternateBanner>` appears in-place (frame detail right rail; corner dot on the scene card).
+1. Workflow finishes, recomputes current hash, finds it diverges from `snapshotInputHash`. Inserts a `*_variants` row with `divergedAt = now()` (e.g. `sheet-divergence.ts`, `music-workflow.ts`). Emits `generation.stale:detected` with the new `divergedVariantId`.
+2. Sonner toast on the affected sequence's view: _"An alternate version is available for Scene 4."_ Click → focuses the shot detail.
+3. `<DivergentAlternateBanner>` appears in-place (detail right rail; corner dot on the scene card for sheet/music paths that surface it).
 4. User picks one of three branches:
+
+**Image mid-flight drift (#989)** does not use this flow: `image-workflow` retains an unselected `frame_variants` version and resets `imageStatus` without emitting `stale:detected`. The user switches primaries via the version picker (`frameVariants.select`).
 
 ### Compare
 
@@ -106,12 +111,11 @@ version. The motion video, if any, will be marked stale.
 [ Cancel ]  [ Promote ]
 ```
 
-The "motion video, if any, will be marked stale" copy adapts based on which downstream artifacts exist for the entity. The mutation:
+The "motion video, if any, will be marked stale" copy adapts based on which downstream artifacts exist for the entity. The mutation depends on artifact type:
 
-1. Copies the variant's `url` / `path` into the primary slot on `frames` (`thumbnailUrl`, `thumbnailPath`, etc.).
-2. Sets the matching `*_input_hash` column on `frames` to the variant's `input_hash`.
-3. Deletes the variant row (or sets `discarded_at` — see below).
-4. Emits `image:progress` / `video:progress` / `audio:progress` with `status: completed` so existing realtime listeners refresh.
+- **Images (#989):** promotion is retired — `buildPromoteUpdate` throws for `variantType === 'image'`. Switching primaries uses `frameVariants.select` (pointer repoint + mirror), not a divergent-alternate promote.
+- **Shot video / audio:** copies the `shot_variants` row's `url` / `storagePath` into `shots.videoUrl` / `audioUrl` (and matching `*InputHash`), clears `divergedAt` or sets `discardedAt`, emits `video:progress` / `audio:progress` with `status: completed`.
+- **Sheets:** copies into the live entity via `characters.updateSheet` / location/talent equivalents; clears the divergent variant row or sets `discardedAt`; `sheet-divergence.ts` already emitted `stale:detected` at insert time.
 
 ### Discard
 
@@ -121,23 +125,22 @@ Soft-delete: set `discarded_at = now()` on the variant row. UI hides discarded v
 
 One row per `(entityType, artifact)` from the `stale:detected` payload. "Stage" is the architecture-doc stage that lands the backend support.
 
-| Entity / artifact            | Surface (card)                                                 | Surface (detail)                                                        | Stage |
-| ---------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------------- | ----- |
-| `frame` / `thumbnail`        | corner dot on `scene-list-item`                                | inline banner on `scenes-view` image-prompt tab                         | 1     |
-| `frame` / `video`            | (none — same card; covered by thumbnail dot if both)           | inline banner on motion-prompt tab                                      | 1     |
-| `frame` / `audio`            | (none)                                                         | inline banner on (future) audio tab                                     | 1     |
-| `frame` / `variant-image`    | (none — internal; only matters for the divergence path itself) | banner inside the per-model variants area in `scene-script-prompts.tsx` | 1     |
-| `character` / `sheet`        | corner dot on `talent-card`                                    | inline banner above sheet image in `character-detail-view`              | 2     |
-| `location` / `sheet`         | corner dot on `location-card`                                  | inline banner above reference image in `location-detail-view`           | 2     |
-| `library-location` / `sheet` | corner dot on `location-library-card`                          | inline banner in `location-library` edit dialog                         | 2     |
-| `talent` / `sheet`           | corner dot on `talent-library-card`                            | inline banner in `talent-library` edit dialog                           | 2     |
-| `sequence` / merged video    | (none)                                                         | inline banner above scene player when merged-video is stale             | 3     |
-| `sequence` / music           | (none)                                                         | inline banner in `music-view`                                           | 3     |
-| `frame` / `visual-prompt`    | (none)                                                         | "prompt stale" badge on image-prompt tab + history sheet                | 4     |
-| `frame` / `motion-prompt`    | (none)                                                         | "prompt stale" badge on motion-prompt tab + history sheet               | 4     |
-| `sequence` / `music-prompt`  | (none)                                                         | "prompt stale" badge in `music-view` + history sheet                    | 4     |
+| Entity / artifact            | Surface (card)                                                 | Surface (detail)                                                                | Status                                                      |
+| ---------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `shot` / `thumbnail`         | (none — no staleness corner dot on `scene-list-item` today)    | inline banner via `ShotStalenessBanners` / `scene-script-prompts.tsx` image tab | shipped (staleness); image divergence banner retired (#989) |
+| `shot` / `video`             | divergent corner dot when `shot_variants` divergent row exists | inline staleness + divergent banner on motion tab in `scene-script-prompts.tsx` | partial                                                     |
+| `shot` / `audio`             | (none)                                                         | inline banner on (future) audio tab                                             | deferred                                                    |
+| `character` / `sheet`        | corner dot on `talent-card`                                    | inline banner above sheet image in `character-detail-view`                      | shipped                                                     |
+| `location` / `sheet`         | corner dot on `location-card`                                  | inline banner above reference image in `location-detail-view`                   | shipped                                                     |
+| `library-location` / `sheet` | corner dot on `location-library-card`                          | inline banner in `location-library` edit dialog                                 | shipped                                                     |
+| `talent` / `sheet`           | corner dot on `talent-library-card`                            | inline banner in `talent-library` edit dialog                                   | shipped                                                     |
+| `sequence` / video (render)  | (none)                                                         | inline banner when segment video is stale (#990)                                | deferred                                                    |
+| `sequence` / `music`         | (none)                                                         | inline banner in `music-view` + divergent via `stale:detected`                  | partial                                                     |
+| `shot` / `visual-prompt`     | (none)                                                         | staleness corner dot on image-prompt tab (`scene-script-prompts.tsx`)           | shipped                                                     |
+| `shot` / `motion-prompt`     | (none)                                                         | staleness corner dot on motion-prompt tab                                       | shipped                                                     |
+| `sequence` / `music-prompt`  | (none)                                                         | "prompt stale" badge in `music-view` + history sheet                            | deferred                                                    |
 
-Stage 1 is the only row block we commit to in v1. The rest is sketched so that when the matching stage backend ticket is picked up, the UI work has a clear home and consistent vocabulary.
+Rows marked **shipped** or **partial** reflect what exists in the codebase today; **deferred** rows are sketched so matching backend/UI tickets have a documented home.
 
 ## Bulk operations
 
@@ -152,15 +155,11 @@ Not in v1. Listed here so it has a documented home when we pick it up.
 
 Backend implementation details that need to be in place before the divergence UI works correctly:
 
-1. **`frame_variants` unique indexes** (resolved in #615). The schema now carries two partial unique indexes instead of a single `(frameId, variantType, model)` constraint:
-   - `frame_variants_primary_key` on `(frameId, variantType, model)` WHERE `diverged_at IS NULL` — at most one primary slot per model. `image-workflow`'s speculative upsert and convergent reconcile both target this index.
-   - `frame_variants_divergent_key` on `(frameId, variantType, model, input_hash)` WHERE `diverged_at IS NOT NULL` — divergent alternates distinguished by input-hash, so multiple divergences of the same model can coexist.
+1. **Divergent indexes live on `shot_variants` (video/audio), not `frame_variants` (images).** `shot_variants` carries `shot_variants_primary_key` (WHERE `divergedAt IS NULL`) and `shot_variants_divergent_key` (WHERE `divergedAt IS NOT NULL`). The comparison dialog and corner-dot queries for video divergence filter `divergedAt IS NOT NULL` on `shot_variants`.
 
-   Implication for the UI: the corner-dot count and the comparison dialog both query `diverged_at IS NOT NULL` rows. A frame can have multiple divergent alternates of the same model (one per distinct `input_hash`), and the dialog should list them in `diverged_at` order.
+   **`frame_variants` (#989)** has no `divergedAt` — flat image versions indexed by `(frameId, kind, model)`. Mid-flight image drift surfaces as an unselected version, not a divergent alternate banner.
 
-2. **`promptHash` vs `input_hash`.** `frame_variants.promptHash` already exists (`frame-variants.ts`). Either reuse it as the new `input_hash` (rename) or add `input_hash` as a separate column — #614's call. The UI reads through the scoped getter, so as long as one of them is the canonical staleness signal, the UI is unaffected.
-
-   _Status_: Stage 1 added `input_hash` as a separate column alongside `promptHash`. `input_hash` is the canonical staleness signal; `promptHash` is unchanged.
+2. **`promptHash` vs `inputHash` on `frame_variants`.** Both columns exist; **`inputHash` is canonical** for staleness. `promptHash` is retained for legacy reads. UI and workflows should compare `inputHash`.
 
 ## Out of scope for v1
 
@@ -173,5 +172,5 @@ Backend implementation details that need to be in place before the divergence UI
 
 ## Open questions
 
-- **Toast frequency.** If a long workflow lands many divergent variants in quick succession (a recast that diverges across N frames), do we toast once with a count, or once per frame? Default: debounce to one toast per sequence per 5s with a count.
+- **Toast frequency.** If a long workflow lands many divergent variants in quick succession (a recast that diverges across N shots), do we toast once with a count, or once per shot? Default: debounce to one toast per sequence per 5s with a count.
 - **Promote-while-generating.** What happens if the user clicks Promote on a variant while a fresh regenerate is already in flight? Default: confirm dialog warns and offers to cancel the in-flight workflow, then promotes. Implementation depends on tracking the relevant Cloudflare Workflows instance ids and terminating the in-flight run safely before promotion.

--- a/docs/architecture/staleness-and-divergence-ux.md
+++ b/docs/architecture/staleness-and-divergence-ux.md
@@ -174,4 +174,4 @@ Backend implementation details that need to be in place before the divergence UI
 ## Open questions
 
 - **Toast frequency.** If a long workflow lands many divergent variants in quick succession (a recast that diverges across N frames), do we toast once with a count, or once per frame? Default: debounce to one toast per sequence per 5s with a count.
-- **Promote-while-generating.** What happens if the user clicks Promote on a variant while a fresh regenerate is already in flight? Default: confirm dialog warns and offers to cancel the in-flight workflow, then promotes. Implementation depends on QStash cancel-by-id.
+- **Promote-while-generating.** What happens if the user clicks Promote on a variant while a fresh regenerate is already in flight? Default: confirm dialog warns and offers to cancel the in-flight workflow, then promotes. Implementation depends on tracking the relevant Cloudflare Workflows instance ids and terminating the in-flight run safely before promotion.

--- a/docs/architecture/staleness-and-divergence-ux.md
+++ b/docs/architecture/staleness-and-divergence-ux.md
@@ -144,7 +144,7 @@ Stage 1 is the only row block we commit to in v1. The rest is sketched so that w
 Single proposal, deferred to stage 1.5 or stage 2:
 
 - A "Stale" filter pill at the top of the scene list (`scene-list.tsx`) that hides non-stale frames.
-- When the filter is active, a "Regenerate all stale" CTA appears next to the filter, triggering one `regenerateFramesWorkflow` for the union of stale frames.
+- When the filter is active, a "Regenerate all stale" CTA appears next to the filter, triggering one `regenerateShotsWorkflow` for the union of stale shots.
 
 Not in v1. Listed here so it has a documented home when we pick it up.
 

--- a/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
+++ b/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
@@ -6,7 +6,7 @@ It composes with [scoped-db-context-implementation.md](./scoped-db-context-imple
 
 ## The two failure modes we're closing
 
-**1. Lost-work mid-generation.** `regenerateFramesWorkflow` (`src/lib/workflows/regenerate-frames-workflow.ts`) reads mutable sequence state during workflow execution. If a user edits a character, location, or prompt while the workflow is running, the generation can read a mix of pre- and post-edit inputs. The result is written as the primary artifact either way, with no signal that what landed isn't what the user had in mind when they triggered the workflow.
+**1. Lost-work mid-generation.** Content-generation workflows must not read mutable DB state for anything that should be frozen at trigger time. Before the snapshot pattern, `regenerateShotsWorkflow` (`RegenerateShotsWorkflow` in `src/lib/workflows/regenerate-shots-workflow.ts`) could re-resolve sequence fields or sheet references mid-flight. If a user edits a character, location, or prompt while the workflow is running, generation can read a mix of pre- and post-edit inputs. The result is written as the primary artifact either way, with no signal that what landed isn't what the user had in mind when they triggered the workflow. `RegenerateShotsWorkflow` is the reference fix: it inlines per-shot snapshot DTOs and a batch `snapshotInputHash` at trigger time via `src/lib/workflows/regenerate-shots-snapshot.ts`.
 
 **2. Silent staleness.** After a character recast or location swap, downstream frames, character sheets, location sheets, and talent sheets still display their prior outputs. Nothing in the schema records which inputs those outputs were derived from, so the UI can't distinguish "still current" from "stale but not yet regenerated" — and neither can a workflow about to apply a new result.
 
@@ -24,7 +24,7 @@ Before describing the design, it's worth stating what the original doc recommend
 | Postgres JSONB / SKIP LOCKED      | The app runs on Cloudflare D1 (SQLite). Cloudflare Workflows is already the durable job engine; we don't need a DB-level queue at all.                                                                                                  |
 | Entity version chains / branching | `frame_variants` (`src/lib/db/schema/frame-variants.ts`) already holds alternate per-model outputs, which covers the realistic "keep old vs new" use case for frame artifacts. General-purpose branching adds complexity we don't need. |
 | Property-level LWW + rebasing     | We are not a concurrent editor. TanStack Query + server functions give us implicit last-writer-wins at the server boundary.                                                                                                             |
-| Dependency edge table (v1)        | Character/location → frame linkage is inferred at runtime via `characterTags` in `frame.metadata` (`matchCharactersToFrame`). Good enough until we have a reason to materialize it.                                                     |
+| Dependency edge table (v1)        | Character/location → shot linkage is inferred at runtime via `characterTags` in shot metadata and `matchCharactersToScene` (`src/lib/workflows/scene-matching.ts`). Good enough until we have a reason to materialize it.               |
 | `stale` status enum value (v1)    | Staleness is a **derived** boolean (`generatedFromInputHash !== computeInputHash(entity)`). Adding it to the enum is a v2 question if the derived form ever proves insufficient.                                                        |
 
 ## Pillar 1: Input-hash staleness
@@ -99,34 +99,42 @@ Workflows must not read mutable state inside a `step.do()` for anything that sho
 
 **At write time** (inside the final `step.do()` that commits the artifact): recompute `currentInputHash` from the _live_ scoped-DB state, and branch on whether it still matches `snapshotInputHash`. (See Pillar 3.)
 
-### Shared workflow snapshot extension
+### Per-workflow snapshot modules
 
-The shared Cloudflare Workflows base/helper layer gains an optional `snapshot` configuration:
+There is no centralized `snapshot` config on `OpenStoryWorkflowEntrypoint`. Each migrated workflow owns a companion `*-snapshot.ts` module that:
+
+1. **Builds the inlined DTO at trigger time** (server function / parent workflow) from live scoped-DB state — e.g. `buildRegenerateShotSnapshot` in `regenerate-shots-snapshot.ts`, scene snapshot builders in `sheet-snapshots.ts`.
+2. **Hashes the DTO** for tamper detection — e.g. `computeRegenerateShotsBatchHash`, `computeShotImagesHashFromDto`, per-artifact helpers in `image-workflow-snapshot.ts`.
+3. **Validates at workflow start** inside `step.do('validate-snapshot')` by recomputing the hash from `event.payload` and comparing to `snapshotInputHash`.
+4. **Branches at write time** by recomputing a current hash from live state and comparing to the frozen `snapshotInputHash` — convergent results apply as primary; divergent results route through `sheet-divergence.ts` or `frame_variants` insert helpers.
 
 ```ts
-class MyWorkflow extends OpenStoryWorkflowEntrypoint<
-  MyWorkflowInput & { snapshotInputHash: string }
-> {
-  protected override async runImpl(event, step, scopedDb) {
-    // Snapshot-aware helpers validate event.payload.snapshotInputHash and
-    // expose computeCurrent(input, scopedDb) for write-time divergence checks.
+// illustrative — RegenerateShotsWorkflow start-time validation
+await step.do('validate-snapshot', async () => {
+  const expected = event.payload.snapshotInputHash;
+  if (!expected) return;
+  const recomputed = await computeRegenerateShotsBatchHash(event.payload);
+  if (recomputed !== expected) {
+    throw new NonRetryableError(
+      'snapshotInputHash does not match the inlined DTO'
+    );
   }
-}
+});
 ```
 
-When `snapshot` is configured, the shared helper validates that the payload carries `snapshotInputHash`, and exposes `{ snapshotInputHash, computeCurrent() }` to workflow code. Workflows that have been migrated use it; workflows that haven't are unchanged.
+Workflows that have not been migrated yet keep their existing behaviour until they gain a `*-snapshot.ts` module and the trigger path inlines the DTO.
 
 ### Per-workflow input surface
 
 For the workflows that do content generation, "input" is specifically:
 
-- **`regenerateFramesWorkflow`** (`RegenerateFramesWorkflowInput`) — already passes `frameIds`, `triggeringCharacterId`, `imageModel`. Needs to additionally inline the resolved character-sheet hashes and location-sheet hashes for each affected frame at trigger time. Remove the live `scopedDb.sequences.getById` read from the generation step.
-- **`characterSheetWorkflow`** (`CharacterSheetWorkflowInput`) — already inlines `characterMetadata`, `talentMetadata`, `referenceImageUrl`, `styleConfig`. Add: the `input_hash` of the referenced talent sheet (if any).
-- **`locationSheetWorkflow`** (`LocationSheetWorkflowInput`) — already inlines `locationMetadata`, `referenceImageUrl`, `libraryLocationDescription`, `styleConfig`. Add: the `reference_input_hash` of the referenced library location (if any).
-- **`libraryTalentSheetWorkflow`** (`LibraryTalentSheetWorkflowInput`) — already inlines `referenceImageUrls`, `talentDescription`. Talent media is append-only in practice, so the snapshot is the list of reference URLs themselves.
-- **`frameImagesWorkflow`** (`FrameImagesWorkflowInput`) — already inlines `charactersWithSheets`, `locationsWithSheets`, `elements`, `scenesWithVisualPrompts`. The shape is right; what's missing is the hash-per-sheet alongside each URL so downstream staleness checks can use it.
+- **`regenerateShotsWorkflow`** (`RegenerateShotsWorkflowInput`, `src/lib/workflows/regenerate-shots-workflow.ts`) — **reference implementation.** Trigger time inlines `shotSnapshots` (per-shot prompt, reference URLs, and sheet hashes via `buildRegenerateShotSnapshot`), freezes `aspectRatio`, and sets `snapshotInputHash` from `computeRegenerateShotsBatchHash`. The workflow body reads only the inlined DTO; start-time validation runs in `step.do('validate-snapshot')`.
+- **`shotImagesWorkflow`** (`ShotImagesWorkflowInput`, `src/lib/workflows/shot-images-workflow.ts`) — inlines `sceneSnapshots` (per-scene upstream sheet hashes) and optional `snapshotInputHash`. Hash helpers live in `image-workflow-snapshot.ts` and `sheet-snapshots.ts`.
+- **`characterSheetWorkflow`** (`CharacterSheetWorkflowInput`) — inlines character/talent metadata and reference URLs; carries `snapshotInputHash`. Write-time divergence routes through `decideSheetDivergence` / `saveDivergentCharacterSheet` in `sheet-divergence.ts`.
+- **`locationSheetWorkflow`** (`LocationSheetWorkflowInput`) — same pattern for location sheets and library-location references.
+- **`libraryTalentSheetWorkflow`** (`LibraryTalentSheetWorkflowInput`) — inlines `referenceImageUrls`, `talentDescription`, and `snapshotInputHash`. Talent media is append-only in practice, so the snapshot is the list of reference URLs themselves.
 
-Most of the work is additive — these payloads already carry the data. We add the hashes and remove the live reads.
+Most migrations are additive — payloads already carry most of the data. The work is inlining hashes, validating at start, and branching at write time.
 
 ### Snapshot size
 
@@ -137,26 +145,42 @@ Cloudflare Workflows has event payload size limits, but our payloads are dominat
 Before writing a generation result, compare hashes:
 
 ```ts
-// illustrative — runs inside the final step.do() of the workflow
-const currentInputHash = await context.snapshot.computeCurrent(input, scopedDb);
+// illustrative — runs inside a sheet workflow's final step.do()
+const snapshotInputHash = input.snapshotInputHash ?? null;
+const currentInputHash = await computeCharacterSheetHashCurrent(
+  input,
+  scopedDb
+);
+const decision = decideSheetDivergence(snapshotInputHash, currentInputHash);
 
-if (currentInputHash === context.snapshot.snapshotInputHash) {
-  // Inputs unchanged — apply as the primary artifact (existing behaviour)
-  await scopedDb.frames.updateThumbnail(frameId, {
+if (decision.kind === 'convergent') {
+  // Inputs unchanged — apply as the primary sheet (existing behaviour)
+  await scopedDb.characters.updateSheet(characterId, {
     url,
     inputHash: currentInputHash,
   });
 } else {
-  // Diverged mid-generation — save without disturbing live state
-  await saveDivergedResult(
+  // Diverged mid-generation — park in variants without disturbing live state
+  const { id: divergedVariantId } = await saveDivergentCharacterSheet({
     scopedDb,
-    input,
-    result,
-    context.snapshot.snapshotInputHash
-  );
-  await channel.emit('stale:detected', { frameId, artifact: 'thumbnail' });
+    characterId,
+    sequenceId,
+    model,
+    url,
+    snapshotInputHash: decision.snapshotInputHash,
+    currentInputHash: decision.currentInputHash,
+  });
+  await getGenerationChannel(sequenceId).emit('generation.stale:detected', {
+    entityType: 'character',
+    entityId: characterId,
+    artifact: 'sheet',
+    snapshotInputHash: decision.snapshotInputHash,
+    divergedVariantId,
+  });
 }
 ```
+
+Per-shot image artifacts follow the same hash comparison inside `image-workflow` / `regenerate-shots-workflow`, routing divergent thumbnails into `frame_variants` and emitting `generation.stale:detected` with `entityType: 'shot'`.
 
 ### Where diverged results land
 
@@ -174,24 +198,34 @@ if (currentInputHash === context.snapshot.snapshotInputHash) {
 
 ### Realtime event
 
-Extend `realtimeSchema.generation` in `src/lib/realtime/index.ts` with:
+`realtimeSchema.generation` in `src/lib/realtime/index.ts` defines `stale:detected` as a discriminated union on `entityType`. Clients subscribe on the generation channel and listen for the dotted path `generation.stale:detected`:
 
 ```ts
-'stale:detected': z.object({
-  entityType: z.enum(['frame', 'character', 'location', 'library-location', 'talent']),
-  entityId: z.string(),
-  artifact: z.enum(['thumbnail', 'variant-image', 'video', 'audio', 'sheet']).optional(),
-  snapshotInputHash: z.string(),
-  divergedVariantId: z.string().optional(), // populated for frame artifacts
-}),
+'stale:detected': z.discriminatedUnion('entityType', [
+  z.object({
+    entityType: z.literal('shot'),
+    entityId: z.string(),
+    artifact: z.enum(['thumbnail', 'variant-image', 'video', 'audio']),
+    snapshotInputHash: z.string(),
+    divergedVariantId: z.string(),
+  }),
+  z.object({
+    entityType: z.literal('character'),
+    entityId: z.string(),
+    artifact: z.literal('sheet'),
+    snapshotInputHash: z.string(),
+    divergedVariantId: z.string(),
+  }),
+  // ...location, library-location, talent, and sequence (music) branches
+]),
 ```
 
-This gives the UI a single event to listen for across all four entity types without adding new channels.
+`divergedVariantId` is required on every branch — emitters in `sheet-divergence.ts` and `regenerate-shots-workflow.ts` always park the divergent artifact first, then reference the new variant row's id. This gives the UI a single event shape across entity types without adding new channels.
 
 ## How it composes with existing patterns
 
 - **Scoped DB** (`src/lib/db/scoped/*`) is the only entry point. Staleness reads go through scoped getters; hash computation helpers accept a `ScopedDb` and use it. No code path bypasses team scoping.
-- **Shared workflow helpers** gain the optional `snapshot` extension described above — existing workflows keep working unchanged until they opt in.
+- **Per-workflow snapshot modules** (`*-snapshot.ts`) own DTO building, hashing, and validation — existing workflows keep working unchanged until they gain one.
 - **Status columns** stay `pending | generating | completed | failed`. Staleness does not become a fifth value. The UI composes `status === 'completed' && isStale(entity)` when it needs "completed but stale".
 - **`frame_variants`** is the divergence sink for frame artifacts in addition to its existing role for per-model alternates. The unique key was split into two partial indexes (primary slot vs divergent alternates keyed by `input_hash`) so primaries and alternates of the same model coexist without overwriting each other. `input_hash` and `diverged_at` are columns on this table.
 
@@ -238,7 +272,7 @@ Prompts are themselves generated artifacts of an upstream context (scene metadat
 
 Everything else from the original doc that we're explicitly _not_ implementing yet:
 
-- **`frame_dependencies` edge table.** Keep inferring from `characterTags` / `matchCharactersToFrame` (`src/lib/workflows/regenerate-frames-workflow.ts`) until there's a concrete reason to materialize it — e.g., needing to walk dependents faster than a scan allows.
+- **`frame_dependencies` edge table.** Keep inferring from `characterTags` / `matchCharactersToScene` (`src/lib/workflows/scene-matching.ts`, used by `sheet-snapshots.ts` and `shot-images-workflow.ts`) until there's a concrete reason to materialize it — e.g., needing to walk dependents faster than a scan allows.
 - **`stale` as a status enum value.** The derived boolean is sufficient until it isn't.
 - **Topological regeneration queue.** Not needed until we have a materialized dependency graph to walk.
 - **Content-addressable snapshot table** (`workflow_input_snapshots`). Not needed until inlining snapshots into Cloudflare Workflows payloads actually strains the payload-size budget.
@@ -253,7 +287,7 @@ Answering every row of the original doc's decision table for our stack:
 | Staleness detection      | Content hash comparison                   | **Kept**: SHA-256 input-hash comparison, derived at read time.                                                                                                                    |
 | Invalidation propagation | Lazy dirty bits + demand verification     | **Adapted**: no dirty-bit table; staleness is a pure read of the current graph.                                                                                                   |
 | Collaborative sync       | Property-level LWW + transactions         | **Dropped**: not a concurrent editor. Server is authoritative.                                                                                                                    |
-| Workflow isolation       | Application-level snapshots               | **Kept**: snapshot inlined in the Cloudflare Workflows payload; shared workflow helpers enforce it.                                                                               |
+| Workflow isolation       | Application-level snapshots               | **Kept**: snapshot inlined in the Cloudflare Workflows payload; per-workflow `*-snapshot.ts` modules build, hash, and validate it.                                                |
 | Lifecycle management     | XState machines                           | **Dropped**: existing status columns are sufficient.                                                                                                                              |
 | Workflow orchestration   | Inngest (or Temporal)                     | **Dropped**: Cloudflare Workflows already does this.                                                                                                                              |
 | Real-time events         | Redis pub/sub + PG NOTIFY                 | **Kept, different plumbing**: typed SSE events delivered through `RealtimeChannel` Durable Objects; one new event type.                                                           |
@@ -268,9 +302,9 @@ Recommended build order for stage 1, each step independently shippable:
 1. `src/lib/ai/input-hash.ts` with the per-artifact helpers and their unit tests. No schema changes yet.
 2. Add `input_hash` and `diverged_at` columns to `frame_variants`, plus `input_hash` to the sheet tables. Backfill is unnecessary — null means "unknown, treat as non-stale". Split the existing `(frameId, variantType, model)` unique index into `frame_variants_primary_key` (WHERE `diverged_at IS NULL`) and `frame_variants_divergent_key` on `(frameId, variantType, model, input_hash)` (WHERE `diverged_at IS NOT NULL`) so divergent alternates can coexist with the primary slot.
 3. Add the four `*_input_hash` columns to `frames`.
-4. Extend the shared Cloudflare Workflows base/helper layer with the optional `snapshot` config.
-5. Migrate **one** workflow end-to-end (`regenerateFramesWorkflow` is the highest-value target given it's the concrete bug described in the problem statement). Prove the pattern, including the divergence path into `frame_variants`.
-6. Extend `realtimeSchema.generation` with `stale:detected` and wire one UI surface to it.
-7. Migrate remaining workflows one at a time.
+4. Add or extend per-workflow `*-snapshot.ts` helpers for each content-generation workflow (DTO build at trigger time, hash at trigger time, `computeCurrent` for write-time checks).
+5. **`RegenerateShotsWorkflow` is the reference implementation** — already migrated end-to-end with `regenerate-shots-snapshot.ts`, start-time validation, and divergence routing into `frame_variants`. Use it as the template for remaining workflows.
+6. `realtimeSchema.generation['stale:detected']` is live; wire additional UI surfaces to `generation.stale:detected` as needed.
+7. Migrate remaining workflows one at a time (`shotImagesWorkflow`, sheet workflows, etc.).
 
 Each step preserves the existing system; nothing in here requires a big-bang migration. Stages 2-5 are taken on independently, in whatever order user-facing pressure dictates.

--- a/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
+++ b/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
@@ -1,5 +1,7 @@
 # Workflow snapshots and content-hash staleness
 
+> **Scene → Shot → Frame.** The still-image surface, version pointers, and retired image `divergedAt` path are defined in [scene-shot-frame-redesign.md](./scene-shot-frame-redesign.md) (#989). This doc covers input-hash staleness and workflow snapshots on top of that model.
+
 This is the companion to [managing-complex-dependency-graphs-in-collaborative-ai-video-platforms.md](./managing-complex-dependency-graphs-in-collaborative-ai-video-platforms.md). The original doc proposed a general-purpose versioned-DAG architecture with branching, XState lifecycles, Inngest, Postgres MVCC, Redis pub/sub, and Linear-style transaction sync. A review against the codebase shows that most of that infrastructure is already solved differently on our stack (Cloudflare Workflows, Durable Object-backed SSE realtime, Cloudflare D1, Drizzle, and scoped DB access from workflow payload `teamId`/`userId`) — and most of what remains unsolved reduces to a critical path of three ideas. This doc is the stack-specific subset we intend to ship.
 
 It composes with [scoped-db-context-implementation.md](./scoped-db-context-implementation.md); every new data-access path described here flows through `ScopedDb`.
@@ -8,7 +10,7 @@ It composes with [scoped-db-context-implementation.md](./scoped-db-context-imple
 
 **1. Lost-work mid-generation.** Content-generation workflows must not read mutable DB state for anything that should be frozen at trigger time. Before the snapshot pattern, `regenerateShotsWorkflow` (`RegenerateShotsWorkflow` in `src/lib/workflows/regenerate-shots-workflow.ts`) could re-resolve sequence fields or sheet references mid-flight. If a user edits a character, location, or prompt while the workflow is running, generation can read a mix of pre- and post-edit inputs. The result is written as the primary artifact either way, with no signal that what landed isn't what the user had in mind when they triggered the workflow. `RegenerateShotsWorkflow` is the reference fix: it inlines per-shot snapshot DTOs and a batch `snapshotInputHash` at trigger time via `src/lib/workflows/regenerate-shots-snapshot.ts`.
 
-**2. Silent staleness.** After a character recast or location swap, downstream frames, character sheets, location sheets, and talent sheets still display their prior outputs. Nothing in the schema records which inputs those outputs were derived from, so the UI can't distinguish "still current" from "stale but not yet regenerated" — and neither can a workflow about to apply a new result.
+**2. Silent staleness.** After a character recast or location swap, downstream shots (and their anchor-frame stills), character sheets, location sheets, and talent sheets still display their prior outputs. Nothing in the schema records which inputs those outputs were derived from, so the UI can't distinguish "still current" from "stale but not yet regenerated" — and neither can a workflow about to apply a new result.
 
 Both failure modes collapse into one missing primitive: **every generated artifact needs to remember the inputs it was generated from**, and every workflow needs to **freeze those inputs at start time and verify them at write time**.
 
@@ -16,16 +18,16 @@ Both failure modes collapse into one missing primitive: **every generated artifa
 
 Before describing the design, it's worth stating what the original doc recommended that we're skipping, and why — so future implementers don't accidentally drift back toward it:
 
-| Original recommendation           | Why we skip it                                                                                                                                                                                                                          |
-| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Inngest for orchestration         | Cloudflare Workflows is already wired, and `OpenStoryWorkflowEntrypoint` (`src/lib/workflow/base-workflow.ts`) enforces `teamId`/`userId` on every run. Swapping orchestrators would be pure churn.                                     |
-| XState v5 lifecycle machines      | Status columns (`thumbnailStatus`, `variantImageStatus`, `videoStatus`, `audioStatus`, `sequences.status`) already model `pending → generating → completed → failed`. Adding XState on top would duplicate state, not replace it.       |
-| Custom Redis pub/sub + PG NOTIFY  | `src/lib/realtime/index.ts` already provides a typed `realtimeSchema`; delivery runs through the in-repo SSE client and `RealtimeChannel` Durable Object. We extend this schema, we don't replace it.                                   |
-| Postgres JSONB / SKIP LOCKED      | The app runs on Cloudflare D1 (SQLite). Cloudflare Workflows is already the durable job engine; we don't need a DB-level queue at all.                                                                                                  |
-| Entity version chains / branching | `frame_variants` (`src/lib/db/schema/frame-variants.ts`) already holds alternate per-model outputs, which covers the realistic "keep old vs new" use case for frame artifacts. General-purpose branching adds complexity we don't need. |
-| Property-level LWW + rebasing     | We are not a concurrent editor. TanStack Query + server functions give us implicit last-writer-wins at the server boundary.                                                                                                             |
-| Dependency edge table (v1)        | Character/location → shot linkage is inferred at runtime via `characterTags` in shot metadata and `matchCharactersToScene` (`src/lib/workflows/scene-matching.ts`). Good enough until we have a reason to materialize it.               |
-| `stale` status enum value (v1)    | Staleness is a **derived** boolean (`generatedFromInputHash !== computeInputHash(entity)`). Adding it to the enum is a v2 question if the derived form ever proves insufficient.                                                        |
+| Original recommendation           | Why we skip it                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Inngest for orchestration         | Cloudflare Workflows is already wired, and `OpenStoryWorkflowEntrypoint` (`src/lib/workflow/base-workflow.ts`) enforces `teamId`/`userId` on every run. Swapping orchestrators would be pure churn.                                                                                                                                                     |
+| XState v5 lifecycle machines      | Per-artifact status columns on `frames` (`imageStatus`) and `shots` (`videoStatus`, `audioStatus`) already model `pending → generating → completed → failed`. `sequences.status` is sequence lifecycle (`draft → processing → completed → failed → archived`), not per-artifact generation. Adding XState on top would duplicate state, not replace it. |
+| Custom Redis pub/sub + PG NOTIFY  | `src/lib/realtime/index.ts` already provides a typed `realtimeSchema`; delivery runs through the in-repo SSE client and `RealtimeChannel` Durable Object. We extend this schema, we don't replace it.                                                                                                                                                   |
+| Postgres JSONB / SKIP LOCKED      | The app runs on Cloudflare D1 (SQLite). Cloudflare Workflows is already the durable job engine; we don't need a DB-level queue at all.                                                                                                                                                                                                                  |
+| Entity version chains / branching | `frame_variants` (`src/lib/db/schema/frame-variants.ts`) already holds alternate per-model outputs, which covers the realistic "keep old vs new" use case for frame artifacts. General-purpose branching adds complexity we don't need.                                                                                                                 |
+| Property-level LWW + rebasing     | We are not a concurrent editor. TanStack Query + server functions give us implicit last-writer-wins at the server boundary.                                                                                                                                                                                                                             |
+| Dependency edge table (v1)        | Character/location → shot linkage is inferred at runtime via `characterTags` in shot metadata and `matchCharactersToScene` (`src/lib/workflows/scene-matching.ts`). Good enough until we have a reason to materialize it.                                                                                                                               |
+| `stale` status enum value (v1)    | Staleness is a **derived** boolean (`generatedFromInputHash !== computeInputHash(entity)`). Adding it to the enum is a v2 question if the derived form ever proves insufficient.                                                                                                                                                                        |
 
 ## Pillar 1: Input-hash staleness
 
@@ -35,12 +37,14 @@ Every artifact-bearing row stores the SHA-256 hash of the canonical serializatio
 
 The rule is: anything that, if changed, should cause the user to see a "regenerate" affordance. For our artifacts this is:
 
-- **Frame image/variant** — the composed visual prompt, the image model, image params (aspect ratio, size, seed), and the **content hash of each referenced character sheet, location sheet, and element reference**. Crucially, the hash is over the _referenced sheets' hashes_, not their URLs — a character sheet that's been regenerated with a new URL but identical inputs should not invalidate dependent frames.
-- **Frame video** — the source image URL (or variant hash), motion prompt, motion model, duration, fps, aspect ratio.
-- **Frame audio** — music prompt, tags, duration, audio model.
-- **Character sheet** (`characters.sheetImageUrl`) — character bible entry, talent reference hash (if any), style config, image model.
-- **Location sheet** (`locationSheets.referenceImageUrl`, `locationLibrary.referenceImageUrl`) — location bible entry, library location reference hash (if any), style config, image model.
-- **Talent sheet** (`talentSheets`) — talent metadata, reference media hashes, image model.
+- **Frame image** (`frames.imageInputHash`, mirrored on the selected `frame_variants` version) — the composed visual prompt (`frame.imagePrompt` or `shot.metadata` fallback), image model, aspect ratio, and the **content hash of each referenced character sheet, location sheet, and element reference**. Crucially, the hash is over the _referenced sheets' hashes_, not their URLs.
+- **Shot video** (`shots.videoInputHash`) — source still selection, motion prompt, motion model, duration, fps, aspect ratio.
+- **Shot audio** (`shots.audioInputHash`) — music prompt, tags, duration, audio model.
+- **Visual prompt** (`frames.visualPromptInputHash`) — upstream scene metadata + style config + character/location bible + analysis model.
+- **Motion prompt** (`shots.motionPromptInputHash`) — same upstream context plus the starting-frame image hash.
+- **Character sheet** (`characters.sheetInputHash`) — character bible entry, talent reference hash (if any), style config, image model.
+- **Sequence location reference** (`sequence_locations.referenceInputHash`) and **library location template** (`location_library.referenceInputHash`) — location bible entry, library reference hash (if any), style config, image model. Per-sequence generated sheets also carry `location_sheets.inputHash`.
+- **Talent sheet** (`talent_sheets.inputHash`) — talent metadata, reference media hashes, image model.
 
 Model _version strings_ count as inputs. If we upgrade an image model, every existing artifact it produced becomes stale — which is the correct behaviour.
 
@@ -48,36 +52,48 @@ Model _version strings_ count as inputs. If we upgrade an image model, every exi
 
 One column per artifact per row. The column is nullable because pre-existing rows won't have one until they're regenerated.
 
-| Table             | New columns                                                                                |
-| ----------------- | ------------------------------------------------------------------------------------------ |
-| `frames`          | `thumbnail_input_hash`, `variant_image_input_hash`, `video_input_hash`, `audio_input_hash` |
-| `frame_variants`  | `input_hash` (single artifact per row)                                                     |
-| `characters`      | `sheet_input_hash`                                                                         |
-| `location_sheets` | `input_hash`                                                                               |
-| `locationLibrary` | `reference_input_hash`                                                                     |
-| `talent_sheets`   | `input_hash`                                                                               |
+| Table                     | Hash columns (nullable — null means "unknown, not stale")                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------ |
+| `frames`                  | `imageInputHash`, `visualPromptInputHash`                                                  |
+| `frame_variants`          | `inputHash` (per image version; `promptHash` retained for legacy reads)                    |
+| `shots`                   | `videoInputHash`, `audioInputHash`, `motionPromptInputHash`                                |
+| `characters`              | `sheetInputHash`                                                                           |
+| `sequence_locations`      | `referenceInputHash`                                                                       |
+| `location_sheets`         | `inputHash`                                                                                |
+| `location_library`        | `referenceInputHash`                                                                       |
+| `talent_sheets`           | `inputHash`                                                                                |
+| `shot_variants`           | `inputHash` (video/audio divergent alternates; image variants retired to `frame_variants`) |
+| `*_sheet_variants`        | `inputHash` + `divergedAt` on divergent sheet rows                                         |
+| `sequence_music_variants` | `inputHash` + `divergedAt` on divergent music rows                                         |
 
 We deliberately do **not** add a `content_hash` column on upstream entities themselves (characters, locations, talent) — the referenced-sheet's `input_hash` _is_ the content hash for downstream staleness. This avoids a second-order invalidation layer.
 
 ### Where the helpers live
 
-A new `src/lib/ai/input-hash.ts` exports one `computeInputHash` variant per artifact type. Each helper accepts the minimal input DTO it needs (never a whole DB row) and returns a `string`. This keeps callers honest about what counts as input and makes the helpers trivially unit-testable without DB setup.
+`src/lib/ai/input-hash.ts` exports one named helper per artifact type (e.g. `computeShotImageInputHash`, `computeCharacterSheetInputHash`, `computeMotionPromptInputHash`). Each helper accepts the minimal input DTO it needs (never a whole DB row) and returns a `string`. This keeps callers honest about what counts as input and makes the helpers trivially unit-testable without DB setup.
 
-The existing `src/lib/utils/hash.ts` (`simpleHash`) is not cryptographic and is too weak for this purpose — it stays where it is for its existing non-security uses, and the new staleness helpers use `crypto.subtle.digest('SHA-256', ...)` or `Bun.CryptoHasher`.
+The existing `src/lib/utils/hash.ts` (`simpleHash`) is not cryptographic and is too weak for this purpose — it stays where it is for its existing non-security uses, and the staleness helpers use `crypto.subtle.digest('SHA-256', ...)`.
 
 Canonical serialization matters: object key order, array order for unordered sets (character refs), and trimming of free-text prompts all need to be deterministic. The helper file is the one place this is defined.
 
 ### Staleness as a derived read
 
 ```ts
-// ScopedDb frame method, illustrative
-async isStale(frameId: string, artifact: 'thumbnail' | 'variantImage' | 'video' | 'audio'): Promise<boolean> {
-  const frame = await this.get(frameId);
-  const stored = frame[`${artifact}InputHash`];
-  if (!stored) return false; // never generated — not stale, just absent
-  const current = await computeInputHashForArtifact(this, frame, artifact);
-  return current !== stored;
-}
+// Caller computes the fresh hash, then asks scoped getters to compare.
+// Null stored hash → "unknown, not stale" (legacy rows).
+
+const currentImageHash = await computeShotImageInputHash(hashInput);
+const imageStale = await scopedDb.frames.isStale(
+  anchorFrameId,
+  currentImageHash
+);
+
+const currentVideoHash = await computeShotVideoInputHash(videoHashInput);
+const videoStale = await scopedDb.shots.isStale(
+  shotId,
+  'video',
+  currentVideoHash
+);
 ```
 
 The UI calls this (or a batch variant) when rendering. There is no cascading propagation, no dirty-bit table, no LISTEN/NOTIFY. The staleness calculation is a pure read of the current graph — if character sheets haven't changed, their hash is the same, and the comparison trivially passes.
@@ -106,7 +122,7 @@ There is no centralized `snapshot` config on `OpenStoryWorkflowEntrypoint`. Each
 1. **Builds the inlined DTO at trigger time** (server function / parent workflow) from live scoped-DB state — e.g. `buildRegenerateShotSnapshot` in `regenerate-shots-snapshot.ts`, scene snapshot builders in `sheet-snapshots.ts`.
 2. **Hashes the DTO** for tamper detection — e.g. `computeRegenerateShotsBatchHash`, `computeShotImagesHashFromDto`, per-artifact helpers in `image-workflow-snapshot.ts`.
 3. **Validates at workflow start** inside `step.do('validate-snapshot')` by recomputing the hash from `event.payload` and comparing to `snapshotInputHash`.
-4. **Branches at write time** by recomputing a current hash from live state and comparing to the frozen `snapshotInputHash` — convergent results apply as primary; divergent results route through `sheet-divergence.ts` or `frame_variants` insert helpers.
+4. **Branches at write time** by recomputing a current hash from live state and comparing to the frozen `snapshotInputHash` — convergent results apply as primary; divergent results route through `sheet-divergence.ts`, `music-workflow.ts`, or (for images) pointer-retention in `image-workflow.ts` (see Pillar 3).
 
 ```ts
 // illustrative — RegenerateShotsWorkflow start-time validation
@@ -178,19 +194,19 @@ await scopedDb.characters.updateSheet(
 
 Per-shot **image** artifacts use the same hash comparison inside `image-workflow`, but mid-flight drift no longer routes to divergent `frame_variants` rows or `generation.stale:detected` (#989): the workflow appends a new `frame_variants` version, stamps `inputHash`, and deliberately does not repoint `selectedImageVersionId`. `regenerate-shots-workflow` fans out to `image-workflow` children and does not perform its own divergence emit — `divergedShotIds` is always empty today.
 
-### Where diverged results land
+### Where divergent / drifted results land
 
-- **Per-frame image/video/audio**: insert into `frame_variants` (`src/lib/db/schema/frame-variants.ts`) tagged with the model that produced them and the `snapshotInputHash` that scoped them. The user sees an "alternate available" affordance and can promote it or regenerate from current inputs.
+Two models — do not conflate them:
 
-  The table carries two partial unique indexes:
-  - `frame_variants_primary_key` on `(frameId, variantType, model)` WHERE `diverged_at IS NULL` — at most one primary row per model. `image-workflow`'s speculative pre-write and convergent reconcile both target this slot.
-  - `frame_variants_divergent_key` on `(frameId, variantType, model, input_hash)` WHERE `diverged_at IS NOT NULL` — divergent alternates are inserted (not updated) and distinguished by `input_hash`, so multiple divergences of the same model coexist.
+**A. Pointer drift (images, #989).** `image-workflow` compares `snapshotInputHash` vs a live recompute. On drift it appends a new `frame_variants` version with `inputHash`, does **not** repoint `frames.selectedImageVersionId`, and does **not** emit `generation.stale:detected`. The retained unselected version is the drift signal; the user switches primaries via `frameVariants.select` (pointer repoint). Versions are soft-hidden with `discardedAt`, not hard-deleted. `frame_variants` has no `divergedAt` — each row is a flat version (`kind: 'model' | 'framing'`).
 
-  On divergence, the workflow performs three writes (revert frame thumbnail, revert primary variant row's speculative URL, insert divergent alternate). These should land in a transaction once `scopedDb` exposes one — see the "Outstanding hardening" notes on PR #633.
+**B. Divergent alternates (sheets, music, legacy shot video/audio).** Write-time hash mismatch parks a row in a `*_variants` table with `divergedAt`, then emits `generation.stale:detected` with a required `divergedVariantId`:
 
-- **Frame variant artifacts** (already-variant rows being regenerated): leave the row as-is but do not promote it to the frame's primary thumbnail/video/audio. The `diverged_at` timestamp marks the divergence for the UI.
+- **Character / location / talent sheets** → `character_sheet_variants`, `location_sheet_variants`, `talent_sheet_variants` via `sheet-divergence.ts`.
+- **Sequence music** → `sequence_music_variants` via `music-workflow.ts`.
+- **Shot video / audio** (when the divergent path is used) → `shot_variants` with partial unique indexes `shot_variants_primary_key` (WHERE `divergedAt IS NULL`) and `shot_variants_divergent_key` (WHERE `divergedAt IS NOT NULL`). No production workflow emits divergent **image** rows on `shot_variants` today — images moved to model A.
 
-- **Sheet entities** (character, location, library location, talent), **sequence-level merged video**, **sequence-level music**, **prompts**: no variants infrastructure today. For stage 1 we **discard and re-queue**: log the divergence, emit a realtime event, trigger a new workflow with the current inputs. Each of these gets a proper variants table in later stages (see below).
+**Convergent image writes** repoint `frames.selectedImageVersionId`, mirror `frames.imageUrl`, and stamp `frames.imageInputHash` — see `image-workflow.ts` and `frameVariants.select`.
 
 ### Realtime event
 
@@ -216,53 +232,39 @@ Per-shot **image** artifacts use the same hash comparison inside `image-workflow
 ]),
 ```
 
-`divergedVariantId` is required on every branch — emitters in `sheet-divergence.ts` and `regenerate-shots-workflow.ts` always park the divergent artifact first, then reference the new variant row's id. This gives the UI a single event shape across entity types without adding new channels.
+`divergedVariantId` is required on every branch — emitters in `sheet-divergence.ts` and `music-workflow.ts` park the divergent artifact first, then reference the new variant row's id. Image drift (model A) does **not** use this event. This gives the UI a single event shape across sheet/music (and future video) divergence without adding new channels.
 
 ## How it composes with existing patterns
 
 - **Scoped DB** (`src/lib/db/scoped/*`) is the only entry point. Staleness reads go through scoped getters; hash computation helpers accept a `ScopedDb` and use it. No code path bypasses team scoping.
 - **Per-workflow snapshot modules** (`*-snapshot.ts`) own DTO building, hashing, and validation — existing workflows keep working unchanged until they gain one.
-- **Status columns** stay `pending | generating | completed | failed`. Staleness does not become a fifth value. The UI composes `status === 'completed' && isStale(entity)` when it needs "completed but stale".
-- **`frame_variants`** is the divergence sink for frame artifacts in addition to its existing role for per-model alternates. The unique key was split into two partial indexes (primary slot vs divergent alternates keyed by `input_hash`) so primaries and alternates of the same model coexist without overwriting each other. `input_hash` and `diverged_at` are columns on this table.
+- **Status columns** on `frames` / `shots` stay `pending | generating | completed | failed`. Staleness does not become a fifth value. The UI composes `status === 'completed' && isStale(...)` when it needs "completed but stale".
+- **`frame_variants`** stores flat image versions with `inputHash`; selection is `frames.selectedImageVersionId`. **`shot_variants`** still carries `divergedAt` for video/audio divergent alternates; image variants on this table are legacy.
 
-## Future stages
+## Shipped vs deferred
 
-Stage 1 (this doc's main body) ships input-hash staleness, workflow snapshots, and divergence routing for per-frame artifacts that already have a home in `frame_variants`. Everything below is deliberately deferred — listed both so it doesn't creep in by accident, and so the order is clear when we do pick it up.
+Much of the original "stage 1" plan is live. This section separates what exists today from what remains deferred so implementers don't re-build shipped tables.
 
-### Stage 2: sheet variants
+### Shipped
 
-Adds variants tables for character sheets, location sheets, and talent sheets so divergence-on-completion can save a competing sheet without overwriting the live one.
+- **`src/lib/ai/input-hash.ts`** — per-artifact SHA-256 helpers + unit tests.
+- **Hash columns** — on `frames`, `shots`, `characters`, `sequence_locations`, `location_sheets`, `location_library`, `talent_sheets`, `frame_variants`, `shot_variants`.
+- **Workflow snapshots** — per-workflow `*-snapshot.ts` modules; `RegenerateShotsWorkflow` is the reference implementation.
+- **Image versions (#989)** — `frame_variants` flat versions + `frames.selectedImageVersionId` pointer; drift = unselected version, not `stale:detected`.
+- **Sheet divergent alternates** — `character_sheet_variants`, `location_sheet_variants`, `talent_sheet_variants` + `sheet-divergence.ts` + `generation.stale:detected`.
+- **Music divergent alternates** — `sequence_music_variants` + `music-workflow.ts` emit path.
+- **Prompt version history** — `frame_prompt_versions` (visual) and `shot_prompt_versions` (motion), with `visualPromptInputHash` / `motionPromptInputHash` staleness mirrors.
+- **Realtime** — `realtimeSchema.generation['stale:detected']` discriminated union is live.
 
-- **New tables** — `character_sheet_variants`, `location_sheet_variants` (covering both `locationSheets` and `locationLibrary`), `talent_sheet_variants`. Each carries the same shape as `frame_variants`: parent FK, model, URL/path, `input_hash`, `diverged_at`, status, error.
-- **Replaces stage-1 re-queue behaviour** for these entities — divergence inserts a row instead of triggering a new workflow.
-- **UI surface** — "alternate available" affordance on character/location/talent detail views, parallel to what frames already get.
-- **Trigger** — pick this up when we see real-world divergence on sheet workflows (recasts during generation are the obvious case) or when users start asking to compare sheet outputs across models.
+### Still deferred
 
-### Stage 3: sequence-level video and music variants
+### Stage 3 (video): render-segment video variants (#990)
 
-Sequence-level merged video (`sequences.mergedVideoUrl`, `mergedVideoPath`, …) and sequence-level music (`sequences.musicUrl`, `musicPath`, `musicPrompt`, `musicTags`, …) are stored as columns directly on `sequences`. They have no variants story, so:
+Scene video is tiled into ≤15s `render_segments`; per-shot video selection moves to `video_variants` with a render manifest. No `sequences.mergedVideoUrl` columns — merged output is a function of segment variants. Divergence routing for video will follow the sheet pattern once Phase 3 lands.
 
-- **`sequence_video_variants`** — captures alternate merged videos. Columns: `sequenceId`, `url`, `path`, `model`/`workflow`, `input_hash`, `status`, `diverged_at`, `created_at`. The input-hash for merged video is over the ordered list of source frame video hashes plus `targetFps`/`resolution` from `MergeVideoWorkflowInput`.
-- **`sequence_music_variants`** — captures alternate music tracks. Columns: `sequenceId`, `url`, `path`, `prompt`, `tags`, `model`, `duration`, `input_hash`, `status`, `diverged_at`, `created_at`. The input-hash is over `prompt + tags + duration + model`. The merged final video then becomes a function of `(merged_video_variant, music_variant)`, and `merge-audio-video-workflow.ts` takes both as explicit inputs.
-- **Promotion** — promoting a variant updates the matching `sequences.*Url`/`*Path` columns. The columns stay (existing UI reads from them) — the variants table is purely additive.
-- **Trigger** — needed once users start trying alternate music tracks or want to compare cuts before committing.
+### Stage 4 (remaining prompt UX)
 
-### Stage 4: prompt versioning
-
-Prompts currently exist in three forms with no history:
-
-- AI-generated visual/motion prompts inside `frame.metadata.prompts.{visual,motion}.fullPrompt` (and components/parameters).
-- User overrides in `frames.imagePrompt` and `frames.motionPrompt` (overwrite the AI version on save — the previous text is lost).
-- Sequence-level `sequences.musicPrompt` / `musicTags` (also overwrite-on-save).
-
-Prompts are themselves generated artifacts of an upstream context (scene metadata, character/location bibles, style config, analysis model). They deserve the same input-hash + variants treatment as visual artifacts, both for staleness ("your scene metadata changed; the visual prompt is stale") and for history ("revert to the AI-generated prompt before I edited it").
-
-- **`frame_prompt_variants`** — one row per prompt revision. Columns: `frameId`, `promptType` (`'visual' | 'motion'`), `text`, `components` (json), `parameters` (json), `source` (`'ai-generated' | 'user-edit' | 'regenerated'`), `input_hash` (over the upstream context that produced an AI prompt; null for user edits), `analysisModel`, `created_at`, `created_by`. The "current" prompt is the most recent row of each type.
-- **`sequence_music_prompt_variants`** — same shape, parent on `sequenceId`, `promptType` `'music'`, fields capture both `prompt` and `tags`.
-- **Read path** — `frame.imagePrompt`/`motionPrompt` and `sequences.musicPrompt`/`musicTags` stay as cached "current" pointers (no read change for callers); writes go through a helper that inserts a variant row and updates the cached column atomically.
-- **Migration of existing prompts** — backfill is unnecessary; existing prompts are simply the row before the first new variant. The variant chain starts from the next save.
-- **Staleness for prompts** — visual and motion prompts get `*_prompt_input_hash` columns on `frames`, computed from scene metadata + style config + character/location bible + analysis model. When upstream context changes, the prompt itself is flagged stale (independently of whether the rendered image is stale). Music prompts similarly hash over `sequence.musicDesign` plus the analysis model.
-- **Trigger** — pick this up alongside or before stage 2/3 if user prompt-editing UX surfaces a need for undo/history; otherwise it can come after.
+Prompt **storage** is shipped (`frame_prompt_versions`, `shot_prompt_versions`). Still open: full history UI, field-level diff inside `<DivergenceCompareDialog>`, and sequence-level music-prompt version table if music prompt undo is needed beyond the cached `sequences.musicPrompt` / `musicTags` columns.
 
 ### Stage 5: dependency materialization
 
@@ -277,30 +279,26 @@ Everything else from the original doc that we're explicitly _not_ implementing y
 
 Answering every row of the original doc's decision table for our stack:
 
-| Original decision area   | Original recommendation                   | This doc                                                                                                                                                                          |
-| ------------------------ | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Versioning approach      | Immutable snapshots + version chains      | **Adapted**: per-artifact `input_hash` (stage 1). Variants tables for sheets, sequence video/music, and prompts (stages 2-4). No version chains.                                  |
-| Staleness detection      | Content hash comparison                   | **Kept**: SHA-256 input-hash comparison, derived at read time.                                                                                                                    |
-| Invalidation propagation | Lazy dirty bits + demand verification     | **Adapted**: no dirty-bit table; staleness is a pure read of the current graph.                                                                                                   |
-| Collaborative sync       | Property-level LWW + transactions         | **Dropped**: not a concurrent editor. Server is authoritative.                                                                                                                    |
-| Workflow isolation       | Application-level snapshots               | **Kept**: snapshot inlined in the Cloudflare Workflows payload; per-workflow `*-snapshot.ts` modules build, hash, and validate it.                                                |
-| Lifecycle management     | XState machines                           | **Dropped**: existing status columns are sufficient.                                                                                                                              |
-| Workflow orchestration   | Inngest (or Temporal)                     | **Dropped**: Cloudflare Workflows already does this.                                                                                                                              |
-| Real-time events         | Redis pub/sub + PG NOTIFY                 | **Kept, different plumbing**: typed SSE events delivered through `RealtimeChannel` Durable Objects; one new event type.                                                           |
-| Job distribution         | SKIP LOCKED queue                         | **Dropped**: Cloudflare Workflows is the durable job engine.                                                                                                                      |
-| Branching                | `parentVersion` + branch names            | **Dropped**. Variants tables (stages 2-4) cover the realistic "keep old vs new" use case.                                                                                         |
-| Divergence handling      | Three options: re-queue / alternate / ask | **Adapted**: per-frame artifacts save to `frame_variants` (stage 1); sheets, sequence-level video/music, and prompts get their own variants tables in stages 2-4. No user prompt. |
+| Original decision area   | Original recommendation                   | This doc                                                                                                                                                                                                         |
+| ------------------------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Versioning approach      | Immutable snapshots + version chains      | **Adapted**: per-artifact `input_hash` (stage 1). Variants tables for sheets, sequence video/music, and prompts (stages 2-4). No version chains.                                                                 |
+| Staleness detection      | Content hash comparison                   | **Kept**: SHA-256 input-hash comparison, derived at read time.                                                                                                                                                   |
+| Invalidation propagation | Lazy dirty bits + demand verification     | **Adapted**: no dirty-bit table; staleness is a pure read of the current graph.                                                                                                                                  |
+| Collaborative sync       | Property-level LWW + transactions         | **Dropped**: not a concurrent editor. Server is authoritative.                                                                                                                                                   |
+| Workflow isolation       | Application-level snapshots               | **Kept**: snapshot inlined in the Cloudflare Workflows payload; per-workflow `*-snapshot.ts` modules build, hash, and validate it.                                                                               |
+| Lifecycle management     | XState machines                           | **Dropped**: existing status columns are sufficient.                                                                                                                                                             |
+| Workflow orchestration   | Inngest (or Temporal)                     | **Dropped**: Cloudflare Workflows already does this.                                                                                                                                                             |
+| Real-time events         | Redis pub/sub + PG NOTIFY                 | **Kept, different plumbing**: typed SSE events delivered through `RealtimeChannel` Durable Objects; one new event type.                                                                                          |
+| Job distribution         | SKIP LOCKED queue                         | **Dropped**: Cloudflare Workflows is the durable job engine.                                                                                                                                                     |
+| Branching                | `parentVersion` + branch names            | **Dropped**. Variants tables (stages 2-4) cover the realistic "keep old vs new" use case.                                                                                                                        |
+| Divergence handling      | Three options: re-queue / alternate / ask | **Adapted**: images → pointer-retained `frame_variants` versions (#989); sheets + music → `*_variants` + `stale:detected`; shot video/audio divergent path → `shot_variants` when emitters land. No user prompt. |
 
-## Where to start (stage 1)
+## Where to go next
 
-Recommended build order for stage 1, each step independently shippable:
+Stage 1 core is shipped (see "Shipped vs deferred"). Remaining work, roughly in priority order:
 
-1. `src/lib/ai/input-hash.ts` with the per-artifact helpers and their unit tests. No schema changes yet.
-2. Add `input_hash` and `diverged_at` columns to `frame_variants`, plus `input_hash` to the sheet tables. Backfill is unnecessary — null means "unknown, treat as non-stale". Split the existing `(frameId, variantType, model)` unique index into `frame_variants_primary_key` (WHERE `diverged_at IS NULL`) and `frame_variants_divergent_key` on `(frameId, variantType, model, input_hash)` (WHERE `diverged_at IS NOT NULL`) so divergent alternates can coexist with the primary slot.
-3. Add the four `*_input_hash` columns to `frames`.
-4. Add or extend per-workflow `*-snapshot.ts` helpers for each content-generation workflow (DTO build at trigger time, hash at trigger time, `computeCurrent` for write-time checks).
-5. **`RegenerateShotsWorkflow` is the reference implementation** — already migrated end-to-end with `regenerate-shots-snapshot.ts`, start-time validation, and divergence routing into `frame_variants`. Use it as the template for remaining workflows.
-6. `realtimeSchema.generation['stale:detected']` is live; wire additional UI surfaces to `generation.stale:detected` as needed.
-7. Migrate remaining workflows one at a time (`shotImagesWorkflow`, sheet workflows, etc.).
-
-Each step preserves the existing system; nothing in here requires a big-bang migration. Stages 2-5 are taken on independently, in whatever order user-facing pressure dictates.
+1. **Finish snapshot migration** on any workflow that still live-reads scoped state mid-flight (`shotImagesWorkflow` is largely there; audit the long tail).
+2. **Wire UI** to `generation.stale:detected` and `isStale` on surfaces listed in [staleness-and-divergence-ux.md](./staleness-and-divergence-ux.md) — sheet banners are live; shot image divergence banners are retired (#989).
+3. **Video variants (#990)** — `video_variants` divergence emitters + render-segment selection pointers.
+4. **Prompt history UX** — expose `frame_prompt_versions` / `shot_prompt_versions` in the UI (storage exists).
+5. **Dependency materialization** (stage 5) — only if runtime inference via `matchCharactersToScene` becomes a bottleneck.

--- a/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
+++ b/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
@@ -145,42 +145,38 @@ Cloudflare Workflows has event payload size limits, but our payloads are dominat
 Before writing a generation result, compare hashes:
 
 ```ts
-// illustrative — runs inside a sheet workflow's final step.do()
+// illustrative — character-sheet-workflow reconcile step
 const snapshotInputHash = input.snapshotInputHash ?? null;
-const currentInputHash = await computeCharacterSheetHashCurrent(
-  input,
-  scopedDb
-);
-const decision = decideSheetDivergence(snapshotInputHash, currentInputHash);
+const currentHash = snapshotInputHash
+  ? await computeCharacterSheetHashCurrent(input, scopedDb)
+  : null;
+const decision = decideSheetDivergence(snapshotInputHash, currentHash);
 
-if (decision.kind === 'convergent') {
-  // Inputs unchanged — apply as the primary sheet (existing behaviour)
-  await scopedDb.characters.updateSheet(characterId, {
-    url,
-    inputHash: currentInputHash,
-  });
-} else {
-  // Diverged mid-generation — park in variants without disturbing live state
-  const { id: divergedVariantId } = await saveDivergentCharacterSheet({
+if (decision.kind === 'divergent') {
+  // Parks in character_sheet_variants and emits generation.stale:detected
+  await saveDivergentCharacterSheet({
     scopedDb,
     characterId,
     sequenceId,
     model,
     url,
+    storagePath,
+    workflowRunId,
     snapshotInputHash: decision.snapshotInputHash,
-    currentInputHash: decision.currentInputHash,
   });
-  await getGenerationChannel(sequenceId).emit('generation.stale:detected', {
-    entityType: 'character',
-    entityId: characterId,
-    artifact: 'sheet',
-    snapshotInputHash: decision.snapshotInputHash,
-    divergedVariantId,
-  });
+  return { kind: 'divergent' };
 }
+
+// Inputs unchanged — apply as the primary sheet (existing behaviour)
+await scopedDb.characters.updateSheet(
+  characterId,
+  url,
+  storagePath,
+  snapshotInputHash
+);
 ```
 
-Per-shot image artifacts follow the same hash comparison inside `image-workflow` / `regenerate-shots-workflow`, routing divergent thumbnails into `frame_variants` and emitting `generation.stale:detected` with `entityType: 'shot'`.
+Per-shot **image** artifacts use the same hash comparison inside `image-workflow`, but mid-flight drift no longer routes to divergent `frame_variants` rows or `generation.stale:detected` (#989): the workflow appends a new `frame_variants` version, stamps `inputHash`, and deliberately does not repoint `selectedImageVersionId`. `regenerate-shots-workflow` fans out to `image-workflow` children and does not perform its own divergence emit — `divergedShotIds` is always empty today.
 
 ### Where diverged results land
 

--- a/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
+++ b/docs/architecture/workflow-snapshots-and-content-hash-staleness.md
@@ -1,12 +1,12 @@
 # Workflow snapshots and content-hash staleness
 
-This is the companion to [managing-complex-dependency-graphs-in-collaborative-ai-video-platforms.md](./managing-complex-dependency-graphs-in-collaborative-ai-video-platforms.md). The original doc proposed a general-purpose versioned-DAG architecture with branching, XState lifecycles, Inngest, Postgres MVCC, Redis pub/sub, and Linear-style transaction sync. A review against the codebase shows that most of that infrastructure is already solved differently on our stack (QStash + `@upstash/workflow`, `@upstash/realtime`, Cloudflare D1, Drizzle, the scoped-DB context from `#603`) — and most of what remains unsolved reduces to a critical path of three ideas. This doc is the stack-specific subset we intend to ship.
+This is the companion to [managing-complex-dependency-graphs-in-collaborative-ai-video-platforms.md](./managing-complex-dependency-graphs-in-collaborative-ai-video-platforms.md). The original doc proposed a general-purpose versioned-DAG architecture with branching, XState lifecycles, Inngest, Postgres MVCC, Redis pub/sub, and Linear-style transaction sync. A review against the codebase shows that most of that infrastructure is already solved differently on our stack (Cloudflare Workflows, Durable Object-backed SSE realtime, Cloudflare D1, Drizzle, and scoped DB access from workflow payload `teamId`/`userId`) — and most of what remains unsolved reduces to a critical path of three ideas. This doc is the stack-specific subset we intend to ship.
 
 It composes with [scoped-db-context-implementation.md](./scoped-db-context-implementation.md); every new data-access path described here flows through `ScopedDb`.
 
 ## The two failure modes we're closing
 
-**1. Lost-work mid-generation.** `regenerateFramesWorkflow` (`src/lib/workflows/regenerate-frames-workflow.ts`) currently calls `scopedDb.sequences.getById` inside `context.run`. If a user edits a character, location, or prompt while the workflow is running, the generation silently reads a mix of pre- and post-edit inputs. The result is written as the primary artifact either way, with no signal that what landed isn't what the user had in mind when they triggered the workflow.
+**1. Lost-work mid-generation.** `regenerateFramesWorkflow` (`src/lib/workflows/regenerate-frames-workflow.ts`) reads mutable sequence state during workflow execution. If a user edits a character, location, or prompt while the workflow is running, the generation can read a mix of pre- and post-edit inputs. The result is written as the primary artifact either way, with no signal that what landed isn't what the user had in mind when they triggered the workflow.
 
 **2. Silent staleness.** After a character recast or location swap, downstream frames, character sheets, location sheets, and talent sheets still display their prior outputs. Nothing in the schema records which inputs those outputs were derived from, so the UI can't distinguish "still current" from "stale but not yet regenerated" — and neither can a workflow about to apply a new result.
 
@@ -18,10 +18,10 @@ Before describing the design, it's worth stating what the original doc recommend
 
 | Original recommendation           | Why we skip it                                                                                                                                                                                                                          |
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Inngest for orchestration         | QStash + `@upstash/workflow` is already wired, and `createScopedWorkflow` (`src/lib/workflow/scoped-workflow.ts`) enforces `teamId`/`userId` on every run. Swapping orchestrators would be pure churn.                                  |
+| Inngest for orchestration         | Cloudflare Workflows is already wired, and `OpenStoryWorkflowEntrypoint` (`src/lib/workflow/base-workflow.ts`) enforces `teamId`/`userId` on every run. Swapping orchestrators would be pure churn.                                     |
 | XState v5 lifecycle machines      | Status columns (`thumbnailStatus`, `variantImageStatus`, `videoStatus`, `audioStatus`, `sequences.status`) already model `pending → generating → completed → failed`. Adding XState on top would duplicate state, not replace it.       |
-| Custom Redis pub/sub + PG NOTIFY  | `src/lib/realtime/index.ts` already provides a typed `realtimeSchema` on top of `@upstash/realtime`. We extend this schema, we don't replace it.                                                                                        |
-| Postgres JSONB / SKIP LOCKED      | The app runs on Cloudflare D1 (SQLite). QStash is already the queue; we don't need a DB-level queue at all.                                                                                                                             |
+| Custom Redis pub/sub + PG NOTIFY  | `src/lib/realtime/index.ts` already provides a typed `realtimeSchema`; delivery runs through the in-repo SSE client and `RealtimeChannel` Durable Object. We extend this schema, we don't replace it.                                   |
+| Postgres JSONB / SKIP LOCKED      | The app runs on Cloudflare D1 (SQLite). Cloudflare Workflows is already the durable job engine; we don't need a DB-level queue at all.                                                                                                  |
 | Entity version chains / branching | `frame_variants` (`src/lib/db/schema/frame-variants.ts`) already holds alternate per-model outputs, which covers the realistic "keep old vs new" use case for frame artifacts. General-purpose branching adds complexity we don't need. |
 | Property-level LWW + rebasing     | We are not a concurrent editor. TanStack Query + server functions give us implicit last-writer-wins at the server boundary.                                                                                                             |
 | Dependency edge table (v1)        | Character/location → frame linkage is inferred at runtime via `characterTags` in `frame.metadata` (`matchCharactersToFrame`). Good enough until we have a reason to materialize it.                                                     |
@@ -84,43 +84,43 @@ The UI calls this (or a batch variant) when rendering. There is no cascading pro
 
 ## Pillar 2: Workflow input snapshots
 
-Workflows must not read mutable state inside `context.run` for anything that should be frozen. The "input snapshot" is just the fully-resolved input DTO, passed end-to-end through the QStash payload.
+Workflows must not read mutable state inside a `step.do()` for anything that should be frozen. The "input snapshot" is just the fully-resolved input DTO, passed end-to-end through the Cloudflare Workflows event payload.
 
 ### The pattern
 
-**At trigger time** (server function, before `qstash.publishJSON`):
+**At trigger time** (server handler/function, before `triggerWorkflow()` calls the workflow binding):
 
 1. Resolve every referenced sheet URL and read its `input_hash`.
 2. Assemble the full input DTO for the workflow — prompt, model, params, referenced sheet hashes.
 3. Compute `snapshotInputHash = computeInputHash(dto)`.
-4. Publish the DTO _and_ `snapshotInputHash` as the QStash payload.
+4. Pass the DTO _and_ `snapshotInputHash` to `triggerWorkflow()`, which resolves the Cloudflare Workflows binding and calls `binding.create({ id, params })`.
 
 **At workflow-start**: the workflow validates `snapshotInputHash` matches what it recomputes from the DTO (cheap tamper/format check), then proceeds using only the DTO.
 
-**At write time** (inside the final `context.run` that commits the artifact): recompute `currentInputHash` from the _live_ scoped-DB state, and branch on whether it still matches `snapshotInputHash`. (See Pillar 3.)
+**At write time** (inside the final `step.do()` that commits the artifact): recompute `currentInputHash` from the _live_ scoped-DB state, and branch on whether it still matches `snapshotInputHash`. (See Pillar 3.)
 
-### `createScopedWorkflow` extension
+### Shared workflow snapshot extension
 
-`src/lib/workflow/scoped-workflow.ts` gains an optional `snapshot` configuration:
+The shared Cloudflare Workflows base/helper layer gains an optional `snapshot` configuration:
 
 ```ts
-createScopedWorkflow<MyWorkflowInput & { snapshotInputHash: string }>(
-  async (context, scopedDb) => { ... },
-  {
-    snapshot: {
-      computeCurrent: (input, scopedDb) => computeFrameInputHash(input, scopedDb),
-    },
-  },
-);
+class MyWorkflow extends OpenStoryWorkflowEntrypoint<
+  MyWorkflowInput & { snapshotInputHash: string }
+> {
+  protected override async runImpl(event, step, scopedDb) {
+    // Snapshot-aware helpers validate event.payload.snapshotInputHash and
+    // expose computeCurrent(input, scopedDb) for write-time divergence checks.
+  }
+}
 ```
 
-When `snapshot` is configured, the wrapper adds a middleware that validates the payload carries `snapshotInputHash`, and exposes a `context.snapshot` helper with `{ snapshotInputHash, computeCurrent() }`. Workflows that have been migrated use it; workflows that haven't are unchanged.
+When `snapshot` is configured, the shared helper validates that the payload carries `snapshotInputHash`, and exposes `{ snapshotInputHash, computeCurrent() }` to workflow code. Workflows that have been migrated use it; workflows that haven't are unchanged.
 
 ### Per-workflow input surface
 
 For the workflows that do content generation, "input" is specifically:
 
-- **`regenerateFramesWorkflow`** (`RegenerateFramesWorkflowInput`) — already passes `frameIds`, `triggeringCharacterId`, `imageModel`. Needs to additionally inline the resolved character-sheet hashes and location-sheet hashes for each affected frame at trigger time. Remove the live `scopedDb.sequences.getById` read inside `context.run`.
+- **`regenerateFramesWorkflow`** (`RegenerateFramesWorkflowInput`) — already passes `frameIds`, `triggeringCharacterId`, `imageModel`. Needs to additionally inline the resolved character-sheet hashes and location-sheet hashes for each affected frame at trigger time. Remove the live `scopedDb.sequences.getById` read from the generation step.
 - **`characterSheetWorkflow`** (`CharacterSheetWorkflowInput`) — already inlines `characterMetadata`, `talentMetadata`, `referenceImageUrl`, `styleConfig`. Add: the `input_hash` of the referenced talent sheet (if any).
 - **`locationSheetWorkflow`** (`LocationSheetWorkflowInput`) — already inlines `locationMetadata`, `referenceImageUrl`, `libraryLocationDescription`, `styleConfig`. Add: the `reference_input_hash` of the referenced library location (if any).
 - **`libraryTalentSheetWorkflow`** (`LibraryTalentSheetWorkflowInput`) — already inlines `referenceImageUrls`, `talentDescription`. Talent media is append-only in practice, so the snapshot is the list of reference URLs themselves.
@@ -130,14 +130,14 @@ Most of the work is additive — these payloads already carry the data. We add t
 
 ### Snapshot size
 
-QStash has per-message size limits, but our payloads are dominated by prompts, sheet URLs, and metadata — not by the artifacts themselves, which are accessed by URL. We inline snapshots into the payload in v1. If that becomes a problem we add a `workflow_input_snapshots` table with content-addressable storage (as the original doc proposed), but this is not part of v1.
+Cloudflare Workflows has event payload size limits, but our payloads are dominated by prompts, sheet URLs, and metadata — not by the artifacts themselves, which are accessed by URL. We inline snapshots into the payload in v1. If that becomes a problem we add a `workflow_input_snapshots` table with content-addressable storage (as the original doc proposed), but this is not part of v1.
 
 ## Pillar 3: Divergence-on-completion
 
 Before writing a generation result, compare hashes:
 
 ```ts
-// illustrative — runs inside the final context.run of the workflow
+// illustrative — runs inside the final step.do() of the workflow
 const currentInputHash = await context.snapshot.computeCurrent(input, scopedDb);
 
 if (currentInputHash === context.snapshot.snapshotInputHash) {
@@ -191,7 +191,7 @@ This gives the UI a single event to listen for across all four entity types with
 ## How it composes with existing patterns
 
 - **Scoped DB** (`src/lib/db/scoped/*`) is the only entry point. Staleness reads go through scoped getters; hash computation helpers accept a `ScopedDb` and use it. No code path bypasses team scoping.
-- **`createScopedWorkflow`** gains the optional `snapshot` extension described above — existing workflows keep working unchanged until they opt in.
+- **Shared workflow helpers** gain the optional `snapshot` extension described above — existing workflows keep working unchanged until they opt in.
 - **Status columns** stay `pending | generating | completed | failed`. Staleness does not become a fifth value. The UI composes `status === 'completed' && isStale(entity)` when it needs "completed but stale".
 - **`frame_variants`** is the divergence sink for frame artifacts in addition to its existing role for per-model alternates. The unique key was split into two partial indexes (primary slot vs divergent alternates keyed by `input_hash`) so primaries and alternates of the same model coexist without overwriting each other. `input_hash` and `diverged_at` are columns on this table.
 
@@ -241,7 +241,7 @@ Everything else from the original doc that we're explicitly _not_ implementing y
 - **`frame_dependencies` edge table.** Keep inferring from `characterTags` / `matchCharactersToFrame` (`src/lib/workflows/regenerate-frames-workflow.ts`) until there's a concrete reason to materialize it — e.g., needing to walk dependents faster than a scan allows.
 - **`stale` as a status enum value.** The derived boolean is sufficient until it isn't.
 - **Topological regeneration queue.** Not needed until we have a materialized dependency graph to walk.
-- **Content-addressable snapshot table** (`workflow_input_snapshots`). Not needed until inlining snapshots into QStash payloads actually strains the payload-size budget.
+- **Content-addressable snapshot table** (`workflow_input_snapshots`). Not needed until inlining snapshots into Cloudflare Workflows payloads actually strains the payload-size budget.
 
 ## Decision summary
 
@@ -253,11 +253,11 @@ Answering every row of the original doc's decision table for our stack:
 | Staleness detection      | Content hash comparison                   | **Kept**: SHA-256 input-hash comparison, derived at read time.                                                                                                                    |
 | Invalidation propagation | Lazy dirty bits + demand verification     | **Adapted**: no dirty-bit table; staleness is a pure read of the current graph.                                                                                                   |
 | Collaborative sync       | Property-level LWW + transactions         | **Dropped**: not a concurrent editor. Server is authoritative.                                                                                                                    |
-| Workflow isolation       | Application-level snapshots               | **Kept**: snapshot inlined in QStash payload; `createScopedWorkflow` extension enforces it.                                                                                       |
+| Workflow isolation       | Application-level snapshots               | **Kept**: snapshot inlined in the Cloudflare Workflows payload; shared workflow helpers enforce it.                                                                               |
 | Lifecycle management     | XState machines                           | **Dropped**: existing status columns are sufficient.                                                                                                                              |
-| Workflow orchestration   | Inngest (or Temporal)                     | **Dropped**: QStash + `@upstash/workflow` already does this.                                                                                                                      |
-| Real-time events         | Redis pub/sub + PG NOTIFY                 | **Kept, different plumbing**: `@upstash/realtime` channels; one new event type.                                                                                                   |
-| Job distribution         | SKIP LOCKED queue                         | **Dropped**: QStash is the queue.                                                                                                                                                 |
+| Workflow orchestration   | Inngest (or Temporal)                     | **Dropped**: Cloudflare Workflows already does this.                                                                                                                              |
+| Real-time events         | Redis pub/sub + PG NOTIFY                 | **Kept, different plumbing**: typed SSE events delivered through `RealtimeChannel` Durable Objects; one new event type.                                                           |
+| Job distribution         | SKIP LOCKED queue                         | **Dropped**: Cloudflare Workflows is the durable job engine.                                                                                                                      |
 | Branching                | `parentVersion` + branch names            | **Dropped**. Variants tables (stages 2-4) cover the realistic "keep old vs new" use case.                                                                                         |
 | Divergence handling      | Three options: re-queue / alternate / ask | **Adapted**: per-frame artifacts save to `frame_variants` (stage 1); sheets, sequence-level video/music, and prompts get their own variants tables in stages 2-4. No user prompt. |
 
@@ -268,7 +268,7 @@ Recommended build order for stage 1, each step independently shippable:
 1. `src/lib/ai/input-hash.ts` with the per-artifact helpers and their unit tests. No schema changes yet.
 2. Add `input_hash` and `diverged_at` columns to `frame_variants`, plus `input_hash` to the sheet tables. Backfill is unnecessary — null means "unknown, treat as non-stale". Split the existing `(frameId, variantType, model)` unique index into `frame_variants_primary_key` (WHERE `diverged_at IS NULL`) and `frame_variants_divergent_key` on `(frameId, variantType, model, input_hash)` (WHERE `diverged_at IS NOT NULL`) so divergent alternates can coexist with the primary slot.
 3. Add the four `*_input_hash` columns to `frames`.
-4. Extend `createScopedWorkflow` with the optional `snapshot` config.
+4. Extend the shared Cloudflare Workflows base/helper layer with the optional `snapshot` config.
 5. Migrate **one** workflow end-to-end (`regenerateFramesWorkflow` is the highest-value target given it's the concrete bug described in the problem statement). Prove the pattern, including the divergence path into `frame_variants`.
 6. Extend `realtimeSchema.generation` with `stale:detected` and wire one UI surface to it.
 7. Migrate remaining workflows one at a time.


### PR DESCRIPTION
## Summary

Closes #887

- Replaced stale QStash-as-current-architecture wording in workflow architecture docs
- Updated snapshot workflow guidance around Cloudflare Workflows event payloads, step.do, and triggerWorkflow/binding.create
- Updated realtime wording to reference the in-repo SSE client and RealtimeChannel Durable Object
- Left historical Cloudflare Workflows migration investigation docs unchanged

## Testing

- bun format:check

Pre-commit also passed format for the staged docs files.