### PR TITLE
Document intentional FAL_PROXY_URL bypass for per-request fal clients

### DIFF
--- a/scripts/verify-fal-costs.ts
+++ b/scripts/verify-fal-costs.ts
@@ -68,6 +68,10 @@ const compareOnly = args.includes('--compare');
 const imageUrlIdx = args.indexOf('--image-url');
 const testImageUrl = imageUrlIdx >= 0 ? args[imageUrlIdx + 1] : undefined;
 
+// Intentionally direct clients that bypass FAL_PROXY_URL (see
+// configureFalProxyFromEnv in src/lib/ai/fal-config.ts): this script exists
+// to verify real fal costs against real usage data, so routing it through
+// the e2e aimock proxy would be pointless.
 const falLow = createFalClient({ credentials: FAL_KEY_LOW });
 const falHigh = createFalClient({ credentials: FAL_KEY_HIGH });
 

--- a/src/lib/ai/fal-config.ts
+++ b/src/lib/ai/fal-config.ts
@@ -50,10 +50,12 @@ function composeMiddleware(
  *
  * The `@tanstack/ai-fal` adapters call `fal.config({ credentials })` on the
  * singleton and would otherwise wipe any `requestMiddleware` we set, so we
- * monkey-patch `fal.config` to compose ours back in. Note: callers that build
- * a per-request client via `@fal-ai/client`'s `createFalClient(...)` get an
- * independent client whose config closure this monkey-patch can't touch —
- * those bypass the proxy.
+ * monkey-patch `fal.config` to compose ours back in. Callers that build a
+ * per-request client via `@fal-ai/client`'s `createFalClient(...)` get an
+ * independent client whose config closure this monkey-patch can't touch. The
+ * two call sites that do (`src/lib/storage/external-url.ts` and
+ * `scripts/verify-fal-costs.ts`) bypass the proxy intentionally — see the
+ * rationale comments there (#890).
  */
 export function configureFalProxyFromEnv(): void {
   if (configured) return;


### PR DESCRIPTION
## Summary

Resolves #890 via its documentation arm: instead of wiring proxy middleware into per-request fal clients, document that both direct `createFalClient` call sites bypass `FAL_PROXY_URL` intentionally.

- `scripts/verify-fal-costs.ts` — add a rationale comment on the direct clients: the script exists to verify **real** fal costs against **real** usage data, so routing it through the e2e aimock proxy would be pointless. (`src/lib/storage/external-url.ts` already documents its own bypass in place.)
- `src/lib/ai/fal-config.ts` — update the `configureFalProxyFromEnv` docstring to name the two intentional-bypass call sites and point at their rationale comments.

Context: `FAL_PROXY_URL` is only ever set by `playwright.config.ts` for the full-pipeline e2e app server; neither script/tooling flow runs under it, so the previously proposed proxy-aware client factory (PR #1015, now closed) had no realistic caller. Comments-only change, no runtime impact.

Closes #890

## Credit

Thanks to @AdemBenAbdallah, whose PR #1015 prompted resolving #890 — it wired the proxy into the script and its review surfaced that the documentation arm of the issue was the better fit. The analysis and tests there informed this change.

## Validation

- `bun format:check`
- `bun lint`
- pre-commit: dead-code, format, lint, typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)
