### PR TITLE
fix(#1026): preserve dialogue when regenerating motion prompts

### DIFF
--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -20,6 +20,7 @@ import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { simpleHash } from '@/lib/utils/hash';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type {
   MotionPromptWorkflowInput,
   MusicPromptWorkflowInput,
@@ -438,6 +439,22 @@ export const regenerateShotPromptFn = createServerFn({ method: 'POST' })
       label: buildWorkflowLabel(sequence.id),
     };
 
+    // Neighbour scenes give the motion LLM the same continuity context the
+    // analysis batch pipeline passes via MotionPromptBatchWorkflow (#929).
+    let sceneBefore: Scene | undefined;
+    let sceneAfter: Scene | undefined;
+    if (data.promptType === 'motion') {
+      const shotsInSeq = await scopedDb.shots.listBySequence(sequence.id);
+      const idx = shotsInSeq.findIndex((s) => s.id === shot.id);
+      const prevShot = idx > 0 ? shotsInSeq[idx - 1] : undefined;
+      const nextShot =
+        idx >= 0 && idx < shotsInSeq.length - 1
+          ? shotsInSeq[idx + 1]
+          : undefined;
+      sceneBefore = prevShot?.metadata ?? undefined;
+      sceneAfter = nextShot?.metadata ?? undefined;
+    }
+
     const workflowRunId =
       data.promptType === 'visual'
         ? // `frameId` is REQUIRED on FramePromptWorkflowInput — the workflow
@@ -454,7 +471,12 @@ export const regenerateShotPromptFn = createServerFn({ method: 'POST' })
           // swap it). The still lives on the anchor frame now (#989).
           await triggerWorkflow<MotionPromptWorkflowInput>(
             '/motion-prompt',
-            { ...commonInput, startingFrameImageUrl: frame.imageUrl },
+            {
+              ...commonInput,
+              startingFrameImageUrl: frame.imageUrl,
+              sceneBefore,
+              sceneAfter,
+            },
             triggerOpts
           );
 

--- a/src/lib/motion/hydrate-motion-prompt.test.ts
+++ b/src/lib/motion/hydrate-motion-prompt.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import type { MotionPrompt, Scene } from '@/lib/ai/scene-analysis.schema';
+import { hydrateMotionPromptFromScene } from './hydrate-motion-prompt';
+
+const baseScene = {
+  sceneId: 'scene-1',
+  sceneNumber: 1,
+  originalScript: {
+    extract: 'SARAH speaks.',
+    dialogue: [
+      {
+        character: 'SARAH',
+        line: 'We need to leave.',
+        tone: 'urgent',
+      },
+    ],
+  },
+  metadata: {
+    title: 'T',
+    durationSeconds: 5,
+    location: 'INT. ROOM',
+    timeOfDay: 'day',
+    storyBeat: 'beat',
+  },
+  continuity: {
+    characterTags: [],
+    environmentTag: '',
+    colorPalette: '',
+    lightingSetup: '',
+    styleTag: '',
+  },
+} satisfies Scene;
+
+const baseMotionPrompt = {
+  fullPrompt: 'Slow dolly in.',
+  components: {
+    cameraMovement: 'dolly',
+    startPosition: '',
+    endPosition: '',
+    durationSeconds: 5,
+    speed: 'slow',
+    smoothness: 'smooth',
+    subjectTracking: '',
+    equipment: '',
+  },
+  parameters: {
+    durationSeconds: 5,
+    fps: 24,
+    motionAmount: 'low' as const,
+    cameraControl: { pan: 0, tilt: 0, zoom: 1, movement: 'dolly' },
+  },
+  dialogue: null,
+  audio: { ambientSound: 'quiet room', soundEffects: [] },
+} satisfies MotionPrompt;
+
+describe('hydrateMotionPromptFromScene', () => {
+  it('fills dialogue from originalScript when the LLM omitted it', () => {
+    const result = hydrateMotionPromptFromScene(baseScene, baseMotionPrompt);
+    expect(result.dialogue).toEqual({
+      presence: true,
+      lines: baseScene.originalScript.dialogue,
+    });
+  });
+
+  it('leaves LLM-extracted dialogue untouched', () => {
+    const withDialogue: MotionPrompt = {
+      ...baseMotionPrompt,
+      dialogue: {
+        presence: true,
+        lines: [
+          {
+            character: 'SARAH',
+            line: 'Custom tone from model.',
+            tone: 'whispered',
+          },
+        ],
+      },
+    };
+    expect(hydrateMotionPromptFromScene(baseScene, withDialogue)).toBe(
+      withDialogue
+    );
+  });
+
+  it('does nothing when the scene has no script dialogue', () => {
+    const silentScene: Scene = {
+      ...baseScene,
+      originalScript: { extract: 'No speech.', dialogue: [] },
+    };
+    expect(hydrateMotionPromptFromScene(silentScene, baseMotionPrompt)).toBe(
+      baseMotionPrompt
+    );
+  });
+});

--- a/src/lib/motion/hydrate-motion-prompt.ts
+++ b/src/lib/motion/hydrate-motion-prompt.ts
@@ -1,0 +1,39 @@
+import type {
+  MotionDialogue,
+  MotionPrompt,
+  Scene,
+} from '@/lib/ai/scene-analysis.schema';
+
+function hasDialogue(dialogue: MotionPrompt['dialogue']): boolean {
+  return Boolean(dialogue?.presence && dialogue.lines.length > 0);
+}
+
+/**
+ * Ensure structured dialogue is present when the scene script carries lines.
+ *
+ * The analysis pipeline sources dialogue from `originalScript.dialogue` (see
+ * `deriveMotionPrompt` in shot-list.derive.ts). The motion-prompt LLM usually
+ * extracts it too, but regenerate runs can return `dialogue: null` — hydrate
+ * from the scene so audio-capable models still get lip-sync lines.
+ */
+export function hydrateMotionPromptFromScene(
+  scene: Scene,
+  motionPrompt: MotionPrompt
+): MotionPrompt {
+  if (hasDialogue(motionPrompt.dialogue)) {
+    return motionPrompt;
+  }
+
+  const scriptLines = scene.originalScript.dialogue;
+  if (!scriptLines.length) {
+    return motionPrompt;
+  }
+
+  return {
+    ...motionPrompt,
+    dialogue: {
+      presence: true,
+      lines: scriptLines,
+    } satisfies MotionDialogue,
+  };
+}

--- a/src/lib/workflows/motion-prompt-workflow.ts
+++ b/src/lib/workflows/motion-prompt-workflow.ts
@@ -16,6 +16,7 @@ import type { ScopedDb } from '@/lib/db/scoped';
 import { getShotPromptChannel, getGenerationChannel } from '@/lib/realtime';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import type { MotionPromptWorkflowInput } from '@/lib/workflow/types';
+import { hydrateMotionPromptFromScene } from '@/lib/motion/hydrate-motion-prompt';
 import { durableStreamingLLMCallCf } from '@/lib/workflows/llm-call-helper';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 import { getLogger } from '@/lib/observability/logger';
@@ -101,7 +102,7 @@ export class MotionPromptWorkflow extends OpenStoryWorkflowEntrypoint<MotionProm
       `[MotionPromptWorkflow:cf] Generating motion prompt for scene ${scene.sceneId}`
     );
 
