### PR TITLE
Redesign Scenes editor as selection-driven unified canvas

### DIFF
--- a/src/components/element/elements-view.tsx
+++ b/src/components/element/elements-view.tsx
@@ -1,3 +1,4 @@
+import { BackButton } from '@/components/layout/back-button';
 import { Button } from '@/components/ui/button';
 import {
   FileUpload,
@@ -54,71 +55,78 @@ export const ElementsView: React.FC<ElementsViewProps> = ({ sequenceId }) => {
   );
 
   return (
-    <div className="flex h-full flex-col gap-6 overflow-auto px-6 py-6">
-      <div className="flex flex-col gap-2">
-        <h2 className="text-lg font-semibold">Elements</h2>
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
+        <BackButton
+          fallbackTo="/sequences/$id/scenes"
+          sequenceId={sequenceId}
+          label="Back to scenes"
+        />
+        <h1 className="text-lg font-semibold">Elements</h1>
+      </div>
+      <div className="flex flex-1 flex-col gap-6 overflow-auto px-6 py-6">
         <p className="text-sm text-muted-foreground">
           Upload reference images (logos, products, screenshots) and reference
           them by the UPPERCASE token in your script. Images are described by a
           vision model and used when generating scene shots.
         </p>
+
+        <FileUpload
+          accept="image/*"
+          multiple
+          value={files}
+          onValueChange={setFiles}
+          onUpload={onUpload}
+        >
+          <FileUploadDropzone className="min-h-[120px] focus:border-ring/50 focus:bg-accent/30">
+            <Upload className="size-8 text-muted-foreground/50" />
+            <p className="text-sm font-medium">Drag & drop or paste</p>
+            <FileUploadTrigger asChild>
+              <Button type="button" variant="outline" size="sm">
+                Browse files
+              </Button>
+            </FileUploadTrigger>
+          </FileUploadDropzone>
+          <FileUploadList className="grid grid-cols-4 gap-3">
+            {files.map((file) => (
+              <FileUploadItem
+                key={getFileKey(file)}
+                value={file}
+                className="relative aspect-square p-0 border-0 overflow-hidden rounded-md"
+              >
+                <FileUploadItemPreview className="size-full rounded-none border-0" />
+                <FileUploadItemProgress className="absolute bottom-0 left-0 right-0 h-1" />
+                <FileUploadItemDelete asChild>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    size="icon"
+                    className="absolute top-1 right-1 size-6"
+                  >
+                    <X className="size-3" />
+                  </Button>
+                </FileUploadItemDelete>
+              </FileUploadItem>
+            ))}
+          </FileUploadList>
+        </FileUpload>
+
+        {elements.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No elements yet.</p>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {elements.map((el) => (
+              <ElementCard
+                key={el.id}
+                element={el}
+                sequenceId={sequenceId}
+                affectedShotCount={shotCounts?.[el.id]?.shotCount ?? 0}
+                affectedVideoCount={shotCounts?.[el.id]?.videoCount ?? 0}
+              />
+            ))}
+          </div>
+        )}
       </div>
-
-      <FileUpload
-        accept="image/*"
-        multiple
-        value={files}
-        onValueChange={setFiles}
-        onUpload={onUpload}
-      >
-        <FileUploadDropzone className="min-h-[120px] focus:border-ring/50 focus:bg-accent/30">
-          <Upload className="size-8 text-muted-foreground/50" />
-          <p className="text-sm font-medium">Drag & drop or paste</p>
-          <FileUploadTrigger asChild>
-            <Button type="button" variant="outline" size="sm">
-              Browse files
-            </Button>
-          </FileUploadTrigger>
-        </FileUploadDropzone>
-        <FileUploadList className="grid grid-cols-4 gap-3">
-          {files.map((file) => (
-            <FileUploadItem
-              key={getFileKey(file)}
-              value={file}
-              className="relative aspect-square p-0 border-0 overflow-hidden rounded-md"
-            >
-              <FileUploadItemPreview className="size-full rounded-none border-0" />
-              <FileUploadItemProgress className="absolute bottom-0 left-0 right-0 h-1" />
-              <FileUploadItemDelete asChild>
-                <Button
-                  type="button"
-                  variant="destructive"
-                  size="icon"
-                  className="absolute top-1 right-1 size-6"
-                >
-                  <X className="size-3" />
-                </Button>
-              </FileUploadItemDelete>
-            </FileUploadItem>
-          ))}
-        </FileUploadList>
-      </FileUpload>
-
-      {elements.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No elements yet.</p>
-      ) : (
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {elements.map((el) => (
-            <ElementCard
-              key={el.id}
-              element={el}
-              sequenceId={sequenceId}
-              affectedShotCount={shotCounts?.[el.id]?.shotCount ?? 0}
-              affectedVideoCount={shotCounts?.[el.id]?.videoCount ?? 0}
-            />
-          ))}
-        </div>
-      )}
     </div>
   );
 };

--- a/src/components/eval/eval-matrix.tsx
+++ b/src/components/eval/eval-matrix.tsx
@@ -80,8 +80,9 @@ export const EvalMatrix: React.FC<EvalMatrixProps> = ({
   const handleOpenTheatre = (sequenceIndex: number) => {
     const sequence = sequences[sequenceIndex];
     if (!sequence) return;
+    // Whole-sequence playback is the Scenes editor's nothing-selected state (#986).
     void navigate({
-      to: '/sequences/$id/theatre',
+      to: '/sequences/$id/scenes',
       params: { id: sequence.id },
     });
   };

--- a/src/components/layout/back-button.tsx
+++ b/src/components/layout/back-button.tsx
@@ -1,0 +1,53 @@
+/**
+ * History-aware back arrow. Goes back when this session has an in-app entry
+ * to return to (preserving e.g. the Scenes selection carried in search
+ * params); on a deep link / fresh tab it falls back to the given route.
+ */
+
+import { Link, useCanGoBack, useRouter } from '@tanstack/react-router';
+import { ArrowLeft } from 'lucide-react';
+
+type BackButtonProps = {
+  /** Where to go when there's no history to go back to. */
+  fallbackTo:
+    | '/sequences/$id/scenes'
+    | '/sequences/$id/cast'
+    | '/sequences/$id/locations';
+  sequenceId: string;
+  label: string;
+};
+
+const arrowClass =
+  'flex h-8 w-8 shrink-0 items-center justify-center rounded-md hover:bg-muted';
+
+export const BackButton: React.FC<BackButtonProps> = ({
+  fallbackTo,
+  sequenceId,
+  label,
+}) => {
+  const router = useRouter();
+  const canGoBack = useCanGoBack();
+
+  if (canGoBack) {
+    return (
+      <button
+        type="button"
+        aria-label={label}
+        onClick={() => router.history.back()}
+        className={arrowClass}
+      >
+        <ArrowLeft className="h-4 w-4" />
+      </button>
+    );
+  }
+  return (
+    <Link
+      to={fallbackTo}
+      params={{ id: sequenceId }}
+      aria-label={label}
+      className={arrowClass}
+    >
+      <ArrowLeft className="h-4 w-4" />
+    </Link>
+  );
+};

--- a/src/components/locations/location-detail-view.tsx
+++ b/src/components/locations/location-detail-view.tsx
@@ -1,3 +1,4 @@
+import { BackButton } from '@/components/layout/back-button';
 import { SheetComparisonDialog } from '@/components/sheets/sheet-comparison-dialog';
 import { SheetStalenessBanners } from '@/components/sheets/sheet-staleness-banners';
 import { Button } from '@/components/ui/button';
@@ -23,7 +24,7 @@ import { useSheetStaleDetected } from '@/lib/realtime/use-sheet-stale-detected';
 import { cn } from '@/lib/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { ArrowLeft, Loader2, MapPin, RefreshCw, Sparkles } from 'lucide-react';
+import { Loader2, MapPin, RefreshCw, Sparkles } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { LocationPickerDialog } from './location-picker-dialog';
@@ -288,13 +289,11 @@ export const LocationDetailView: React.FC<LocationDetailViewProps> = ({
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {/* Header with back button */}
       <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
-        <Link
-          to="/sequences/$id/locations"
-          params={{ id: sequenceId }}
-          className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
+        <BackButton
+          fallbackTo="/sequences/$id/locations"
+          sequenceId={sequenceId}
+          label="Back"
+        />
         <h1 className="text-lg font-semibold">{location.name}</h1>
       </div>
 

--- a/src/components/locations/location-view.tsx
+++ b/src/components/locations/location-view.tsx
@@ -1,3 +1,4 @@
+import { BackButton } from '@/components/layout/back-button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSequenceLocationDivergentVariants } from '@/hooks/use-location-sheet-variants';
 import { useSequenceLocations } from '@/hooks/use-sequence-locations';
@@ -26,59 +27,78 @@ export const LocationView: React.FC<LocationViewProps> = ({ sequenceId }) => {
     return map;
   }, [divergentVariants]);
 
+  const header = (
+    <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
+      <BackButton
+        fallbackTo="/sequences/$id/scenes"
+        sequenceId={sequenceId}
+        label="Back to scenes"
+      />
+      <h1 className="text-lg font-semibold">Locations</h1>
+    </div>
+  );
+
   if (error) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <p className="text-sm text-destructive">Failed to load locations</p>
-          <p className="mt-1 text-xs text-muted-foreground">{error.message}</p>
+      <div className="flex h-full min-h-0 flex-col">
+        {header}
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-destructive">Failed to load locations</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {error.message}
+            </p>
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="h-full overflow-auto p-6">
-      {isLoading ? (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="space-y-2">
-              <Skeleton className="aspect-video w-full rounded-lg" />
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-3 w-1/2" />
+    <div className="flex h-full min-h-0 flex-col">
+      {header}
+      <div className="flex-1 overflow-auto p-6">
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="aspect-video w-full rounded-lg" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            ))}
+          </div>
+        ) : !locations || locations.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+            <div className="rounded-full bg-muted p-6">
+              <MapPin className="h-12 w-12 text-muted-foreground/50" />
             </div>
-          ))}
-        </div>
-      ) : !locations || locations.length === 0 ? (
-        <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
-          <div className="rounded-full bg-muted p-6">
-            <MapPin className="h-12 w-12 text-muted-foreground/50" />
+            <div>
+              <h3 className="text-lg font-medium">No locations found</h3>
+              <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                Locations will appear here once your script has been analyzed.
+                Add a script to your sequence to get started.
+              </p>
+            </div>
           </div>
-          <div>
-            <h3 className="text-lg font-medium">No locations found</h3>
-            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-              Locations will appear here once your script has been analyzed. Add
-              a script to your sequence to get started.
-            </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {locations.map((location) => (
+              <Link
+                key={location.id}
+                to="/sequences/$id/locations/$locationId"
+                params={{ id: sequenceId, locationId: location.id }}
+                className="block"
+              >
+                <LocationCard
+                  location={location}
+                  divergentVariantId={divergentByLocationId.get(location.id)}
+                />
+              </Link>
+            ))}
           </div>
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-          {locations.map((location) => (
-            <Link
-              key={location.id}
-              to="/sequences/$id/locations/$locationId"
-              params={{ id: sequenceId, locationId: location.id }}
-              className="block"
-            >
-              <LocationCard
-                location={location}
-                divergentVariantId={divergentByLocationId.get(location.id)}
-              />
-            </Link>
-          ))}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/scenes/batch-motion-footer.tsx
+++ b/src/components/scenes/batch-motion-footer.tsx
@@ -1,0 +1,177 @@
+/**
+ * Sticky "Generate N/M shots" batch-motion footer, shared by the desktop
+ * spine (#986) and the legacy scene list used in the mobile drawer.
+ */
+
+import { MusicModelSelector } from '@/components/model/music-model-selector';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { DEFAULT_MUSIC_MODEL, type AudioModel } from '@/lib/ai/models';
+import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import { Loader2, Video } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+
+export type BatchGenerateMotionArgs = {
+  includeMusic: boolean;
+  musicModel: AudioModel;
+  /** Lets the user suppress model-emitted audio (sfx/dialogue/ambient) for the
+   *  batch. The flag is honored only by models that produce audio — non-audio
+   *  models ignore it downstream during motion-prompt assembly. */
+  generateAudio: boolean;
+};
+
+type BatchMotionFooterProps = {
+  shots?: ShotWithImage[] | undefined;
+  regeneratingMotion: Set<string>;
+  onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
+  musicPromptsReady: boolean;
+  /** Hide the batch motion button (e.g. while auto-generate motion is in flight). */
+  hideBatchButton?: boolean;
+  /** Initial music model for the batch selector (from `sequence.musicModel`). */
+  initialMusicModel?: AudioModel;
+};
+
+export const BatchMotionFooter: React.FC<BatchMotionFooterProps> = ({
+  shots,
+  regeneratingMotion,
+  onBatchGenerateMotion,
+  musicPromptsReady,
+  hideBatchButton = false,
+  initialMusicModel,
+}) => {
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [includeMusic, setIncludeMusic] = useState(true);
+  const [generateAudio, setGenerateAudio] = useState(true);
+  const [musicModel, setMusicModel] = useState<AudioModel>(
+    initialMusicModel ?? DEFAULT_MUSIC_MODEL
+  );
+
+  // Sync local selection when the sequence's saved model changes from outside
+  // (e.g. after generation completes and the workflow persists the new model).
+  const prevInitialMusicRef = useRef(initialMusicModel);
+  if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
+    prevInitialMusicRef.current = initialMusicModel;
+    setMusicModel(initialMusicModel);
+  }
+
+  const totalShots = shots?.length ?? 0;
+
+  // Shots that need to be kicked off (not already generating)
+  const notStartedShots = useMemo(() => {
+    if (!shots) return [];
+    return shots.filter(
+      (f) =>
+        (f.videoStatus === 'pending' || f.videoStatus === 'failed') &&
+        f.thumbnailStatus === 'completed'
+    );
+  }, [shots]);
+
+  const hasGeneratingShots = useMemo(() => {
+    if (!shots) return false;
+    return shots.some(
+      (f) => f.videoStatus === 'generating' && f.thumbnailStatus === 'completed'
+    );
+  }, [shots]);
+
+  // Check if all eligible shots have motion prompts ready
+  const motionPromptsReady = useMemo(() => {
+    if (!notStartedShots.length) return true;
+    return notStartedShots.every(
+      (f) => f.motionPrompt || f.motionPromptData?.fullPrompt
+    );
+  }, [notStartedShots]);
+
+  const handleGenerateMotion = async () => {
+    if (!onBatchGenerateMotion || notStartedShots.length === 0) return;
+
+    setIsGenerating(true);
+    try {
+      await onBatchGenerateMotion({
+        includeMusic,
+        musicModel,
+        generateAudio,
+      });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  const isMotionInProgress = regeneratingMotion.size > 0 || hasGeneratingShots;
+  const showButton =
+    !hideBatchButton && notStartedShots.length > 0 && !isMotionInProgress;
+  const isButtonDisabled =
+    isGenerating ||
+    notStartedShots.length === 0 ||
+    !motionPromptsReady ||
+    (includeMusic && !musicPromptsReady);
+
+  if (!showButton) return null;
+
+  return (
+    <div className="sticky bottom-0 border-t bg-background p-4 flex flex-col gap-3">
+      {includeMusic && (
+        <div className="flex flex-col gap-1">
+          <span className="text-xs text-muted-foreground">Music model</span>
+          <MusicModelSelector
+            selectedModel={musicModel}
+            onModelChange={setMusicModel}
+            disabled={isGenerating || isMotionInProgress}
+          />
+        </div>
+      )}
+      <Button
+        variant="default"
+        className="w-full"
+        onClick={() => void handleGenerateMotion()}
+        disabled={isButtonDisabled}
+      >
+        {isGenerating ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Generating…
+          </>
+        ) : !motionPromptsReady ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Writing motion prompts…
+          </>
+        ) : includeMusic && !musicPromptsReady ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Composing music…
+          </>
+        ) : (
+          <>
+            <Video className="mr-2 h-4 w-4" />
+            Generate {notStartedShots.length} / {totalShots}{' '}
+            {totalShots === 1 ? 'shot' : 'shots'}
+          </>
+        )}
+      </Button>
+      <label className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Checkbox
+          checked={includeMusic}
+          onCheckedChange={(checked) => setIncludeMusic(checked === true)}
+          disabled={!musicPromptsReady}
+        />
+        <span>
+          Also generate music
+          {!musicPromptsReady && (
+            <span className="text-xs ml-1">(preparing…)</span>
+          )}
+        </span>
+      </label>
+      <label
+        htmlFor="batch-generate-audio"
+        className="flex items-center gap-2 text-sm text-muted-foreground"
+      >
+        <Checkbox
+          id="batch-generate-audio"
+          checked={generateAudio}
+          onCheckedChange={(checked) => setGenerateAudio(checked === true)}
+        />
+        <span>Include SFX &amp; dialogue (when the model supports it)</span>
+      </label>
+    </div>
+  );
+};

--- a/src/components/scenes/mobile-scene-drawer.tsx
+++ b/src/components/scenes/mobile-scene-drawer.tsx
@@ -34,12 +34,6 @@ type MobileSceneDrawerProps = {
   initialMusicModel?: AudioModel;
 };
 
-const isCompleted = (shot: ShotWithImage) => {
-  return (
-    shot.thumbnailStatus === 'completed' && shot.videoStatus === 'completed'
-  );
-};
-
 export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
   shots,
   selectedShotId,
@@ -179,7 +173,6 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
                     shot={undefined}
                     aspectRatio={aspectRatio}
                     isActive={false}
-                    isCompleted={false}
                     onSelect={() => {}}
                   />
                 ))}
