### PR TITLE
Make public talent read-only

### DIFF
--- a/src/functions/talent.ts
+++ b/src/functions/talent.ts
@@ -6,7 +6,7 @@ import {
   getPublicTalentWithRelations,
   listPublicTalent,
 } from '@/lib/db/scoped';
-import type { Talent, TalentWithSheets } from '@/lib/db/schema';
+import type { TalentWithSheets } from '@/lib/db/schema';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import {
   createTalentSchema,
@@ -34,23 +34,6 @@ const talentIdSchema = z.object({ talentId: ulidSchema });
 const sheetIdSchema = z.object({ sheetId: ulidSchema });
 const mediaIdSchema = z.object({ mediaId: ulidSchema });
 const characterIdSchema = z.object({ characterId: ulidSchema });
-
-/**
- * Verify a talent record belongs to the given team, throwing if not found.
- * Uses scopedDb which is already team-scoped.
- */
-async function requireTalentOwnership(
-  scopedDb: {
-    talent: { getById: (id: string) => Promise<Talent | undefined> };
-  },
-  talentId: string
-): Promise<Talent> {
-  const record = await scopedDb.talent.getById(talentId);
-  if (!record) {
-    throw new Error('Talent not found');
-  }
-  return record;
-}
 
 // List Talent
 
@@ -175,8 +158,6 @@ export const createTalentSheetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
   .inputValidator(zodValidator(createTalentSheetSchema))
   .handler(async ({ context, data }) => {
-    await requireTalentOwnership(context.scopedDb, data.talentId);
-
     return context.scopedDb.talent.sheets.create({
       talentId: data.talentId,
       name: data.name,
@@ -204,8 +185,6 @@ export const deleteTalentSheetFn = createServerFn({ method: 'POST' })
       throw new Error('Sheet not found');
     }
 
-    await requireTalentOwnership(context.scopedDb, sheet.talentId);
-
     const deleted = await context.scopedDb.talent.sheets.delete(data.sheetId);
     if (!deleted) {
       throw new Error('Failed to delete sheet');
@@ -224,8 +203,6 @@ export const setDefaultSheetFn = createServerFn({ method: 'POST' })
     if (!sheet) {
       throw new Error('Sheet not found');
     }
-
-    await requireTalentOwnership(context.scopedDb, sheet.talentId);
 
     const updated = await context.scopedDb.talent.sheets.update(data.sheetId, {
       isDefault: true,
@@ -248,7 +225,10 @@ export const deleteTalentMediaFn = createServerFn({ method: 'POST' })
       throw new Error('Media not found');
     }
 
-    await requireTalentOwnership(context.scopedDb, media.talentId);
+    const deleted = await context.scopedDb.talent.media.delete(data.mediaId);
+    if (!deleted) {
+      throw new Error('Failed to delete media');
+    }
 
     if (media.path) {
       try {
@@ -259,11 +239,6 @@ export const deleteTalentMediaFn = createServerFn({ method: 'POST' })
       } catch {
         // Storage deletion is best-effort
       }
-    }
-
-    const deleted = await context.scopedDb.talent.media.delete(data.mediaId);
-    if (!deleted) {
-      throw new Error('Failed to delete media');
     }
 
     return { success: true };
@@ -286,7 +261,15 @@ export const presignTalentUploadFn = createServerFn({ method: 'POST' })
   )
   .handler(async ({ context, data }) => {
     if (data.talentId) {
-      await requireTalentOwnership(context.scopedDb, data.talentId);
+      const talentRecord = await context.scopedDb.talent.getById(data.talentId);
+      if (
+        !talentRecord ||
+        !isTeamWritableTalent(talentRecord, context.teamId)
+      ) {
+        throw new Error(
+          'Talent not found or you do not have permission to modify it'
+        );
+      }
     }
 
     const ext = getExtensionFromUrl(data.filename);
@@ -323,8 +306,6 @@ export const finalizeTalentUploadFn = createServerFn({ method: 'POST' })
     if (!data.path.startsWith(`talent/${context.teamId}/`)) {
       throw new Error('Invalid storage path');
     }
-
-    await requireTalentOwnership(context.scopedDb, data.talentId);
 
     await context.scopedDb.talent.media.create({
       id: data.mediaId,

--- a/src/functions/talent.ts
+++ b/src/functions/talent.ts
@@ -141,11 +141,19 @@ export const deleteTalentFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
   .inputValidator(zodValidator(talentIdSchema))
   .handler(async ({ context, data }) => {
+    const talentRecord = await context.scopedDb.talent.getById(data.talentId);
+    if (!talentRecord) {
+      throw new Error('Talent not found');
+    }
+    if (talentRecord.isPublic || talentRecord.teamId !== context.teamId) {
+      throw new Error('You do not have permission to delete this talent');
+    }
+
     await requireTeamAdminAccess(context.user.id, context.teamId);
 
     const deleted = await context.scopedDb.talent.delete(data.talentId);
     if (!deleted) {
-      throw new Error('Talent not found or failed to delete');
+      throw new Error('Failed to delete talent');
     }
 
     return { success: true };

--- a/src/functions/talent.ts
+++ b/src/functions/talent.ts
@@ -23,6 +23,7 @@ import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import type { LibraryTalentSheetWorkflowInput } from '@/lib/workflow/types';
 import { computeLibraryTalentSheetHashFromDto } from '@/lib/workflows/sheet-snapshots';
+import { isTeamWritableTalent } from '@/lib/db/scoped/talent';
 import { createLibraryTalent } from '@/lib/talent/create-library-talent';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
@@ -353,6 +354,12 @@ export const generateTalentSheetFn = createServerFn({ method: 'POST' })
 
     if (!talentRecord) {
       throw new Error('Talent not found');
+    }
+
+    if (!isTeamWritableTalent(talentRecord, context.teamId)) {
+      throw new Error(
+        'Talent not found or you do not have permission to modify it'
+      );
     }
 
     const imageMedia =

--- a/src/functions/talent.ts
+++ b/src/functions/talent.ts
@@ -141,19 +141,13 @@ export const deleteTalentFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
   .inputValidator(zodValidator(talentIdSchema))
   .handler(async ({ context, data }) => {
-    const talentRecord = await context.scopedDb.talent.getById(data.talentId);
-    if (!talentRecord) {
-      throw new Error('Talent not found');
-    }
-    if (talentRecord.isPublic || talentRecord.teamId !== context.teamId) {
-      throw new Error('You do not have permission to delete this talent');
-    }
-
     await requireTeamAdminAccess(context.user.id, context.teamId);
 
     const deleted = await context.scopedDb.talent.delete(data.talentId);
     if (!deleted) {
-      throw new Error('Failed to delete talent');
+      throw new Error(
+        'Talent not found, is read-only, or you do not have permission to delete it'
+      );
     }
 
     return { success: true };

--- a/src/hooks/use-talent.ts
+++ b/src/hooks/use-talent.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import {
   createTalentFn,
   deleteTalentFn,
@@ -110,6 +111,11 @@ export function useDeleteTalent() {
     mutationFn: (talentId: string) => deleteTalentFn({ data: { talentId } }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: talentKeys.lists() });
+    },
+    onError: (error) => {
+      toast.error('Failed to delete talent', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
     },
   });
 }

--- a/src/lib/db/scoped.ts
+++ b/src/lib/db/scoped.ts
@@ -308,7 +308,7 @@ export function createScopedDb(teamId: string, userId: string) {
     sequenceEvents: createSequenceEventsMethods(db),
     characterSheetVariants: createCharacterSheetVariantsMethods(db),
     locationSheetVariants: createLocationSheetVariantsMethods(db),
-    talentSheetVariants: createTalentSheetVariantsMethods(db),
+    talentSheetVariants: createTalentSheetVariantsMethods(db, teamId),
     sequenceMusicPromptVersions: createSequenceMusicPromptVersionsMethods(db),
     sequenceVariants: createSequenceVariantsMethods(db),
     sequenceExports: createSequenceExportsMethods(db),

--- a/src/lib/db/scoped/sheet-variants.test.ts
+++ b/src/lib/db/scoped/sheet-variants.test.ts
@@ -284,7 +284,7 @@ describe('location-sheet-variants insertDivergent', () => {
 
 describe('talent-sheet-variants insertDivergent', () => {
   it('is idempotent on (talentSheetId, model, inputHash)', async () => {
-    const methods = createTalentSheetVariantsMethods(db);
+    const methods = createTalentSheetVariantsMethods(db, team.id);
     const divergedAt = new Date('2026-04-29T00:00:00Z');
 
     const first = await methods.insertDivergent({
@@ -427,7 +427,7 @@ describe('location-sheet-variants discard / promote', () => {
 
 describe('talent-sheet-variants discard / promote', () => {
   it('promoteAtomically writes onto talent_sheets and discards the variant', async () => {
-    const methods = createTalentSheetVariantsMethods(db);
+    const methods = createTalentSheetVariantsMethods(db, team.id);
     const divergedAt = new Date('2026-04-29T00:00:00Z');
     const variant = await methods.insertDivergent({
       talentSheetId,
@@ -678,12 +678,12 @@ describe('sheet-variants list filters and empty-input short-circuits', () => {
   });
 
   it('talent listDivergentActiveByTalents returns [] for empty input', async () => {
-    const methods = createTalentSheetVariantsMethods(db);
+    const methods = createTalentSheetVariantsMethods(db, team.id);
     expect(await methods.listDivergentActiveByTalents([])).toEqual([]);
   });
 
   it('talent listDivergentActiveByTalentSheets returns [] for empty input', async () => {
-    const methods = createTalentSheetVariantsMethods(db);
+    const methods = createTalentSheetVariantsMethods(db, team.id);
     expect(await methods.listDivergentActiveByTalentSheets([])).toEqual([]);
   });
 
@@ -767,7 +767,7 @@ describe('sheet-variants list filters and empty-input short-circuits', () => {
 
 describe('talent-sheet-variants promoteAtomically negative cases', () => {
   it('throws when the talent sheet does not exist; variant is not soft-deleted', async () => {
-    const methods = createTalentSheetVariantsMethods(db);
+    const methods = createTalentSheetVariantsMethods(db, team.id);
     const variant = await methods.insertDivergent({
       talentSheetId,
       model: 'flux-pro',
@@ -794,7 +794,7 @@ describe('talent-sheet-variants promoteAtomically negative cases', () => {
   });
 
   it('throws when the variant does not exist; talent_sheets is not updated', async () => {
-    const methods = createTalentSheetVariantsMethods(db);
+    const methods = createTalentSheetVariantsMethods(db, team.id);
     expect(
       methods.promoteAtomically(
         talentSheetId,

--- a/src/lib/db/scoped/talent-sheet-variants.ts
+++ b/src/lib/db/scoped/talent-sheet-variants.ts
@@ -123,6 +123,8 @@ export function createTalentSheetVariantsMethods(db: Database, teamId: string) {
     insert: async (
       values: NewTalentSheetVariant
     ): Promise<TalentSheetVariant> => {
+      await assertTalentSheetWritableForTeam(db, values.talentSheetId, teamId);
+
       const [row] = await db
         .insert(talentSheetVariants)
         .values(values)
@@ -145,6 +147,8 @@ export function createTalentSheetVariantsMethods(db: Database, teamId: string) {
         divergedAt: Date;
       }
     ): Promise<TalentSheetVariant> => {
+      await assertTalentSheetWritableForTeam(db, values.talentSheetId, teamId);
+
       const findExisting = () =>
         db
           .select()

--- a/src/lib/db/scoped/talent-sheet-variants.ts
+++ b/src/lib/db/scoped/talent-sheet-variants.ts
@@ -11,6 +11,7 @@ import type {
 import { talentSheetVariants, talentSheets } from '@/lib/db/schema';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 import { insertDivergentRaceTolerant } from './divergent-insert';
+import { assertTalentSheetWritableForTeam } from './talent';
 
 type PromoteTalentSheetUpdate = {
   imageUrl: string | null;
@@ -18,7 +19,7 @@ type PromoteTalentSheetUpdate = {
   inputHash: string | null;
 };
 
-export function createTalentSheetVariantsMethods(db: Database) {
+export function createTalentSheetVariantsMethods(db: Database, teamId: string) {
   return {
     listByTalentSheet: async (
       talentSheetId: string
@@ -165,6 +166,14 @@ export function createTalentSheetVariantsMethods(db: Database) {
 
     /** Soft-delete a divergent alternate; preserves the row for the toast Undo. */
     discard: async (variantId: string): Promise<Date> => {
+      const variant = await db.query.talentSheetVariants.findFirst({
+        where: { id: variantId },
+      });
+      if (!variant) {
+        throw new Error(`TalentSheetVariant ${variantId} not found`);
+      }
+      await assertTalentSheetWritableForTeam(db, variant.talentSheetId, teamId);
+
       const discardedAt = new Date();
       const result = await db
         .update(talentSheetVariants)
@@ -178,6 +187,14 @@ export function createTalentSheetVariantsMethods(db: Database) {
     },
 
     undiscard: async (variantId: string): Promise<void> => {
+      const variant = await db.query.talentSheetVariants.findFirst({
+        where: { id: variantId },
+      });
+      if (!variant) {
+        throw new Error(`TalentSheetVariant ${variantId} not found`);
+      }
+      await assertTalentSheetWritableForTeam(db, variant.talentSheetId, teamId);
+
       const result = await db
         .update(talentSheetVariants)
         .set({ discardedAt: null, updatedAt: new Date() })
@@ -214,6 +231,8 @@ export function createTalentSheetVariantsMethods(db: Database) {
       if (!existingVariant) {
         throw new Error(`TalentSheetVariant ${variantId} not found`);
       }
+
+      await assertTalentSheetWritableForTeam(db, talentSheetId, teamId);
 
       const now = new Date();
       const updateSheet = db

--- a/src/lib/db/scoped/talent-writes.test.ts
+++ b/src/lib/db/scoped/talent-writes.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Write-side ACL tests for scoped talent mutations. Public/system templates
+ * are readable cross-team but must not accept sheet/media/talent writes.
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type Client, createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { generateId } from '@/lib/db/id';
+import {
+  talent,
+  talentMedia,
+  talentSheets,
+  teams,
+  user,
+} from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import type { Database } from '@/lib/db/client';
+import { createTalentMethods, isTeamWritableTalent } from './talent';
+
+let client: Client;
+let db: Database;
+
+const teamA = { id: '', name: 'Team A', slug: 'team-a' };
+const teamB = { id: '', name: 'Team B', slug: 'team-b' };
+const userA = { id: '', name: 'User A', email: 'a@example.com' };
+
+let publicTalentId = '';
+let publicSheetId = '';
+let publicMediaId = '';
+
+async function seedFixtures() {
+  await db.delete(talentMedia);
+  await db.delete(talentSheets);
+  await db.delete(talent);
+  await db.delete(teams);
+  await db.delete(user);
+
+  teamA.id = generateId();
+  teamB.id = generateId();
+  userA.id = generateId();
+
+  await db
+    .insert(user)
+    .values([{ id: userA.id, name: userA.name, email: userA.email }]);
+  await db.insert(teams).values([teamA, teamB]);
+
+  const [publicTalent] = await db
+    .insert(talent)
+    .values({ teamId: teamB.id, name: 'System Template', isPublic: true })
+    .returning();
+  if (!publicTalent) throw new Error('Failed to seed public talent');
+  publicTalentId = publicTalent.id;
+
+  const [sheet] = await db
+    .insert(talentSheets)
+    .values({
+      talentId: publicTalentId,
+      name: 'Default',
+      imageUrl: 'https://example.com/sheet.png',
+    })
+    .returning();
+  if (!sheet) throw new Error('Failed to seed public sheet');
+  publicSheetId = sheet.id;
+
+  const [media] = await db
+    .insert(talentMedia)
+    .values({
+      talentId: publicTalentId,
+      type: 'image',
+      url: 'https://example.com/ref.png',
+      path: 'talent/ref.png',
+    })
+    .returning();
+  if (!media) throw new Error('Failed to seed public media');
+  publicMediaId = media.id;
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seedFixtures();
+});
+
+describe('isTeamWritableTalent', () => {
+  it('rejects public talent even when teamId matches', () => {
+    expect(
+      isTeamWritableTalent({ teamId: teamB.id, isPublic: true }, teamB.id)
+    ).toBe(false);
+  });
+});
+
+describe('scoped talent write ACL', () => {
+  const teamAMethods = () => createTalentMethods(db, teamA.id, userA.id);
+
+  it('blocks update on public talent owned by another team', async () => {
+    const result = await teamAMethods().update(publicTalentId, {
+      name: 'Hacked',
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('blocks delete on public talent owned by another team', async () => {
+    expect(await teamAMethods().delete(publicTalentId)).toBe(false);
+  });
+
+  it('blocks sheet create on public talent visible to another team', async () => {
+    await expect(
+      teamAMethods().sheets.create({
+        talentId: publicTalentId,
+        name: 'Injected',
+        imageUrl: 'https://example.com/injected.png',
+      })
+    ).rejects.toThrow(/permission to modify/);
+  });
+
+  it('blocks sheet delete on public talent sheets', async () => {
+    expect(await teamAMethods().sheets.delete(publicSheetId)).toBe(false);
+  });
+
+  it('blocks media create on public talent', async () => {
+    await expect(
+      teamAMethods().media.create({
+        talentId: publicTalentId,
+        type: 'image',
+        url: 'https://example.com/new.png',
+        path: 'talent/new.png',
+      })
+    ).rejects.toThrow(/permission to modify/);
+  });
+
+  it('blocks media delete on public talent media', async () => {
+    expect(await teamAMethods().media.delete(publicMediaId)).toBe(false);
+  });
+
+  it('blocks update on public talent owned by the same team', async () => {
+    const ownerMethods = createTalentMethods(db, teamB.id, userA.id);
+    const result = await ownerMethods.update(publicTalentId, {
+      name: 'Renamed Template',
+    });
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/lib/db/scoped/talent-writes.test.ts
+++ b/src/lib/db/scoped/talent-writes.test.ts
@@ -11,6 +11,7 @@ import { generateId } from '@/lib/db/id';
 import {
   talent,
   talentMedia,
+  talentSheetVariants,
   talentSheets,
   teams,
   user,
@@ -18,6 +19,7 @@ import {
 import { relations } from '@/lib/db/schema/relations';
 import type { Database } from '@/lib/db/client';
 import { createTalentMethods, isTeamWritableTalent } from './talent';
+import { createTalentSheetVariantsMethods } from './talent-sheet-variants';
 
 let client: Client;
 let db: Database;
@@ -31,6 +33,7 @@ let publicSheetId = '';
 let publicMediaId = '';
 
 async function seedFixtures() {
+  await db.delete(talentSheetVariants);
   await db.delete(talentMedia);
   await db.delete(talentSheets);
   await db.delete(talent);
@@ -148,5 +151,51 @@ describe('scoped talent write ACL', () => {
       name: 'Renamed Template',
     });
     expect(result).toBeUndefined();
+  });
+});
+
+describe('scoped talent sheet variant write ACL', () => {
+  const teamAVariants = () => createTalentSheetVariantsMethods(db, teamA.id);
+
+  it('blocks insertDivergent on a public talent sheet', async () => {
+    await expect(
+      teamAVariants().insertDivergent({
+        talentSheetId: publicSheetId,
+        model: 'flux-pro',
+        url: 'https://example.com/divergent.png',
+        status: 'completed',
+        inputHash: 'hash-1',
+        divergedAt: new Date(),
+      })
+    ).rejects.toThrow(/permission to modify/);
+  });
+
+  it('blocks promoteAtomically on a public talent sheet', async () => {
+    const variants = teamAVariants();
+    const variant = await db
+      .insert(talentSheetVariants)
+      .values({
+        talentSheetId: publicSheetId,
+        model: 'flux-pro',
+        url: 'https://example.com/divergent.png',
+        status: 'completed',
+        inputHash: 'hash-promote',
+        divergedAt: new Date(),
+      })
+      .returning();
+    const row = variant[0];
+    if (!row) throw new Error('Failed to seed variant');
+
+    await expect(
+      variants.promoteAtomically(
+        publicSheetId,
+        {
+          imageUrl: row.url,
+          imagePath: row.storagePath,
+          inputHash: row.inputHash,
+        },
+        row.id
+      )
+    ).rejects.toThrow(/permission to modify/);
   });
 });

--- a/src/lib/db/scoped/talent.ts
+++ b/src/lib/db/scoped/talent.ts
@@ -16,6 +16,61 @@ import type {
 import { talent, talentMedia, talentSheets } from '@/lib/db/schema';
 import { and, asc, desc, eq, or, sql } from 'drizzle-orm';
 
+const TALENT_WRITE_DENIED =
+  'Talent not found or you do not have permission to modify it';
+
+/**
+ * Write-side ACL for scoped talent mutations. Public/system templates are
+ * readable by every team but writable only by non-public, team-owned rows.
+ */
+export function isTeamWritableTalent(
+  record: { teamId: string; isPublic: boolean | null },
+  teamId: string
+): boolean {
+  return record.teamId === teamId && !record.isPublic;
+}
+
+async function getWritableTalent(
+  db: Database,
+  talentId: string,
+  teamId: string
+): Promise<Talent | undefined> {
+  const record = await db.query.talent.findFirst({
+    where: { id: talentId },
+  });
+  if (!record || !isTeamWritableTalent(record, teamId)) {
+    return undefined;
+  }
+  return record;
+}
+
+async function requireWritableTalent(
+  db: Database,
+  talentId: string,
+  teamId: string
+): Promise<Talent> {
+  const record = await getWritableTalent(db, talentId, teamId);
+  if (!record) {
+    throw new Error(TALENT_WRITE_DENIED);
+  }
+  return record;
+}
+
+/** Resolve a sheet to its parent talent and enforce the write ACL. */
+export async function assertTalentSheetWritableForTeam(
+  db: Database,
+  talentSheetId: string,
+  teamId: string
+): Promise<void> {
+  const sheet = await db.query.talentSheets.findFirst({
+    where: { id: talentSheetId },
+  });
+  if (!sheet) {
+    throw new Error(`TalentSheet ${talentSheetId} not found`);
+  }
+  await requireWritableTalent(db, sheet.talentId, teamId);
+}
+
 /**
  * Shared implementation for team-scoped and public (anonymous) talent reads.
  * A null teamId means public-only scope: every query filters on isPublic with
@@ -283,6 +338,10 @@ export function createTalentMethods(
       talentId: string,
       data: Partial<Omit<Talent, 'id' | 'teamId' | 'createdAt' | 'createdBy'>>
     ): Promise<Talent | undefined> => {
+      if (!(await getWritableTalent(db, talentId, teamId))) {
+        return undefined;
+      }
+
       const [updated] = await db
         .update(talent)
         .set({ ...data, updatedAt: new Date() })
@@ -292,6 +351,10 @@ export function createTalentMethods(
     },
 
     delete: async (talentId: string): Promise<boolean> => {
+      if (!(await getWritableTalent(db, talentId, teamId))) {
+        return false;
+      }
+
       const result = await db
         .delete(talent)
         .where(and(eq(talent.id, talentId), eq(talent.teamId, teamId)));
@@ -300,10 +363,8 @@ export function createTalentMethods(
     },
 
     toggleFavorite: async (talentId: string): Promise<Talent | undefined> => {
-      const existing = await db.query.talent.findFirst({
-        where: { id: talentId },
-      });
-      if (!existing || existing.teamId !== teamId) return undefined;
+      const existing = await getWritableTalent(db, talentId, teamId);
+      if (!existing) return undefined;
 
       const [updated] = await db
         .update(talent)
@@ -317,6 +378,8 @@ export function createTalentMethods(
       ...read.sheets,
 
       create: async (data: NewTalentSheet): Promise<TalentSheet> => {
+        await requireWritableTalent(db, data.talentId, teamId);
+
         const existingSheets = await db
           .select({ count: sql<number>`count(*)`.mapWith(Number) })
           .from(talentSheets)
@@ -349,16 +412,21 @@ export function createTalentMethods(
         sheetId: string,
         data: Partial<Omit<TalentSheet, 'id' | 'talentId' | 'createdAt'>>
       ): Promise<TalentSheet | undefined> => {
+        const sheetForAcl = await db.query.talentSheets.findFirst({
+          where: { id: sheetId },
+        });
+        if (
+          !sheetForAcl ||
+          !(await getWritableTalent(db, sheetForAcl.talentId, teamId))
+        ) {
+          return undefined;
+        }
+
         if (data.isDefault) {
-          const sheet = await db.query.talentSheets.findFirst({
-            where: { id: sheetId },
-          });
-          if (sheet) {
-            await db
-              .update(talentSheets)
-              .set({ isDefault: false })
-              .where(eq(talentSheets.talentId, sheet.talentId));
-          }
+          await db
+            .update(talentSheets)
+            .set({ isDefault: false })
+            .where(eq(talentSheets.talentId, sheetForAcl.talentId));
         }
 
         const [updated] = await db
@@ -374,7 +442,9 @@ export function createTalentMethods(
         const sheet = await db.query.talentSheets.findFirst({
           where: { id: sheetId },
         });
-        if (!sheet) return false;
+        if (!sheet || !(await getWritableTalent(db, sheet.talentId, teamId))) {
+          return false;
+        }
 
         const result = await db
           .delete(talentSheets)
@@ -406,12 +476,21 @@ export function createTalentMethods(
       ...read.media,
 
       create: async (data: NewTalentMedia): Promise<TalentMediaRecord> => {
+        await requireWritableTalent(db, data.talentId, teamId);
+
         const [media] = await db.insert(talentMedia).values(data).returning();
         if (!media) throw new Error('Failed to create talent media');
         return media;
       },
 
       delete: async (mediaId: string): Promise<boolean> => {
+        const media = await db.query.talentMedia.findFirst({
+          where: { id: mediaId },
+        });
+        if (!media || !(await getWritableTalent(db, media.talentId, teamId))) {
+          return false;
+        }
+
         const result = await db
           .delete(talentMedia)
           .where(eq(talentMedia.id, mediaId));

--- a/src/routes/_app/talent/$id.tsx
+++ b/src/routes/_app/talent/$id.tsx
@@ -63,19 +63,6 @@ function TalentDetailPage() {
   const deleteTalent = useDeleteTalent();
   const generateSheet = useGenerateTalentSheet();
   const setDefaultSheet = useSetDefaultSheet();
-  const {
-    isGenerating: isGeneratingSheet,
-    phase: generatingPhase,
-    error: sheetError,
-    startGenerating,
-    // Anonymous visitors view talent read-only; don't open a realtime channel.
-  } = useTalentSheetRealtime(isAuthenticated ? id : undefined);
-
-  const handleGenerateSheet = () => {
-    if (!talent) return;
-    startGenerating(); // Show generating state immediately
-    generateSheet.mutate({ talentId: talent.id });
-  };
 
   const canManageTalent = Boolean(
     isAuthenticated &&
@@ -84,6 +71,19 @@ function TalentDetailPage() {
     talent.teamId === profile.teamId &&
     !talent.isPublic
   );
+
+  const {
+    isGenerating: isGeneratingSheet,
+    phase: generatingPhase,
+    error: sheetError,
+    startGenerating,
+  } = useTalentSheetRealtime(canManageTalent ? id : undefined);
+
+  const handleGenerateSheet = () => {
+    if (!talent) return;
+    startGenerating(); // Show generating state immediately
+    generateSheet.mutate({ talentId: talent.id });
+  };
 
   const handleDelete = () => {
     if (!talent) return;

--- a/src/routes/_app/talent/$id.tsx
+++ b/src/routes/_app/talent/$id.tsx
@@ -2,6 +2,7 @@ import { useAuthGate } from '@/components/auth/auth-gate-provider';
 import { routeParams } from '@/components/layout/breadcrumbs';
 import { EditTalentDialog } from '@/components/talent-library/edit-talent-dialog';
 import { PageContainer } from '@/components/layout/page-container';
+import { getCurrentUserProfileFn } from '@/functions/user';
 import { PageDescription } from '@/components/typography/page-description';
 import { PageHeader } from '@/components/typography/page-header';
 import { Button } from '@/components/ui/button';
@@ -16,6 +17,7 @@ import {
   useToggleTalentFavorite,
 } from '@/hooks/use-talent';
 import { cn } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
   ArrowLeft,
@@ -51,6 +53,12 @@ function TalentDetailPage() {
   const navigate = useNavigate();
   const { isAuthenticated } = useAuthGate();
   const { data: talent, isLoading, error } = useTalentById(id);
+  const { data: profile } = useQuery({
+    queryKey: ['currentUserProfile'],
+    queryFn: () => getCurrentUserProfileFn(),
+    staleTime: 5 * 60 * 1000,
+    enabled: isAuthenticated,
+  });
   const toggleFavorite = useToggleTalentFavorite();
   const deleteTalent = useDeleteTalent();
   const generateSheet = useGenerateTalentSheet();
@@ -69,12 +77,21 @@ function TalentDetailPage() {
     generateSheet.mutate({ talentId: talent.id });
   };
 
-  const handleDelete = async () => {
+  const canManageTalent = Boolean(
+    isAuthenticated &&
+    profile?.teamId &&
+    talent &&
+    talent.teamId === profile.teamId &&
+    !talent.isPublic
+  );
+
+  const handleDelete = () => {
     if (!talent) return;
     if (!confirm(`Delete "${talent.name}"? This cannot be undone.`)) return;
 
-    await deleteTalent.mutateAsync(talent.id);
-    void navigate({ to: '/talent' });
+    deleteTalent.mutate(talent.id, {
+      onSuccess: () => void navigate({ to: '/talent' }),
+    });
   };
 
   if (isLoading) {
@@ -128,7 +145,7 @@ function TalentDetailPage() {
 
         <PageHeader
           actions={
-            isAuthenticated ? (
+            canManageTalent ? (
               <div className="flex items-center gap-2">
                 <EditTalentDialog
                   talent={talent}
@@ -156,7 +173,7 @@ function TalentDetailPage() {
                 <Button
                   variant="outline"
                   size="icon"
-                  onClick={() => void handleDelete()}
+                  onClick={handleDelete}
                   disabled={deleteTalent.isPending}
                 >
                   <Trash2 className="h-4 w-4 text-destructive" />
@@ -225,7 +242,7 @@ function TalentDetailPage() {
             {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard */}
             {talent.media &&
               talent.media.filter((m) => m.type === 'image').length > 0 &&
-              isAuthenticated && (
+              canManageTalent && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -249,7 +266,7 @@ function TalentDetailPage() {
               {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime guard */}
               {talent.media &&
               talent.media.filter((m) => m.type === 'image').length > 0 &&
-              isAuthenticated ? (
+              canManageTalent ? (
                 <div>
                   <p className="text-muted-foreground mb-3">
                     {isGeneratingSheet
@@ -333,7 +350,7 @@ function TalentDetailPage() {
                     <p className="font-medium text-sm line-clamp-1">
                       {sheet.name}
                     </p>
-                    {isAuthenticated &&
+                    {canManageTalent &&
                       talent.sheets.length > 1 &&
                       !sheet.isDefault && (
                         <Button


### PR DESCRIPTION
## Summary

Closes #666

- Hide owner-only actions on public/system talent detail pages for non-owning teams
- Gate edit/delete/favorite/generate-sheet/set-default controls behind team ownership
- Surface delete failures with a toast instead of silently leaving the page stuck
- Return clearer server-side delete errors for not-found, forbidden, and failed-delete cases

## Testing

- bun typecheck
- bun format:check
- bun lint: 0 errors; existing unrelated warnings remain

Pre-commit also passed dead-code, format, lint, and typecheck for the staged files.