### PR TITLE
ci: make e2e hermetic so fork PRs pass (drop secret/env deps)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,17 @@ on:
 permissions:
   contents: read
 
+# E2E is fully hermetic — LLM + fal.ai calls hit the aimock server, D1 + R2 are
+# local Miniflare, and login uses the dev email-OTP backdoor — so the suite needs
+# no real credentials. These fixed throwaway values replace the former `secrets.*`
+# + `environment: staging` wiring, which GitHub (correctly) withholds from fork
+# PRs; that was the sole reason e2e failed on external contributions.
+env:
+  E2E_BETTER_AUTH_SECRET: e2e-not-a-real-secret-do-not-use-in-production
+  E2E_GOOGLE_CLIENT_ID: test-google-client-id
+  E2E_GOOGLE_CLIENT_SECRET: test-google-client-secret
+  E2E_EMAIL_FROM: e2e@example.com
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -78,7 +89,6 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    environment: staging
     needs: build-e2e
 
     steps:
@@ -115,28 +125,21 @@ jobs:
         # file. The built e2e path uses `-c dist/server/wrangler.json`, so the
         # file MUST live next to that config (`dist/server/.dev.vars`) —
         # writing it at the project root is invisible to `wrangler -c`.
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          FAL_KEY: ${{ secrets.FAL_KEY }}
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+        # All values are hermetic constants (see top-level `env:`): the worker
+        # only signs throwaway sessions, fal.ai/LLM go through aimock, and no
+        # test exercises real Google OAuth or email delivery.
         run: |
-          if [ -z "$BETTER_AUTH_SECRET" ]; then
-            echo "::error::BETTER_AUTH_SECRET is empty — secret not exposed to this job (check environment: staging scoping)"
-            exit 1
-          fi
           # No R2 creds or R2_PUBLIC_STORAGE_DOMAIN: e2e R2 is the local
           # Miniflare binding, with reads served by the worker's /r2/$ route.
           cat > dist/server/.dev.vars <<EOF
-          BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET
+          BETTER_AUTH_SECRET=$E2E_BETTER_AUTH_SECRET
           BETTER_AUTH_URL=http://localhost:3001
           OPENROUTER_KEY=test-mock-key
           OPENROUTER_BASE_URL=http://localhost:4010
-          FAL_KEY=$FAL_KEY
-          GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
-          GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
-          EMAIL_FROM=$EMAIL_FROM
+          FAL_KEY=test-mock-key
+          GOOGLE_CLIENT_ID=$E2E_GOOGLE_CLIENT_ID
+          GOOGLE_CLIENT_SECRET=$E2E_GOOGLE_CLIENT_SECRET
+          EMAIL_FROM=$E2E_EMAIL_FROM
           E2E_TEST=true
           VITE_APP_URL=http://localhost:3001
           EOF
@@ -169,20 +172,20 @@ jobs:
           # Miniflare, so wrangler skips the remote-proxy auth check.
           BETTER_AUTH_URL: http://localhost:3001
           VITE_R2_PUBLIC_ASSETS_DOMAIN: ${{ vars.VITE_R2_PUBLIC_ASSETS_DOMAIN }}
-          # Auth - preview environment
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          # Hermetic constants — see top-level `env:`. The built worker reads
+          # auth/creds from dist/server/.dev.vars; these process.env values are
+          # only for any node-side test tooling and never leave the runner.
+          GOOGLE_CLIENT_ID: ${{ env.E2E_GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ env.E2E_GOOGLE_CLIENT_SECRET }}
+          BETTER_AUTH_SECRET: ${{ env.E2E_BETTER_AUTH_SECRET }}
           # AI services — LLM calls mocked via aimock server, fal.ai via Playwright routes
-          FAL_KEY: ${{ secrets.FAL_KEY }}
+          FAL_KEY: test-mock-key
           OPENROUTER_KEY: test-mock-key
           OPENROUTER_BASE_URL: http://localhost:4010
-          # Email - preview environment
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM: ${{ env.E2E_EMAIL_FROM }}
 
   e2e-full-pipeline:
     runs-on: ubuntu-latest
-    environment: staging
     needs: build-e2e
 
     steps:
@@ -214,29 +217,21 @@ jobs:
       - name: Write .dev.vars for wrangler dev
         # See e2e job above. Built path uses `wrangler dev -c
         # dist/server/wrangler.json` which resolves `.dev.vars` relative to
-        # the config, so the file must live in dist/server/.
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+        # the config, so the file must live in dist/server/. Values are
+        # hermetic constants (see top-level `env:`).
         run: |
-          if [ -z "$BETTER_AUTH_SECRET" ]; then
-            echo "::error::BETTER_AUTH_SECRET is empty — secret not exposed to this job (check environment: staging scoping)"
-            exit 1
-          fi
           # No R2 creds or R2_PUBLIC_STORAGE_DOMAIN: e2e R2 is the local
           # Miniflare binding, with reads served by the worker's /r2/$ route.
           cat > dist/server/.dev.vars <<EOF
