### PR TITLE
fix(#1019): chunk anchor-frame inserts to respect D1's 100-param ceiling

### DIFF
--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -33,6 +33,10 @@ import { buildEventInsert } from './sequence-events';
 
 const logger = getLogger(['openstory', 'db', 'shot-prompt-versions']);
 
+// `getSelectedMotionByShots` binds one id param per shot; 90 keeps each query
+// under D1's 100-bound-parameter ceiling (matches SHOTS_BY_IDS_BATCH).
+const SELECTED_MOTION_BY_SHOTS_BATCH = 90;
+
 type WriteShotPromptVersionBase = {
   shotId: string;
   promptType: ShotPromptType;
@@ -315,15 +319,23 @@ export function createShotPromptVersionsMethods(db: Database) {
       shotIds: string[]
     ): Promise<Map<string, ShotPromptVersion>> => {
       if (shotIds.length === 0) return new Map();
-      const rows = await db
-        .select({ shotId: shots.id, version: shotPromptVersions })
-        .from(shots)
-        .innerJoin(
-          shotPromptVersions,
-          eq(shots.selectedMotionPromptVersionId, shotPromptVersions.id)
-        )
-        .where(inArray(shots.id, shotIds));
-      return new Map(rows.map((r) => [r.shotId, r.version]));
+      // Chunk the id list to stay under D1's 100-bound-parameter ceiling — this
+      // runs on the getShotsFn read path with every shot of a sequence, so a
+      // long sequence (#1019) would otherwise overflow the limit and throw.
+      const result = new Map<string, ShotPromptVersion>();
+      for (let i = 0; i < shotIds.length; i += SELECTED_MOTION_BY_SHOTS_BATCH) {
+        const batch = shotIds.slice(i, i + SELECTED_MOTION_BY_SHOTS_BATCH);
+        const rows = await db
+          .select({ shotId: shots.id, version: shotPromptVersions })
+          .from(shots)
+          .innerJoin(
+            shotPromptVersions,
+            eq(shots.selectedMotionPromptVersionId, shotPromptVersions.id)
+          )
+          .where(inArray(shots.id, batch));
+        for (const r of rows) result.set(r.shotId, r.version);
+      }
+      return result;
     },
 
     /**

--- a/src/lib/db/scoped/shots-anchor.test.ts
+++ b/src/lib/db/scoped/shots-anchor.test.ts
@@ -118,6 +118,23 @@ describe('shots anchor-frame materialization', () => {
     expect(new Set(anchorIds).size).toBe(2);
   });
 
+  it('ensureAnchorFrames returns an anchor id for every shot across chunk boundaries', async () => {
+    // #1019: the read path (getShotsFn) calls ensureAnchorFrames with a whole
+    // sequence's shots at once. A single INSERT of >~10 anchor rows overflowed
+    // D1's 100-bound-parameter ceiling, so it now chunks. Use more shots than
+    // the internal batch size to prove the per-chunk RETURNING maps are merged.
+    const methods = createShotsMethods(db);
+    const shots = await methods.createBulk(
+      Array.from({ length: 25 }, (_, i) => ({ sequenceId, orderIndex: i }))
+    );
+    const anchors = await methods.ensureAnchorFrames(shots);
+
+    expect(anchors.size).toBe(shots.length);
+    for (const shot of shots) {
+      expect(anchors.get(shot.id)).toBeTruthy();
+    }
+  });
+
   it('preserves an existing anchor frame and its image on replay', async () => {
     const methods = createShotsMethods(db);
     const shot = await methods.upsert({ sequenceId, orderIndex: 0 });

--- a/src/lib/db/scoped/shots.ts
+++ b/src/lib/db/scoped/shots.ts
@@ -114,6 +114,10 @@ const SHOT_ARTIFACT_HASH_COLUMNS = {
   audio: 'audioInputHash',
 } as const satisfies Record<string, keyof Shot>;
 
+// Anchor-frame inserts bind ~10 params per row; 9 rows/chunk keeps each INSERT
+// well under D1's 100-bound-parameter ceiling (see `ensureAnchorFrames`).
+const ANCHOR_FRAMES_BATCH = 9;
+
 export type ShotArtifact = keyof typeof SHOT_ARTIFACT_HASH_COLUMNS;
 
 type ShotFilters = {
@@ -132,19 +136,31 @@ export function createShotsMethods(db: Database) {
   // plain `onConflictDoNothing` omits for the conflicting (pre-existing) rows. This
   // lets callers capture the anchor id at write time and thread it downstream
   // instead of reading it back (#991: no DB reads in workflows).
+  //
+  // Chunked to stay under D1's 100-bound-parameter ceiling: each anchor row binds
+  // ~10 params (id, shotId, sequenceId, orderIndex, role, source, imageStatus,
+  // imageModel, createdAt, updatedAt — the schema defaults are inlined as binds),
+  // so a single INSERT of a whole sequence's shots overflowed the limit and threw
+  // (#1019: getShotsFn calls this with every shot on each read, so sequences with
+  // more than ~10 shots stopped listing their scenes entirely).
   const ensureAnchorFrames = async (
     rows: ReadonlyArray<Pick<Shot, 'id' | 'sequenceId'>>
   ): Promise<Map<string, string>> => {
     if (rows.length === 0) return new Map();
-    const anchors = await db
-      .insert(frames)
-      .values(rows.map(anchorFrameValues))
-      .onConflictDoUpdate({
-        target: [frames.shotId, frames.orderIndex],
-        set: { orderIndex: sql.raw(`excluded."order_index"`) },
-      })
-      .returning({ id: frames.id, shotId: frames.shotId });
-    return new Map(anchors.map((a) => [a.shotId, a.id]));
+    const result = new Map<string, string>();
+    for (let i = 0; i < rows.length; i += ANCHOR_FRAMES_BATCH) {
+      const batch = rows.slice(i, i + ANCHOR_FRAMES_BATCH);
+      const anchors = await db
+        .insert(frames)
+        .values(batch.map(anchorFrameValues))
+        .onConflictDoUpdate({
+          target: [frames.shotId, frames.orderIndex],
+          set: { orderIndex: sql.raw(`excluded."order_index"`) },
+        })
+        .returning({ id: frames.id, shotId: frames.shotId });
+      for (const a of anchors) result.set(a.shotId, a.id);
+    }
+    return result;
   };
 
   return {


### PR DESCRIPTION
## Problem

Scenes weren't listing on some sequences (e.g. `01KWGDCGQ3GTFF202MSBZ2QMNK`). Confirmed via PostHog logs (`openstory-prd`):

```
serverFn "getShotsFn" failed: "UNKNOWN" "Failed query: insert into "frames" … (22+ value tuples) …"
```

`getShotsFn` calls `scopedDb.shots.ensureAnchorFrames(shotRows)` with **every** shot of the sequence at once, in a single unchunked `INSERT INTO frames …`. Each anchor row binds ~10 params (schema defaults like `source`/`imageStatus`/`imageModel`/timestamps are inlined as binds), so a sequence with more than ~10 shots overflowed **D1's 100-bound-parameter ceiling** and the query threw.

When `getShotsFn` rejects, `useShotsBySequence` leaves `shots` `undefined`, and `SceneList` renders skeletons forever (it treats `undefined`/empty the same as loading) — so scenes never list. This only bit **long** sequences, matching "on some sequences". The React #419 SSR errors on the `/scenes` URL are the downstream symptom.

## Fix

- Chunk `ensureAnchorFrames` inserts at 9 rows/chunk (~90 params) and merge the RETURNING maps.
- Chunk `getSelectedMotionByShots` (unchunked `inArray` on the same read path — would overflow at ~100 shots) at 90 ids/chunk.
- Regression test covering a shot count that spans multiple chunks.

## Test plan

- `bun run test src/lib/db/scoped/shots-anchor.test.ts` — 5 passed
- `bun run test src/lib/db/scoped/shot-prompt-versions.test.ts src/functions/__tests__/shots.test.ts` — 30 passed
- `bun tsgo --noEmit` + `bun lint` clean

## Still open (separate, tracked in #1019)

"Worker exceeded memory limit" and "Disallowed operation called within global scope" errors clustered in the same window on this mega-sequence. The global-scope one has no stack and appears fresh-isolate-wide, so it looks like a latent module-init issue rather than the `getShotsFn` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)