### PR TITLE
Auto-request code-owner review on every PR via CODEOWNERS catch-all

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,10 @@
 # Sensitive paths require code-owner review.
 # Docs: https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
 
+# Catch-all — auto-request review on every PR (#1017). Later, more specific
+# rules take precedence, so the sensitive-path entries below stay authoritative.
+*                     @tombeckenham
+
 # CI workflows — anything merged here can leak secrets on next main push
 /.github/workflows/   @tombeckenham
 


### PR DESCRIPTION
## Summary

- Add a catch-all `*` rule to `.github/CODEOWNERS` so @tombeckenham is auto-requested for review on every PR, not just those touching the sensitive paths already listed.
- Placed first so the more specific sensitive-path rules below remain the effective (last) match for those files.

Notes:
- GitHub never requests review from the PR author, so this applies to PRs opened by others (contributors, automation) — not self-authored PRs.
- This auto-requests review but does not enforce it; blocking merges until code-owner approval is the "Require review from Code Owners" branch-protection setting.

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