@@ -190,7 +183,6 @@ export const MobileSceneDrawer: React.FC<MobileSceneDrawerProps> = ({
                   shot={shot}
                   aspectRatio={aspectRatio}
                   isActive={shot.id === selectedShotId}
-                  isCompleted={isCompleted(shot)}
                   onSelect={() => handleSelectShot(shot.id)}
                   isRegeneratingImage={regeneratingImages.has(shot.id)}
                   isRegeneratingMotion={regeneratingMotion.has(shot.id)}

--- a/src/components/scenes/scene-cast-tab.tsx
+++ b/src/components/scenes/scene-cast-tab.tsx
@@ -1,19 +1,21 @@
 /**
- * Scene Cast Tab
- * Displays characters appearing in the current shot with a cinematic/editorial design
+ * Cast facet (#986)
+ * Selection-scoped character list: `characterTags: null` shows the whole
+ * sequence's cast (nothing selected), a tag set shows the union for the
+ * selected scene(s)/shot. Cards deep-link to the existing edit pages.
  */
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSequenceCharacters } from '@/hooks/use-sequence-characters';
 import type { Character } from '@/lib/db/schema';
 import { matchCharactersToScene } from '@/lib/workflows/scene-matching';
-import type { Shot } from '@/types/database';
 import { Link } from '@tanstack/react-router';
 import { Film, User } from 'lucide-react';
 
 type SceneCastTabProps = {
-  shot?: Shot;
   sequenceId: string;
+  /** Selection-derived character tags; `null` = no filter (whole sequence). */
+  characterTags: string[] | null;
 };
 
 type CastCardProps = {
@@ -88,39 +90,40 @@ const CastCardSkeleton: React.FC = () => (
 );
 
 export const SceneCastTab: React.FC<SceneCastTabProps> = ({
-  shot,
   sequenceId,
+  characterTags,
 }) => {
   const { data: characters, isLoading } = useSequenceCharacters(sequenceId);
 
-  // Get character tags from shot metadata
-  const characterTags = shot?.metadata?.continuity?.characterTags ?? [];
-
-  // Match characters to this shot
-  const shotCast = characters
-    ? matchCharactersToScene(characters, characterTags)
-    : [];
+  const scopedCast = !characters
+    ? []
+    : characterTags === null
+      ? characters
+      : matchCharactersToScene(characters, characterTags);
 
   // Loading state
   if (isLoading) {
     return (
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-        <CastCardSkeleton />
+      <div className="grid grid-cols-2 gap-4">
         <CastCardSkeleton />
         <CastCardSkeleton />
       </div>
     );
   }
 
-  // Empty state - no characters in this scene
-  if (shotCast.length === 0) {
+  // Empty state - no characters in this selection
+  if (scopedCast.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <div className="rounded-full bg-muted p-4 mb-4">
           <Film className="h-8 w-8 text-muted-foreground/50" />
         </div>
-        <p className="text-sm text-muted-foreground">No cast in this scene</p>
-        {characterTags.length > 0 && (
+        <p className="text-sm text-muted-foreground">
+          {characterTags === null
+            ? 'No cast in this sequence'
+            : 'No cast in this selection'}
+        </p>
+        {characterTags !== null && characterTags.length > 0 && (
           <p className="mt-2 text-xs text-muted-foreground/70">
             {characterTags.length} character tag
             {characterTags.length > 1 ? 's' : ''} found but no matches
@@ -132,18 +135,16 @@ export const SceneCastTab: React.FC<SceneCastTabProps> = ({
 
   return (
     <div className="space-y-4">
-      {/* Scene cast header */}
       <div className="flex items-center gap-2 text-xs text-muted-foreground uppercase tracking-wider">
-        <span>Scene Cast</span>
+        <span>Cast</span>
         <span className="text-muted-foreground/50">·</span>
         <span>
-          {shotCast.length} character{shotCast.length > 1 ? 's' : ''}
+          {scopedCast.length} character{scopedCast.length > 1 ? 's' : ''}
         </span>
       </div>
 
-      {/* Cast grid */}
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {shotCast.map((character) => (
+      <div className="grid grid-cols-2 gap-4">
+        {scopedCast.map((character) => (
           <CastCard
             key={character.id}
             character={character}

--- a/src/components/scenes/scene-command-palette.tsx
+++ b/src/components/scenes/scene-command-palette.tsx
@@ -1,0 +1,258 @@
+/**
+ * ⌘K command palette for the Scenes editor (#986).
+ *
+ * Jump to any scene or shot, switch inspector facets, set the Look/Motion
+ * model at the current scope, or clear the selection — all filterable from
+ * one input. Deliberately dependency-free: a Dialog + filtered list.
+ */
+
+import { type FacetValue } from '@/components/scenes/scope-inspector';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Kbd } from '@/components/ui/kbd';
+import {
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+  type ImageToVideoModel,
+  type TextToImageModel,
+} from '@/lib/ai/models';
+import {
+  selectScene,
+  selectShot,
+  type SceneSelection,
+} from '@/lib/scenes/selection';
+import type { SceneRow } from '@/lib/db/schema';
+import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import { cn } from '@/lib/utils';
+import { typedEntries } from '@/lib/utils/typed-object';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+type PaletteCommand = {
+  id: string;
+  group: string;
+  label: string;
+  keywords: string;
+  run: () => void;
+};
+
+type SceneCommandPaletteProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  shots?: ShotWithImage[];
+  scenes?: SceneRow[];
+  onSelectionChange: (next: SceneSelection) => void;
+  onFacetChange: (facet: FacetValue) => void;
+  onSetImageModel: (model: TextToImageModel) => void;
+  onSetVideoModel: (model: ImageToVideoModel) => void;
+};
+
+const FACETS: Array<{ value: FacetValue; label: string }> = [
+  { value: 'cast', label: 'Show Cast' },
+  { value: 'locations', label: 'Show Locations' },
+  { value: 'elements', label: 'Show Elements' },
+  { value: 'music', label: 'Show Music' },
+  { value: 'script', label: 'Show Script' },
+];
+
+export const SceneCommandPalette: React.FC<SceneCommandPaletteProps> = ({
+  open,
+  onOpenChange,
+  shots,
+  scenes,
+  onSelectionChange,
+  onFacetChange,
+  onSetImageModel,
+  onSetVideoModel,
+}) => {
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement | null>(null);
+
+  const commands = useMemo<PaletteCommand[]>(() => {
+    const result: PaletteCommand[] = [
+      {
+        id: 'scope-sequence',
+        group: 'Scope',
+        label: 'Whole sequence',
+        keywords: 'sequence clear all everything theatre play',
+        run: () => onSelectionChange({ sceneIds: [] }),
+      },
+    ];
+    for (const scene of scenes ?? []) {
+      result.push({
+        id: `scene-${scene.id}`,
+        group: 'Scenes',
+        label: scene.title ?? `Scene ${scene.orderIndex + 1}`,
+        keywords: `scene ${scene.orderIndex + 1} ${scene.location ?? ''}`,
+        run: () => onSelectionChange(selectScene(scene.id)),
+      });
+    }
+    for (const shot of shots ?? []) {
+      const title =
+        shot.metadata?.metadata?.title ?? `Shot ${shot.orderIndex + 1}`;
+      result.push({
+        id: `shot-${shot.id}`,
+        group: 'Shots',
+        label: title,
+        keywords: `shot ${shot.orderIndex + 1} ${
+          shot.metadata?.metadata?.location ?? ''
+        }`,
+        run: () => onSelectionChange(selectShot(shot.id)),
+      });
+    }
+    for (const facet of FACETS) {
+      result.push({
+        id: `facet-${facet.value}`,
+        group: 'Facets',
+        label: facet.label,
+        keywords: `facet inspector ${facet.value}`,
+        run: () => onFacetChange(facet.value),
+      });
+    }
+    for (const [key, config] of typedEntries(IMAGE_MODELS)) {
+      result.push({
+        id: `image-model-${key}`,
+        group: 'Look model',
+        label: `Set Look: ${config.name}`,
+        keywords: `image look model ${config.name}`,
+        run: () => onSetImageModel(key),
+      });
+    }
+    for (const [key, config] of typedEntries(IMAGE_TO_VIDEO_MODELS)) {
+      result.push({
+        id: `video-model-${key}`,
+        group: 'Motion model',
+        label: `Set Motion: ${config.name}`,
+        keywords: `video motion model ${config.name}`,
+        run: () => onSetVideoModel(key),
+      });
+    }
+    return result;
+  }, [
+    scenes,
+    shots,
+    onSelectionChange,
+    onFacetChange,
+    onSetImageModel,
+    onSetVideoModel,
+  ]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return commands;
+    const terms = q.split(/\s+/);
+    return commands.filter((command) => {
+      const haystack = `${command.label} ${command.keywords}`.toLowerCase();
+      return terms.every((term) => haystack.includes(term));
+    });
+  }, [commands, query]);
+
+  // Reset the cursor whenever the palette opens or the result set changes.
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [query, open]);
+  useEffect(() => {
+    if (open) setQuery('');
+  }, [open]);
+
+  const runCommand = (command: PaletteCommand | undefined) => {
+    if (!command) return;
+    onOpenChange(false);
+    command.run();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.min(filtered.length - 1, i + 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      runCommand(filtered[activeIndex]);
+    }
+  };
+
+  // Keep the active row visible while arrowing through results.
+  useEffect(() => {
+    const active = listRef.current?.querySelector('[data-active="true"]');
+    active?.scrollIntoView({ block: 'nearest' });
+  }, [activeIndex]);
+
+  let lastGroup = '';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="top-[20%] max-w-lg translate-y-0 gap-0 p-0">
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <div className="border-b p-2">
+          <Input
+            // oxlint-disable-next-line jsx-a11y/no-autofocus -- the palette exists to receive immediate typing
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Jump to a scene or shot, switch facets, set models…"
+            aria-label="Search commands"
+            className="border-0 shadow-none focus-visible:ring-0"
+          />
+        </div>
+        <div
+          ref={listRef}
+          // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- ARIA listbox pattern; native <select> can't render grouped commands
+          role="listbox"
+          aria-label="Commands"
+          className="max-h-80 overflow-y-auto p-2"
+        >
+          {filtered.length === 0 && (
+            <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+              No matches.
+            </p>
+          )}
+          {filtered.map((command, index) => {
+            const showGroup = command.group !== lastGroup;
+            lastGroup = command.group;
+            return (
+              <div key={command.id}>
+                {showGroup && (
+                  <div className="px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    {command.group}
+                  </div>
+                )}
+                <button
+                  type="button"
+                  // oxlint-disable-next-line jsx-a11y/prefer-tag-over-role -- ARIA listbox option; see listbox note above
+                  role="option"
+                  aria-selected={index === activeIndex}
+                  data-active={index === activeIndex}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => runCommand(command)}
+                  className={cn(
+                    'w-full rounded-md px-2 py-1.5 text-left text-sm',
+                    index === activeIndex
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-muted'
+                  )}
+                >
+                  {command.label}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex items-center gap-3 border-t px-3 py-2 text-[11px] text-muted-foreground">
+          <span>
+            <Kbd>↑↓</Kbd> navigate
+          </span>
+          <span>
+            <Kbd>↵</Kbd> run
+          </span>
+          <span>
+            <Kbd>esc</Kbd> close
+          </span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/components/scenes/scene-elements-tab.tsx
+++ b/src/components/scenes/scene-elements-tab.tsx
@@ -1,42 +1,46 @@
 /**
- * Scene Elements Tab
- * Displays user-uploaded reference elements (logos, products) referenced in
- * the current shot by UPPERCASE token.
+ * Elements facet (#986)
+ * Selection-scoped element list: `elementTags: null` shows every uploaded
+ * element (nothing selected); a tag set shows the union referenced across the
+ * selected scene(s)/shot by UPPERCASE token.
  */
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSequenceElements } from '@/hooks/use-sequence-elements';
 import type { SequenceElement } from '@/lib/db/schema';
 import { matchElementsToScene } from '@/lib/workflows/scene-matching';
-import type { Shot } from '@/types/database';
 import { Link } from '@tanstack/react-router';
 import { ImagePlus, Loader2 } from 'lucide-react';
 
 type SceneElementsTabProps = {
-  shot?: Shot;
   sequenceId: string;
+  /** Selection-derived element tokens; `null` = no filter (whole sequence). */
+  elementTags: string[] | null;
+  /** Covered shots' script extracts — fallback token matching in prose. */
+  scriptText?: string;
 };
 
 export const SceneElementsTab: React.FC<SceneElementsTabProps> = ({
-  shot,
   sequenceId,
+  elementTags,
+  scriptText = '',
 }) => {
   const { data: elements = [], isLoading } = useSequenceElements(sequenceId);
 
-  const elementTags = shot?.metadata?.continuity?.elementTags ?? [];
-  const sceneScript = shot?.metadata?.originalScript.extract ?? '';
-
-  const matchedIds = new Set(
-    matchElementsToScene(elements, elementTags, sceneScript).map((el) => el.id)
-  );
-  const sceneElements: SequenceElement[] = elements.filter((el) =>
-    matchedIds.has(el.id)
-  );
+  let sceneElements: SequenceElement[];
+  if (elementTags === null) {
+    sceneElements = elements;
+  } else {
+    const matchedIds = new Set(
+      matchElementsToScene(elements, elementTags, scriptText).map((el) => el.id)
+    );
+    sceneElements = elements.filter((el) => matchedIds.has(el.id));
+  }
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {Array.from({ length: 3 }).map((_, i) => (
+      <div className="grid grid-cols-2 gap-4">
+        {Array.from({ length: 2 }).map((_, i) => (
           <Skeleton key={i} className="aspect-square rounded-lg" />
         ))}
       </div>
@@ -50,9 +54,11 @@ export const SceneElementsTab: React.FC<SceneElementsTabProps> = ({
           <ImagePlus className="h-8 w-8 text-muted-foreground/50" />
         </div>
         <p className="text-sm text-muted-foreground">
-          No elements in this scene
+          {elementTags === null
+            ? 'No elements in this sequence'
+            : 'No elements in this selection'}
         </p>
-        {elementTags.length > 0 && (
+        {elementTags !== null && elementTags.length > 0 && (
           <p className="mt-2 text-xs text-muted-foreground/70">
             Looking for: {elementTags.join(', ')}
           </p>
@@ -71,7 +77,7 @@ export const SceneElementsTab: React.FC<SceneElementsTabProps> = ({
   return (
     <div className="space-y-4">
       <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
-        <span>Scene Elements</span>
+        <span>Elements</span>
         <span className="text-muted-foreground/50">·</span>
         <span>
           {sceneElements.length} reference
@@ -79,7 +85,7 @@ export const SceneElementsTab: React.FC<SceneElementsTabProps> = ({
         </span>
       </div>
 
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+      <div className="grid grid-cols-2 gap-4">
         {sceneElements.map((el) => (
           <Link
             key={el.id}

--- a/src/components/scenes/scene-list-item.stories.tsx
+++ b/src/components/scenes/scene-list-item.stories.tsx
@@ -148,7 +148,6 @@ export const Inactive: Story = {
   args: {
     shot: mockShot,
     isActive: false,
-    isCompleted: false,
   },
 };
 
@@ -156,23 +155,40 @@ export const Active: Story = {
   args: {
     shot: mockShot,
     isActive: true,
-    isCompleted: false,
   },
 };
 
-export const Completed: Story = {
+/** Play badge on the thumbnail: the shot has a completed video. */
+export const MotionReady: Story = {
   args: {
-    shot: mockShot,
+    shot: {
+      ...mockShot,
+      videoUrl: 'https://example.com/video.mp4',
+      videoStatus: 'completed',
+    },
     isActive: false,
-    isCompleted: true,
   },
 };
 
-export const ActiveAndCompleted: Story = {
+/** Pulsing play badge while motion generates. */
+export const MotionGenerating: Story = {
   args: {
-    shot: mockShot,
+    shot: {
+      ...mockShot,
+      videoStatus: 'generating',
+    },
+    isActive: false,
+  },
+};
+
+export const ActiveAndMotionReady: Story = {
+  args: {
+    shot: {
+      ...mockShot,
+      videoUrl: 'https://example.com/video.mp4',
+      videoStatus: 'completed',
+    },
     isActive: true,
-    isCompleted: true,
   },
 };
 
@@ -184,7 +200,6 @@ export const Generating: Story = {
       thumbnailStatus: 'generating',
     },
     isActive: false,
-    isCompleted: false,
   },
 };
 
@@ -196,7 +211,6 @@ export const GeneratingActive: Story = {
       thumbnailStatus: 'generating',
     },
     isActive: true,
-    isCompleted: false,
   },
 };
 
@@ -209,7 +223,6 @@ export const Failed: Story = {
       thumbnailError: 'Generation timeout',
     },
     isActive: false,
-    isCompleted: false,
   },
 };
 
@@ -249,7 +262,6 @@ export const LongTitle: Story = {
       } satisfies Shot['metadata'],
     },
     isActive: false,
-    isCompleted: false,
   },
 };
 
@@ -292,6 +304,5 @@ export const LongScript: Story = {
       } satisfies Shot['metadata'],
     },
     isActive: false,
-    isCompleted: false,
   },
 };

--- a/src/components/scenes/scene-list-item.tsx
+++ b/src/components/scenes/scene-list-item.tsx
@@ -10,7 +10,7 @@ import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import { cn } from '@/lib/utils';
 import { stripMarkdown } from '@/lib/utils/markdown-plain';
 import type { ShotWithImage } from '@/lib/shots/shot-with-image';
-import { Check, Loader2 } from 'lucide-react';
+import { Loader2, Play } from 'lucide-react';
 import { memo } from 'react';
 import { SceneThumbnail } from './scene-thumbnail';
 
@@ -18,9 +18,6 @@ type SceneListItemProps = {
   shot?: ShotWithImage | undefined;
   aspectRatio: AspectRatio;
   isActive?: boolean;
-  /** Shot is under the playhead during scene/sequence playback (#986). */
-  isPlaying?: boolean;
-  isCompleted?: boolean;
   onSelect?: () => void;
   variant?: 'stacked' | 'horizontal' | 'responsive';
   isRegeneratingImage?: boolean;
@@ -42,8 +39,6 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
   shot,
   aspectRatio,
   isActive = false,
-  isPlaying = false,
-  isCompleted = false,
   onSelect,
   variant = 'responsive',
   isRegeneratingImage = false,
@@ -55,10 +50,12 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
 }) => {
   // Divergent alternate takes precedence: promoting it resolves staleness too.
   const showDivergentDot = !!divergentVariantId;
-  const showStatusIndicator =
-    !showDivergentDot &&
-    (isCompleted ||
-      (shot && (isRegeneratingImage || isRegeneratingMotion || !isCompleted)));
+  // Motion state lives on the thumbnail as a play badge: solid = the shot has
+  // a video, pulsing = motion is generating. Image regeneration keeps the
+  // corner spinner (the thumbnail itself is what's being replaced).
+  const hasVideo = shot?.videoStatus === 'completed' && !!shot.videoUrl;
+  const isGeneratingVideo =
+    !!shot && (shot.videoStatus === 'generating' || isRegeneratingMotion);
   // Extract scene data from shot metadata
   const metadata = shot?.metadata;
 
@@ -81,8 +78,11 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
       className={cn(
         '@container/scene relative transition-all',
         isSkeleton ? 'pointer-events-none' : 'cursor-pointer',
-        isActive ? 'border-primary bg-primary/5' : 'hover:bg-muted/50',
-        isPlaying && 'ring-2 ring-primary/60',
+        // Selection = scope: match the selected scene header's treatment so
+        // "selected" reads the same at every level of the spine. The playhead
+        // is only marked in the player's filmstrip — a second rectangle here
+        // read as a phantom selection (#986).
+        isActive ? 'border-primary bg-primary/10' : 'hover:bg-muted/50',
         variant === 'responsive' && '@[280px]/scene:py-3',
         variant === 'horizontal' && 'py-3',
         'py-3'
@@ -111,32 +111,14 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
           />
         </div>
       )}
-      {showStatusIndicator && isCompleted && (
-        <Check
+      {!showDivergentDot && shot && isRegeneratingImage && (
+        <Loader2
           className={cn(
-            'absolute right-4 top-4 z-10 h-6 w-6 p-1 rounded-full',
-            'bg-success text-success-foreground'
+            'absolute right-4 top-4 z-10 h-6 w-6 p-1 rounded-full animate-spin',
+            'bg-primary/10 text-primary'
           )}
         />
       )}
-      {showStatusIndicator &&
-        shot &&
-        !isCompleted &&
-        (isRegeneratingImage || isRegeneratingMotion) && (
-          <Loader2
-            className={cn(
-              'absolute right-4 top-4 z-10 h-6 w-6 p-1 rounded-full animate-spin',
-              'bg-primary/10 text-primary'
-            )}
-          />
-        )}
-      {showStatusIndicator &&
-        shot &&
-        !isCompleted &&
-        !isRegeneratingImage &&
-        !isRegeneratingMotion && (
-          <Skeleton className="absolute right-4 top-4 z-10 h-6 w-6 rounded-full" />
-        )}
 
       <CardHeader>
         <div
@@ -149,7 +131,7 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
         >
           <div
             className={cn(
-              'relative w-full',
+              'w-full',
               aspectRatio === '9:16' && [
                 variant === 'responsive' &&
                   '@[280px]/scene:w-20 @[280px]/scene:shrink-0',
@@ -162,26 +144,42 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
               ]
             )}
           >
-            <SceneThumbnail
-              thumbnailUrl={shot?.thumbnailUrl}
-              previewThumbnailUrl={shot?.previewThumbnailUrl}
-              thumbnailStatus={shot?.thumbnailStatus || undefined}
-              alt={title ?? 'Scene thumbnail'}
-              aspectRatio={aspectRatio}
-              className="w-full rounded-md"
-            />
-            {modelMissing && (
-              <span
-                className="absolute bottom-1 left-1 rounded bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white"
-                aria-label={
-                  modelMissingLabel
-                    ? `Not generated with ${modelMissingLabel}`
-                    : 'Not generated with the selected model'
-                }
-              >
-                No {modelMissingLabel}
-              </span>
-            )}
+            {/* Badges anchor to the thumbnail, not the (taller) text row. */}
+            <div className="relative">
+              <SceneThumbnail
+                thumbnailUrl={shot?.thumbnailUrl}
+                previewThumbnailUrl={shot?.previewThumbnailUrl}
+                thumbnailStatus={shot?.thumbnailStatus || undefined}
+                alt={title ?? 'Scene thumbnail'}
+                aspectRatio={aspectRatio}
+                className="w-full rounded-md"
+              />
+              {(hasVideo || isGeneratingVideo) && (
+                <span
+                  aria-label={
+                    isGeneratingVideo ? 'Generating motion…' : 'Motion ready'
+                  }
+                  className={cn(
+                    'absolute bottom-1 right-1 flex h-4 w-4 items-center justify-center rounded-full bg-background/60 text-foreground/80',
+                    isGeneratingVideo && 'motion-safe:animate-pulse'
+                  )}
+                >
+                  <Play className="h-2.5 w-2.5 fill-current" />
+                </span>
+              )}
+              {modelMissing && (
+                <span
+                  className="absolute bottom-1 left-1 rounded bg-amber-500/90 px-1.5 py-0.5 text-[10px] font-medium leading-none text-white"
+                  aria-label={
+                    modelMissingLabel
+                      ? `Not generated with ${modelMissingLabel}`
+                      : 'Not generated with the selected model'
+                  }
+                >
+                  No {modelMissingLabel}
+                </span>
+              )}
+            </div>
           </div>
 
           <div className="flex flex-col gap-1.5">
@@ -208,8 +206,6 @@ const areEqual = (
   if (
     prevProps.aspectRatio !== nextProps.aspectRatio ||
     prevProps.isActive !== nextProps.isActive ||
-    prevProps.isPlaying !== nextProps.isPlaying ||
-    prevProps.isCompleted !== nextProps.isCompleted ||
     prevProps.variant !== nextProps.variant ||
     prevProps.isRegeneratingImage !== nextProps.isRegeneratingImage ||
     prevProps.isRegeneratingMotion !== nextProps.isRegeneratingMotion ||

--- a/src/components/scenes/scene-list-item.tsx
+++ b/src/components/scenes/scene-list-item.tsx
@@ -18,6 +18,8 @@ type SceneListItemProps = {
   shot?: ShotWithImage | undefined;
   aspectRatio: AspectRatio;
   isActive?: boolean;
+  /** Shot is under the playhead during scene/sequence playback (#986). */
+  isPlaying?: boolean;
   isCompleted?: boolean;
   onSelect?: () => void;
   variant?: 'stacked' | 'horizontal' | 'responsive';
@@ -40,6 +42,7 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
   shot,
   aspectRatio,
   isActive = false,
+  isPlaying = false,
   isCompleted = false,
   onSelect,
   variant = 'responsive',
@@ -79,6 +82,7 @@ const SceneListItemComponent: React.FC<SceneListItemProps> = ({
         '@container/scene relative transition-all',
         isSkeleton ? 'pointer-events-none' : 'cursor-pointer',
         isActive ? 'border-primary bg-primary/5' : 'hover:bg-muted/50',
+        isPlaying && 'ring-2 ring-primary/60',
         variant === 'responsive' && '@[280px]/scene:py-3',
         variant === 'horizontal' && 'py-3',
         'py-3'
@@ -204,6 +208,7 @@ const areEqual = (
   if (
     prevProps.aspectRatio !== nextProps.aspectRatio ||
     prevProps.isActive !== nextProps.isActive ||
+    prevProps.isPlaying !== nextProps.isPlaying ||
     prevProps.isCompleted !== nextProps.isCompleted ||
     prevProps.variant !== nextProps.variant ||
     prevProps.isRegeneratingImage !== nextProps.isRegeneratingImage ||

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -1,23 +1,16 @@
-import { MusicModelSelector } from '@/components/model/music-model-selector';
-import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
+import {
+  BatchMotionFooter,
+  type BatchGenerateMotionArgs,
+} from '@/components/scenes/batch-motion-footer';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { DEFAULT_MUSIC_MODEL, type AudioModel } from '@/lib/ai/models';
+import { type AudioModel } from '@/lib/ai/models';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import type { ShotVariant } from '@/lib/db/schema';
 import type { ShotWithImage } from '@/lib/shots/shot-with-image';
-import { Loader2, Video } from 'lucide-react';
-import { memo, useMemo, useRef, useState } from 'react';
+import { memo, useMemo } from 'react';
 import { SceneListItem } from './scene-list-item';
 
-export type BatchGenerateMotionArgs = {
-  includeMusic: boolean;
-  musicModel: AudioModel;
-  /** Lets the user suppress model-emitted audio (sfx/dialogue/ambient) for the
-   *  batch. The flag is honored only by models that produce audio — non-audio
-   *  models ignore it downstream during motion-prompt assembly. */
-  generateAudio: boolean;
-};
+export type { BatchGenerateMotionArgs };
 
 type SceneListProps = {
   shots?: ShotWithImage[] | undefined;
@@ -75,72 +68,6 @@ const SceneListComponent: React.FC<SceneListProps> = ({
     return map;
   }, [divergentVariants]);
 
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [includeMusic, setIncludeMusic] = useState(true);
-  const [generateAudio, setGenerateAudio] = useState(true);
-  const [musicModel, setMusicModel] = useState<AudioModel>(
-    initialMusicModel ?? DEFAULT_MUSIC_MODEL
-  );
-
-  // Sync local selection when the sequence's saved model changes from outside
-  // (e.g. after generation completes and the workflow persists the new model).
-  const prevInitialMusicRef = useRef(initialMusicModel);
-  if (initialMusicModel && initialMusicModel !== prevInitialMusicRef.current) {
-    prevInitialMusicRef.current = initialMusicModel;
-    setMusicModel(initialMusicModel);
-  }
-
-  const totalShots = shots?.length ?? 0;
-
-  // Shots that need to be kicked off (not already generating)
-  const notStartedShots = useMemo(() => {
-    if (!shots) return [];
-    return shots.filter(
-      (f) =>
-        (f.videoStatus === 'pending' || f.videoStatus === 'failed') &&
-        f.thumbnailStatus === 'completed'
-    );
-  }, [shots]);
-
-  const hasGeneratingShots = useMemo(() => {
-    if (!shots) return false;
-    return shots.some(
-      (f) => f.videoStatus === 'generating' && f.thumbnailStatus === 'completed'
-    );
-  }, [shots]);
-
-  // Check if all eligible shots have motion prompts ready
-  const motionPromptsReady = useMemo(() => {
-    if (!notStartedShots.length) return true;
-    return notStartedShots.every(
-      (f) => f.motionPrompt || f.motionPromptData?.fullPrompt
-    );
-  }, [notStartedShots]);
-
-  const handleGenerateMotion = async () => {
-    if (!onBatchGenerateMotion || notStartedShots.length === 0) return;
-
-    setIsGenerating(true);
-    try {
-      await onBatchGenerateMotion({
-        includeMusic,
-        musicModel,
-        generateAudio,
-      });
-    } finally {
-      setIsGenerating(false);
-    }
-  };
-
-  const isMotionInProgress = regeneratingMotion.size > 0 || hasGeneratingShots;
-  const showButton =
-    !hideBatchButton && notStartedShots.length > 0 && !isMotionInProgress;
-  const isButtonDisabled =
-    isGenerating ||
-    notStartedShots.length === 0 ||
-    !motionPromptsReady ||
-    (includeMusic && !musicPromptsReady);
-
   const renderShotCard = (shot: ShotWithImage) => {
     const divergent = divergentByShotId.get(shot.id);
     return (
@@ -192,74 +119,14 @@ const SceneListComponent: React.FC<SceneListProps> = ({
         </div>
       </ScrollArea>
 
-      {/* Sticky footer with Generate Motion button */}
-      {showButton && (
-        <div className="sticky bottom-0 border-t bg-background p-4 flex flex-col gap-3">
-          {includeMusic && (
-            <div className="flex flex-col gap-1">
-              <span className="text-xs text-muted-foreground">Music model</span>
-              <MusicModelSelector
-                selectedModel={musicModel}
-                onModelChange={setMusicModel}
-                disabled={isGenerating || isMotionInProgress}
-              />
-            </div>
-          )}
-          <Button
-            variant="default"
-            className="w-full"
-            onClick={() => void handleGenerateMotion()}
-            disabled={isButtonDisabled}
-          >
-            {isGenerating ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Generating…
-              </>
-            ) : !motionPromptsReady ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Writing motion prompts…
-              </>
-            ) : includeMusic && !musicPromptsReady ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Composing music…
-              </>
-            ) : (
-              <>
-                <Video className="mr-2 h-4 w-4" />
-                Generate {notStartedShots.length} / {totalShots}{' '}
-                {totalShots === 1 ? 'shot' : 'shots'}
-              </>
-            )}
-          </Button>
-          <label className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Checkbox
-              checked={includeMusic}
-              onCheckedChange={(checked) => setIncludeMusic(checked === true)}
-              disabled={!musicPromptsReady}
-            />
-            <span>
-              Also generate music
-              {!musicPromptsReady && (
-                <span className="text-xs ml-1">(preparing…)</span>
-              )}
-            </span>
-          </label>
-          <label
-            htmlFor="batch-generate-audio"
-            className="flex items-center gap-2 text-sm text-muted-foreground"
-          >
-            <Checkbox
-              id="batch-generate-audio"
-              checked={generateAudio}
-              onCheckedChange={(checked) => setGenerateAudio(checked === true)}
-            />
-            <span>Include SFX &amp; dialogue (when the model supports it)</span>
-          </label>
-        </div>
-      )}
+      <BatchMotionFooter
+        shots={shots}
+        regeneratingMotion={regeneratingMotion}
+        onBatchGenerateMotion={onBatchGenerateMotion}
+        musicPromptsReady={musicPromptsReady}
+        hideBatchButton={hideBatchButton}
+        initialMusicModel={initialMusicModel}
+      />
     </div>
   );
 };

--- a/src/components/scenes/scene-list.tsx
+++ b/src/components/scenes/scene-list.tsx
@@ -38,9 +38,6 @@ type SceneListProps = {
   modelMissingLabel?: string | null;
 };
 
-const isCompleted = (shot: ShotWithImage) =>
-  shot.thumbnailStatus === 'completed' && shot.videoStatus === 'completed';
-
 const SceneListComponent: React.FC<SceneListProps> = ({
   shots,
   selectedShotId,
@@ -76,7 +73,6 @@ const SceneListComponent: React.FC<SceneListProps> = ({
         shot={shot}
         aspectRatio={aspectRatio}
         isActive={shot.id === selectedShotId}
-        isCompleted={isCompleted(shot)}
         onSelect={() => onSelectShot(shot.id)}
         isRegeneratingImage={regeneratingImages.has(shot.id)}
         isRegeneratingMotion={regeneratingMotion.has(shot.id)}
@@ -111,7 +107,6 @@ const SceneListComponent: React.FC<SceneListProps> = ({
                 shot={undefined}
                 aspectRatio={aspectRatio}
                 isActive={false}
-                isCompleted={false}
               />
             ))}
 

--- a/src/components/scenes/scene-location-tab.tsx
+++ b/src/components/scenes/scene-location-tab.tsx
@@ -1,22 +1,24 @@
 /**
- * Scene Location Tab
- * Displays the location for the current shot with reference image and details
+ * Locations facet (#986)
+ * Selection-scoped location list: `environmentTags: null` shows every
+ * location (nothing selected); a tag set shows the union matched across the
+ * selected scene(s)/shot. Cards deep-link to the existing edit pages.
  */
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { useSequenceLocations } from '@/hooks/use-sequence-locations';
 import type { SequenceLocation } from '@/lib/db/schema';
-import type { Shot } from '@/types/database';
 import { Link } from '@tanstack/react-router';
-import { ExternalLink, MapPin } from 'lucide-react';
+import { MapPin } from 'lucide-react';
 
 type SceneLocationTabProps = {
-  shot?: Shot;
   sequenceId: string;
+  /** Selection-derived environment tags; `null` = no filter (whole sequence). */
+  environmentTags: string[] | null;
 };
 
 /**
- * Match a location to a shot's environmentTag
+ * Match a location to an environment tag.
  * Replicates logic from sequence-locations.ts locationMatchesTag
  */
 function locationMatchesTag(
@@ -41,55 +43,78 @@ function locationMatchesTag(
   return false;
 }
 
-/**
- * Match location to shot's environmentTag or metadata.location
- */
-function matchLocationToShot(
+function matchLocationsToTags(
   locations: SequenceLocation[],
-  shot: Shot
-): SequenceLocation | null {
-  const environmentTag = shot.metadata?.continuity?.environmentTag ?? '';
-  const sceneLocation = shot.metadata?.metadata?.location ?? '';
-
-  if (!environmentTag && !sceneLocation) return null;
-
-  const match = locations.find((location) => {
-    return (
-      (environmentTag && locationMatchesTag(location, environmentTag)) ||
-      (sceneLocation && locationMatchesTag(location, sceneLocation))
-    );
-  });
-
-  return match ?? null;
+  environmentTags: string[]
+): SequenceLocation[] {
+  return locations.filter((location) =>
+    environmentTags.some((tag) => locationMatchesTag(location, tag))
+  );
 }
 
-type DetailRowProps = {
-  label: string;
-  value: string | null | undefined;
-};
+const typeLabel = (type: SequenceLocation['type']): string | null =>
+  type === 'interior'
+    ? 'INT'
+    : type === 'exterior'
+      ? 'EXT'
+      : type
+        ? 'INT/EXT'
+        : null;
 
-const DetailRow: React.FC<DetailRowProps> = ({ label, value }) => {
-  if (!value) return null;
-
-  return (
-    <div className="space-y-1">
-      <dt className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-        {label}
-      </dt>
-      <dd className="text-sm leading-relaxed">{value}</dd>
+const LocationCard: React.FC<{
+  location: SequenceLocation;
+  sequenceId: string;
+}> = ({ location, sequenceId }) => (
+  <Link
+    to="/sequences/$id/locations/$locationId"
+    params={{ id: sequenceId, locationId: location.id }}
+    className="group block overflow-hidden rounded-lg bg-card cursor-pointer"
+  >
+    <div className="relative aspect-video overflow-hidden bg-muted">
+      {location.referenceImageUrl ? (
+        <img
+          src={location.referenceImageUrl}
+          alt={location.name}
+          className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+        />
+      ) : (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-2">
+          <MapPin className="h-8 w-8 text-muted-foreground/20" />
+          <p className="text-xs text-muted-foreground">
+            {location.referenceStatus === 'generating'
+              ? 'Generating reference…'
+              : 'No reference image'}
+          </p>
+        </div>
+      )}
+      {typeLabel(location.type) && (
+        <div className="absolute left-2 top-2 rounded-full bg-black/60 px-2 py-0.5 text-xs font-medium text-white">
+          {typeLabel(location.type)}
+        </div>
+      )}
     </div>
-  );
-};
+    <div className="p-3 border-t border-border/50">
+      <h3 className="text-sm font-medium">{location.name}</h3>
+      {location.description && (
+        <p className="mt-1 line-clamp-2 text-xs leading-relaxed text-muted-foreground">
+          {location.description}
+        </p>
+      )}
+    </div>
+  </Link>
+);
 
 export const SceneLocationTab: React.FC<SceneLocationTabProps> = ({
-  shot,
   sequenceId,
+  environmentTags,
 }) => {
   const { data: locations, isLoading } = useSequenceLocations(sequenceId);
 
-  // Match location to this shot
-  const shotLocation =
-    shot && locations ? matchLocationToShot(locations, shot) : null;
+  const scopedLocations = !locations
+    ? []
+    : environmentTags === null
+      ? locations
+      : matchLocationsToTags(locations, environmentTags);
 
   // Loading state
   if (isLoading) {
@@ -99,28 +124,25 @@ export const SceneLocationTab: React.FC<SceneLocationTabProps> = ({
         <div className="space-y-3">
           <Skeleton className="h-4 w-3/4" />
           <Skeleton className="h-4 w-1/2" />
-          <Skeleton className="h-4 w-2/3" />
         </div>
       </div>
     );
   }
 
-  // Empty state - no location matched
-  if (!shotLocation) {
-    const environmentTag = shot?.metadata?.continuity?.environmentTag;
-    const sceneLocation = shot?.metadata?.metadata?.location;
-
+  if (scopedLocations.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <div className="mb-4 rounded-full bg-muted p-4">
           <MapPin className="h-8 w-8 text-muted-foreground/50" />
         </div>
         <p className="text-sm text-muted-foreground">
-          No location for this scene
+          {environmentTags === null
+            ? 'No locations in this sequence'
+            : 'No location for this selection'}
         </p>
-        {(environmentTag || sceneLocation) && (
+        {environmentTags !== null && environmentTags.length > 0 && (
           <p className="mt-2 text-xs text-muted-foreground/70">
-            Looking for: {environmentTag || sceneLocation}
+            Looking for: {environmentTags.join(', ')}
           </p>
         )}
       </div>
@@ -129,93 +151,24 @@ export const SceneLocationTab: React.FC<SceneLocationTabProps> = ({
 
   return (
     <div className="space-y-4">
-      {/* Location header with link */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
-          <span>Scene Location</span>
-          {shotLocation.type && (
-            <>
-              <span className="text-muted-foreground/50">·</span>
-              <span>
-                {shotLocation.type === 'interior'
-                  ? 'Interior'
-                  : shotLocation.type === 'exterior'
-                    ? 'Exterior'
-                    : 'Int/Ext'}
-              </span>
-            </>
-          )}
-        </div>
-        <Link
-          to="/sequences/$id/locations/$locationId"
-          params={{ id: sequenceId, locationId: shotLocation.id }}
-          className="flex items-center gap-1 text-xs text-primary hover:underline"
-        >
-          View Details
-          <ExternalLink className="h-3 w-3" />
-        </Link>
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+        <span>Locations</span>
+        <span className="text-muted-foreground/50">·</span>
+        <span>
+          {scopedLocations.length} location
+          {scopedLocations.length > 1 ? 's' : ''}
+        </span>
       </div>
 
-      {/* Reference image */}
-      <div className="relative aspect-video overflow-hidden rounded-lg bg-muted">
-        {shotLocation.referenceImageUrl ? (
-          <img
-            src={shotLocation.referenceImageUrl}
-            alt={shotLocation.name}
-            className="h-full w-full object-cover"
+      <div className="flex flex-col gap-4">
+        {scopedLocations.map((location) => (
+          <LocationCard
+            key={location.id}
+            location={location}
+            sequenceId={sequenceId}
           />
-        ) : (
-          <div className="flex h-full w-full flex-col items-center justify-center gap-2">
-            <MapPin className="h-12 w-12 text-muted-foreground/20" />
-            <p className="text-xs text-muted-foreground">
-              {shotLocation.referenceStatus === 'generating'
-                ? 'Generating reference…'
-                : 'No reference image'}
-            </p>
-          </div>
-        )}
-
-        {/* Type badge overlay */}
-        {shotLocation.type && shotLocation.referenceImageUrl && (
-          <div className="absolute left-2 top-2 rounded-full bg-black/60 px-2 py-0.5 text-xs font-medium text-white">
-            {shotLocation.type === 'interior'
-              ? 'INT'
-              : shotLocation.type === 'exterior'
-                ? 'EXT'
-                : 'INT/EXT'}
-          </div>
-        )}
+        ))}
       </div>
-
-      {/* Location name */}
-      <h3 className="text-sm font-medium">{shotLocation.name}</h3>
-
-      {/* Location details */}
-      <dl className="space-y-3">
-        <DetailRow label="Description" value={shotLocation.description} />
-        <div className="grid grid-cols-2 gap-3">
-          <DetailRow label="Time of Day" value={shotLocation.timeOfDay} />
-          <DetailRow
-            label="Architectural Style"
-            value={shotLocation.architecturalStyle}
-          />
-        </div>
-        <DetailRow label="Key Features" value={shotLocation.keyFeatures} />
-        <div className="grid grid-cols-2 gap-3">
-          <DetailRow label="Color Palette" value={shotLocation.colorPalette} />
-          <DetailRow label="Lighting" value={shotLocation.lightingSetup} />
-        </div>
-        <DetailRow label="Ambiance" value={shotLocation.ambiance} />
-
-        {/* Consistency tag */}
-        {shotLocation.consistencyTag && (
-          <div className="pt-2">
-            <span className="rounded bg-muted px-2 py-1 font-mono text-xs text-muted-foreground">
-              {shotLocation.consistencyTag}
-            </span>
-          </div>
-        )}
-      </dl>
     </div>
   );
 };

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -66,9 +66,6 @@ import { CopyIcon, History, Loader2, Minimize2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { ShotStalenessBanners } from './shot-staleness-banners';
-import { SceneCastTab } from './scene-cast-tab';
-import { SceneElementsTab } from './scene-elements-tab';
-import { SceneLocationTab } from './scene-location-tab';
 import { SceneScriptTab } from './scene-script-tab';
 import { VariantSelector } from './variant-selector';
 
@@ -76,14 +73,13 @@ import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'ui', 'scenes', 'scene-script-prompts']);
 
+// Cast/Location/Elements left this panel for the selection-scoped inspector
+// facets (#986) — this panel is now purely the shot's prompt/variant editor.
 export type TabValue =
   | 'script'
   | 'image-prompt'
   | 'motion-prompt'
-  | 'scene-variants'
-  | 'cast'
-  | 'location'
-  | 'elements';
+  | 'scene-variants';
 
 function isInsufficientCreditsError(error: unknown): boolean {
   if (error instanceof Error) {
@@ -100,10 +96,7 @@ function isValidTabValue(value: string): value is TabValue {
     value === 'script' ||
     value === 'image-prompt' ||
     value === 'motion-prompt' ||
-    value === 'scene-variants' ||
-    value === 'cast' ||
-    value === 'location' ||
-    value === 'elements'
+    value === 'scene-variants'
   );
 }
 
@@ -998,9 +991,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           <SelectContent>
             <SelectItem value="scene-variants">Variants</SelectItem>
             <SelectItem value="script">Script</SelectItem>
-            <SelectItem value="cast">Cast</SelectItem>
-            <SelectItem value="location">Location</SelectItem>
-            <SelectItem value="elements">Elements</SelectItem>
             <SelectItem value="image-prompt">Image</SelectItem>
             <SelectItem value="motion-prompt">Motion</SelectItem>
           </SelectContent>
@@ -1011,9 +1001,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       <TabsList className="hidden md:flex">
         <TabsTrigger value="scene-variants">Variants</TabsTrigger>
         <TabsTrigger value="script">Script</TabsTrigger>
-        <TabsTrigger value="cast">Cast</TabsTrigger>
-        <TabsTrigger value="location">Location</TabsTrigger>
-        <TabsTrigger value="elements">Elements</TabsTrigger>
         <TabsTrigger value="image-prompt" className="gap-1.5">
           Image
           {staleness?.visualPrompt === 'stale' && (
@@ -1615,18 +1602,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 : 'Generate Scene Variants'}
           </Button>
         </div>
-      </TabsContent>
-
-      <TabsContent value="cast">
-        <SceneCastTab shot={shot} sequenceId={sequenceId} />
-      </TabsContent>
-
-      <TabsContent value="location">
-        <SceneLocationTab shot={shot} sequenceId={sequenceId} />
-      </TabsContent>
-
-      <TabsContent value="elements">
-        <SceneElementsTab shot={shot} sequenceId={sequenceId} />
       </TabsContent>
 
       <BillingGateDialog {...falGateProps} stripeEnabled={stripeEnabled} />

--- a/src/components/scenes/scene-spine.tsx
+++ b/src/components/scenes/scene-spine.tsx
@@ -1,0 +1,308 @@
+/**
+ * Spine (#986) — the left rail of the unified Scenes editor.
+ *
+ * Shots grouped under their scene headers; selection is the scope control:
+ * click a scene header = scene scope, click a shot = shot scope,
+ * cmd/ctrl-click = toggle a scene into the multi-selection, shift-click =
+ * contiguous scene range. The header row ("Scenes") clears back to
+ * whole-sequence scope. During playback the playing shot is highlighted and
+ * clicking any shot jumps the playhead there (wired by the parent).
+ */
+
+import {
+  BatchMotionFooter,
+  type BatchGenerateMotionArgs,
+} from '@/components/scenes/batch-motion-footer';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import {
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+  isValidImageToVideoModel,
+  isValidTextToImageModel,
+  type AudioModel,
+} from '@/lib/ai/models';
+import {
+  resolveSceneImageModel,
+  resolveSceneVideoModel,
+} from '@/lib/ai/resolve-scene-models';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type { SceneRow, ShotVariant } from '@/lib/db/schema';
+import {
+  rangeSelectScenes,
+  selectScene,
+  selectShot,
+  toggleScene,
+  type SceneSelection,
+} from '@/lib/scenes/selection';
+import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import { cn } from '@/lib/utils';
+import type { Sequence } from '@/types/database';
+import { memo, useMemo } from 'react';
+import { SceneListItem } from './scene-list-item';
+
+type SceneSpineProps = {
+  shots?: ShotWithImage[] | undefined;
+  scenes?: SceneRow[] | undefined;
+  sequence?: Sequence | undefined;
+  aspectRatio: AspectRatio;
+  selection: SceneSelection;
+  onSelectionChange: (next: SceneSelection) => void;
+  /** Shot currently under the playhead (scene/sequence playback), if any. */
+  playingShotId?: string | null;
+  regeneratingImages: Set<string>;
+  regeneratingMotion: Set<string>;
+  onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
+  musicPromptsReady: boolean;
+  hideBatchButton?: boolean;
+  divergentVariants?: ShotVariant[];
+  onCompareDivergent?: (variant: ShotVariant) => void;
+  initialMusicModel?: AudioModel;
+  modelMissingShotIds?: Set<string>;
+  modelMissingLabel?: string | null;
+};
+
+const isCompleted = (shot: ShotWithImage) =>
+  shot.thumbnailStatus === 'completed' && shot.videoStatus === 'completed';
+
+type SceneGroup = {
+  sceneId: string | null;
+  scene?: SceneRow;
+  shots: ShotWithImage[];
+};
+
+function modelName(kind: 'image' | 'video', model: string): string {
+  if (kind === 'image') {
+    return isValidTextToImageModel(model) ? IMAGE_MODELS[model].name : model;
+  }
+  return isValidImageToVideoModel(model)
+    ? IMAGE_TO_VIDEO_MODELS[model].name
+    : model;
+}
+
+const SceneSpineComponent: React.FC<SceneSpineProps> = ({
+  shots,
+  scenes,
+  sequence,
+  aspectRatio,
+  selection,
+  onSelectionChange,
+  playingShotId,
+  regeneratingImages,
+  regeneratingMotion,
+  onBatchGenerateMotion,
+  musicPromptsReady,
+  hideBatchButton = false,
+  divergentVariants,
+  onCompareDivergent,
+  initialMusicModel,
+  modelMissingShotIds,
+  modelMissingLabel,
+}) => {
+  const divergentByShotId = useMemo(() => {
+    const map = new Map<string, ShotVariant>();
+    for (const v of divergentVariants ?? []) {
+      if (v.variantType !== 'image') continue;
+      if (!map.has(v.shotId)) map.set(v.shotId, v);
+    }
+    return map;
+  }, [divergentVariants]);
+
+  const scenesById = useMemo(() => {
+    const map = new Map<string, SceneRow>();
+    for (const scene of scenes ?? []) map.set(scene.id, scene);
+    return map;
+  }, [scenes]);
+
+  // Group ordered shots under their scene, preserving playback order. Shots
+  // with no sceneId (legacy) get a headerless trailing group.
+  const groups = useMemo<SceneGroup[]>(() => {
+    if (!shots) return [];
+    const ordered = [...shots].sort((a, b) => a.orderIndex - b.orderIndex);
+    const result: SceneGroup[] = [];
+    const byScene = new Map<string, SceneGroup>();
+    for (const shot of ordered) {
+      const key = shot.sceneId ?? null;
+      if (key === null) {
+        const last = result[result.length - 1];
+        if (last && last.sceneId === null) last.shots.push(shot);
+        else result.push({ sceneId: null, shots: [shot] });
+        continue;
+      }
+      const existing = byScene.get(key);
+      if (existing) {
+        existing.shots.push(shot);
+      } else {
+        const group: SceneGroup = {
+          sceneId: key,
+          scene: scenesById.get(key),
+          shots: [shot],
+        };
+        byScene.set(key, group);
+        result.push(group);
+      }
+    }
+    return result;
+  }, [shots, scenesById]);
+
+  const selectedScenes = useMemo(
+    () => new Set(selection.sceneIds),
+    [selection.sceneIds]
+  );
+
+  const handleSceneClick = (sceneId: string, e: React.MouseEvent) => {
+    if (!shots) return;
+    if (e.metaKey || e.ctrlKey) {
+      onSelectionChange(toggleScene(selection, sceneId));
+    } else if (e.shiftKey) {
+      onSelectionChange(rangeSelectScenes(selection, sceneId, shots));
+    } else {
+      onSelectionChange(selectScene(sceneId));
+    }
+  };
+
+  const sequenceModels = {
+    imageModel: sequence?.imageModel,
+    videoModel: sequence?.videoModel,
+  };
+
+  const renderShotCard = (shot: ShotWithImage) => {
+    const divergent = divergentByShotId.get(shot.id);
+    return (
+      <SceneListItem
+        key={shot.id}
+        shot={shot}
+        aspectRatio={aspectRatio}
+        isActive={shot.id === selection.shotId}
+        isPlaying={shot.id === playingShotId}
+        isCompleted={isCompleted(shot)}
+        onSelect={() => onSelectionChange(selectShot(shot.id))}
+        isRegeneratingImage={regeneratingImages.has(shot.id)}
+        isRegeneratingMotion={regeneratingMotion.has(shot.id)}
+        divergentVariantId={divergent?.id}
+        onCompareDivergent={
+          divergent ? () => onCompareDivergent?.(divergent) : undefined
+        }
+        modelMissing={
+          !!modelMissingLabel && (modelMissingShotIds?.has(shot.id) ?? false)
+        }
+        modelMissingLabel={modelMissingLabel}
+      />
+    );
+  };
+
+  return (
+    <div className="flex h-full w-[280px] xl:w-[320px] flex-col rounded-lg border bg-background">
+      {/* Header — clicking it clears back to whole-sequence scope. */}
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'h-7 px-2 text-sm font-semibold uppercase tracking-wide',
+            selection.sceneIds.length === 0 && !selection.shotId
+              ? 'text-foreground'
+              : 'text-muted-foreground'
+          )}
+          onClick={() => onSelectionChange({ sceneIds: [] })}
+          title="Show the whole sequence (Esc)"
+        >
+          Scenes
+        </Button>
+        {shots && (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {shots.length} {shots.length === 1 ? 'shot' : 'shots'}
+          </span>
+        )}
+      </div>
+
+      <ScrollArea className="flex-1 min-h-0">
+        <div className="flex flex-col gap-2 p-3">
+          {(shots === undefined || shots.length === 0) &&
+            [1, 2, 3].map((i) => (
+              <SceneListItem
+                key={`shot-skeleton-${i}`}
+                shot={undefined}
+                aspectRatio={aspectRatio}
+                isActive={false}
+                isCompleted={false}
+              />
+            ))}
+
+          {groups.map((group, groupIndex) => {
+            const groupSceneId = group.sceneId;
+            const isSelected =
+              groupSceneId !== null && selectedScenes.has(groupSceneId);
+            const title =
+              group.scene?.title ??
+              group.shots[0]?.metadata?.metadata?.title ??
+              `Scene ${groupIndex + 1}`;
+            const lookModel = resolveSceneImageModel(
+              group.scene,
+              sequenceModels
+            );
+            const motionModel = resolveSceneVideoModel(
+              group.scene,
+              sequenceModels
+            );
+            return (
+              <div
+                key={groupSceneId ?? `ungrouped-${groupIndex}`}
+                className="flex flex-col gap-2"
+              >
+                {groupSceneId !== null && (
+                  <button
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={(e) => handleSceneClick(groupSceneId, e)}
+                    className={cn(
+                      'flex w-full flex-col gap-0.5 rounded-md border px-3 py-2 text-left transition-colors',
+                      isSelected
+                        ? 'border-primary bg-primary/10'
+                        : 'border-transparent bg-muted/40 hover:bg-muted'
+                    )}
+                    title="Click to scope to this scene · ⌘-click to multi-select · ⇧-click for a range"
+                  >
+                    <span className="flex items-baseline justify-between gap-2">
+                      <span className="truncate text-sm font-medium">
+                        {title}
+                      </span>
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                        {group.shots.length}{' '}
+                        {group.shots.length === 1 ? 'shot' : 'shots'}
+                      </span>
+                    </span>
+                    <span className="truncate text-[11px] text-muted-foreground">
+                      {modelName('image', lookModel)} ·{' '}
+                      {modelName('video', motionModel)}
+                    </span>
+                  </button>
+                )}
+                <div
+                  className={cn(
+                    'flex flex-col gap-2',
+                    groupSceneId !== null && 'pl-2 border-l-2',
+                    isSelected ? 'border-primary' : 'border-border'
+                  )}
+                >
+                  {group.shots.map(renderShotCard)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </ScrollArea>
+
+      <BatchMotionFooter
+        shots={shots}
+        regeneratingMotion={regeneratingMotion}
+        onBatchGenerateMotion={onBatchGenerateMotion}
+        musicPromptsReady={musicPromptsReady}
+        hideBatchButton={hideBatchButton}
+        initialMusicModel={initialMusicModel}
+      />
+    </div>
+  );
+};
+
+export const SceneSpine = memo(SceneSpineComponent);

--- a/src/components/scenes/scene-spine.tsx
+++ b/src/components/scenes/scene-spine.tsx
@@ -4,9 +4,10 @@
  * Shots grouped under their scene headers; selection is the scope control:
  * click a scene header = scene scope, click a shot = shot scope,
  * cmd/ctrl-click = toggle a scene into the multi-selection, shift-click =
- * contiguous scene range. The header row ("Scenes") clears back to
- * whole-sequence scope. During playback the playing shot is highlighted and
- * clicking any shot jumps the playhead there (wired by the parent).
+ * contiguous scene range. The header row ("Scenes") toggles all scenes
+ * selected ↔ none. During playback clicking any shot jumps the playhead
+ * there (wired by the parent); the playhead itself is only marked in the
+ * player's filmstrip.
  */
 
 import {
@@ -32,6 +33,7 @@ import {
   rangeSelectScenes,
   selectScene,
   selectShot,
+  toggleAllScenes,
   toggleScene,
   type SceneSelection,
 } from '@/lib/scenes/selection';
@@ -48,8 +50,6 @@ type SceneSpineProps = {
   aspectRatio: AspectRatio;
   selection: SceneSelection;
   onSelectionChange: (next: SceneSelection) => void;
-  /** Shot currently under the playhead (scene/sequence playback), if any. */
-  playingShotId?: string | null;
   regeneratingImages: Set<string>;
   regeneratingMotion: Set<string>;
   onBatchGenerateMotion?: (args: BatchGenerateMotionArgs) => Promise<void>;
@@ -61,9 +61,6 @@ type SceneSpineProps = {
   modelMissingShotIds?: Set<string>;
   modelMissingLabel?: string | null;
 };
-
-const isCompleted = (shot: ShotWithImage) =>
-  shot.thumbnailStatus === 'completed' && shot.videoStatus === 'completed';
 
 type SceneGroup = {
   sceneId: string | null;
@@ -87,7 +84,6 @@ const SceneSpineComponent: React.FC<SceneSpineProps> = ({
   aspectRatio,
   selection,
   onSelectionChange,
-  playingShotId,
   regeneratingImages,
   regeneratingMotion,
   onBatchGenerateMotion,
@@ -174,8 +170,6 @@ const SceneSpineComponent: React.FC<SceneSpineProps> = ({
         shot={shot}
         aspectRatio={aspectRatio}
         isActive={shot.id === selection.shotId}
-        isPlaying={shot.id === playingShotId}
-        isCompleted={isCompleted(shot)}
         onSelect={() => onSelectionChange(selectShot(shot.id))}
         isRegeneratingImage={regeneratingImages.has(shot.id)}
         isRegeneratingMotion={regeneratingMotion.has(shot.id)}
@@ -193,7 +187,8 @@ const SceneSpineComponent: React.FC<SceneSpineProps> = ({
 
   return (
     <div className="flex h-full w-[280px] xl:w-[320px] flex-col rounded-lg border bg-background">
-      {/* Header — clicking it clears back to whole-sequence scope. */}
+      {/* Header — clicking it toggles all scenes selected ↔ none (Esc always
+          clears back to whole-sequence scope). */}
       <div className="flex items-center justify-between border-b px-4 py-2">
         <Button
           variant="ghost"
@@ -204,8 +199,10 @@ const SceneSpineComponent: React.FC<SceneSpineProps> = ({
               ? 'text-foreground'
               : 'text-muted-foreground'
           )}
-          onClick={() => onSelectionChange({ sceneIds: [] })}
-          title="Show the whole sequence (Esc)"
+          onClick={() =>
+            onSelectionChange(toggleAllScenes(selection, shots ?? []))
+          }
+          title="Select all scenes · click again to clear (Esc)"
         >
           Scenes
         </Button>
@@ -225,7 +222,6 @@ const SceneSpineComponent: React.FC<SceneSpineProps> = ({
                 shot={undefined}
                 aspectRatio={aspectRatio}
                 isActive={false}
-                isCompleted={false}
               />
             ))}
 

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -1,15 +1,28 @@
 import { GenerationProgressBanner } from '@/components/generation/generation-progress-banner';
 import { MotionProgressBanner } from '@/components/generation/motion-progress-banner';
 import { type ModelGenerationStatus } from '@/components/model/base-model-selector';
-import { ScenePlayer } from '@/components/motion/scene-player';
 import { DivergenceCompareDialog } from '@/components/scenes/divergence-compare-dialog';
 import { MobileSceneDrawer } from '@/components/scenes/mobile-scene-drawer';
 import type { BatchGenerateMotionArgs } from '@/components/scenes/scene-list';
-import { SceneList } from '@/components/scenes/scene-list';
+import { SceneCommandPalette } from '@/components/scenes/scene-command-palette';
 import {
   SceneScriptPrompts,
   type TabValue,
 } from '@/components/scenes/scene-script-prompts';
+import { SceneSpine } from '@/components/scenes/scene-spine';
+import {
+  ScopeInspector,
+  type FacetValue,
+} from '@/components/scenes/scope-inspector';
+import { SequenceCanvas } from '@/components/scenes/sequence-canvas';
+import { type SequencePlayerControls } from '@/components/theatre/sequence-player';
+import { useScenesKeyboard } from '@/hooks/use-scenes-keyboard';
+import {
+  scopeOf,
+  selectionTags,
+  selectShot,
+  type SceneSelection,
+} from '@/lib/scenes/selection';
 import { FailureSummaryBanner } from '@/components/sequence/failure-summary-banner';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { batchGenerateMotionFn } from '@/functions/motion-functions';
@@ -20,7 +33,11 @@ import { useActiveImageModel } from '@/hooks/use-active-image-model';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { useScenesBySequence, useUpdateSceneModel } from '@/hooks/use-scenes';
-import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
+import {
+  sequenceKeys,
+  useSequence,
+  useUpdateSequenceModels,
+} from '@/hooks/use-sequences';
 import {
   shotKeys,
   useDiscardVariant,
@@ -61,8 +78,8 @@ import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
 import type { Sequence } from '@/types/database';
 import { usePostHog } from '@posthog/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getRouteApi, useNavigate } from '@tanstack/react-router';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 /**
@@ -202,13 +219,72 @@ function isInsufficientCreditsError(error: unknown): boolean {
   );
 }
 
+const routeApi = getRouteApi('/_app/sequences/$id/scenes');
+
 export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const posthog = usePostHog();
 
-  const [selectedShotId, setSelectedShotId] = useState<string | undefined>();
-  const [selectedTab, setSelectedTab] = useState<TabValue>('scene-variants');
+  // Selection is the scope control (#986), carried in the URL so back/forward
+  // and shared links restore the exact editing context.
+  const search = routeApi.useSearch();
+  const routeNavigate = routeApi.useNavigate();
+  const selection = useMemo<SceneSelection>(
+    () => ({ sceneIds: search.scenes ?? [], shotId: search.shot }),
+    [search.scenes, search.shot]
+  );
+  const selectedTab: TabValue = search.tab ?? 'scene-variants';
+  const facet: FacetValue = search.facet ?? 'cast';
+
+  const setSelection = useCallback(
+    (next: SceneSelection, opts?: { replace?: boolean }) => {
+      void routeNavigate({
+        search: (prev) => ({
+          ...prev,
+          scenes: next.sceneIds.length > 0 ? next.sceneIds : undefined,
+          shot: next.shotId,
+        }),
+        replace: opts?.replace ?? false,
+      });
+    },
+    [routeNavigate]
+  );
+  // Keyboard steps replace the history entry — arrowing through 30 shots
+  // shouldn't take 30 Back presses to escape.
+  const setSelectionReplace = useCallback(
+    (next: SceneSelection) => setSelection(next, { replace: true }),
+    [setSelection]
+  );
+  const setSelectedTab = useCallback(
+    (tab: TabValue) => {
+      void routeNavigate({
+        search: (prev) => ({ ...prev, tab }),
+        replace: true,
+      });
+    },
+    [routeNavigate]
+  );
+  const setFacet = useCallback(
+    (next: FacetValue) => {
+      void routeNavigate({
+        search: (prev) => ({ ...prev, facet: next }),
+        replace: true,
+      });
+    },
+    [routeNavigate]
+  );
+  const handleSelectShot = useCallback(
+    (shotId: string) => setSelection(selectShot(shotId)),
+    [setSelection]
+  );
+
+  // Playhead↔selection link (#986): the shot under the playhead during
+  // scene/sequence playback, highlighted in spine + filmstrip.
+  const [playingShotId, setPlayingShotId] = useState<string | null>(null);
+  const playerControlsRef = useRef<SequencePlayerControls | null>(null);
+  const canvasContainerRef = useRef<HTMLDivElement | null>(null);
+  const [paletteOpen, setPaletteOpen] = useState(false);
 
   const [regeneratingImages, setRegeneratingImages] = useState<Set<string>>(
     () => new Set()
@@ -441,10 +517,18 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     [sequenceId, promoteVariant]
   );
 
-  const curSelectedShotId = selectedShotId || shots?.[0]?.id;
+  // Shot scope only — the whole-sequence/scene scopes have no "current shot";
+  // the canvas and inspector derive their content from the selection instead.
+  const curSelectedShotId = selection.shotId;
   const selectedShot = useMemo(
     () => shots?.find((shot) => shot.id === curSelectedShotId),
     [shots, curSelectedShotId]
+  );
+
+  // Selection-derived facet tags (null = whole sequence, no filter).
+  const tags = useMemo(
+    () => selectionTags(selection, shots ?? []),
+    [selection, shots]
   );
 
   // Scenes group the shots and own model selection (#909). The selected shot's
@@ -525,6 +609,70 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
     },
     [selectedScene, sequenceId, updateSceneModel]
   );
+
+  // Palette "Set Look/Motion" — applies at the current scope: sequence scope
+  // edits the default, scene scope edits every selected scene, shot scope
+  // edits the shot's scene (#909 keeps overrides scene-level).
+  const updateSequenceModels = useUpdateSequenceModels(sequenceId);
+  const scopedSceneIds = useMemo(() => {
+    const scope = scopeOf(selection);
+    if (scope === 'scene') return selection.sceneIds;
+    if (scope === 'shot' && selectedShot?.sceneId)
+      return [selectedShot.sceneId];
+    return [];
+  }, [selection, selectedShot]);
+  const paletteSetImageModel = useCallback(
+    (model: TextToImageModel) => {
+      if (scopedSceneIds.length === 0) {
+        updateSequenceModels.mutate({ imageModel: model });
+        return;
+      }
+      for (const sceneId of scopedSceneIds) {
+        updateSceneModel.mutate({ sequenceId, sceneId, imageModel: model });
+      }
+    },
+    [scopedSceneIds, sequenceId, updateSceneModel, updateSequenceModels]
+  );
+  const paletteSetVideoModel = useCallback(
+    (model: ImageToVideoModel) => {
+      if (scopedSceneIds.length === 0) {
+        updateSequenceModels.mutate({ videoModel: model });
+        return;
+      }
+      for (const sceneId of scopedSceneIds) {
+        updateSceneModel.mutate({ sequenceId, sceneId, videoModel: model });
+      }
+    },
+    [scopedSceneIds, sequenceId, updateSceneModel, updateSequenceModels]
+  );
+
+  // Space plays/pauses whatever the canvas shows: the stitched player exposes
+  // imperative controls; the single-shot player is a native <video>, reached
+  // via the canvas container.
+  const handleTogglePlay = useCallback(() => {
+    if (playerControlsRef.current) {
+      playerControlsRef.current.togglePlay();
+      return;
+    }
+    const video = canvasContainerRef.current?.querySelector('video');
+    if (!video) return;
+    if (video.paused) void video.play();
+    else video.pause();
+  }, []);
+
+  const openPalette = useCallback(() => setPaletteOpen(true), []);
+  useScenesKeyboard({
+    shots,
+    selection,
+    onSelectionChange: setSelectionReplace,
+    onTogglePlay: handleTogglePlay,
+    onOpenPalette: openPalette,
+  });
+
+  // The playhead highlight only exists during multi-shot playback.
+  useEffect(() => {
+    if (selection.shotId) setPlayingShotId(null);
+  }, [selection.shotId]);
 
   // In-flight retry state (#882) for the selected shot. Image retry matters
   // before the thumbnail exists; video retry after — the image entry is cleared
@@ -976,13 +1124,16 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
       )}
 
       <div className="flex flex-1 min-h-0">
-        {/* Desktop: Scene List sidebar */}
+        {/* Desktop: spine (grouped, multi-selectable) */}
         <div className="hidden md:block pl-4 py-4">
-          <SceneList
+          <SceneSpine
             shots={shots}
-            selectedShotId={curSelectedShotId}
+            scenes={scenes}
+            sequence={sequence}
             aspectRatio={aspectRatio}
-            onSelectShot={setSelectedShotId}
+            selection={selection}
+            onSelectionChange={setSelection}
+            playingShotId={playingShotId}
             regeneratingImages={regeneratingImages}
             regeneratingMotion={regeneratingMotion}
             onBatchGenerateMotion={handleBatchMotionGeneration}
@@ -1004,7 +1155,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             shots={shots}
             selectedShotId={curSelectedShotId}
             aspectRatio={aspectRatio}
-            onSelectShot={setSelectedShotId}
+            onSelectShot={handleSelectShot}
             regeneratingImages={regeneratingImages}
             regeneratingMotion={regeneratingMotion}
             onBatchGenerateMotion={handleBatchMotionGeneration}
@@ -1016,65 +1167,104 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
           />
         </div>
 
-        {/* Main content area */}
-        <ScrollArea className="flex-1 px-4 md:px-8 gap-8 flex flex-col pb-20 md:pb-0 pt-4">
-          <div className="flex flex-1 min-h-0 justify-center pb-8">
-            <ScenePlayer
+        {/* Center: adaptive canvas + shot panel (shot scope only) */}
+        <ScrollArea className="flex-1 px-4 md:px-6 gap-8 flex flex-col pb-20 md:pb-0 pt-4">
+          <div
+            ref={canvasContainerRef}
+            className="flex flex-1 min-h-0 justify-center pb-8"
+          >
+            <SequenceCanvas
+              sequence={sequence}
               shots={playerShots}
-              selectedShotId={curSelectedShotId}
+              selection={selection}
+              onSelectShot={handleSelectShot}
               aspectRatio={aspectRatio}
-              onSelectShot={setSelectedShotId}
-              selectedTab={selectedTab}
-              overrideImageUrl={previewVariantUrl}
-              overrideVideoUrl={previewVariantVideoUrl}
-              badgeMessage={playerBadgeMessage}
-              modelMismatchLabel={
-                selectedTab === 'scene-variants' &&
-                activeImageModelLabel &&
-                curSelectedShotId &&
-                shotsMissingActiveImage.has(curSelectedShotId)
-                  ? `Not generated with ${activeImageModelLabel}`
-                  : null
-              }
-              progressMessage={
-                generationState.phases.find((p) => p.status === 'active')
-                  ?.phaseName
-              }
-              retry={selectedShotRetry}
               posterUrl={sequence?.posterUrl ?? undefined}
-              className={PLAYER_MAX_H}
-              wrapperClassName={PLAYER_MAX_W_BY_RATIO[aspectRatio]}
+              playingShotId={playingShotId}
+              onPlayingShotChange={setPlayingShotId}
+              controlsRef={playerControlsRef}
+              shotPlayerProps={{
+                selectedTab,
+                overrideImageUrl: previewVariantUrl,
+                overrideVideoUrl: previewVariantVideoUrl,
+                badgeMessage: playerBadgeMessage,
+                modelMismatchLabel:
+                  selectedTab === 'scene-variants' &&
+                  activeImageModelLabel &&
+                  curSelectedShotId &&
+                  shotsMissingActiveImage.has(curSelectedShotId)
+                    ? `Not generated with ${activeImageModelLabel}`
+                    : null,
+                progressMessage: generationState.phases.find(
+                  (p) => p.status === 'active'
+                )?.phaseName,
+                retry: selectedShotRetry,
+                className: PLAYER_MAX_H,
+                wrapperClassName: PLAYER_MAX_W_BY_RATIO[aspectRatio],
+              }}
             />
           </div>
-          <SceneScriptPrompts
-            shot={selectedShot}
+          {selectedShot && (
+            <SceneScriptPrompts
+              shot={selectedShot}
+              sequenceId={sequenceId}
+              selectedTab={selectedTab}
+              onTabChange={setSelectedTab}
+              regeneratingImages={regeneratingImages}
+              regeneratingMotion={regeneratingMotion}
+              regeneratingSceneVariants={regeneratingSceneVariants}
+              onRegenerateStart={handleRegenerateStart}
+              aspectRatio={aspectRatio}
+              variantForSelectedModel={variantForSelectedModel}
+              videoVariantForSelectedModel={videoVariantForSelectedModel}
+              sceneImageModel={sceneImageModel}
+              sceneVideoModel={sceneVideoModel}
+              imageModelStatuses={sceneImageModelStatuses}
+              videoModelStatuses={sceneVideoModelStatuses}
+              onImageModelChange={handleSceneImageModelChange}
+              onVideoModelChange={handleSceneVideoModelChange}
+              styleCategory={styleCategory}
+              styleName={styleName}
+              recommendedImageModel={recommendedImageModel}
+              recommendedVideoModel={recommendedVideoModel}
+              shotDivergentVariants={divergentVariants?.filter(
+                (v) => v.shotId === curSelectedShotId
+              )}
+              onCompareDivergent={(variant) => setCompareVariant(variant)}
+            />
+          )}
+        </ScrollArea>
+
+        {/* Desktop: faceted inspector */}
+        <div className="hidden lg:block w-[340px] xl:w-[400px] shrink-0 pr-4 py-4">
+          <ScopeInspector
             sequenceId={sequenceId}
-            selectedTab={selectedTab}
-            onTabChange={setSelectedTab}
-            regeneratingImages={regeneratingImages}
-            regeneratingMotion={regeneratingMotion}
-            regeneratingSceneVariants={regeneratingSceneVariants}
-            onRegenerateStart={handleRegenerateStart}
+            sequence={sequence}
+            shots={shots}
+            selection={selection}
+            onSelectionChange={setSelection}
+            tags={tags}
+            facet={facet}
+            onFacetChange={setFacet}
             aspectRatio={aspectRatio}
-            variantForSelectedModel={variantForSelectedModel}
-            videoVariantForSelectedModel={videoVariantForSelectedModel}
-            sceneImageModel={sceneImageModel}
-            sceneVideoModel={sceneVideoModel}
-            imageModelStatuses={sceneImageModelStatuses}
-            videoModelStatuses={sceneVideoModelStatuses}
-            onImageModelChange={handleSceneImageModelChange}
-            onVideoModelChange={handleSceneVideoModelChange}
             styleCategory={styleCategory}
             styleName={styleName}
             recommendedImageModel={recommendedImageModel}
             recommendedVideoModel={recommendedVideoModel}
-            shotDivergentVariants={divergentVariants?.filter(
-              (v) => v.shotId === curSelectedShotId
-            )}
-            onCompareDivergent={(variant) => setCompareVariant(variant)}
           />
-        </ScrollArea>
+        </div>
       </div>
+
+      <SceneCommandPalette
+        open={paletteOpen}
+        onOpenChange={setPaletteOpen}
+        shots={shots}
+        scenes={scenes}
+        onSelectionChange={setSelection}
+        onFacetChange={setFacet}
+        onSetImageModel={paletteSetImageModel}
+        onSetVideoModel={paletteSetVideoModel}
+      />
 
       {compareVariant &&
         (() => {

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -280,7 +280,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
   );
 
   // Playhead↔selection link (#986): the shot under the playhead during
-  // scene/sequence playback, highlighted in spine + filmstrip.
+  // scene/sequence playback, highlighted in the player's filmstrip.
   const [playingShotId, setPlayingShotId] = useState<string | null>(null);
   const playerControlsRef = useRef<SequencePlayerControls | null>(null);
   const canvasContainerRef = useRef<HTMLDivElement | null>(null);
@@ -1133,7 +1133,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({ sequenceId }) => {
             aspectRatio={aspectRatio}
             selection={selection}
             onSelectionChange={setSelection}
-            playingShotId={playingShotId}
             regeneratingImages={regeneratingImages}
             regeneratingMotion={regeneratingMotion}
             onBatchGenerateMotion={handleBatchMotionGeneration}

--- a/src/components/scenes/scope-inspector.tsx
+++ b/src/components/scenes/scope-inspector.tsx
@@ -1,0 +1,652 @@
+/**
+ * Faceted inspector (#986) — the right pane of the unified Scenes editor.
+ *
+ * One inspector, scoped by selection:
+ * - Scope breadcrumb (Sequence › Scene › Shot) — each crumb re-scopes.
+ * - Look/Motion models: sequence scope edits the sequence default, scene
+ *   scope edits the scene override (multi-scene shows Mixed + set-all,
+ *   #909 locked overrides to scene scope), shot scope is read-only.
+ * - Facets (Cast / Locations / Elements / Music / Script) re-use the scene
+ *   tabs fed by `selectionTags()` — the same lens at every scope.
+ */
+
+import { ImageModelSelector } from '@/components/model/image-model-selector';
+import { MotionModelSelector } from '@/components/model/motion-model-selector';
+import { SceneCastTab } from '@/components/scenes/scene-cast-tab';
+import { SceneElementsTab } from '@/components/scenes/scene-elements-tab';
+import { SceneLocationTab } from '@/components/scenes/scene-location-tab';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Kbd } from '@/components/ui/kbd';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useScenesBySequence, useUpdateSceneModel } from '@/hooks/use-scenes';
+import {
+  useSetSequenceMusic,
+  useUpdateSequenceModels,
+} from '@/hooks/use-sequences';
+import {
+  DEFAULT_IMAGE_MODEL,
+  DEFAULT_VIDEO_MODEL,
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+  isValidImageToVideoModel,
+  isValidTextToImageModel,
+  safeImageToVideoModel,
+  safeTextToImageModel,
+  type ImageToVideoModel,
+  type TextToImageModel,
+} from '@/lib/ai/models';
+import {
+  resolveSceneImageModel,
+  resolveSceneVideoModel,
+} from '@/lib/ai/resolve-scene-models';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type { SceneRow } from '@/lib/db/schema';
+import {
+  scopeOf,
+  selectScene,
+  shotsInSelection,
+  type SceneSelection,
+  type SelectionTags,
+} from '@/lib/scenes/selection';
+import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import { cn } from '@/lib/utils';
+import { stripMarkdown } from '@/lib/utils/markdown-plain';
+import type { Sequence } from '@/types/database';
+import { Link } from '@tanstack/react-router';
+import { ExternalLink, Music } from 'lucide-react';
+import { useMemo } from 'react';
+
+export type FacetValue = 'cast' | 'locations' | 'elements' | 'music' | 'script';
+
+type ScopeInspectorProps = {
+  sequenceId: string;
+  sequence?: Sequence;
+  shots?: ShotWithImage[];
+  selection: SceneSelection;
+  onSelectionChange: (next: SceneSelection) => void;
+  tags: SelectionTags | null;
+  facet: FacetValue;
+  onFacetChange: (facet: FacetValue) => void;
+  aspectRatio: AspectRatio;
+  styleCategory?: string;
+  styleName?: string;
+  recommendedImageModel?: string | null;
+  recommendedVideoModel?: string | null;
+};
+
+function isFacetValue(value: string): value is FacetValue {
+  return (
+    value === 'cast' ||
+    value === 'locations' ||
+    value === 'elements' ||
+    value === 'music' ||
+    value === 'script'
+  );
+}
+
+export const ScopeInspector: React.FC<ScopeInspectorProps> = ({
+  sequenceId,
+  sequence,
+  shots,
+  selection,
+  onSelectionChange,
+  tags,
+  facet,
+  onFacetChange,
+  aspectRatio,
+  styleCategory,
+  styleName,
+  recommendedImageModel,
+  recommendedVideoModel,
+}) => {
+  const scope = scopeOf(selection);
+  const { data: scenes } = useScenesBySequence(sequenceId);
+
+  const covered = useMemo(
+    () => (shots ? shotsInSelection(selection, shots) : []),
+    [selection, shots]
+  );
+
+  const selectedShot = selection.shotId
+    ? shots?.find((s) => s.id === selection.shotId)
+    : undefined;
+
+  const scenesById = useMemo(() => {
+    const map = new Map<string, SceneRow>();
+    for (const scene of scenes ?? []) map.set(scene.id, scene);
+    return map;
+  }, [scenes]);
+
+  const selectedScenes = useMemo(() => {
+    if (scope === 'shot') {
+      const scene = selectedShot?.sceneId
+        ? scenesById.get(selectedShot.sceneId)
+        : undefined;
+      return scene ? [scene] : [];
+    }
+    if (scope === 'scene') {
+      return selection.sceneIds
+        .map((id) => scenesById.get(id))
+        .filter((scene): scene is SceneRow => scene !== undefined);
+    }
+    return [];
+  }, [scope, selection.sceneIds, selectedShot, scenesById]);
+
+  const shotScene = scope === 'shot' ? selectedScenes[0] : undefined;
+
+  const scriptText = tags ? tags.scriptExtracts.join('\n\n') : '';
+
+  return (
+    <div className="flex h-full flex-col gap-4 rounded-lg border bg-background p-4">
+      <ScopeBreadcrumb
+        scope={scope}
+        selection={selection}
+        onSelectionChange={onSelectionChange}
+        selectedScenes={selectedScenes}
+        selectedShot={selectedShot}
+        shotScene={shotScene}
+      />
+
+      <ModelSection
+        scope={scope}
+        sequenceId={sequenceId}
+        sequence={sequence}
+        selectedScenes={selectedScenes}
+        shotScene={shotScene}
+        aspectRatio={aspectRatio}
+        styleCategory={styleCategory}
+        styleName={styleName}
+        recommendedImageModel={recommendedImageModel}
+        recommendedVideoModel={recommendedVideoModel}
+      />
+
+      <Tabs
+        value={facet}
+        onValueChange={(value) => {
+          if (isFacetValue(value)) onFacetChange(value);
+        }}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        <TabsList className="w-full">
+          <TabsTrigger value="cast">Cast</TabsTrigger>
+          <TabsTrigger value="locations">Locations</TabsTrigger>
+          <TabsTrigger value="elements">Elements</TabsTrigger>
+          <TabsTrigger value="music" aria-label="Music">
+            <Music className="h-3.5 w-3.5" />
+          </TabsTrigger>
+          <TabsTrigger value="script">Script</TabsTrigger>
+        </TabsList>
+
+        <div className="min-h-0 flex-1 overflow-y-auto pt-3">
+          <TabsContent value="cast" className="mt-0">
+            <FacetHeaderLink to="/sequences/$id/cast" sequenceId={sequenceId}>
+              Manage cast
+            </FacetHeaderLink>
+            <SceneCastTab
+              sequenceId={sequenceId}
+              characterTags={tags ? tags.characterTags : null}
+            />
+          </TabsContent>
+
+          <TabsContent value="locations" className="mt-0">
+            <FacetHeaderLink
+              to="/sequences/$id/locations"
+              sequenceId={sequenceId}
+            >
+              Manage locations
+            </FacetHeaderLink>
+            <SceneLocationTab
+              sequenceId={sequenceId}
+              environmentTags={tags ? tags.environmentTags : null}
+            />
+          </TabsContent>
+
+          <TabsContent value="elements" className="mt-0">
+            <FacetHeaderLink
+              to="/sequences/$id/elements"
+              sequenceId={sequenceId}
+            >
+              Manage elements
+            </FacetHeaderLink>
+            <SceneElementsTab
+              sequenceId={sequenceId}
+              elementTags={tags ? tags.elementTags : null}
+              scriptText={scriptText}
+            />
+          </TabsContent>
+
+          <TabsContent value="music" className="mt-0">
+            <MusicFacet
+              sequence={sequence}
+              scope={scope}
+              covered={covered}
+              sequenceId={sequenceId}
+            />
+          </TabsContent>
+
+          <TabsContent value="script" className="mt-0">
+            <ScriptFacet covered={covered} sequenceId={sequenceId} />
+          </TabsContent>
+        </div>
+      </Tabs>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Scope breadcrumb
+// ---------------------------------------------------------------------------
+
+type ScopeBreadcrumbProps = {
+  scope: 'sequence' | 'scene' | 'shot';
+  selection: SceneSelection;
+  onSelectionChange: (next: SceneSelection) => void;
+  selectedScenes: SceneRow[];
+  selectedShot?: ShotWithImage;
+  shotScene?: SceneRow;
+};
+
+const ScopeBreadcrumb: React.FC<ScopeBreadcrumbProps> = ({
+  scope,
+  onSelectionChange,
+  selectedScenes,
+  selectedShot,
+  shotScene,
+}) => {
+  const sceneLabel =
+    scope === 'scene'
+      ? selectedScenes.length > 1
+        ? `${selectedScenes.length} scenes`
+        : (selectedScenes[0]?.title ?? 'Scene')
+      : (shotScene?.title ?? 'Scene');
+  const shotLabel =
+    selectedShot?.metadata?.metadata?.title ??
+    (selectedShot ? `Shot ${selectedShot.orderIndex + 1}` : '');
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <nav
+        aria-label="Selection scope"
+        className="flex min-w-0 items-center gap-1 text-sm"
+      >
+        <button
+          type="button"
+          onClick={() => onSelectionChange({ sceneIds: [] })}
+          className={cn(
+            'shrink-0 rounded px-1 py-0.5 hover:bg-muted',
+            scope === 'sequence'
+              ? 'font-medium text-foreground'
+              : 'text-muted-foreground'
+          )}
+        >
+          Sequence
+        </button>
+        {scope !== 'sequence' && (
+          <>
+            <span className="text-muted-foreground/50">›</span>
+            {scope === 'shot' && shotScene ? (
+              <button
+                type="button"
+                onClick={() => onSelectionChange(selectScene(shotScene.id))}
+                className="min-w-0 truncate rounded px-1 py-0.5 text-muted-foreground hover:bg-muted"
+              >
+                {sceneLabel}
+              </button>
+            ) : (
+              <span className="min-w-0 truncate px-1 py-0.5 font-medium">
+                {sceneLabel}
+              </span>
+            )}
+          </>
+        )}
+        {scope === 'shot' && (
+          <>
+            <span className="text-muted-foreground/50">›</span>
+            <span className="min-w-0 truncate px-1 py-0.5 font-medium">
+              {shotLabel}
+            </span>
+          </>
+        )}
+      </nav>
+      {scope !== 'sequence' && (
+        <span className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+          <Kbd>esc</Kbd> up
+        </span>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Scope-aware model section
+// ---------------------------------------------------------------------------
+
+type ModelSectionProps = {
+  scope: 'sequence' | 'scene' | 'shot';
+  sequenceId: string;
+  sequence?: Sequence;
+  selectedScenes: SceneRow[];
+  shotScene?: SceneRow;
+  aspectRatio: AspectRatio;
+  styleCategory?: string;
+  styleName?: string;
+  recommendedImageModel?: string | null;
+  recommendedVideoModel?: string | null;
+};
+
+const ModelSection: React.FC<ModelSectionProps> = ({
+  scope,
+  sequenceId,
+  sequence,
+  selectedScenes,
+  shotScene,
+  aspectRatio,
+  styleCategory,
+  styleName,
+  recommendedImageModel,
+  recommendedVideoModel,
+}) => {
+  const updateSceneModel = useUpdateSceneModel();
+  const updateSequenceModels = useUpdateSequenceModels(sequenceId);
+
+  const sequenceModels = {
+    imageModel: sequence?.imageModel,
+    videoModel: sequence?.videoModel,
+  };
+  const sequenceImageModel = safeTextToImageModel(
+    sequence?.imageModel,
+    DEFAULT_IMAGE_MODEL
+  );
+  const sequenceVideoModel = safeImageToVideoModel(
+    sequence?.videoModel,
+    DEFAULT_VIDEO_MODEL
+  );
+
+  const resolvedImage = selectedScenes.map((scene) =>
+    resolveSceneImageModel(scene, sequenceModels)
+  );
+  const resolvedVideo = selectedScenes.map((scene) =>
+    resolveSceneVideoModel(scene, sequenceModels)
+  );
+  const imageMixed = new Set(resolvedImage).size > 1;
+  const videoMixed = new Set(resolvedVideo).size > 1;
+  const hasOverrides = selectedScenes.some(
+    (scene) => scene.imageModel !== null || scene.videoModel !== null
+  );
+
+  const setSceneModels = (
+    input:
+      | { imageModel?: TextToImageModel | null }
+      | {
+          videoModel?: ImageToVideoModel | null;
+        }
+  ) => {
+    for (const scene of selectedScenes) {
+      updateSceneModel.mutate({ sequenceId, sceneId: scene.id, ...input });
+    }
+  };
+
+  if (scope === 'shot') {
+    const look = resolveSceneImageModel(shotScene, sequenceModels);
+    const motion = resolveSceneVideoModel(shotScene, sequenceModels);
+    return (
+      <div className="flex flex-col gap-1 rounded-md border bg-muted/30 px-3 py-2">
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Look</span>
+          <span className="font-medium">
+            {isValidTextToImageModel(look) ? IMAGE_MODELS[look].name : look}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Motion</span>
+          <span className="font-medium">
+            {isValidImageToVideoModel(motion)
+              ? IMAGE_TO_VIDEO_MODELS[motion].name
+              : motion}
+          </span>
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Models are set on the scene — select it to change them.
+        </p>
+      </div>
+    );
+  }
+
+  const isSceneScope = scope === 'scene' && selectedScenes.length > 0;
+  const imageValue = isSceneScope
+    ? (resolvedImage[0] ?? sequenceImageModel)
+    : sequenceImageModel;
+  const videoValue = isSceneScope
+    ? (resolvedVideo[0] ?? sequenceVideoModel)
+    : sequenceVideoModel;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+          {isSceneScope
+            ? selectedScenes.length > 1
+              ? `Models · ${selectedScenes.length} scenes`
+              : 'Scene models'
+            : 'Sequence defaults'}
+        </span>
+        {isSceneScope && hasOverrides && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-muted-foreground"
+            onClick={() => {
+              setSceneModels({ imageModel: null });
+              setSceneModels({ videoModel: null });
+            }}
+          >
+            Reset to default
+          </Button>
+        )}
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2 text-xs text-muted-foreground">
+          Look
+          {isSceneScope && imageMixed && (
+            <Badge variant="outline" className="h-4 px-1 text-[10px]">
+              Mixed
+            </Badge>
+          )}
+        </span>
+        <ImageModelSelector
+          selectedModel={imageValue}
+          onModelChange={(model) => {
+            if (isSceneScope) setSceneModels({ imageModel: model });
+            else updateSequenceModels.mutate({ imageModel: model });
+          }}
+          recommendedImageModel={recommendedImageModel}
+          styleName={styleName}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2 text-xs text-muted-foreground">
+          Motion
+          {isSceneScope && videoMixed && (
+            <Badge variant="outline" className="h-4 px-1 text-[10px]">
+              Mixed
+            </Badge>
+          )}
+        </span>
+        <MotionModelSelector
+          selectedModel={videoValue}
+          onModelChange={(model) => {
+            if (isSceneScope) setSceneModels({ videoModel: model });
+            else updateSequenceModels.mutate({ videoModel: model });
+          }}
+          aspectRatio={aspectRatio}
+          styleCategory={styleCategory}
+          styleName={styleName}
+          recommendedVideoModel={recommendedVideoModel}
+        />
+      </div>
+      {!isSceneScope && (
+        <p className="text-[11px] text-muted-foreground">
+          Scenes without their own choice inherit these.
+        </p>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Music facet
+// ---------------------------------------------------------------------------
+
+type MusicFacetProps = {
+  sequence?: Sequence;
+  scope: 'sequence' | 'scene' | 'shot';
+  covered: ShotWithImage[];
+  sequenceId: string;
+};
+
+const MusicFacet: React.FC<MusicFacetProps> = ({
+  sequence,
+  scope,
+  covered,
+  sequenceId,
+}) => {
+  const setMusicEnabled = useSetSequenceMusic(sequenceId);
+
+  if (scope !== 'sequence') {
+    // Scene/shot scope: music is a sequence-level asset; show the covered
+    // shots' music design read-only.
+    const designs = covered
+      .map((shot) => shot.metadata?.musicDesign)
+      .filter((design) => design !== undefined);
+    return (
+      <div className="flex flex-col gap-3">
+        {designs.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No music design for this selection.
+          </p>
+        ) : (
+          designs.map((design, i) => (
+            <div
+              key={i}
+              className="rounded-md border bg-muted/30 px-3 py-2 text-xs"
+            >
+              <span className="font-medium">{design.style}</span>
+              <span className="text-muted-foreground">
+                {' '}
+                · {design.mood} · {design.presence}
+              </span>
+            </div>
+          ))
+        )}
+        <p className="text-[11px] text-muted-foreground">
+          The music track belongs to the whole sequence — press <Kbd>esc</Kbd>{' '}
+          to edit it.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <FacetHeaderLink to="/sequences/$id/music" sequenceId={sequenceId}>
+        Open music editor
+      </FacetHeaderLink>
+      {sequence?.musicUrl ? (
+        // eslint-disable-next-line jsx-a11y/media-has-caption -- music track, no dialogue
+        <audio controls src={sequence.musicUrl} className="w-full" />
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          {sequence?.musicStatus === 'generating'
+            ? 'Composing music…'
+            : 'No music yet.'}
+        </p>
+      )}
+      {sequence?.musicPrompt && (
+        <p className="line-clamp-4 text-xs leading-relaxed text-muted-foreground">
+          {sequence.musicPrompt}
+        </p>
+      )}
+      {sequence && (
+        <label
+          htmlFor="inspector-include-music"
+          className="flex items-center gap-2 text-sm text-muted-foreground"
+        >
+          <Checkbox
+            id="inspector-include-music"
+            checked={sequence.includeMusic}
+            onCheckedChange={(checked) =>
+              setMusicEnabled.mutate(checked === true)
+            }
+          />
+          <span>Play music with the sequence</span>
+        </label>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Script facet
+// ---------------------------------------------------------------------------
+
+type ScriptFacetProps = {
+  covered: ShotWithImage[];
+  sequenceId: string;
+};
+
+const ScriptFacet: React.FC<ScriptFacetProps> = ({ covered, sequenceId }) => {
+  return (
+    <div className="flex flex-col gap-3">
+      <FacetHeaderLink to="/sequences/$id/script" sequenceId={sequenceId}>
+        Edit script
+      </FacetHeaderLink>
+      {covered.length === 0 && (
+        <p className="text-sm text-muted-foreground">No script yet.</p>
+      )}
+      {covered.map((shot) => {
+        const title =
+          shot.metadata?.metadata?.title ?? `Scene ${shot.orderIndex + 1}`;
+        const extract = shot.metadata?.originalScript.extract;
+        if (!extract) return null;
+        return (
+          <div key={shot.id} className="flex flex-col gap-1">
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {title}
+            </span>
+            <p className="whitespace-pre-wrap text-sm leading-relaxed">
+              {stripMarkdown(extract)}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Shared facet header link
+// ---------------------------------------------------------------------------
+
+const FacetHeaderLink: React.FC<{
+  to:
+    | '/sequences/$id/cast'
+    | '/sequences/$id/locations'
+    | '/sequences/$id/elements'
+    | '/sequences/$id/music'
+    | '/sequences/$id/script';
+  sequenceId: string;
+  children: React.ReactNode;
+}> = ({ to, sequenceId, children }) => (
+  <div className="mb-3 flex justify-end">
+    <Link
+      to={to}
+      params={{ id: sequenceId }}
+      className="flex items-center gap-1 text-xs text-primary hover:underline"
+    >
+      {children}
+      <ExternalLink className="h-3 w-3" />
+    </Link>
+  </div>
+);

--- a/src/components/scenes/sequence-canvas.tsx
+++ b/src/components/scenes/sequence-canvas.tsx
@@ -1,0 +1,400 @@
+/**
+ * Adaptive canvas (#986) — the center pane of the unified Scenes editor.
+ *
+ * Renders what the current selection scopes to:
+ * - shot selected      → the single-shot `ScenePlayer` (unchanged behaviour)
+ * - scene(s) selected  → those scenes' shots stitched and played in order
+ * - nothing selected   → whole-sequence playback with music + export
+ *   (absorbs the Theatre tab)
+ *
+ * Multi-shot playback reuses `SequencePlayer`; a filmstrip below the player
+ * doubles as the timeline: each covered shot is a segment, the playing one is
+ * highlighted, clicking a ready segment seeks to it and clicking an un-ready
+ * one selects the shot so it can be fixed.
+ */
+
+import { ScenePlayer } from '@/components/motion/scene-player';
+import { type TabValue } from '@/components/scenes/scene-script-prompts';
+import { SceneThumbnail } from '@/components/scenes/scene-thumbnail';
+import {
+  SequencePlayer,
+  type SequencePlayerControls,
+} from '@/components/theatre/sequence-player';
+import { useSequenceExport } from '@/components/theatre/use-sequence-export';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useSetSequenceMusic } from '@/hooks/use-sequences';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import {
+  scopeOf,
+  shotsInSelection,
+  type SceneSelection,
+} from '@/lib/scenes/selection';
+import type { SceneInput } from '@/lib/sequence-player/concatenated-video-source';
+import type { ExportProgress } from '@/lib/sequence-player/export';
+import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import { cn } from '@/lib/utils';
+import type { Sequence } from '@/types/database';
+import { Download, Link, Loader2, Share2 } from 'lucide-react';
+import { usePostHog } from '@posthog/react';
+import { useCallback, useMemo } from 'react';
+import { toast } from 'sonner';
+
+/** Shot-scope passthroughs — the existing `ScenePlayer` surface, unchanged. */
+type ShotPlayerProps = {
+  selectedTab: TabValue;
+  overrideImageUrl: string | null;
+  overrideVideoUrl: string | null;
+  badgeMessage: string | null;
+  modelMismatchLabel: string | null;
+  progressMessage?: string;
+  retry?: { attempt: number; maxAttempts?: number };
+  className?: string;
+  wrapperClassName?: string;
+};
+
+type SequenceCanvasProps = {
+  sequence?: Sequence;
+  /** Player-remapped shots (viewer-local model pins applied). */
+  shots?: ShotWithImage[];
+  selection: SceneSelection;
+  onSelectShot: (shotId: string) => void;
+  aspectRatio: AspectRatio;
+  posterUrl?: string;
+  shotPlayerProps: ShotPlayerProps;
+  /** Shot under the playhead (owned by the parent, echoed to the spine). */
+  playingShotId: string | null;
+  /** Reports the shot under the playhead during multi-shot playback. */
+  onPlayingShotChange: (shotId: string | null) => void;
+  /** Imperative playback controls, shared with spine clicks + Space key. */
+  controlsRef: React.RefObject<SequencePlayerControls | null>;
+};
+
+export const SequenceCanvas: React.FC<SequenceCanvasProps> = ({
+  sequence,
+  shots,
+  selection,
+  onSelectShot,
+  aspectRatio,
+  posterUrl,
+  shotPlayerProps,
+  playingShotId,
+  onPlayingShotChange,
+  controlsRef,
+}) => {
+  const scope = scopeOf(selection);
+
+  const covered = useMemo(
+    () => (shots ? shotsInSelection(selection, shots) : []),
+    [selection, shots]
+  );
+  const ready = useMemo(
+    () =>
+      covered.filter(
+        (s): s is (typeof covered)[number] & { videoUrl: string } =>
+          s.videoStatus === 'completed' && Boolean(s.videoUrl)
+      ),
+    [covered]
+  );
+
+  if (scope === 'shot' || ready.length === 0) {
+    // Shot scope, or nothing playable yet in this scope (e.g. mid-generation):
+    // the single-shot player handles stills, progress overlays and retries.
+    const fallbackShotId = selection.shotId ?? covered[0]?.id;
+    return (
+      <ScenePlayer
+        shots={shots}
+        selectedShotId={fallbackShotId}
+        aspectRatio={aspectRatio}
+        onSelectShot={onSelectShot}
+        posterUrl={posterUrl}
+        {...shotPlayerProps}
+      />
+    );
+  }
+
+  if (!sequence) return null;
+  return (
+    <MultiShotCanvas
+      sequence={sequence}
+      covered={covered}
+      ready={ready}
+      scope={scope}
+      onSelectShot={onSelectShot}
+      aspectRatio={aspectRatio}
+      playingShotId={playingShotId}
+      onPlayingShotChange={onPlayingShotChange}
+      controlsRef={controlsRef}
+      wrapperClassName={shotPlayerProps.wrapperClassName}
+    />
+  );
+};
+
+type MultiShotCanvasProps = {
+  sequence: Sequence;
+  covered: ShotWithImage[];
+  ready: Array<ShotWithImage & { videoUrl: string }>;
+  scope: 'sequence' | 'scene';
+  onSelectShot: (shotId: string) => void;
+  aspectRatio: AspectRatio;
+  playingShotId: string | null;
+  onPlayingShotChange: (shotId: string | null) => void;
+  controlsRef: React.RefObject<SequencePlayerControls | null>;
+  wrapperClassName?: string;
+};
+
+const MultiShotCanvas: React.FC<MultiShotCanvasProps> = ({
+  sequence,
+  covered,
+  ready,
+  scope,
+  onSelectShot,
+  aspectRatio,
+  playingShotId,
+  onPlayingShotChange,
+  controlsRef,
+  wrapperClassName,
+}) => {
+  const setMusicEnabled = useSetSequenceMusic(sequence.id);
+
+  // Keyed by the urls so the engine only re-prepares when the actual playback
+  // set changes, not on unrelated shots-list refetches.
+  const playbackKey = ready.map((s) => s.videoUrl).join('|');
+  const scenes = useMemo<SceneInput[]>(
+    () =>
+      ready.map((s) => ({ orderIndex: s.orderIndex, videoUrl: s.videoUrl })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- identity keyed on the playback set
+    [playbackKey]
+  );
+
+  // Map the player's scene index (over `ready`) back to the shot id.
+  const handleActiveSceneChange = useCallback(
+    (index: number) => {
+      onPlayingShotChange(index >= 0 ? (ready[index]?.id ?? null) : null);
+    },
+    [ready, onPlayingShotChange]
+  );
+
+  const readyIndexByShotId = useMemo(() => {
+    const map = new Map<string, number>();
+    ready.forEach((s, i) => map.set(s.id, i));
+    return map;
+  }, [ready]);
+
+  // Sequence music only makes sense across the full sequence — a scene
+  // subset would start the track from 0:00 against the wrong shots.
+  const musicUrl = scope === 'sequence' ? (sequence.musicUrl ?? null) : null;
+
+  const allReady = ready.length === covered.length;
+
+  return (
+    <div className={cn('flex w-full flex-col gap-2', wrapperClassName)}>
+      <SequencePlayer
+        scenes={scenes}
+        musicUrl={musicUrl}
+        musicLoudnessGainDb={null}
+        musicEnabled={sequence.includeMusic}
+        onMusicEnabledChange={(enabled) => setMusicEnabled.mutate(enabled)}
+        aspectRatio={aspectRatio}
+        overlayActions={
+          scope === 'sequence' && allReady ? (
+            <ExportMenu sequence={sequence} />
+          ) : undefined
+        }
+        onActiveSceneChange={handleActiveSceneChange}
+        controlsRef={controlsRef}
+      />
+
+      {!allReady && (
+        <p className="text-xs text-muted-foreground">
+          Playing {ready.length} of {covered.length} shots — the rest have no
+          video yet.
+        </p>
+      )}
+
+      {/* Filmstrip timeline: one segment per covered shot. */}
+      <div className="flex gap-1 overflow-x-auto pb-1">
+        {covered.map((shot) => {
+          const readyIndex = readyIndexByShotId.get(shot.id);
+          const isReady = readyIndex !== undefined;
+          return (
+            <FilmstripSegment
+              key={shot.id}
+              shot={shot}
+              aspectRatio={aspectRatio}
+              isReady={isReady}
+              isPlaying={shot.id === playingShotId}
+              onClick={() => {
+                if (readyIndex !== undefined) {
+                  controlsRef.current?.seekToScene(readyIndex);
+                } else {
+                  // Not playable yet — jump to the shot to fix it.
+                  onSelectShot(shot.id);
+                }
+              }}
+              onDoubleClick={() => onSelectShot(shot.id)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+type FilmstripSegmentProps = {
+  shot: ShotWithImage;
+  aspectRatio: AspectRatio;
+  isReady: boolean;
+  isPlaying: boolean;
+  onClick: () => void;
+  onDoubleClick: () => void;
+};
+
+const FilmstripSegment: React.FC<FilmstripSegmentProps> = ({
+  shot,
+  aspectRatio,
+  isReady,
+  isPlaying,
+  onClick,
+  onDoubleClick,
+}) => {
+  const title =
+    shot.metadata?.metadata?.title ?? `Scene ${shot.orderIndex + 1}`;
+  return (
+    <button
+      type="button"
+      data-shot-id={shot.id}
+      data-playing={isPlaying}
+      onClick={onClick}
+      onDoubleClick={onDoubleClick}
+      className={cn(
+        'group relative w-16 shrink-0 overflow-hidden rounded-sm border transition-all',
+        'data-[playing=true]:border-primary data-[playing=true]:ring-1 data-[playing=true]:ring-primary',
+        'border-transparent hover:border-muted-foreground/40',
+        !isReady && 'opacity-40'
+      )}
+      title={
+        isReady
+          ? `${title} — click to play from here, double-click to edit`
+          : `${title} — no video yet, click to open`
+      }
+      aria-label={title}
+    >
+      <SceneThumbnail
+        thumbnailUrl={shot.thumbnailUrl}
+        previewThumbnailUrl={shot.previewThumbnailUrl}
+        thumbnailStatus={shot.thumbnailStatus || undefined}
+        alt={title}
+        aspectRatio={aspectRatio}
+        className="w-full"
+      />
+    </button>
+  );
+};
+
+const ExportMenu: React.FC<{ sequence: Sequence }> = ({ sequence }) => {
+  const posthog = usePostHog();
+  const sequenceExport = useSequenceExport(sequence);
+  const shareUrl = sequenceExport.latestExportUrl;
+
+  const handleCopyShareUrl = useCallback(async () => {
+    if (!shareUrl) {
+      toast.error('Export an MP4 first to get a shareable URL.');
+      return;
+    }
+    try {
+      // Stored export URLs are origin-relative (#894) — absolutize against the
+      // current origin so the copied link is usable when pasted elsewhere.
+      const absoluteUrl = new URL(shareUrl, window.location.origin).href;
+      await navigator.clipboard.writeText(absoluteUrl);
+      toast.success('Video URL copied');
+      posthog.capture('video_url_copied', { sequence_id: sequence.id });
+    } catch (err) {
+      toast.error('Failed to copy URL');
+      posthog.captureException(err);
+    }
+  }, [shareUrl, sequence.id, posthog]);
+
+  const handleDownloadLatest = useCallback(() => {
+    if (!shareUrl) {
+      sequenceExport.start();
+      return;
+    }
+    const a = document.createElement('a');
+    a.href = shareUrl;
+    a.download = `${sequence.title || 'sequence'}_openstory.mp4`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    posthog.capture('video_downloaded', { sequence_id: sequence.id });
+  }, [shareUrl, sequence.id, sequence.title, posthog, sequenceExport]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 bg-black/50 text-white hover:bg-black/70"
+          aria-label="Share"
+        >
+          <Share2 className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => void handleCopyShareUrl()}>
+          <Link className="h-4 w-4" />
+          Copy latest export URL
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={sequenceExport.start}
+          disabled={sequenceExport.isRunning}
+        >
+          {sequenceExport.isRunning ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+          {sequenceExport.isRunning
+            ? formatExportProgress(sequenceExport.progress)
+            : 'Export as MP4'}
+        </DropdownMenuItem>
+        {shareUrl && (
+          <DropdownMenuItem onClick={handleDownloadLatest}>
+            <Download className="h-4 w-4" />
+            Download last export
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+function formatExportProgress(progress: ExportProgress | null): string {
+  if (!progress) return 'Exporting…';
+  const phaseLabel: Record<ExportProgress['phase'], string> = {
+    prepare: 'Preparing',
+    video: 'Stitching video',
+    music: 'Downloading music',
+    dialogue: 'Decoding dialogue',
+    mix: 'Mixing audio',
+    encode: 'Encoding audio',
+    finalize: 'Finalizing',
+    upload: 'Uploading',
+    commit: 'Saving',
+  };
+  const label = phaseLabel[progress.phase];
+  if (progress.total > 0) {
+    const pct = Math.min(
+      100,
+      Math.round((progress.completed / progress.total) * 100)
+    );
+    return `${label}… ${pct}%`;
+  }
+  return `${label}…`;
+}

--- a/src/components/sequence/sequence-tabs.tsx
+++ b/src/components/sequence/sequence-tabs.tsx
@@ -7,15 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  FileText,
-  Film,
-  Grid3X3,
-  ImagePlus,
-  MapPin,
-  Music,
-  Users,
-} from 'lucide-react';
+import { FileText, Grid3X3 } from 'lucide-react';
 
 type SequenceTabsProps = {
   sequenceId: string;
@@ -33,6 +25,9 @@ export function getDefaultSequenceTabPath(sequenceId: string): string {
   return `/sequences/${sequenceId}/script`;
 }
 
+// Cast/Locations/Elements/Music became selection-scoped inspector facets and
+// Theatre folded into the Scenes canvas (#986) — the tab bar is just the two
+// primary surfaces now. The old index routes stay as deep-link targets.
 function useSequenceTabItems(sequenceId: string): TabItem[] {
   return [
     {
@@ -44,31 +39,6 @@ function useSequenceTabItems(sequenceId: string): TabItem[] {
       label: 'Scenes',
       href: `/sequences/${sequenceId}/scenes`,
       icon: <Grid3X3 className="h-4 w-4" />,
-    },
-    {
-      label: 'Cast',
-      href: `/sequences/${sequenceId}/cast`,
-      icon: <Users className="h-4 w-4" />,
-    },
-    {
-      label: 'Locations',
-      href: `/sequences/${sequenceId}/locations`,
-      icon: <MapPin className="h-4 w-4" />,
-    },
-    {
-      label: 'Elements',
-      href: `/sequences/${sequenceId}/elements`,
-      icon: <ImagePlus className="h-4 w-4" />,
-    },
-    {
-      label: 'Music',
-      href: `/sequences/${sequenceId}/music`,
-      icon: <Music className="h-4 w-4" />,
-    },
-    {
-      label: 'Theatre',
-      href: `/sequences/${sequenceId}/theatre`,
-      icon: <Film className="h-4 w-4" />,
     },
   ];
 }

--- a/src/components/talent/character-detail-view.tsx
+++ b/src/components/talent/character-detail-view.tsx
@@ -1,3 +1,4 @@
+import { BackButton } from '@/components/layout/back-button';
 import { SheetComparisonDialog } from '@/components/sheets/sheet-comparison-dialog';
 import { SheetStalenessBanners } from '@/components/sheets/sheet-staleness-banners';
 import { Button } from '@/components/ui/button';
@@ -23,14 +24,7 @@ import { useSheetStaleDetected } from '@/lib/realtime/use-sheet-stale-detected';
 import { cn } from '@/lib/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import {
-  ArrowLeft,
-  Library,
-  Loader2,
-  RefreshCw,
-  Sparkles,
-  User,
-} from 'lucide-react';
+import { Library, Loader2, RefreshCw, Sparkles, User } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { RecastConfirmDialog } from './recast-confirm-dialog';
@@ -287,13 +281,11 @@ export const CharacterDetailView: React.FC<CharacterDetailViewProps> = ({
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       {/* Header with back button */}
       <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
-        <Link
-          to="/sequences/$id/cast"
-          params={{ id: sequenceId }}
-          className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-muted"
-        >
-          <ArrowLeft className="h-4 w-4" />
-        </Link>
+        <BackButton
+          fallbackTo="/sequences/$id/cast"
+          sequenceId={sequenceId}
+          label="Back"
+        />
         <h1 className="text-lg font-semibold">{character.name}</h1>
       </div>
 

--- a/src/components/talent/talent-view.tsx
+++ b/src/components/talent/talent-view.tsx
@@ -1,3 +1,4 @@
+import { BackButton } from '@/components/layout/back-button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useCharacterDivergentVariants } from '@/hooks/use-character-sheet-variants';
 import {
@@ -57,59 +58,80 @@ export const TalentView: React.FC<TalentViewProps> = ({ sequenceId }) => {
     return map;
   }, [divergentVariants]);
 
+  const header = (
+    <div className="flex shrink-0 items-center gap-3 border-b px-4 py-3">
+      <BackButton
+        fallbackTo="/sequences/$id/scenes"
+        sequenceId={sequenceId}
+        label="Back to scenes"
+      />
+      <h1 className="text-lg font-semibold">Cast</h1>
+    </div>
+  );
+
   if (error) {
     return (
-      <div className="flex h-full items-center justify-center">
-        <div className="text-center">
-          <p className="text-sm text-destructive">Failed to load characters</p>
-          <p className="mt-1 text-xs text-muted-foreground">{error.message}</p>
+      <div className="flex h-full min-h-0 flex-col">
+        {header}
+        <div className="flex flex-1 items-center justify-center">
+          <div className="text-center">
+            <p className="text-sm text-destructive">
+              Failed to load characters
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {error.message}
+            </p>
+          </div>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="h-full overflow-auto p-6">
-      {isLoading ? (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="space-y-2">
-              <Skeleton className="aspect-square w-full rounded-lg" />
-              <Skeleton className="h-4 w-3/4" />
-              <Skeleton className="h-3 w-1/2" />
+    <div className="flex h-full min-h-0 flex-col">
+      {header}
+      <div className="flex-1 overflow-auto p-6">
+        {isLoading ? (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="aspect-square w-full rounded-lg" />
+                <Skeleton className="h-4 w-3/4" />
+                <Skeleton className="h-3 w-1/2" />
+              </div>
+            ))}
+          </div>
+        ) : !characters || characters.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
+            <div className="rounded-full bg-muted p-6">
+              <Users className="h-12 w-12 text-muted-foreground/50" />
             </div>
-          ))}
-        </div>
-      ) : !characters || characters.length === 0 ? (
-        <div className="flex h-full flex-col items-center justify-center gap-4 text-center">
-          <div className="rounded-full bg-muted p-6">
-            <Users className="h-12 w-12 text-muted-foreground/50" />
+            <div>
+              <h3 className="text-lg font-medium">No cast found</h3>
+              <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                Characters will appear here once your script has been analyzed.
+                Add a script to your sequence to get started.
+              </p>
+            </div>
           </div>
-          <div>
-            <h3 className="text-lg font-medium">No cast found</h3>
-            <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-              Characters will appear here once your script has been analyzed.
-              Add a script to your sequence to get started.
-            </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+            {characters.map((character) => (
+              <Link
+                key={character.id}
+                to="/sequences/$id/cast/$characterId"
+                params={{ id: sequenceId, characterId: character.id }}
+                className="block"
+              >
+                <TalentCard
+                  character={character}
+                  divergentVariantId={divergentByCharacterId.get(character.id)}
+                />
+              </Link>
+            ))}
           </div>
-        </div>
-      ) : (
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
-          {characters.map((character) => (
-            <Link
-              key={character.id}
-              to="/sequences/$id/cast/$characterId"
-              params={{ id: sequenceId, characterId: character.id }}
-              className="block"
-            >
-              <TalentCard
-                character={character}
-                divergentVariantId={divergentByCharacterId.get(character.id)}
-              />
-            </Link>
-          ))}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/theatre/sequence-player.tsx
+++ b/src/components/theatre/sequence-player.tsx
@@ -35,6 +35,19 @@ import {
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
+/**
+ * Imperative handle for the canvas/spine to drive playback (#986): the spine
+ * seeks by shot, the keyboard grammar's Space toggles play. Exposed via the
+ * `controlsRef` prop rather than events so callers can act at interaction
+ * time without re-rendering the player.
+ */
+export type SequencePlayerControls = {
+  /** Seek to the start of the Nth scene (playback order). */
+  seekToScene: (index: number) => void;
+  togglePlay: () => void;
+  isPlaying: () => boolean;
+};
+
 type SequencePlayerProps = {
   scenes: SceneInput[];
   musicUrl: string | null;
@@ -51,6 +64,14 @@ type SequencePlayerProps = {
   className?: string;
   /** Slot rendered as an overlay (top-right) — e.g. the Share dropdown. */
   overlayActions?: React.ReactNode;
+  /**
+   * Fired when the playhead crosses into a different scene (#986) — lets the
+   * spine/filmstrip highlight the shot that is actually playing. Reports -1
+   * before metadata is ready.
+   */
+  onActiveSceneChange?: (index: number) => void;
+  /** Receives the imperative playback controls; nulled on unmount. */
+  controlsRef?: React.RefObject<SequencePlayerControls | null>;
 };
 
 export const SequencePlayer: React.FC<SequencePlayerProps> = ({
@@ -62,9 +83,15 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
   aspectRatio,
   className,
   overlayActions,
+  onActiveSceneChange,
+  controlsRef,
 }) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const engineRef = useRef<SequencePlayerEngine | null>(null);
+  const activeSceneRef = useRef(-1);
+  // Mirrors the `meta` state for the imperative controls, which must read the
+  // latest offsets without re-registering on every prepare.
+  const metaRef = useRef<SequencePlayerMeta | null>(null);
 
   const [meta, setMeta] = useState<SequencePlayerMeta | null>(null);
   const [playing, setPlaying] = useState(false);
@@ -80,6 +107,13 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
       setError('No scenes ready to play yet.');
       return;
     }
+
+    // Re-preparing for a different playback set (#986: selection re-scopes
+    // the player) must not leave the previous run's clock/meta on screen.
+    setMeta(null);
+    setPlaying(false);
+    setCurrentTime(0);
+    activeSceneRef.current = -1;
 
     let cancelled = false;
     const engine = new SequencePlayerEngine({
@@ -104,6 +138,7 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
       .prepare()
       .then((m) => {
         if (cancelled) return;
+        metaRef.current = m;
         setMeta(m);
       })
       .catch((err: unknown) => {
@@ -115,6 +150,8 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
       cancelled = true;
       engine.dispose();
       engineRef.current = null;
+      metaRef.current = null;
+      activeSceneRef.current = -1;
     };
     // The scene list/music identity drives the engine lifecycle; volume/muted/
     // musicEnabled are pushed through setters below (toggling music must not
@@ -133,6 +170,49 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
   useEffect(() => {
     engineRef.current?.setMusicEnabled(musicEnabled);
   }, [musicEnabled]);
+
+  // Map the playhead to the scene it's inside and report crossings (#986).
+  useEffect(() => {
+    if (!onActiveSceneChange) return;
+    const offsets = meta?.sceneOffsetsSeconds ?? [];
+    let index = -1;
+    for (let i = offsets.length - 1; i >= 0; i--) {
+      const offset = offsets[i];
+      if (offset !== undefined && currentTime >= offset) {
+        index = i;
+        break;
+      }
+    }
+    if (index !== activeSceneRef.current) {
+      activeSceneRef.current = index;
+      onActiveSceneChange(index);
+    }
+  }, [currentTime, meta, onActiveSceneChange]);
+
+  useEffect(() => {
+    if (!controlsRef) return;
+    controlsRef.current = {
+      seekToScene: (index: number) => {
+        const engine = engineRef.current;
+        const offset = metaRef.current?.sceneOffsetsSeconds[index];
+        if (engine && offset !== undefined) void engine.seek(offset);
+      },
+      togglePlay: () => {
+        const engine = engineRef.current;
+        if (!engine) return;
+        if (engine.isPlaying()) {
+          engine.pause();
+          setPlaying(false);
+        } else {
+          void engine.play().then(() => setPlaying(true));
+        }
+      },
+      isPlaying: () => engineRef.current?.isPlaying() ?? false,
+    };
+    return () => {
+      controlsRef.current = null;
+    };
+  }, [controlsRef]);
 
   const togglePlay = () => {
     const engine = engineRef.current;

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -214,6 +214,47 @@ export const setSequenceMusicFn = createServerFn({ method: 'POST' })
   });
 
 // ============================================================================
+// Set Sequence Default Models (#986)
+// ============================================================================
+
+const updateSequenceModelsInputSchema = z.object({
+  sequenceId: ulidSchema,
+  imageModel: z.string().min(1).optional(),
+  videoModel: z.string().min(1).optional(),
+});
+
+/**
+ * Persist the sequence's default image/video model — what scenes with no
+ * override inherit (#909). The inspector edits this at sequence scope (#986).
+ *
+ * Deliberately separate from {@link updateSequenceFn}: that path force-defaults
+ * `aspectRatio` and runs regeneration/credit logic. This is a minimal
+ * preference write with no side effects, mirroring {@link setSequenceMusicFn}.
+ */
+export const updateSequenceModelsFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(zodValidator(updateSequenceModelsInputSchema))
+  .handler(async ({ data, context }) => {
+    if (
+      data.imageModel !== undefined &&
+      !isValidTextToImageModel(data.imageModel)
+    ) {
+      throw new Error('Invalid image model');
+    }
+    if (
+      data.videoModel !== undefined &&
+      !isValidImageToVideoModel(data.videoModel)
+    ) {
+      throw new Error('Invalid video model');
+    }
+    return await context.scopedDb.sequences.update({
+      id: data.sequenceId,
+      ...(data.imageModel !== undefined ? { imageModel: data.imageModel } : {}),
+      ...(data.videoModel !== undefined ? { videoModel: data.videoModel } : {}),
+    });
+  });
+
+// ============================================================================
 // Retry Failed Storyboard
 // ============================================================================
 

--- a/src/hooks/use-scenes-keyboard.ts
+++ b/src/hooks/use-scenes-keyboard.ts
@@ -1,0 +1,102 @@
+/**
+ * Keyboard grammar for the unified Scenes editor (#986).
+ *
+ * ↑/↓ step shots · ←/→ step scenes · ⇧↑/⇧↓ grow/shrink the scene range ·
+ * Esc zooms out one scope · Space plays/pauses the current scope ·
+ * Enter drills into the selection · ⌘K opens the command palette.
+ *
+ * Keys are ignored while typing (inputs, textareas, contenteditable) or when
+ * a dialog is open — except ⌘K, which always opens the palette.
+ */
+
+import {
+  extendSceneRange,
+  scopeOf,
+  stepScene,
+  stepShot,
+  zoomOut,
+  type SceneSelection,
+  type SelectableShot,
+} from '@/lib/scenes/selection';
+import { useEffect } from 'react';
+
+type UseScenesKeyboardArgs = {
+  shots: SelectableShot[] | undefined;
+  selection: SceneSelection;
+  onSelectionChange: (next: SceneSelection) => void;
+  onTogglePlay: () => void;
+  onOpenPalette: () => void;
+};
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.closest(
+      'input, textarea, select, [contenteditable="true"], [role="dialog"], [role="menu"], [role="listbox"]'
+    ) !== null
+  );
+}
+
+export function useScenesKeyboard({
+  shots,
+  selection,
+  onSelectionChange,
+  onTogglePlay,
+  onOpenPalette,
+}: UseScenesKeyboardArgs): void {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      // ⌘K works from anywhere, including inputs.
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        onOpenPalette();
+        return;
+      }
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      if (isTypingTarget(e.target)) return;
+      if (!shots || shots.length === 0) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+        case 'ArrowUp': {
+          e.preventDefault();
+          const direction = e.key === 'ArrowDown' ? 1 : -1;
+          if (e.shiftKey && scopeOf(selection) === 'scene') {
+            onSelectionChange(extendSceneRange(selection, shots, direction));
+          } else {
+            onSelectionChange(stepShot(selection, shots, direction));
+          }
+          break;
+        }
+        case 'ArrowRight':
+        case 'ArrowLeft': {
+          e.preventDefault();
+          onSelectionChange(
+            stepScene(selection, shots, e.key === 'ArrowRight' ? 1 : -1)
+          );
+          break;
+        }
+        case 'Escape': {
+          if (scopeOf(selection) === 'sequence') return;
+          e.preventDefault();
+          onSelectionChange(zoomOut(selection, shots));
+          break;
+        }
+        case ' ': {
+          e.preventDefault();
+          onTogglePlay();
+          break;
+        }
+        case 'Enter': {
+          if (scopeOf(selection) === 'shot') return;
+          e.preventDefault();
+          onSelectionChange(stepShot(selection, shots, 1));
+          break;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [shots, selection, onSelectionChange, onTogglePlay, onOpenPalette]);
+}

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -7,6 +7,7 @@ import {
   getSequencesFn,
   setSequenceModelFn,
   setSequenceMusicFn,
+  updateSequenceModelsFn,
   type AddModelResult,
 } from '@/functions/sequences';
 import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
@@ -222,6 +223,47 @@ export function useCreateSequence() {
  * Optimistically patches the sequence detail cache so the live player's music
  * gain and the next export react instantly; rolls back if the write fails.
  */
+/**
+ * Persist the sequence's default image/video model (#986) — what scenes with
+ * no override inherit. Optimistically patches the sequence detail so the
+ * inspector's model bar reflects the choice immediately.
+ */
+export function useUpdateSequenceModels(sequenceId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    Sequence,
+    Error,
+    { imageModel?: string; videoModel?: string },
+    { previous?: Sequence }
+  >({
+    mutationFn: (input) =>
+      updateSequenceModelsFn({ data: { sequenceId, ...input } }),
+    onMutate: async (input) => {
+      const key = sequenceKeys.detail(sequenceId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Sequence>(key);
+      queryClient.setQueryData<Sequence>(key, (old) =>
+        old ? { ...old, ...input } : old
+      );
+      return { previous };
+    },
+    onError: (error, _input, ctx) => {
+      if (ctx?.previous) {
+        queryClient.setQueryData(sequenceKeys.detail(sequenceId), ctx.previous);
+      }
+      toast.error('Failed to update the sequence default model', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({
+        queryKey: sequenceKeys.detail(sequenceId),
+      });
+    },
+  });
+}
+
 export function useSetSequenceMusic(sequenceId: string) {
   const queryClient = useQueryClient();
   const posthog = usePostHog();

--- a/src/lib/scenes/selection.test.ts
+++ b/src/lib/scenes/selection.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'vitest';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import {
+  EMPTY_SELECTION,
+  extendSceneRange,
+  orderedSceneIds,
+  rangeSelectScenes,
+  scopeOf,
+  selectScene,
+  selectShot,
+  selectionTags,
+  shotsInSelection,
+  stepScene,
+  stepShot,
+  toggleScene,
+  zoomOut,
+  type SelectableShot,
+} from './selection';
+
+function makeMetadata(overrides: {
+  characterTags?: string[];
+  environmentTag?: string;
+  elementTags?: string[];
+  location?: string;
+  extract?: string;
+}): Scene {
+  return {
+    sceneId: 'scene_x',
+    sceneNumber: 1,
+    originalScript: {
+      extract: overrides.extract ?? 'INT. SOMEWHERE',
+      dialogue: [],
+    },
+    metadata: {
+      title: 'A scene',
+      durationSeconds: 5,
+      location: overrides.location ?? 'Somewhere',
+      timeOfDay: 'day',
+      storyBeat: 'setup',
+    },
+    continuity: {
+      characterTags: overrides.characterTags ?? [],
+      environmentTag: overrides.environmentTag ?? '',
+      elementTags: overrides.elementTags ?? [],
+      colorPalette: '',
+      lightingSetup: '',
+      styleTag: '',
+    },
+  };
+}
+
+// Two scenes: A (shots 1, 2) and B (shot 3). Order indexes are deliberately
+// passed unsorted to the helpers to verify they sort.
+const shot1: SelectableShot = {
+  id: 'shot1',
+  sceneId: 'sceneA',
+  orderIndex: 0,
+  metadata: makeMetadata({
+    characterTags: ['HERO'],
+    environmentTag: 'diner',
+    elementTags: ['LOGO'],
+    extract: 'Shot one extract',
+  }),
+};
+const shot2: SelectableShot = {
+  id: 'shot2',
+  sceneId: 'sceneA',
+  orderIndex: 1,
+  metadata: makeMetadata({
+    characterTags: ['HERO', 'VILLAIN'],
+    environmentTag: 'diner',
+    extract: 'Shot two extract',
+  }),
+};
+const shot3: SelectableShot = {
+  id: 'shot3',
+  sceneId: 'sceneB',
+  orderIndex: 2,
+  metadata: makeMetadata({
+    characterTags: ['SIDEKICK'],
+    environmentTag: 'rooftop',
+    elementTags: ['PRODUCT'],
+    extract: 'Shot three extract',
+  }),
+};
+const shots = [shot3, shot1, shot2];
+
+describe('scopeOf', () => {
+  it('derives the scope from the selection shape', () => {
+    expect(scopeOf(EMPTY_SELECTION)).toBe('sequence');
+    expect(scopeOf(selectScene('sceneA'))).toBe('scene');
+    expect(scopeOf(selectShot('shot1'))).toBe('shot');
+  });
+});
+
+describe('shotsInSelection', () => {
+  it('returns all shots in order at sequence scope', () => {
+    expect(shotsInSelection(EMPTY_SELECTION, shots).map((s) => s.id)).toEqual([
+      'shot1',
+      'shot2',
+      'shot3',
+    ]);
+  });
+
+  it('returns the selected scenes’ shots in order', () => {
+    expect(
+      shotsInSelection({ sceneIds: ['sceneB', 'sceneA'] }, shots).map(
+        (s) => s.id
+      )
+    ).toEqual(['shot1', 'shot2', 'shot3']);
+    expect(
+      shotsInSelection({ sceneIds: ['sceneB'] }, shots).map((s) => s.id)
+    ).toEqual(['shot3']);
+  });
+
+  it('returns just the selected shot at shot scope', () => {
+    expect(
+      shotsInSelection(selectShot('shot2'), shots).map((s) => s.id)
+    ).toEqual(['shot2']);
+  });
+});
+
+describe('selectionTags', () => {
+  it('is null (no filter) at sequence scope', () => {
+    expect(selectionTags(EMPTY_SELECTION, shots)).toBeNull();
+  });
+
+  it('unions tags across the selected scenes’ shots, deduped', () => {
+    const tags = selectionTags({ sceneIds: ['sceneA'] }, shots);
+    expect(tags?.characterTags).toEqual(['HERO', 'VILLAIN']);
+    expect(tags?.environmentTags).toEqual(['diner', 'Somewhere']);
+    expect(tags?.elementTags).toEqual(['LOGO']);
+    expect(tags?.scriptExtracts).toEqual([
+      'Shot one extract',
+      'Shot two extract',
+    ]);
+  });
+
+  it('unions across multiple scenes', () => {
+    const tags = selectionTags({ sceneIds: ['sceneA', 'sceneB'] }, shots);
+    expect(tags?.characterTags).toEqual(['HERO', 'VILLAIN', 'SIDEKICK']);
+    expect(tags?.elementTags).toEqual(['LOGO', 'PRODUCT']);
+  });
+
+  it('returns only the shot’s own tags at shot scope', () => {
+    const tags = selectionTags(selectShot('shot3'), shots);
+    expect(tags?.characterTags).toEqual(['SIDEKICK']);
+    expect(tags?.environmentTags).toEqual(['rooftop', 'Somewhere']);
+  });
+});
+
+describe('selection transitions', () => {
+  it('toggleScene adds and removes scenes from the multi-selection', () => {
+    const one = toggleScene(EMPTY_SELECTION, 'sceneA');
+    expect(one.sceneIds).toEqual(['sceneA']);
+    const two = toggleScene(one, 'sceneB');
+    expect(two.sceneIds).toEqual(['sceneA', 'sceneB']);
+    expect(toggleScene(two, 'sceneA').sceneIds).toEqual(['sceneB']);
+  });
+
+  it('rangeSelectScenes selects the contiguous range from the anchor', () => {
+    const fromA = rangeSelectScenes(selectScene('sceneA'), 'sceneB', shots);
+    expect(fromA.sceneIds).toEqual(['sceneA', 'sceneB']);
+    // Reversed anchor/target still yields spine order.
+    const fromB = rangeSelectScenes(selectScene('sceneB'), 'sceneA', shots);
+    expect(fromB.sceneIds).toEqual(['sceneA', 'sceneB']);
+    // No anchor → plain select.
+    expect(
+      rangeSelectScenes(EMPTY_SELECTION, 'sceneB', shots).sceneIds
+    ).toEqual(['sceneB']);
+  });
+
+  it('zoomOut steps shot → scene → sequence', () => {
+    const sceneScope = zoomOut(selectShot('shot2'), shots);
+    expect(sceneScope).toEqual({ sceneIds: ['sceneA'] });
+    expect(zoomOut(sceneScope, shots)).toEqual(EMPTY_SELECTION);
+    expect(zoomOut(EMPTY_SELECTION, shots)).toEqual(EMPTY_SELECTION);
+  });
+
+  it('stepShot walks the flat order and clamps at the ends', () => {
+    expect(stepShot(selectShot('shot1'), shots, 1).shotId).toBe('shot2');
+    expect(stepShot(selectShot('shot2'), shots, 1).shotId).toBe('shot3');
+    expect(stepShot(selectShot('shot3'), shots, 1).shotId).toBe('shot3');
+    expect(stepShot(selectShot('shot1'), shots, -1).shotId).toBe('shot1');
+  });
+
+  it('stepShot enters the covered shots from scene/sequence scope', () => {
+    expect(stepShot(EMPTY_SELECTION, shots, 1).shotId).toBe('shot1');
+    expect(stepShot(EMPTY_SELECTION, shots, -1).shotId).toBe('shot3');
+    expect(stepShot({ sceneIds: ['sceneB'] }, shots, 1).shotId).toBe('shot3');
+  });
+
+  it('stepScene moves scene-wise from any scope', () => {
+    expect(stepScene(selectScene('sceneA'), shots, 1).sceneIds).toEqual([
+      'sceneB',
+    ]);
+    expect(stepScene(selectShot('shot1'), shots, 1).sceneIds).toEqual([
+      'sceneB',
+    ]);
+    expect(stepScene(EMPTY_SELECTION, shots, 1).sceneIds).toEqual(['sceneA']);
+    expect(stepScene(selectScene('sceneA'), shots, -1).sceneIds).toEqual([
+      'sceneA',
+    ]);
+  });
+
+  it('extendSceneRange grows and shrinks at the trailing edge', () => {
+    const grown = extendSceneRange(selectScene('sceneA'), shots, 1);
+    expect(grown.sceneIds).toEqual(['sceneA', 'sceneB']);
+    const shrunk = extendSceneRange(grown, shots, -1);
+    expect(shrunk.sceneIds).toEqual(['sceneA']);
+    // Clamped at the end of the spine.
+    expect(extendSceneRange(grown, shots, 1).sceneIds).toEqual([
+      'sceneA',
+      'sceneB',
+    ]);
+  });
+
+  it('orderedSceneIds preserves spine order and dedupes', () => {
+    expect(orderedSceneIds(shots)).toEqual(['sceneA', 'sceneB']);
+  });
+});

--- a/src/lib/scenes/selection.test.ts
+++ b/src/lib/scenes/selection.test.ts
@@ -12,6 +12,7 @@ import {
   shotsInSelection,
   stepScene,
   stepShot,
+  toggleAllScenes,
   toggleScene,
   zoomOut,
   type SelectableShot,
@@ -217,5 +218,23 @@ describe('selection transitions', () => {
 
   it('orderedSceneIds preserves spine order and dedupes', () => {
     expect(orderedSceneIds(shots)).toEqual(['sceneA', 'sceneB']);
+  });
+
+  it('toggleAllScenes toggles between all scenes and none', () => {
+    const all = toggleAllScenes(EMPTY_SELECTION, shots);
+    expect(all.sceneIds).toEqual(['sceneA', 'sceneB']);
+    expect(toggleAllScenes(all, shots)).toEqual(EMPTY_SELECTION);
+    // Partial selections resolve to "all", not "none".
+    expect(toggleAllScenes(selectScene('sceneA'), shots).sceneIds).toEqual([
+      'sceneA',
+      'sceneB',
+    ]);
+    // Shot scope resolves to "all" too — a shot is not "everything selected".
+    expect(toggleAllScenes(selectShot('shot1'), shots).sceneIds).toEqual([
+      'sceneA',
+      'sceneB',
+    ]);
+    // No shots → nothing to select.
+    expect(toggleAllScenes(EMPTY_SELECTION, [])).toEqual(EMPTY_SELECTION);
   });
 });

--- a/src/lib/scenes/selection.ts
+++ b/src/lib/scenes/selection.ts
@@ -139,6 +139,22 @@ export function toggleScene(
 }
 
 /**
+ * Click on the spine's "Scenes" header: toggle between every scene selected
+ * and none (whole-sequence scope). Partial selections resolve to "all".
+ */
+export function toggleAllScenes(
+  selection: SceneSelection,
+  shots: SelectableShot[]
+): SceneSelection {
+  const all = orderedSceneIds(shots);
+  const allSelected =
+    all.length > 0 &&
+    !selection.shotId &&
+    all.every((id) => selection.sceneIds.includes(id));
+  return allSelected ? EMPTY_SELECTION : { sceneIds: all };
+}
+
+/**
  * Shift-click on a scene header: contiguous range from the selection's anchor
  * (its first scene) to the target, in spine order. With no anchor this is a
  * plain scene selection.

--- a/src/lib/scenes/selection.ts
+++ b/src/lib/scenes/selection.ts
@@ -1,0 +1,249 @@
+/**
+ * Selection model for the unified Scenes editor (#986).
+ *
+ * Selection IS the scope control: nothing selected = whole sequence,
+ * scene(s) selected = those scenes, a shot selected = just that shot.
+ * The selection lives in the route's search params so back/forward and
+ * shared links restore it; everything here is a pure derivation over the
+ * already-fetched shots list — no new queries.
+ */
+
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+
+/** Search-param shape: empty = whole sequence. `shotId` wins over `sceneIds`. */
+export type SceneSelection = {
+  sceneIds: string[];
+  shotId?: string;
+};
+
+export type SelectionScope = 'sequence' | 'scene' | 'shot';
+
+/**
+ * The continuity tag sets a selection resolves to, feeding the inspector
+ * facets. `scriptExtracts` carries the covered shots' original script slices
+ * for element matching and the Script facet.
+ */
+export type SelectionTags = {
+  characterTags: string[];
+  environmentTags: string[];
+  elementTags: string[];
+  scriptExtracts: string[];
+};
+
+/** Minimal structural shot shape so the derivations stay pure and testable. */
+export type SelectableShot = {
+  id: string;
+  sceneId: string | null;
+  orderIndex: number;
+  metadata: Scene | null;
+};
+
+export const EMPTY_SELECTION: SceneSelection = { sceneIds: [] };
+
+export function scopeOf(selection: SceneSelection): SelectionScope {
+  if (selection.shotId) return 'shot';
+  if (selection.sceneIds.length > 0) return 'scene';
+  return 'sequence';
+}
+
+function isSelectionEmpty(selection: SceneSelection): boolean {
+  return scopeOf(selection) === 'sequence';
+}
+
+/**
+ * Shots covered by the selection, in playback order. Sequence scope = all
+ * shots; scene scope = shots of the selected scenes; shot scope = that shot.
+ */
+export function shotsInSelection<T extends SelectableShot>(
+  selection: SceneSelection,
+  shots: T[]
+): T[] {
+  const ordered = [...shots].sort((a, b) => a.orderIndex - b.orderIndex);
+  if (selection.shotId) {
+    return ordered.filter((s) => s.id === selection.shotId);
+  }
+  if (selection.sceneIds.length > 0) {
+    const sceneSet = new Set(selection.sceneIds);
+    return ordered.filter((s) => s.sceneId && sceneSet.has(s.sceneId));
+  }
+  return ordered;
+}
+
+function dedupe(values: Array<string | undefined | null>): string[] {
+  const set = new Set<string>();
+  for (const v of values) {
+    if (v) set.add(v);
+  }
+  return [...set];
+}
+
+/**
+ * The uniform selection rule (#986): `null` means "no filter" — facets show
+ * everything at sequence scope. Scene scope unions tags across every covered
+ * shot; shot scope is that shot's own tags (today's behaviour).
+ */
+export function selectionTags(
+  selection: SceneSelection,
+  shots: SelectableShot[]
+): SelectionTags | null {
+  if (isSelectionEmpty(selection)) return null;
+  const covered = shotsInSelection(selection, shots);
+  return {
+    characterTags: dedupe(
+      covered.flatMap((s) => s.metadata?.continuity?.characterTags ?? [])
+    ),
+    environmentTags: dedupe(
+      covered.flatMap((s) => [
+        s.metadata?.continuity?.environmentTag,
+        s.metadata?.metadata?.location,
+      ])
+    ),
+    elementTags: dedupe(
+      covered.flatMap((s) => s.metadata?.continuity?.elementTags ?? [])
+    ),
+    scriptExtracts: dedupe(
+      covered.map((s) => s.metadata?.originalScript.extract)
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Selection transitions (spine clicks + keyboard grammar)
+// ---------------------------------------------------------------------------
+
+/** Ordered distinct scene ids as they appear across the ordered shots. */
+export function orderedSceneIds(shots: SelectableShot[]): string[] {
+  const ordered = [...shots].sort((a, b) => a.orderIndex - b.orderIndex);
+  return dedupe(ordered.map((s) => s.sceneId));
+}
+
+/** Plain click on a scene header: select exactly that scene. */
+export function selectScene(sceneId: string): SceneSelection {
+  return { sceneIds: [sceneId] };
+}
+
+/** Plain click on a shot card: select exactly that shot. */
+export function selectShot(shotId: string): SceneSelection {
+  return { sceneIds: [], shotId };
+}
+
+/** Cmd/ctrl-click on a scene header: toggle it in the multi-selection. */
+export function toggleScene(
+  selection: SceneSelection,
+  sceneId: string
+): SceneSelection {
+  const next = selection.sceneIds.includes(sceneId)
+    ? selection.sceneIds.filter((id) => id !== sceneId)
+    : [...selection.sceneIds, sceneId];
+  return { sceneIds: next };
+}
+
+/**
+ * Shift-click on a scene header: contiguous range from the selection's anchor
+ * (its first scene) to the target, in spine order. With no anchor this is a
+ * plain scene selection.
+ */
+export function rangeSelectScenes(
+  selection: SceneSelection,
+  sceneId: string,
+  shots: SelectableShot[]
+): SceneSelection {
+  const order = orderedSceneIds(shots);
+  const anchor = selection.sceneIds[0];
+  const anchorIdx = anchor ? order.indexOf(anchor) : -1;
+  const targetIdx = order.indexOf(sceneId);
+  if (anchorIdx === -1 || targetIdx === -1) return selectScene(sceneId);
+  const [from, to] =
+    anchorIdx <= targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
+  return { sceneIds: order.slice(from, to + 1) };
+}
+
+/**
+ * Esc zooms out one scope level: shot → its scene, scene(s) → sequence.
+ * Already at sequence scope it's a no-op.
+ */
+export function zoomOut(
+  selection: SceneSelection,
+  shots: SelectableShot[]
+): SceneSelection {
+  if (selection.shotId) {
+    const shot = shots.find((s) => s.id === selection.shotId);
+    return shot?.sceneId ? selectScene(shot.sceneId) : EMPTY_SELECTION;
+  }
+  return EMPTY_SELECTION;
+}
+
+/**
+ * ↑/↓: step the shot selection through the flat playback order, crossing
+ * scene boundaries. From scene/sequence scope, ↓ enters the first covered
+ * shot and ↑ the last, so the keys always land somewhere useful.
+ */
+export function stepShot(
+  selection: SceneSelection,
+  shots: SelectableShot[],
+  direction: 1 | -1
+): SceneSelection {
+  const ordered = [...shots].sort((a, b) => a.orderIndex - b.orderIndex);
+  if (ordered.length === 0) return selection;
+  if (!selection.shotId) {
+    const covered = shotsInSelection(selection, ordered);
+    const pool = covered.length > 0 ? covered : ordered;
+    const entry = direction === 1 ? pool[0] : pool[pool.length - 1];
+    return entry ? selectShot(entry.id) : selection;
+  }
+  const idx = ordered.findIndex((s) => s.id === selection.shotId);
+  if (idx === -1) return selection;
+  const next =
+    ordered[Math.min(ordered.length - 1, Math.max(0, idx + direction))];
+  return next ? selectShot(next.id) : selection;
+}
+
+/**
+ * ←/→: step the selection scene-wise. From shot scope, steps to the
+ * neighbouring scene of the shot's scene; from sequence scope selects the
+ * first/last scene.
+ */
+export function stepScene(
+  selection: SceneSelection,
+  shots: SelectableShot[],
+  direction: 1 | -1
+): SceneSelection {
+  const order = orderedSceneIds(shots);
+  if (order.length === 0) return selection;
+  const currentSceneId = selection.shotId
+    ? (shots.find((s) => s.id === selection.shotId)?.sceneId ?? undefined)
+    : selection.sceneIds[selection.sceneIds.length - 1];
+  if (!currentSceneId) {
+    const entry = direction === 1 ? order[0] : order[order.length - 1];
+    return entry ? selectScene(entry) : selection;
+  }
+  const idx = order.indexOf(currentSceneId);
+  if (idx === -1) return selection;
+  const next = order[Math.min(order.length - 1, Math.max(0, idx + direction))];
+  return next ? selectScene(next) : selection;
+}
+
+/**
+ * Shift+↑/↓ at scene scope: grow/shrink the contiguous scene range at its
+ * trailing edge (Linear-style range extension).
+ */
+export function extendSceneRange(
+  selection: SceneSelection,
+  shots: SelectableShot[],
+  direction: 1 | -1
+): SceneSelection {
+  const order = orderedSceneIds(shots);
+  if (selection.sceneIds.length === 0) return selection;
+  const last = selection.sceneIds[selection.sceneIds.length - 1];
+  const lastIdx = last ? order.indexOf(last) : -1;
+  if (lastIdx === -1) return selection;
+  const targetIdx = lastIdx + direction;
+  if (targetIdx < 0 || targetIdx >= order.length) return selection;
+  const target = order[targetIdx];
+  if (!target) return selection;
+  if (selection.sceneIds.includes(target)) {
+    // Shrinking back over an already-selected scene.
+    return { sceneIds: selection.sceneIds.filter((id) => id !== last) };
+  }
+  return { sceneIds: [...selection.sceneIds, target] };
+}

--- a/src/lib/sequence-player/playback.ts
+++ b/src/lib/sequence-player/playback.ts
@@ -67,6 +67,14 @@ export type SequencePlayerMeta = {
   displayHeight: number;
   hasAudio: boolean;
   /**
+   * Cumulative scene start offsets (seconds), in playback order. Drives the
+   * playhead↔selection link (#986): the UI maps the current time to the
+   * playing scene and can seek to a scene's start.
+   */
+  sceneOffsetsSeconds: number[];
+  /** Per-scene durations (seconds), in playback order. */
+  sceneDurationsSeconds: number[];
+  /**
    * True when the scenes resolve to more than one distinct native resolution.
    * Playback is normalized to a common target regardless, but the UI should
    * warn the user that mixing models produced inconsistent sizes (#791).
@@ -213,6 +221,8 @@ export class SequencePlayerEngine {
       displayWidth: videoMeta.displayWidth,
       displayHeight: videoMeta.displayHeight,
       hasAudio,
+      sceneOffsetsSeconds: videoMeta.sceneOffsetsSeconds,
+      sceneDurationsSeconds: videoMeta.sceneDurationsSeconds,
       hasMixedResolutions: videoMeta.hasMixedResolutions,
       hasMixedAspectRatios: videoMeta.hasMixedAspectRatios,
       resolutionsLabel: videoMeta.resolutionsLabel,

--- a/src/routes/_app/sequences/$id/scenes.tsx
+++ b/src/routes/_app/sequences/$id/scenes.tsx
@@ -1,7 +1,29 @@
 import { ScenesView } from '@/components/scenes/scenes-view';
 import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+
+/**
+ * Selection is the scope control (#986): the spine/canvas/inspector all key
+ * off these params, so back/forward and shared links restore the exact
+ * editing context. Empty = whole-sequence scope.
+ */
+const searchSchema = z.object({
+  /** Selected scene ids (multi-select). Ignored when `shot` is set. */
+  scenes: z.array(z.string()).optional(),
+  /** Selected shot id — the narrowest scope. */
+  shot: z.string().optional(),
+  /** Active inspector facet. */
+  facet: z
+    .enum(['cast', 'locations', 'elements', 'music', 'script'])
+    .optional(),
+  /** Active shot-panel tab (shot scope only). */
+  tab: z
+    .enum(['scene-variants', 'script', 'image-prompt', 'motion-prompt'])
+    .optional(),
+});
 
 export const Route = createFileRoute('/_app/sequences/$id/scenes')({
+  validateSearch: searchSchema,
   component: ScenesPage,
   staticData: { breadcrumb: 'Scenes' },
 });

--- a/src/routes/_app/sequences/$id/theatre.tsx
+++ b/src/routes/_app/sequences/$id/theatre.tsx
@@ -1,43 +1,15 @@
-import { TheatreView } from '@/components/theatre/theatre-view';
-import { Skeleton } from '@/components/ui/skeleton';
-import { useSequence } from '@/hooks/use-sequences';
-import type { AspectRatio } from '@/lib/constants/aspect-ratios';
-import { useSequenceStaleDetected } from '@/lib/realtime/use-sequence-stale-detected';
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
+/**
+ * Theatre folded into the Scenes canvas (#986): whole-sequence playback is
+ * the nothing-selected state of the unified editor. Kept as a redirect so
+ * old links and bookmarks keep working.
+ */
 export const Route = createFileRoute('/_app/sequences/$id/theatre')({
-  component: TheatrePage,
-  staticData: { breadcrumb: 'Theatre' },
+  beforeLoad: ({ params }) => {
+    throw redirect({
+      to: '/sequences/$id/scenes',
+      params: { id: params.id },
+    });
+  },
 });
-
-// Constrain player to fit viewport. Header+tabs ≈ 10rem, so available ≈ 100dvh - 11rem.
-// Full class names required for Tailwind JIT to detect at build time.
-const THEATRE_MAX_CLASS_BY_RATIO: Record<AspectRatio, string> = {
-  '16:9': 'w-full max-h-[calc(100dvh-15rem)] max-w-4xl',
-  '9:16':
-    'w-full max-h-[calc(100dvh-15rem)] max-w-[calc((100dvh-15rem)*0.5625)]',
-  '1:1': 'w-full max-h-[calc(100dvh-15rem)] max-w-[calc(100dvh-15rem)]',
-};
-
-function TheatrePage() {
-  const { id: sequenceId } = Route.useParams();
-
-  const { data: sequence, isLoading } = useSequence(sequenceId);
-  useSequenceStaleDetected(sequenceId);
-
-  if (isLoading || !sequence) {
-    return (
-      <div className="flex-1 p-4">
-        <Skeleton className="aspect-video w-full max-w-4xl mx-auto" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="flex h-full items-center justify-center p-4">
-      <div className={THEATRE_MAX_CLASS_BY_RATIO[sequence.aspectRatio]}>
-        <TheatreView sequence={sequence} />
-      </div>
-    </div>
-  );
-}


### PR DESCRIPTION
Closes #986

## Summary

Replaces the sibling-tab Scenes editor with a selection-driven unified canvas: one spine (left), one adaptive canvas (center), one faceted inspector (right). Selection is the scope control and lives in URL search params, so back/forward and shared links restore the exact editing context.

- **Spine** — shots grouped under scene headers (title, shot count, Look/Motion summary). Click a scene = scene scope, click a shot = shot scope, cmd-click toggles scenes into a multi-selection, shift-click selects a range; the header toggles all scenes selected ↔ none (Esc clears to whole-sequence scope). Shots with video carry a play badge on the thumbnail, pulsing while motion generates; the playhead is marked in the player's filmstrip.
- **Canvas** — adapts to scope: shot = the existing single-shot player with the prompt panel below (slimmed to Variants/Script/Image/Motion); scene(s) = those shots stitched and played in order; nothing = whole-sequence playback with music and MP4 export (absorbs Theatre). A filmstrip timeline under the player seeks by shot; un-ready shots are dimmed and click through to shot scope.
- **Inspector** — scope breadcrumb (each crumb re-scopes), scope-aware Look/Motion models (sequence default / scene override with Mixed + set-all + reset-to-inherit / shot read-only per #909), and Cast/Locations/Elements/Music/Script facets fed by a pure selectionTags() union (null = show all). Kills the Cast/Location/Elements duplication.
- **Speed layer** — arrows step shots/scenes, shift-arrows extend the scene range, Esc zooms out one scope level, Space plays the current scope, Enter drills in, cmd+K command palette (jump to scene/shot, switch facets, set models — zero new dependencies).
- **Routes** — /theatre redirects to /scenes; top tab bar shrinks to Script + Scenes; /cast, /locations, /elements, /music leave the tab bar but survive as deep-link targets; all per-item edit routes preserved.

Scope calls flagged for review: Script stays a top tab (landing/editing surface) plus a read-only facet; scene-scope playback deliberately drops music (the sequence track would start at 0:00 against the wrong shots).

## Review follow-ups (second commit)

- History-aware back arrows on the Cast / Locations / Elements pages and character/location detail pages (`BackButton`): back restores the exact Scenes selection; deep links fall back to a sensible route.
- SCENES spine header now toggles select-all scenes ↔ none.
- Highlight disambiguation: selected shots use the same weight as selected scene headers; the spine no longer draws a selection-lookalike ring for the playhead.
- Shot completion tick replaced by the thumbnail play badge (solid = has video, pulsing = motion generating).

## Test plan

- 16 new unit tests for the selection model (scope derivation, tag unions, range select, keyboard transitions); full suite 1641 passing.
- typecheck / lint / knip clean.
- Browser-verified against seeded demo data: stitched playback with playhead-linked spine+filmstrip highlights (DOM-confirmed in sync), every scope transition, multi-select, all five facets re-scoping, keyboard grammar, and the palette. Found and fixed a stale player clock/meta bug on re-scope.
- Full-pipeline e2e's theatre step follows the /theatre redirect to the same player; worth watching on first CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uin46jYYBT2qn1wJ4apVRN

