### PR TITLE
fix: monotonic ULID for deterministic id ordering (fixes flaky sequence-events test)

### DIFF
--- a/src/lib/db/id.ts
+++ b/src/lib/db/id.ts
@@ -3,7 +3,17 @@
  * Centralized ID generation for all database entities using ULIDs
  */
 
-import { ulid } from 'ulid';
+import { monotonicFactory } from 'ulid';
+
+/**
+ * Monotonic ULID factory. Unlike the plain `ulid()`, calls within the same
+ * millisecond increment the random component so IDs are *strictly* increasing
+ * within a process. This makes `ORDER BY id` a reliable insertion order for
+ * rows created back-to-back (e.g. the `sequence_events` timeline read via
+ * `desc(id)`), instead of the non-deterministic same-ms ordering plain ULIDs
+ * give. Output is still a valid, sortable, globally-unique ULID.
+ */
+const monotonicUlid = monotonicFactory();
 
 /**
  * Generate a ULID (Universally Unique Lexicographically Sortable Identifier)
@@ -25,7 +35,7 @@ import { ulid } from 'ulid';
  * ```
  */
 export function generateId(): string {
-  return ulid();
+  return monotonicUlid();
 }
 
 /**


### PR DESCRIPTION
## Summary

Makes database `id` ordering deterministic by switching `generateId()` from the plain `ulid()` to ulid's `monotonicFactory()`. This fixes the long-standing flaky `sequence-events` test.

## Root cause

`generateId()` (`src/lib/db/id.ts`) used the **non-monotonic** `ulid()`. Two rows created in the same millisecond get identical time prefixes but independent random components, so their lexicographic order is random. Any read that orders by `desc(id)` to mean "newest first" is therefore non-deterministic for same-ms inserts.

`listBySequence` orders by `desc(sequenceEvents.id)`, so this surfaced as an intermittent failure:

```
src/lib/db/scoped/sequence-events.test.ts > listBySequence returns the timeline newest-first
AssertionError: expected [ 'a.first', 'b.second' ] to deeply equal [ 'b.second', 'a.first' ]
```

The two `record()` calls land in the same millisecond, and which ULID sorts higher was a coin flip. This test has failed intermittently across many branches.

## Fix

`monotonicFactory()` returns a generator that, for same-millisecond calls, increments the random component so IDs are **strictly increasing** within a process. Output is still a valid, sortable, globally-unique ULID. `ORDER BY id` now reflects insertion order for back-to-back rows.

One-line-ish change, centralized: `generateId()` is the single production ID source (the only other `ulid()` uses are `faker.string.ulid()` in mocks).

### On the process-local caveat

`monotonicFactory()` keeps its "last timestamp/random" state per process/isolate. Within a single request/isolate (where back-to-back inserts happen) ordering is now strict. Across isolates, same-ms rows fall back to timestamp-prefix ordering — exactly the behavior we have today — so nothing regresses.

## Testing

- The previously-flaky `sequence-events.test.ts` passes **15/15** runs (was a coin flip before).
- 1000 back-to-back `generateId()` calls are verified strictly increasing.
- `bun typecheck`, `bun lint`, `bun format:check`, `bun dead-code` all clean (pre-commit hooks green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
