### PR TITLE
fix(#1019): make SSF Phase 4 migration D1-safe; lint per-row backfills

### DIFF
--- a/drizzle/migrations/20260629104851_stale_the_executioner/migration.sql
+++ b/drizzle/migrations/20260629104851_stale_the_executioner/migration.sql
@@ -12,20 +12,35 @@ ALTER TABLE `shot_prompt_versions` ADD `audio` text;--> statement-breakpoint
 -- `shots.selected_motion_prompt_version_id` was NEVER populated before this PR,
 -- so resolution + the Phase-3 render manifest were ignoring the version table on
 -- every pre-existing shot. Point each shot at its latest motion version so
--- #713's pointer-driven resolution takes effect on existing data. Pure UPDATE,
--- guarded `IS NULL` + `EXISTS` so it is safe to re-run.
+-- #713's pointer-driven resolution takes effect on existing data.
+--
+-- Set-based, NOT a per-row correlated subquery (#1019): the original correlated
+-- form ran one lookup per shot which — combined with step 4's unindexed scan —
+-- blew D1's remote CPU-time limit on production-sized data, rolling the whole
+-- migration back and freezing the deploy pipeline. A single windowed pass over
+-- `shot_prompt_versions` (`latest`), joined to `shots` by its primary key, stays
+-- linear at any table size. Guarded `IS NULL` so it is safe to re-run; the
+-- `latest` subquery only contains shots that have a motion version, so it
+-- inherently skips shots without one.
 UPDATE `shots`
-SET `selected_motion_prompt_version_id` = (
-	SELECT spv.`id` FROM `shot_prompt_versions` spv
-	WHERE spv.`shot_id` = `shots`.`id` AND spv.`prompt_type` = 'motion'
-	ORDER BY spv.`created_at` DESC, spv.`id` DESC
-	LIMIT 1
-)
-WHERE `selected_motion_prompt_version_id` IS NULL
-	AND EXISTS (
-		SELECT 1 FROM `shot_prompt_versions` spv
-		WHERE spv.`shot_id` = `shots`.`id` AND spv.`prompt_type` = 'motion'
-	);--> statement-breakpoint
+SET `selected_motion_prompt_version_id` = `latest`.`version_id`
+FROM (
+	SELECT `shot_id`, `id` AS `version_id`
+	FROM (
+		SELECT
+			`shot_id`,
+			`id`,
+			ROW_NUMBER() OVER (
+				PARTITION BY `shot_id`
+				ORDER BY `created_at` DESC, `id` DESC
+			) AS `rn`
+		FROM `shot_prompt_versions`
+		WHERE `prompt_type` = 'motion'
+	)
+	WHERE `rn` = 1
+) AS `latest`
+WHERE `shots`.`id` = `latest`.`shot_id`
+	AND `shots`.`selected_motion_prompt_version_id` IS NULL;--> statement-breakpoint
 
 -- 4. Hydrate `dialogue` + `audio` on the now-selected motion version from the
 -- shot's legacy `metadata.prompts.motion` (frame.metadata IS the Scene; the old
@@ -34,26 +49,22 @@ WHERE `selected_motion_prompt_version_id` IS NULL
 -- clobbers rows written by the new code path. `json_valid` guards malformed
 -- metadata; `json_extract` of the nested object returns well-formed JSON text
 -- that round-trips through the `text({mode:'json'})` column.
+--
+-- Set-based join, NOT correlated subqueries (#1019): the original form ran three
+-- correlated subqueries per motion row, each a full scan of `shots` (there is no
+-- index on `shots.selected_motion_prompt_version_id`), i.e. O(motion_rows x
+-- shots) — ~10M row reads on production, which tripped D1's remote CPU-time
+-- limit and aborted the deploy. Driving the join from `shots` and matching the
+-- target `shot_prompt_versions` by its primary key (verified via EXPLAIN QUERY
+-- PLAN: `SCAN shots` + `SEARCH spv USING INDEX (id=?)`) is linear.
 UPDATE `shot_prompt_versions`
 SET
-	`dialogue` = (
-		SELECT json_extract(s.`metadata`, '$.prompts.motion.dialogue')
-		FROM `shots` s
-		WHERE s.`selected_motion_prompt_version_id` = `shot_prompt_versions`.`id`
-			AND json_valid(s.`metadata`)
-	),
-	`audio` = (
-		SELECT json_extract(s.`metadata`, '$.prompts.motion.audio')
-		FROM `shots` s
-		WHERE s.`selected_motion_prompt_version_id` = `shot_prompt_versions`.`id`
-			AND json_valid(s.`metadata`)
-	)
-WHERE `prompt_type` = 'motion'
-	AND `dialogue` IS NULL
-	AND `audio` IS NULL
-	AND EXISTS (
-		SELECT 1 FROM `shots` s
-		WHERE s.`selected_motion_prompt_version_id` = `shot_prompt_versions`.`id`
-			AND json_valid(s.`metadata`)
-			AND json_extract(s.`metadata`, '$.prompts.motion') IS NOT NULL
-	);
+	`dialogue` = json_extract(`s`.`metadata`, '$.prompts.motion.dialogue'),
+	`audio` = json_extract(`s`.`metadata`, '$.prompts.motion.audio')
+FROM `shots` `s`
+WHERE `s`.`selected_motion_prompt_version_id` = `shot_prompt_versions`.`id`
+	AND `shot_prompt_versions`.`prompt_type` = 'motion'
+	AND `shot_prompt_versions`.`dialogue` IS NULL
+	AND `shot_prompt_versions`.`audio` IS NULL
+	AND json_valid(`s`.`metadata`)
+	AND json_extract(`s`.`metadata`, '$.prompts.motion') IS NOT NULL;

--- a/scripts/check-migrations.ts
+++ b/scripts/check-migrations.ts
@@ -12,6 +12,15 @@
  * See GitHub issue #612 for the verified mechanism and the production
  * incident on 2026-04-29.
  *
+ * It ALSO flags expensive data-backfill UPDATEs — a correlated/per-row
+ * subquery (a scalar subquery in SET, or a WHERE EXISTS/IN subquery) runs once
+ * per row of the target table, and over a large table (especially filtering on
+ * an unindexed column) trips D1's remote CPU-time limit (error 7429). That
+ * rolls the whole migration back and, because `wrangler d1 migrations apply`
+ * runs before `wrangler deploy`, freezes the deploy pipeline. Local/CI never
+ * catch it: Miniflare D1 has no CPU governor and seed data is tiny. Rewrite as
+ * a set-based `UPDATE … FROM (<join>)` (issue #1019); those are NOT flagged.
+ *
  * Modes:
  *   bun scripts/check-migrations.ts file1.sql file2.sql ...
  *     Scan the given files (used by lefthook with {staged_files}).
@@ -23,10 +32,13 @@
  *     Scan every migration on disk.
  *
  *   bun scripts/check-migrations.ts --allow-destructive
- *     Bypass the failure exit code (escape hatch for local dev).
+ *     Bypass the destructive-operation findings (escape hatch for local dev).
+ *
+ *   bun scripts/check-migrations.ts --allow-expensive
+ *     Bypass the expensive-backfill findings.
  *
  * Exit codes:
- *   0 — no findings
+ *   0 — no findings (or all findings bypassed)
  *   1 — findings found and not bypassed
  */
 
@@ -70,6 +82,36 @@ const DESTRUCTIVE_PATTERNS = [
   },
 ] as const;
 
+// Per-row subquery patterns inside an UPDATE — the #1019 failure class. Each
+// runs the subquery once per outer row, so on a large table it does O(rows^2)
+// work and trips D1's remote CPU-time limit. A set-based `UPDATE … FROM
+// (<join>)` has its SELECT in the FROM clause (evaluated once) with a plain
+// column reference in SET and no EXISTS/IN in WHERE, so none of these match it.
+const EXPENSIVE_UPDATE_PATTERNS = [
+  {
+    // Scalar subquery in SET (or a `col = (SELECT …)` predicate).
+    pattern: /=\s*\(\s*SELECT\b/gi,
+    name: 'per-row scalar subquery',
+  },
+  {
+    // Correlated existence test in WHERE.
+    pattern: /\b(?:NOT\s+)?EXISTS\s*\(\s*SELECT\b/gi,
+    name: 'correlated EXISTS subquery',
+  },
+  {
+    // Membership test against a subquery in WHERE.
+    pattern: /\bIN\s*\(\s*SELECT\b/gi,
+    name: 'subquery in IN (…)',
+  },
+] as const;
+
+type ExpensiveFinding = {
+  file: string;
+  line: number;
+  kind: string;
+  statement: string;
+};
+
 function getAppliedMigrations(): Set<string> {
   if (!existsSync(JOURNAL_PATH)) return new Set();
   const journal: Journal = JSON.parse(readFileSync(JOURNAL_PATH, 'utf-8'));
@@ -92,8 +134,10 @@ function buildCascadeMap(): Map<string, number> {
 
   for (const f of files) {
     const content = readFileSync(join(SCHEMA_DIR, f), 'utf-8');
+    // Tables are declared via `snakeCase.table('name', …)` (the project's
+    // snake_case column-casing wrapper); older ones via `sqliteTable('name', …)`.
     const re =
-      /export\s+const\s+(\w+)\s*=\s*sqliteTable\s*\(\s*['"]([^'"]+)['"]/g;
+      /export\s+const\s+(\w+)\s*=\s*(?:sqliteTable|\w+\.table)\s*\(\s*['"]([^'"]+)['"]/g;
     let m: RegExpExecArray | null;
     while ((m = re.exec(content)) !== null) {
       const varName = m[1];
@@ -159,6 +203,41 @@ function findDestructiveOperations(
   return operations;
 }
 
+/**
+ * Flag UPDATE statements that run a subquery per outer row (#1019). Blanks out
+ * SQL comments first — a migration's own header often explains the anti-pattern
+ * it deliberately avoids ("NOT a `= (SELECT …)`") and must not self-trigger —
+ * while preserving newlines so reported line numbers still point at real SQL.
+ */
+export function findExpensiveBackfills(filePath: string): ExpensiveFinding[] {
+  const raw = readFileSync(filePath, 'utf-8');
+  const fileName = basename(filePath);
+  const cleaned = raw
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/--[^\n]*/g, '');
+
+  const findings: ExpensiveFinding[] = [];
+  // Each UPDATE … up to its terminating `;` (subqueries don't contain `;`).
+  const updateStatement = /\bUPDATE\b[\s\S]*?;/gi;
+  let stmt: RegExpExecArray | null;
+  while ((stmt = updateStatement.exec(cleaned)) !== null) {
+    const text = stmt[0];
+    const line = cleaned.slice(0, stmt.index).split('\n').length;
+    for (const { pattern, name } of EXPENSIVE_UPDATE_PATTERNS) {
+      pattern.lastIndex = 0;
+      if (pattern.test(text)) {
+        findings.push({
+          file: fileName,
+          line,
+          kind: name,
+          statement: text.replace(/\s+/g, ' ').trim().slice(0, 140),
+        });
+      }
+    }
+  }
+  return findings;
+}
+
 function listSqlFiles(all: boolean): string[] {
   if (!existsSync(MIGRATIONS_DIR)) return [];
   const top = readdirSync(MIGRATIONS_DIR).filter((f) => f.endsWith('.sql'));
@@ -180,6 +259,7 @@ function listSqlFiles(all: boolean): string[] {
 function main(): void {
   const args = process.argv.slice(2);
   const allowDestructive = args.includes('--allow-destructive');
+  const allowExpensive = args.includes('--allow-expensive');
   const checkAll = args.includes('--all');
   const positional = args.filter((a) => !a.startsWith('--'));
 
@@ -190,46 +270,91 @@ function main(): void {
       ? positional.map((p) => (isAbsolute(p) ? p : join(process.cwd(), p)))
       : listSqlFiles(checkAll);
 
-  const allOps: Array<DestructiveOperation & { migrationDir: string }> = [];
-  for (const filePath of targets) {
-    if (!existsSync(filePath)) continue;
+  const migrationDirOf = (filePath: string): string => {
     const afterMigrations = filePath.split('/drizzle/migrations/')[1];
     const firstSegment = afterMigrations?.split('/')[0];
-    const dir = firstSegment ? firstSegment.replace(/\.sql$/, '') : 'unknown';
+    return firstSegment ? firstSegment.replace(/\.sql$/, '') : 'unknown';
+  };
+
+  const allOps: Array<DestructiveOperation & { migrationDir: string }> = [];
+  const expensiveOps: Array<ExpensiveFinding & { migrationDir: string }> = [];
+  for (const filePath of targets) {
+    if (!existsSync(filePath)) continue;
+    const dir = migrationDirOf(filePath);
     for (const op of findDestructiveOperations(filePath, cascadesByParent)) {
       allOps.push({ ...op, migrationDir: dir });
     }
+    for (const finding of findExpensiveBackfills(filePath)) {
+      expensiveOps.push({ ...finding, migrationDir: dir });
+    }
   }
 
-  if (allOps.length === 0) {
-    console.log('No destructive operations detected.');
+  if (allOps.length === 0 && expensiveOps.length === 0) {
+    console.log('No migration issues detected.');
     process.exit(0);
   }
 
-  console.log('Destructive operations detected:\n');
-  for (const op of allOps) {
-    const cascade =
-      op.operation === 'DROP TABLE' && op.cascadeChildCount > 0
-        ? ` ⚠ ${op.cascadeChildCount} cascade child FK(s)`
-        : '';
+  if (allOps.length > 0) {
+    console.log('Destructive operations detected:\n');
+    for (const op of allOps) {
+      const cascade =
+        op.operation === 'DROP TABLE' && op.cascadeChildCount > 0
+          ? ` ⚠ ${op.cascadeChildCount} cascade child FK(s)`
+          : '';
+      console.log(
+        `  ${op.migrationDir}/${op.file}:${op.line} — ${op.operation} \`${op.table}\`${cascade}`
+      );
+      console.log(`    ${op.statement}`);
+    }
+    console.log('');
     console.log(
-      `  ${op.migrationDir}/${op.file}:${op.line} — ${op.operation} \`${op.table}\`${cascade}`
+      'These are unsafe on D1/Turso HTTP migrators (issue #612). Either:'
     );
-    console.log(`    ${op.statement}`);
+    console.log(
+      '  1. Refactor the schema change to use ALTER TABLE column ops,'
+    );
+    console.log('  2. Apply manually via `wrangler d1` after a snapshot,');
+    console.log(
+      '  3. Or pass --allow-destructive if data loss is intentional.'
+    );
+    console.log('');
   }
-  console.log('');
-  console.log(
-    'These are unsafe on D1/Turso HTTP migrators (issue #612). Either:'
-  );
-  console.log('  1. Refactor the schema change to use ALTER TABLE column ops,');
-  console.log('  2. Apply manually via `wrangler d1` after a snapshot,');
-  console.log('  3. Or pass --allow-destructive if data loss is intentional.');
 
-  if (allowDestructive) {
-    console.log('\n--allow-destructive set; proceeding.');
-    process.exit(0);
+  if (expensiveOps.length > 0) {
+    console.log('Expensive backfill UPDATEs detected:\n');
+    for (const op of expensiveOps) {
+      console.log(`  ${op.migrationDir}/${op.file}:${op.line} — ${op.kind}`);
+      console.log(`    ${op.statement}`);
+    }
+    console.log('');
+    console.log(
+      'A per-row subquery over a large table trips D1’s remote CPU-time'
+    );
+    console.log(
+      'limit (7429) and freezes the deploy — migrations apply before deploy'
+    );
+    console.log('(issue #1019). Either:');
+    console.log(
+      '  1. Rewrite as a set-based `UPDATE … FROM (<join>)` (verify the plan'
+    );
+    console.log(
+      '     with EXPLAIN QUERY PLAN: scan the driver, search the target by key),'
+    );
+    console.log(
+      '  2. Or pass --allow-expensive if the touched tables are provably small.'
+    );
+    console.log('');
   }
-  process.exit(1);
+
+  const destructiveBlocks = allOps.length > 0 && !allowDestructive;
+  const expensiveBlocks = expensiveOps.length > 0 && !allowExpensive;
+  if (allowDestructive && allOps.length > 0) {
+    console.log('--allow-destructive set; destructive findings bypassed.');
+  }
+  if (allowExpensive && expensiveOps.length > 0) {
+    console.log('--allow-expensive set; expensive findings bypassed.');
+  }
+  process.exit(destructiveBlocks || expensiveBlocks ? 1 : 0);
 }
 
-main();
+if (import.meta.main) main();

--- a/src/lib/db/check-migrations.test.ts
+++ b/src/lib/db/check-migrations.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import { findExpensiveBackfills } from '../../../scripts/check-migrations';
+
+/** Write `sql` to a throwaway migration file and return its path. */
+function migrationFile(sql: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'check-migrations-'));
+  const path = join(dir, 'migration.sql');
+  writeFileSync(path, sql);
+  return path;
+}
+
+describe('findExpensiveBackfills (#1019 per-row subquery guard)', () => {
+  it('flags a scalar subquery in an UPDATE SET', () => {
+    const path = migrationFile(
+      `UPDATE shots SET x = (SELECT id FROM other o WHERE o.shot_id = shots.id LIMIT 1);`
+    );
+    const findings = findExpensiveBackfills(path);
+    expect(findings.some((f) => f.kind.includes('scalar'))).toBe(true);
+  });
+
+  it('flags a correlated EXISTS subquery in WHERE', () => {
+    const path = migrationFile(
+      `UPDATE shots SET x = 1 WHERE EXISTS (SELECT 1 FROM other o WHERE o.shot_id = shots.id);`
+    );
+    expect(
+      findExpensiveBackfills(path).some((f) => f.kind.includes('EXISTS'))
+    ).toBe(true);
+  });
+
+  it('does NOT flag a set-based `UPDATE … FROM (<join>)`', () => {
+    const path = migrationFile(
+      `UPDATE shots
+       SET selected = latest.v
+       FROM (SELECT shot_id, id AS v FROM other) AS latest
+       WHERE shots.id = latest.shot_id AND shots.selected IS NULL;`
+    );
+    expect(findExpensiveBackfills(path)).toEqual([]);
+  });
+
+  it('ignores subquery patterns that appear only in SQL comments', () => {
+    const path = migrationFile(
+      `-- Set-based, NOT a per-row \`= (SELECT …)\` or \`WHERE EXISTS (SELECT …)\`.
+       UPDATE shots
+       SET selected = latest.v
+       FROM (SELECT shot_id, id AS v FROM other) AS latest
+       WHERE shots.id = latest.shot_id;`
+    );
+    expect(findExpensiveBackfills(path)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

The chunking fix for scenes-not-listing (#1020) merged but **never reached production**. Production has been frozen at the pre-#1010 bundle since **2026-07-02 ~01:39 UTC**.

Root cause: `deploy:production` runs `wrangler d1 migrations apply --remote` **before** `wrangler deploy`. The #1010 migration `20260629104851_stale_the_executioner` fails to apply to remote prod D1 — its two backfill `UPDATE`s use per-row correlated subqueries (a scalar subquery in `SET` + a `WHERE EXISTS`) that filter/join on the unindexed `shots.selected_motion_prompt_version_id`, so each of ~2,510 motion rows full-scans ~4,130 shots (~10M+ row reads). Remote D1 returns `429 / 7429 "exceeded its CPU time limit and was reset"`, D1 rolls the whole (implicitly-transactional) migration back, and the deploy aborts before `wrangler deploy`. So every deploy since #1010 — including the scenes fix — has silently no-op'd.

Local/CI never caught it: Miniflare D1 has no CPU governor and seed data is tiny.

## What

1. **Rewrite the migration's backfills as single-pass, set-based `UPDATE … FROM` joins** (windowed latest-motion-version per shot; PK-driven dialogue/audio hydration). The `ALTER … ADD COLUMN`s are unchanged.
   - Verified on **prod D1** via `EXPLAIN QUERY PLAN`: `SCAN` the small/driver side + `SEARCH … USING INDEX (id=?)` — linear.
   - Verified **correct** on SQLite 3.51 with sample data (latest-version tie-break, null-pointer skip, `json_valid` / `prompts.motion` guards, no-clobber guard).
   - Safe to edit in place: it never successfully applied anywhere with real data (local/PR ran on tiny data).

2. **`check-migrations.ts` now flags per-row subqueries in migration `UPDATE`s** (scalar-in-`SET`, correlated `EXISTS`, `IN (SELECT)`) — the #1019 class — with an `--allow-expensive` escape hatch. Set-based `UPDATE … FROM` joins are not flagged. Runs in the existing lefthook pre-commit hook. New unit test covers the contract.

3. Drive-by: fixed the cascade-map regex (schema uses `snakeCase.table`, not `sqliteTable`, so cascade-child annotation was silently always 0).

## Shipping

Merging this unblocks the pipeline: the next deploy applies the fixed migration, then `wrangler deploy` finally ships everything queued since #1010 — **including the scenes fix**.

## Verification

- `bun run test src/lib/db/check-migrations.test.ts` — 4/4 pass.
- Lint blocks the old correlated form (exit 1), passes the new set-based form (exit 0).
- `EXPLAIN QUERY PLAN` on prod D1 confirms linear plans for both rewritten statements.

Related: #1020 (the fix that couldn't ship), #1022 (build-failure alerting — why this went unnoticed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)