-          BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET
+          BETTER_AUTH_SECRET=$E2E_BETTER_AUTH_SECRET
           BETTER_AUTH_URL=http://localhost:3001
           OPENROUTER_KEY=test-mock-key
           OPENROUTER_BASE_URL=http://localhost:4010
           FAL_KEY=test-mock-key
           FAL_PROXY_URL=http://localhost:4010/fal
-          GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
-          GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
-          EMAIL_FROM=$EMAIL_FROM
+          GOOGLE_CLIENT_ID=$E2E_GOOGLE_CLIENT_ID
+          GOOGLE_CLIENT_SECRET=$E2E_GOOGLE_CLIENT_SECRET
+          EMAIL_FROM=$E2E_EMAIL_FROM
           E2E_TEST=true
           E2E_FULL_PIPELINE=true
           VITE_APP_URL=http://localhost:3001
@@ -263,14 +258,15 @@ jobs:
           # Miniflare, so wrangler skips the remote-proxy auth check.
           BETTER_AUTH_URL: http://localhost:3001
           VITE_R2_PUBLIC_ASSETS_DOMAIN: ${{ vars.VITE_R2_PUBLIC_ASSETS_DOMAIN }}
-          # Auth - preview environment
-          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
+          # Hermetic constants — see top-level `env:`. The built worker reads
+          # auth/creds from dist/server/.dev.vars; these process.env values are
+          # only for any node-side test tooling and never leave the runner.
+          GOOGLE_CLIENT_ID: ${{ env.E2E_GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ env.E2E_GOOGLE_CLIENT_SECRET }}
+          BETTER_AUTH_SECRET: ${{ env.E2E_BETTER_AUTH_SECRET }}
           # AI services — both LLM and fal.ai go through aimock (port 4010)
           FAL_KEY: test-mock-key
           FAL_PROXY_URL: http://localhost:4010/fal
           OPENROUTER_KEY: test-mock-key
           OPENROUTER_BASE_URL: http://localhost:4010
-          # Email - preview environment
-          EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+          EMAIL_FROM: ${{ env.E2E_EMAIL_FROM }}


### PR DESCRIPTION
## Summary

Makes the Playwright e2e CI jobs **hermetic** so pull requests from forks pass, instead of hard-failing because GitHub withholds secrets from fork PRs.

### The problem

`test.yml`'s `e2e` and `e2e-full-pipeline` jobs declared `environment: staging` and read real `secrets.*` (`BETTER_AUTH_SECRET`, `FAL_KEY`, `GOOGLE_CLIENT_ID/SECRET`, `EMAIL_FROM`). GitHub deliberately does **not** expose repo/environment secrets to `pull_request` runs whose head branch lives in a fork, so `BETTER_AUTH_SECRET` resolved to an empty string and the job's own guard failed:

```
BETTER_AUTH_SECRET is empty — secret not exposed to this job (check environment: staging scoping)
```

This blocked every external contributor's PR (e.g. #1005).

### Why real secrets were never needed

The e2e suite is designed to be fully hermetic:
- **LLM + fal.ai** calls go through the aimock server / Playwright routes.
- **D1 + R2** are local Miniflare bindings.
- **Login** uses the dev **email-OTP backdoor** — fixtures hit the worker via `/api/test/*` and enter OTP `123456`; the node/Playwright side never touches `BETTER_AUTH_SECRET` or any provider key.
- The `e2e-full-pipeline` job already proved this by hardcoding `FAL_KEY=test-mock-key`.

The only consumer of these values is the worker (via `dist/server/.dev.vars`), and it only needs *some* signing secret — not the production one.

### The change

- Add a top-level `env:` block with **fixed throwaway constants** (`E2E_BETTER_AUTH_SECRET`, `E2E_GOOGLE_CLIENT_ID/SECRET`, `E2E_EMAIL_FROM`). A fixed constant (not a per-step random) keeps the worker's `.dev.vars` and the test-runner env in agreement.
- Drop `environment: staging` from `e2e` and `e2e-full-pipeline`.
- Remove the now-moot empty-secret guards.
- `build-e2e` is left untouched — it uses only the non-secret `vars.VITE_R2_PUBLIC_ASSETS_DOMAIN` and already runs fine on forks.

Result: e2e runs identically on fork PRs and internal branches with **zero secret dependency** — matching the "fully hermetic, no Cloudflare credentials in CI" design already documented in `CLAUDE.md`.

### Notes

- No tracking issue was filed (happy to open one if you'd like). This unblocks the fork PR #1005 among others.
- Does **not** touch `deploy-cloudflare.yml`, which legitimately needs real secrets and already guards itself against forks.

## Testing

- `test.yml` parses as valid YAML; no `secrets.*` expressions remain; `pull_request_target` guard (`workflow-trigger-safety` lefthook) passes.
- Real verification is this PR's own CI run — the `e2e` / `e2e-full-pipeline` checks should now go green without any staging secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