-    const motionPrompt: MotionPrompt = await durableStreamingLLMCallCf(
+    const llmMotionPrompt: MotionPrompt = await durableStreamingLLMCallCf(
       step,
       {
         name: 'motion-prompts',
@@ -131,6 +132,10 @@ export class MotionPromptWorkflow extends OpenStoryWorkflowEntrypoint<MotionProm
             : undefined,
       }
     );
+
+    // Mirror the analysis pipeline: dialogue lines come from the scene script
+    // when the LLM omits them (common on explicit regenerate runs).
+    const motionPrompt = hydrateMotionPromptFromScene(scene, llmMotionPrompt);
 
     if (sequenceId && shotId) {
       if (!motionPrompt.fullPrompt) {


### PR DESCRIPTION
## Summary

- Hydrate motion prompt dialogue from `originalScript.dialogue` after the LLM call when the model omits structured dialogue (matching the analysis pipeline's `deriveMotionPrompt` behavior)
- Pass neighbour scene context (`sceneBefore` / `sceneAfter`) on single-shot motion prompt regenerate so inputs match `MotionPromptBatchWorkflow`

Fixes #1026

## Test plan

- [x] `bun test src/lib/motion/hydrate-motion-prompt.test.ts`
- [x] `bun run typecheck`
- [ ] Regenerate a motion prompt on a scene with script dialogue; confirm the Optimised prompt preview includes dialogue lines for audio-capable models