### PR TITLE
Keep style public flag server-managed

### DIFF
--- a/src/lib/db/scoped/location-library.ts
+++ b/src/lib/db/scoped/location-library.ts
@@ -6,11 +6,32 @@
 import { eq, ilike, and, inArray, or } from 'drizzle-orm';
 import type { Database } from '@/lib/db/client';
 import { locationLibrary, locationSheets } from '@/lib/db/schema';
+import { stripServerManagedColumns } from './server-managed';
 import type {
   LibraryLocation,
   NewLibraryLocation,
   NewLocationSheet,
 } from '@/lib/db/schema';
+
+// Columns callers must never set through the scoped write methods.
+// id/teamId/createdBy/createdAt/updatedAt are injected here or by the
+// database, and the public/template flags are admin/seeder-only — the seeder
+// inserts via raw drizzle. (Locations have no shared Zod schema module; the
+// server-fn validators are inline allow-lists, so this is the second layer
+// of the same defense — excluded from the parameter types AND scrubbed at
+// runtime, since a non-literal object can carry extra keys past an Omit<>
+// parameter and drizzle writes any key that matches a table column.)
+const SERVER_MANAGED_LOCATION_COLUMNS = {
+  id: true,
+  teamId: true,
+  createdBy: true,
+  createdAt: true,
+  updatedAt: true,
+  isPublic: true,
+  isTemplate: true,
+} as const;
+
+type ServerManagedLocationColumn = keyof typeof SERVER_MANAGED_LOCATION_COLUMNS;
 
 /**
  * Public (anonymous) location-library reads. Takes no team scope at all, so
@@ -133,11 +154,15 @@ export function createLocationsMethods(
     ...createLocationsReadMethods(db, teamId),
 
     create: async (
-      data: Omit<NewLibraryLocation, 'teamId' | 'createdBy'>
+      data: Omit<NewLibraryLocation, ServerManagedLocationColumn>
     ): Promise<LibraryLocation> => {
       const [location] = await db
         .insert(locationLibrary)
-        .values({ ...data, teamId, createdBy: userId })
+        .values({
+          ...stripServerManagedColumns(data, SERVER_MANAGED_LOCATION_COLUMNS),
+          teamId,
+          createdBy: userId,
+        })
         .returning();
       if (!location) {
         throw new Error(`Failed to create LibraryLocation for team ${teamId}`);
@@ -146,7 +171,7 @@ export function createLocationsMethods(
     },
 
     createBulk: async (
-      data: Omit<NewLibraryLocation, 'teamId' | 'createdBy'>[]
+      data: Omit<NewLibraryLocation, ServerManagedLocationColumn>[]
     ): Promise<LibraryLocation[]> => {
       if (data.length === 0) return [];
       const BATCH_SIZE = 10;
@@ -156,7 +181,13 @@ export function createLocationsMethods(
         const batch = data.slice(i, i + BATCH_SIZE);
         const batchResults = await db
           .insert(locationLibrary)
-          .values(batch.map((d) => ({ ...d, teamId, createdBy: userId })))
+          .values(
+            batch.map((d) => ({
+              ...stripServerManagedColumns(d, SERVER_MANAGED_LOCATION_COLUMNS),
+              teamId,
+              createdBy: userId,
+            }))
+          )
           .returning();
         results.push(...batchResults);
       }
@@ -182,11 +213,14 @@ export function createLocationsMethods(
 
     update: async (
       id: string,
-      data: Partial<NewLibraryLocation>
+      data: Partial<Omit<NewLibraryLocation, ServerManagedLocationColumn>>
     ): Promise<LibraryLocation> => {
       const [location] = await db
         .update(locationLibrary)
-        .set({ ...data, updatedAt: new Date() })
+        .set({
+          ...stripServerManagedColumns(data, SERVER_MANAGED_LOCATION_COLUMNS),
+          updatedAt: new Date(),
+        })
         .where(eq(locationLibrary.id, id))
         .returning();
 

--- a/src/lib/db/scoped/server-managed.ts
+++ b/src/lib/db/scoped/server-managed.ts
@@ -1,0 +1,25 @@
+import { typedEntries, typedFromEntries } from '@/lib/utils/typed-object';
+
+/**
+ * Runtime scrub for server-managed columns.
+ *
+ * The scoped write methods exclude server-managed columns (isPublic,
+ * isTemplate, …) from their parameter types, but that is compile-time only:
+ * TypeScript's excess-property check applies just to fresh object literals,
+ * so any non-literal object can carry extra keys past an Omit<> parameter —
+ * and drizzle's .values()/.set() writes any key that matches a real table
+ * column. This helper enforces the exclusion at runtime, before the spread.
+ */
+export function stripServerManagedColumns<
+  T extends Record<string, unknown>,
+  K extends PropertyKey,
+>(data: T, columns: Readonly<Record<K, true>>): Omit<T, K> {
+  // Widened to string keys: the rebuilt record is asserted as Omit<T, K>
+  // below, and TS can't compare a Record keyed by Extract<keyof T, string>
+  // against Omit<T, K> for a generic T.
+  const kept: [string, T[keyof T]][] = typedEntries(data).filter(
+    ([key]) => !Object.hasOwn(columns, key)
+  );
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- no type-level way to express "kept lacks exactly the K keys"; the filter guarantees it at runtime
+  return typedFromEntries(kept) as Omit<T, K>;
+}

