### PR TITLE
Respect Fal proxy for per-request script clients

### DIFF
--- a/scripts/verify-fal-costs.ts
+++ b/scripts/verify-fal-costs.ts
@@ -18,6 +18,7 @@
  *   bun scripts/verify-fal-costs.ts --compare            # fetch usage for existing results
  */
 
+import { createProxiedFalClient } from '@/lib/ai/fal-config';
 import { estimateFalCost } from '@/lib/ai/fal-cost';
 import {
   AUDIO_MODELS,
@@ -29,7 +30,6 @@ import {
 import { buildModelInput } from '@/lib/motion/build-model-input';
 import { snapDuration } from '@/lib/motion/motion-generation';
 import { typedEntries } from '@/lib/utils/typed-object';
-import { createFalClient } from '@fal-ai/client';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
@@ -68,8 +68,8 @@ const compareOnly = args.includes('--compare');
 const imageUrlIdx = args.indexOf('--image-url');
 const testImageUrl = imageUrlIdx >= 0 ? args[imageUrlIdx + 1] : undefined;
 
-const falLow = createFalClient({ credentials: FAL_KEY_LOW });
-const falHigh = createFalClient({ credentials: FAL_KEY_HIGH });
+const falLow = createProxiedFalClient({ credentials: FAL_KEY_LOW });
+const falHigh = createProxiedFalClient({ credentials: FAL_KEY_HIGH });
 
 // ============================================================================
 // Types

--- a/src/lib/ai/fal-config.test.ts
+++ b/src/lib/ai/fal-config.test.ts
@@ -1,0 +1,98 @@
+import type { RequestMiddleware } from '@fal-ai/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type RequestConfig = Parameters<RequestMiddleware>[0];
+type FalClientConfig = {
+  credentials?: string;
+  requestMiddleware?: RequestMiddleware;
+};
+
+const createFalClient = vi.fn((config: FalClientConfig) => ({ config }));
+const falConfig = vi.fn();
+
+vi.doMock('@fal-ai/client', () => ({
+  createFalClient,
+  fal: { config: falConfig },
+}));
+
+const { createProxiedFalClient } = await import('./fal-config');
+
+beforeEach(() => {
+  delete process.env.FAL_PROXY_URL;
+  createFalClient.mockClear();
+  falConfig.mockClear();
+});
+
+describe('createProxiedFalClient', () => {
+  it('creates a direct client when FAL_PROXY_URL is unset', () => {
+    createProxiedFalClient({ credentials: 'fal-key' });
+
+    expect(createFalClient).toHaveBeenCalledWith({ credentials: 'fal-key' });
+  });
+
+  it('adds proxy middleware when FAL_PROXY_URL is set', async () => {
+    process.env.FAL_PROXY_URL = 'http://localhost:4010/fal';
+
+    createProxiedFalClient({ credentials: 'fal-key' });
+
+    const config = createFalClient.mock.calls[0]?.[0];
+    expect(config).toMatchObject({ credentials: 'fal-key' });
+    expect(config?.requestMiddleware).toBeTypeOf('function');
+    if (!config?.requestMiddleware)
+      throw new Error('Missing requestMiddleware');
+
+    const rewritten = await config.requestMiddleware({
+      url: 'https://queue.fal.run/model/path?foo=bar',
+      method: 'POST',
+      headers: { authorization: 'Key fal-key' },
+    });
+
+    expect(rewritten).toEqual({
+      url: 'http://localhost:4010/fal/model/path?foo=bar',
+      method: 'POST',
+      headers: {
+        authorization: 'Key fal-key',
+        'x-fal-target-host': 'queue.fal.run',
+      },
+    });
+  });
+
+  it('composes caller middleware before proxy middleware', async () => {
+    process.env.FAL_PROXY_URL = 'http://localhost:4010/fal';
+    const callerMiddleware = vi.fn(async (request: RequestConfig) => ({
+      ...request,
+      url: 'https://fal.run/caller-rewritten',
+    }));
+
+    createProxiedFalClient({
+      credentials: 'fal-key',
+      requestMiddleware: callerMiddleware,
+    });
+
+    const config = createFalClient.mock.calls[0]?.[0];
+    if (!config?.requestMiddleware)
+      throw new Error('Missing requestMiddleware');
+
+    const originalRequest = {
+      url: 'https://example.com/original',
+      method: 'POST',
+    };
+    const rewritten = await config.requestMiddleware(originalRequest);
+
+    expect(callerMiddleware).toHaveBeenCalledWith(originalRequest);
+    expect(rewritten.url).toBe('http://localhost:4010/fal/caller-rewritten');
+  });
+
+  it('leaves non-fal hosts untouched', async () => {
+    process.env.FAL_PROXY_URL = 'http://localhost:4010/fal';
+
+    createProxiedFalClient({ credentials: 'fal-key' });
+
+    const config = createFalClient.mock.calls[0]?.[0];
+    if (!config?.requestMiddleware)
+      throw new Error('Missing requestMiddleware');
+
+    const request = { url: 'https://example.com/file.png', method: 'GET' };
+    await expect(config.requestMiddleware(request)).resolves.toBe(request);
+  });
+});

--- a/src/lib/ai/fal-config.ts
+++ b/src/lib/ai/fal-config.ts
@@ -1,4 +1,4 @@
-import { fal, type RequestMiddleware } from '@fal-ai/client';
+import { createFalClient, fal, type RequestMiddleware } from '@fal-ai/client';
 
 const FAL_HOSTS = new Set([
   'fal.run',
@@ -50,10 +50,9 @@ function composeMiddleware(
  *
  * The `@tanstack/ai-fal` adapters call `fal.config({ credentials })` on the
  * singleton and would otherwise wipe any `requestMiddleware` we set, so we
- * monkey-patch `fal.config` to compose ours back in. Note: callers that build
- * a per-request client via `@fal-ai/client`'s `createFalClient(...)` get an
- * independent client whose config closure this monkey-patch can't touch —
- * those bypass the proxy.
+ * monkey-patch `fal.config` to compose ours back in. Per-request clients that
+ * need the same routing should use `createProxiedFalClient(...)`; direct
+ * `@fal-ai/client` clients intentionally bypass this singleton patch.
  */
 export function configureFalProxyFromEnv(): void {
   if (configured) return;
@@ -74,4 +73,26 @@ export function configureFalProxyFromEnv(): void {
     });
   };
   fal.config({});
+}
+
+/**
+ * Creates a per-request fal client that also respects FAL_PROXY_URL.
+ *
+ * Use this for script/tooling clients with their own credentials. Some runtime
+ * storage shims intentionally use the upstream client directly because fal
+ * storage-initiate calls should not be recorded by aimock.
+ */
+export function createProxiedFalClient(
+  config: NonNullable<Parameters<typeof createFalClient>[0]>
+): ReturnType<typeof createFalClient> {
+  const proxyUrl = process.env.FAL_PROXY_URL;
+  if (!proxyUrl) return createFalClient(config);
+
+  return createFalClient({
+    ...config,
+    requestMiddleware: composeMiddleware(
+      buildProxyMiddleware(proxyUrl),
+      config.requestMiddleware
+    ),
+  });
 }


### PR DESCRIPTION
## Summary
- add a proxy-aware per-request Fal client factory that composes the existing FAL_PROXY_URL middleware
- use it in the fal cost verification script so script clients do not bypass the proxy
- keep fal storage uploads intentionally direct and document that exception from the shared helper
- add unit coverage for proxy rewriting, middleware composition, and non-Fal passthrough

Closes #890

## Validation
- bun run test src/lib/ai/fal-config.test.ts
- bun typecheck
- bun format:check
- bun lint
- pre-commit: dead-code, format, lint, typecheck