--- a/src/lib/db/scoped/styles.test.ts
+++ b/src/lib/db/scoped/styles.test.ts
@@ -21,6 +21,7 @@ import {
   createStylesMethods,
 } from '@/lib/db/scoped/styles';
 import { ValidationError } from '@/lib/errors';
+import type { ServerManagedStyleColumn } from '@/lib/schemas/style.schemas';
 import { createClient, type Client } from '@libsql/client';
 import { asc, desc, eq, or, sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -67,7 +68,7 @@ function makeStylesMethods(database: Database, teamId: string, userId: string) {
       return result[0] ?? null;
     },
     create: async (
-      data: Omit<NewStyle, 'teamId' | 'createdBy'>
+      data: Omit<NewStyle, ServerManagedStyleColumn>
     ): Promise<Style> => {
       const result = await database
         .insert(styles)
@@ -106,6 +107,12 @@ const baseConfig = {
   colorGrading: 'neutral',
 };
 
+// isPublic is server-managed (excluded from the scoped create/update types),
+// so tests publish a style the way admin paths do: a raw drizzle write.
+async function markPublic(styleId: string) {
+  await db.update(styles).set({ isPublic: true }).where(eq(styles.id, styleId));
+}
+
 async function seed() {
   await db.delete(styles);
   await db.delete(teams);
@@ -139,7 +146,6 @@ describe('createStylesMethods.incrementUsage', () => {
     const style = await methods.create({
       name: 'Bumped',
       config: baseConfig,
-      sortOrder: 1,
     });
     expect(style.usageCount).toBe(0);
 
@@ -169,20 +175,19 @@ describe("createStylesMethods.list({ orderBy: 'popular' })", () => {
   it('orders by usageCount desc when popular requested', async () => {
     const methods = makeStylesMethods(db, team.id, userRow.id);
 
+    // All three share the default sortOrder, so the sortOrder listing falls
+    // back to name asc (A, B, C).
     const a = await methods.create({
       name: 'A-cold',
       config: baseConfig,
-      sortOrder: 1,
     });
     const b = await methods.create({
       name: 'B-hot',
       config: baseConfig,
-      sortOrder: 2,
     });
     const c = await methods.create({
       name: 'C-warm',
       config: baseConfig,
-      sortOrder: 3,
     });
 
     await methods.incrementUsage(b.id);
@@ -209,18 +214,15 @@ describe("createStylesMethods.list({ orderBy: 'popular' })", () => {
     const mine = await ownMethods.create({
       name: 'Mine',
       config: baseConfig,
-      sortOrder: 1,
     });
     const theirsPublic = await otherMethods.create({
       name: 'TheirsPublic',
       config: baseConfig,
-      sortOrder: 2,
-      isPublic: true,
     });
+    await markPublic(theirsPublic.id);
     const theirsPrivate = await otherMethods.create({
       name: 'TheirsPrivate',
       config: baseConfig,
-      sortOrder: 3,
     });
 
     const visible = await ownMethods.list();
@@ -280,19 +282,55 @@ describe('createPublicStylesReadMethods', () => {
     const pub = await methods.create({
       name: 'Public',
       config: baseConfig,
-      sortOrder: 1,
-      isPublic: true,
     });
+    await markPublic(pub.id);
     const priv = await methods.create({
       name: 'Private',
       config: baseConfig,
-      sortOrder: 2,
     });
 
     const visible = await createPublicStylesReadMethods(db).list();
     const ids = visible.map((s) => s.id);
     expect(ids).toContain(pub.id);
     expect(ids).not.toContain(priv.id);
+  });
+});
+
+// Uses the REAL createStylesMethods: the Omit<> parameter types exclude
+// server-managed columns, but TypeScript's excess-property check applies only
+// to fresh object literals — a non-literal object with extra keys passes the
+// type checker, and drizzle would write any key matching a table column. The
+// runtime scrub in the write methods is the barrier these tests pin.
+describe('createStylesMethods server-managed column scrubbing (runtime)', () => {
+  it('drops a smuggled isPublic on create', async () => {
+    const methods = createStylesMethods(db, team.id, userRow.id);
+
+    const smuggled: {
+      name: string;
+      config: typeof baseConfig;
+      isPublic: boolean;
+    } = { name: 'Smuggled', config: baseConfig, isPublic: true };
+    const created = await methods.create(smuggled);
+
+    expect(created.isPublic).toBe(false);
+    const publicIds = (await createPublicStylesReadMethods(db).list()).map(
+      (s) => s.id
+    );
+    expect(publicIds).not.toContain(created.id);
+  });
+
+  it('drops a smuggled isPublic on update while applying the rest', async () => {
+    const methods = createStylesMethods(db, team.id, userRow.id);
+    const style = await methods.create({ name: 'Target', config: baseConfig });
+
+    const smuggled: { name: string; isPublic: boolean } = {
+      name: 'Renamed Target',
+      isPublic: true,
+    };
+    const updated = await methods.update(style.id, smuggled);
+
+    expect(updated?.name).toBe('Renamed Target');
+    expect(updated?.isPublic).toBe(false);
   });
 });
 
@@ -303,7 +341,6 @@ describe('createStylesMethods.create — new schema fields round-trip', () => {
     const created = await methods.create({
       name: 'Loaded',
       config: baseConfig,
-      sortOrder: 1,
       sampleVideos: [
         {
           url: 'https://example.com/v.mp4',
@@ -342,11 +379,11 @@ describe('createStylesMethods.create — new schema fields round-trip', () => {
 describe('createStylesMethods slug uniqueness (#956)', () => {
   it('rejects a new style whose slug collides with a public style', async () => {
     const methods = createStylesMethods(db, team.id, userRow.id);
-    await methods.create({
+    const noir = await methods.create({
       name: 'Cinematic Noir',
       config: baseConfig,
-      isPublic: true,
     });
+    await markPublic(noir.id);
     await expect(
       methods.create({ name: 'cinematic  noir!', config: baseConfig })
     ).rejects.toBeInstanceOf(ValidationError);

--- a/src/lib/db/scoped/styles.ts
+++ b/src/lib/db/scoped/styles.ts
@@ -7,6 +7,11 @@ import type { Database } from '@/lib/db/client';
 import type { NewStyle, Style } from '@/lib/db/schema';
 import { styles } from '@/lib/db/schema';
 import { ValidationError } from '@/lib/errors';
+import {
+  SERVER_MANAGED_STYLE_COLUMNS,
+  type ServerManagedStyleColumn,
+} from '@/lib/schemas/style.schemas';
+import { stripServerManagedColumns } from './server-managed';
 import { styleSlug } from '@/lib/style/style-slug';
 import { and, asc, desc, eq, inArray, ne, or, sql } from 'drizzle-orm';
 
@@ -134,13 +139,22 @@ export function createStylesMethods(
   return {
     ...createStylesReadMethods(db, teamId),
 
+    // Server-managed columns (isPublic, isTemplate, usageCount, …) are
+    // excluded from the parameter type AND scrubbed at runtime: the type
+    // alone doesn't stop a non-literal object from carrying extra keys, and
+    // drizzle writes any key that matches a table column. Admin paths (the
+    // system template seeder) insert via raw drizzle instead.
     create: async (
-      data: Omit<NewStyle, 'teamId' | 'createdBy'>
+      data: Omit<NewStyle, ServerManagedStyleColumn>
     ): Promise<Style> => {
       await assertSlugAvailable(db, teamId, data.name);
       const result = await db
         .insert(styles)
-        .values({ ...data, teamId, createdBy: userId })
+        .values({
+          ...stripServerManagedColumns(data, SERVER_MANAGED_STYLE_COLUMNS),
+          teamId,
+          createdBy: userId,
+        })
         .returning();
       const style = result[0];
       if (!style) {
@@ -151,14 +165,14 @@ export function createStylesMethods(
 
     update: async (
       styleId: string,
-      data: Partial<Omit<Style, 'id' | 'teamId' | 'createdAt' | 'createdBy'>>
+      data: Partial<Omit<Style, ServerManagedStyleColumn>>
     ): Promise<Style | undefined> => {
       if (data.name !== undefined) {
         await assertSlugAvailable(db, teamId, data.name, styleId);
       }
       const result = await db
         .update(styles)
-        .set(data)
+        .set(stripServerManagedColumns(data, SERVER_MANAGED_STYLE_COLUMNS))
         .where(and(eq(styles.id, styleId), eq(styles.teamId, teamId)))
         .returning();
       return Array.isArray(result) ? result[0] : undefined;

--- a/src/lib/db/scoped/talent.ts
+++ b/src/lib/db/scoped/talent.ts
@@ -14,7 +14,12 @@ import type {
   TalentWithSheets,
 } from '@/lib/db/schema';
 import { talent, talentMedia, talentSheets } from '@/lib/db/schema';
+import {
+  SERVER_MANAGED_TALENT_COLUMNS,
+  type ServerManagedTalentColumn,
+} from '@/lib/schemas/talent.schemas';
 import { and, asc, desc, eq, or, sql } from 'drizzle-orm';
+import { stripServerManagedColumns } from './server-managed';
 
 const TALENT_WRITE_DENIED =
   'Talent not found or you do not have permission to modify it';
@@ -323,12 +328,21 @@ export function createTalentMethods(
   return {
     ...read,
 
+    // Server-managed columns (isPublic, isTemplate, …) are excluded from the
+    // parameter type AND scrubbed at runtime: the type alone doesn't stop a
+    // non-literal object from carrying extra keys, and drizzle writes any key
+    // that matches a table column. Admin paths (the system template seeder)
+    // insert via raw drizzle instead.
     create: async (
-      data: Omit<NewTalent, 'teamId' | 'createdBy'>
+      data: Omit<NewTalent, ServerManagedTalentColumn>
     ): Promise<Talent> => {
       const [created] = await db
         .insert(talent)
-        .values({ ...data, teamId, createdBy: userId })
+        .values({
+          ...stripServerManagedColumns(data, SERVER_MANAGED_TALENT_COLUMNS),
+          teamId,
+          createdBy: userId,
+        })
         .returning();
       if (!created) throw new Error('Failed to create talent');
       return created;
@@ -336,7 +350,7 @@ export function createTalentMethods(
 
     update: async (
       talentId: string,
-      data: Partial<Omit<Talent, 'id' | 'teamId' | 'createdAt' | 'createdBy'>>
+      data: Partial<Omit<Talent, ServerManagedTalentColumn>>
     ): Promise<Talent | undefined> => {
       if (!(await getWritableTalent(db, talentId, teamId))) {
         return undefined;
@@ -344,7 +358,10 @@ export function createTalentMethods(
 
       const [updated] = await db
         .update(talent)
-        .set({ ...data, updatedAt: new Date() })
+        .set({
+          ...stripServerManagedColumns(data, SERVER_MANAGED_TALENT_COLUMNS),
+          updatedAt: new Date(),
+        })
         .where(and(eq(talent.id, talentId), eq(talent.teamId, teamId)))
         .returning();
       return updated;

--- a/src/lib/schemas/style.schemas.test.ts
+++ b/src/lib/schemas/style.schemas.test.ts
@@ -11,40 +11,42 @@ const baseConfig = {
   colorGrading: 'neutral',
 };
 
+// Every SERVER_MANAGED_COLUMNS entry, injected as a malicious payload — the
+// tests pin the full omit list, so dropping any entry fails here.
+const serverManagedPayload = {
+  id: 'attacker-chosen-id',
+  isPublic: true,
+  isTemplate: true,
+  teamId: 'other-team',
+  createdBy: 'other-user',
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  usageCount: 99,
+  version: 99,
+  sortOrder: 1,
+};
+
 describe('style schemas', () => {
-  it('strips client-provided public/template flags when creating a style', () => {
+  it('strips client-provided server-managed columns when creating a style', () => {
     const parsed = createStyleSchema.parse({
       name: 'Team Style',
       config: baseConfig,
-      isPublic: true,
-      isTemplate: true,
-      teamId: 'other-team',
-      createdBy: 'other-user',
-      usageCount: 99,
-      sortOrder: 1,
+      ...serverManagedPayload,
     });
 
     expect(parsed).toMatchObject({
       name: 'Team Style',
       config: baseConfig,
     });
-    expect(parsed).not.toHaveProperty('isPublic');
-    expect(parsed).not.toHaveProperty('isTemplate');
-    expect(parsed).not.toHaveProperty('teamId');
-    expect(parsed).not.toHaveProperty('createdBy');
-    expect(parsed).not.toHaveProperty('usageCount');
-    expect(parsed).not.toHaveProperty('sortOrder');
+    for (const column of Object.keys(serverManagedPayload)) {
+      expect(parsed).not.toHaveProperty(column);
+    }
   });
 
-  it('strips client-provided public/template flags when updating a style', () => {
+  it('strips client-provided server-managed columns when updating a style', () => {
     const parsed = updateStyleSchema.parse({
       name: 'Updated Style',
-      isPublic: true,
-      isTemplate: true,
-      teamId: 'other-team',
-      createdBy: 'other-user',
-      usageCount: 99,
-      sortOrder: 1,
+      ...serverManagedPayload,
     });
 
     expect(parsed).toEqual({ name: 'Updated Style' });

--- a/src/lib/schemas/style.schemas.test.ts
+++ b/src/lib/schemas/style.schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { createStyleSchema, updateStyleSchema } from './style.schemas';
+
+const baseConfig = {
+  mood: 'neutral',
+  artStyle: 'cinematic',
+  lighting: 'natural',
+  colorPalette: ['#000', '#fff'],
+  cameraWork: 'static',
+  referenceFilms: [],
+  colorGrading: 'neutral',
+};
+
+describe('style schemas', () => {
+  it('strips client-provided public/template flags when creating a style', () => {
+    const parsed = createStyleSchema.parse({
+      name: 'Team Style',
+      config: baseConfig,
+      isPublic: true,
+      isTemplate: true,
+      teamId: 'other-team',
+      createdBy: 'other-user',
+      usageCount: 99,
+      sortOrder: 1,
+    });
+
+    expect(parsed).toMatchObject({
+      name: 'Team Style',
+      config: baseConfig,
+    });
+    expect(parsed).not.toHaveProperty('isPublic');
+    expect(parsed).not.toHaveProperty('isTemplate');
+    expect(parsed).not.toHaveProperty('teamId');
+    expect(parsed).not.toHaveProperty('createdBy');
+    expect(parsed).not.toHaveProperty('usageCount');
+    expect(parsed).not.toHaveProperty('sortOrder');
+  });
+
+  it('strips client-provided public/template flags when updating a style', () => {
+    const parsed = updateStyleSchema.parse({
+      name: 'Updated Style',
+      isPublic: true,
+      isTemplate: true,
+      teamId: 'other-team',
+      createdBy: 'other-user',
+      usageCount: 99,
+      sortOrder: 1,
+    });
+
+    expect(parsed).toEqual({ name: 'Updated Style' });
+  });
+});

--- a/src/lib/schemas/style.schemas.ts
+++ b/src/lib/schemas/style.schemas.ts
@@ -1,6 +1,6 @@
 import {
-  styles,
   StyleConfigSchema,
+  styles,
   StyleSampleVideoSchema,
 } from '@/lib/db/schema';
 import { createInsertSchema, createUpdateSchema } from 'drizzle-orm/zod';

--- a/src/lib/schemas/style.schemas.ts
+++ b/src/lib/schemas/style.schemas.ts
@@ -16,7 +16,8 @@ const sampleVideosSchema = z.array(StyleSampleVideoSchema).nullish();
 
 // Columns the client must never set. usageCount is server-managed (popularity
 // ranking), id/teamId/createdBy/createdAt/updatedAt are injected by the scoped
-// layer, and isTemplate/version/sortOrder are admin/migration-only.
+// layer, and public/template flags, version, and sortOrder are
+// admin/migration-only.
 const SERVER_MANAGED_COLUMNS = {
   id: true,
   teamId: true,
@@ -25,6 +26,7 @@ const SERVER_MANAGED_COLUMNS = {
   updatedAt: true,
   usageCount: true,
   version: true,
+  isPublic: true,
   isTemplate: true,
   sortOrder: true,
 } as const;

--- a/src/lib/schemas/style.schemas.ts
+++ b/src/lib/schemas/style.schemas.ts
@@ -18,7 +18,10 @@ const sampleVideosSchema = z.array(StyleSampleVideoSchema).nullish();
 // ranking), id/teamId/createdBy/createdAt/updatedAt are injected by the scoped
 // layer, and public/template flags, version, and sortOrder are
 // admin/migration-only.
-const SERVER_MANAGED_COLUMNS = {
+// Exported so the scoped-db write methods can exclude the same columns at
+// the type level AND scrub them at runtime — a column added here is enforced
+// in all three places at once.
+export const SERVER_MANAGED_STYLE_COLUMNS = {
   id: true,
   teamId: true,
   createdBy: true,
@@ -31,15 +34,18 @@ const SERVER_MANAGED_COLUMNS = {
   sortOrder: true,
 } as const;
 
+export type ServerManagedStyleColumn =
+  keyof typeof SERVER_MANAGED_STYLE_COLUMNS;
+
 export const createStyleSchema = createInsertSchema(styles, {
   config: () => StyleConfigSchema,
   tags: () => tagsSchema,
   useCases: () => useCasesSchema,
   sampleVideos: () => sampleVideosSchema,
-}).omit(SERVER_MANAGED_COLUMNS);
+}).omit(SERVER_MANAGED_STYLE_COLUMNS);
 export const updateStyleSchema = createUpdateSchema(styles, {
   config: () => StyleConfigSchema.optional(),
   tags: () => tagsSchema,
   useCases: () => useCasesSchema,
   sampleVideos: () => sampleVideosSchema,
-}).omit(SERVER_MANAGED_COLUMNS);
+}).omit(SERVER_MANAGED_STYLE_COLUMNS);

--- a/src/lib/schemas/talent.schemas.test.ts
+++ b/src/lib/schemas/talent.schemas.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { createTalentSchema, updateTalentSchema } from './talent.schemas';
+
+// Every SERVER_MANAGED_COLUMNS entry, injected as a malicious payload — the
+// tests pin the full omit list, so dropping any entry fails here. isPublic is
+// the security-critical one: a client-settable value would publish team
+// talent into the anonymous public catalogue (same class as #869).
+const serverManagedPayload = {
+  id: 'attacker-chosen-id',
+  isPublic: true,
+  isTemplate: true,
+  teamId: 'other-team',
+  createdBy: 'other-user',
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+};
+
+describe('talent schemas', () => {
+  it('strips client-provided server-managed columns when creating talent', () => {
+    const parsed = createTalentSchema.parse({
+      name: 'Team Talent',
+      description: 'A character',
+      referenceImageUrls: ['https://example.com/ref.png'],
+      ...serverManagedPayload,
+    });
+
+    expect(parsed).toMatchObject({
+      name: 'Team Talent',
+      description: 'A character',
+      referenceImageUrls: ['https://example.com/ref.png'],
+    });
+    for (const column of Object.keys(serverManagedPayload)) {
+      expect(parsed).not.toHaveProperty(column);
+    }
+  });
+
+  it('strips client-provided server-managed columns when updating talent', () => {
+    const parsed = updateTalentSchema.parse({
+      name: 'Updated Talent',
+      ...serverManagedPayload,
+    });
+
+    expect(parsed).toEqual({ name: 'Updated Talent' });
+  });
+});

--- a/src/lib/schemas/talent.schemas.ts
+++ b/src/lib/schemas/talent.schemas.ts
@@ -8,29 +8,39 @@ import { z } from 'zod';
  * Shared Zod schemas for talent library operations
  */
 
-// Talent schemas
-export const createTalentSchema = createInsertSchema(talent, {
-  name: z.string().min(1).max(255),
-  description: z.string().optional(),
-})
-  .omit({
-    id: true,
-    teamId: true,
-    createdBy: true,
-    createdAt: true,
-    updatedAt: true,
-  })
-  .extend({
-    referenceImageUrls: z.array(mediaUrlSchema).optional(),
-  });
-
-export const updateTalentSchema = createUpdateSchema(talent).omit({
+// Columns the client must never set. id/teamId/createdBy/createdAt/updatedAt
+// are injected by the scoped layer, and the public/template flags are
+// admin/seeder-only — a client-settable isPublic would let a team publish its
+// own talent into the anonymous public catalogue (same class as #869).
+// Exported so the scoped-db write methods can exclude the same columns at
+// the type level AND scrub them at runtime — a column added here is enforced
+// in all three places at once.
+export const SERVER_MANAGED_TALENT_COLUMNS = {
   id: true,
   teamId: true,
   createdBy: true,
   createdAt: true,
   updatedAt: true,
-});
+  isPublic: true,
+  isTemplate: true,
+} as const;
+
+export type ServerManagedTalentColumn =
+  keyof typeof SERVER_MANAGED_TALENT_COLUMNS;
+
+// Talent schemas
+export const createTalentSchema = createInsertSchema(talent, {
+  name: z.string().min(1).max(255),
+  description: z.string().optional(),
+})
+  .omit(SERVER_MANAGED_TALENT_COLUMNS)
+  .extend({
+    referenceImageUrls: z.array(mediaUrlSchema).optional(),
+  });
+
+export const updateTalentSchema = createUpdateSchema(talent).omit(
+  SERVER_MANAGED_TALENT_COLUMNS
+);
 
 // Talent sheet schemas
 export const createTalentSheetSchema = createInsertSchema(talentSheets, {

--- a/src/lib/utils/typed-object.ts
+++ b/src/lib/utils/typed-object.ts
@@ -6,7 +6,22 @@
  */
 export function typedEntries<T extends Record<string, unknown>>(
   obj: T
-): [keyof T, T[keyof T]][] {
+): [Extract<keyof T, string>, T[keyof T]][] {
   // eslint-disable-next-line @typescript/no-unsafe-type-assertion - this is safe because we control the keys
-  return Object.entries(obj) as [keyof T, T[keyof T]][];
+  return Object.entries(obj) as [Extract<keyof T, string>, T[keyof T]][];
+}
+
+/**
+ * Type-safe Object.fromEntries() that preserves key types.
+ *
+ * Note the asymmetry with typedEntries: an entries array may cover only a
+ * subset of a source object's keys (e.g. after a filter), so this returns
+ * Record<K, V> built from what's actually present — never assert it back to
+ * the source object type.
+ */
+export function typedFromEntries<K extends string, V>(
+  entries: readonly (readonly [K, V])[]
+): Record<K, V> {
+  // eslint-disable-next-line @typescript/no-unsafe-type-assertion - Record<K, V> is exactly what fromEntries builds from these pairs
+  return Object.fromEntries(entries) as Record<K, V>;
 }


### PR DESCRIPTION
## Summary
- make `isPublic` server-managed in style create/update schemas, matching `isTemplate`
- prevent client-submitted style inputs from publishing team-owned styles into the public catalogue
- add schema regression tests covering create/update stripping of public/template and other server-managed fields

## Follow-up hardening (maintainer commit)
Review of the original fix found the same issue class elsewhere plus two enforcement gaps, addressed in `fa0fa9e0`:

- **Talent had the identical hole, and it was live**: `updateTalentSchema` didn't omit `isPublic`, and `updateTalentFn` → `scopedDb.talent.update` spreads client data into `.set()`, so any team member could publish their own talent into the anonymous public catalogue (`getPublicTalentFn`). `isPublic`/`isTemplate` are now stripped from both talent schemas.
- **Schema omits alone weren't enough.** The `Omit<>` parameter types on the scoped write methods are compile-time only — TypeScript's excess-property check applies just to fresh object literals, and drizzle's `.values()`/`.set()` writes any key that matches a real table column. The scoped styles/talent/location write methods now scrub server-managed columns at runtime (`stripServerManagedColumns`) before spreading.
- **One definition drives all layers**: the `SERVER_MANAGED_*` column lists are exported consts, shared by the Zod `.omit()`, the scoped-method parameter types, and the runtime scrub.
- New `typedFromEntries` util (inverse of `typedEntries`); regression tests pin the full omit lists and prove the runtime scrub drops a smuggled `isPublic` from a non-literal object on both create and update paths.

Locations were already safe at the schema level (inline allow-list validators) — they get the type + runtime defense for consistency.

Closes #869

## Validation
- `bun run test` (full suite, 1636 tests)
- `bun typecheck`
- `bun lint` / `bun format:check` / `bun dead-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
