### PR TITLE
Reject music-only sequence creation

### DIFF
--- a/src/functions/__tests__/sequences.test.ts
+++ b/src/functions/__tests__/sequences.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   assertModelNotAlreadyAdded,
   buildAddAudioMusicInput,
+  musicWithoutMotion,
   selectEligibleVideoShots,
   sumShotDurationsSeconds,
 } from '@/functions/sequences';
@@ -226,5 +227,47 @@ describe('buildAddAudioMusicInput (#547)', () => {
       model: 'elevenlabs_music',
       isPrimary: false,
     });
+  });
+});
+
+describe('musicWithoutMotion (#823)', () => {
+  const flags = (autoGenerateMusic: boolean, autoGenerateMotion: boolean) => ({
+    autoGenerateMusic,
+    autoGenerateMotion,
+  });
+
+  it('rejects an update that sets music on while motion is off', () => {
+    expect(musicWithoutMotion(flags(true, false), flags(false, false))).toBe(
+      true
+    );
+  });
+
+  it('rejects music set alone onto a motion-off sequence', () => {
+    expect(
+      musicWithoutMotion({ autoGenerateMusic: true }, flags(false, false))
+    ).toBe(true);
+  });
+
+  it('rejects motion turned off while music stays on', () => {
+    expect(
+      musicWithoutMotion({ autoGenerateMotion: false }, flags(true, true))
+    ).toBe(true);
+  });
+
+  it('accepts music set alone when motion is already on', () => {
+    expect(
+      musicWithoutMotion({ autoGenerateMusic: true }, flags(false, true))
+    ).toBe(false);
+  });
+
+  it('accepts an update that leaves both flags untouched', () => {
+    expect(musicWithoutMotion({}, flags(false, false))).toBe(false);
+    expect(musicWithoutMotion({}, flags(true, true))).toBe(false);
+  });
+
+  it('accepts turning music off regardless of motion', () => {
+    expect(
+      musicWithoutMotion({ autoGenerateMusic: false }, flags(true, false))
+    ).toBe(false);
   });
 });

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -30,6 +30,7 @@ import { VARIANT_TYPES, type VariantType } from '@/lib/db/schema/shot-variants';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import {
   createSequenceSchema,
+  MUSIC_REQUIRES_MOTION_ERROR,
   updateSequenceSchema,
 } from '@/lib/schemas/sequence.schemas';
 import { triggerWorkflow } from '@/lib/workflow/client';
@@ -101,6 +102,19 @@ export const createSequenceFn = createServerFn({ method: 'POST' })
   });
 
 /**
+ * Music only generates inside the motion phase (#823), so an update whose
+ * merged flags leave music on without motion would strand music as a silent
+ * no-op on the next regeneration. The schema alone can't catch this — it
+ * doesn't see the persisted flags a partial update leaves untouched.
+ */
+export const musicWithoutMotion = (
+  update: { autoGenerateMusic?: boolean; autoGenerateMotion?: boolean },
+  existing: { autoGenerateMusic: boolean; autoGenerateMotion: boolean }
+): boolean =>
+  (update.autoGenerateMusic ?? existing.autoGenerateMusic) &&
+  !(update.autoGenerateMotion ?? existing.autoGenerateMotion);
+
+/**
  * Update a sequence.
  * Triggers storyboard regeneration if script/style/aspectRatio/model changes.
  */
@@ -111,6 +125,10 @@ export const updateSequenceFn = createServerFn({ method: 'POST' })
   )
   .handler(async ({ data, context }) => {
     const { sequenceId, ...updateData } = data;
+
+    if (musicWithoutMotion(updateData, context.sequence)) {
+      throw new Error(MUSIC_REQUIRES_MOTION_ERROR);
+    }
 
     const needsRegeneration =
       updateData.script !== undefined ||

--- a/src/lib/api-v1/input-schema.test.ts
+++ b/src/lib/api-v1/input-schema.test.ts
@@ -11,6 +11,19 @@ describe('apiCreateSequenceSchema', () => {
     expect(parsed.music).toBe(false);
   });
 
+  it('rejects music without motion', () => {
+    const result = apiCreateSequenceSchema.safeParse({
+      script: 'A valid length script here.',
+      motion: false,
+      music: true,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('requires motion');
+    }
+  });
+
   it('rejects an invalid enhance mode', () => {
     expect(
       apiCreateSequenceSchema.safeParse({

--- a/src/lib/api-v1/input-schema.test.ts
+++ b/src/lib/api-v1/input-schema.test.ts
@@ -20,8 +20,32 @@ describe('apiCreateSequenceSchema', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toContain('requires motion');
+      const issue = result.error.issues.find((i) => i.path[0] === 'music');
+      expect(issue?.message).toContain('requires motion');
     }
+  });
+
+  it('rejects music when motion is omitted (defaults to false)', () => {
+    const result = apiCreateSequenceSchema.safeParse({
+      script: 'A valid length script here.',
+      music: true,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === 'music');
+      expect(issue?.message).toContain('requires motion');
+    }
+  });
+
+  it('accepts music with motion', () => {
+    const result = apiCreateSequenceSchema.safeParse({
+      script: 'A valid length script here.',
+      motion: true,
+      music: true,
+    });
+
+    expect(result.success).toBe(true);
   });
 
   it('rejects an invalid enhance mode', () => {

--- a/src/lib/api-v1/input-schema.ts
+++ b/src/lib/api-v1/input-schema.ts
@@ -11,6 +11,7 @@
  */
 
 import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
+import { MUSIC_REQUIRES_MOTION_ERROR } from '@/lib/schemas/sequence.schemas';
 import { z } from 'zod';
 
 const entityName = z
@@ -68,9 +69,6 @@ const locationRefSchema = z
     description:
       'Existing location by id or name (string), or an inline create object.',
   });
-
-const MUSIC_REQUIRES_MOTION_ERROR =
-  'Music generation currently requires motion. Turn on motion or disable music.';
 
 export const apiCreateSequenceSchema = z
   .object({
@@ -187,14 +185,9 @@ export const apiCreateSequenceSchema = z
         'Reserved for phase 2: URL to receive a signed completion webhook. Stored intent only — delivery is not implemented yet.',
     }),
   })
-  .superRefine((data, ctx) => {
-    if (data.music && !data.motion) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['music'],
-        message: MUSIC_REQUIRES_MOTION_ERROR,
-      });
-    }
+  .refine((data) => !data.music || data.motion, {
+    path: ['music'],
+    message: MUSIC_REQUIRES_MOTION_ERROR,
   })
   .meta({
     id: 'CreateSequenceRequest',

--- a/src/lib/api-v1/input-schema.ts
+++ b/src/lib/api-v1/input-schema.ts
@@ -69,6 +69,9 @@ const locationRefSchema = z
       'Existing location by id or name (string), or an inline create object.',
   });
 
+const MUSIC_REQUIRES_MOTION_ERROR =
+  'Music generation currently requires motion. Turn on motion or disable music.';
+
 export const apiCreateSequenceSchema = z
   .object({
     script: z
@@ -183,6 +186,15 @@ export const apiCreateSequenceSchema = z
       description:
         'Reserved for phase 2: URL to receive a signed completion webhook. Stored intent only — delivery is not implemented yet.',
     }),
+  })
+  .superRefine((data, ctx) => {
+    if (data.music && !data.motion) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['music'],
+        message: MUSIC_REQUIRES_MOTION_ERROR,
+      });
+    }
   })
   .meta({
     id: 'CreateSequenceRequest',

--- a/src/lib/schemas/sequence.schemas.test.ts
+++ b/src/lib/schemas/sequence.schemas.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { createSequenceSchema } from './sequence.schemas';
+
+describe('createSequenceSchema', () => {
+  it('rejects music without motion', () => {
+    const result = createSequenceSchema.safeParse({
+      script: 'A valid length script here.',
+      styleId: 'style_1',
+      autoGenerateMotion: false,
+      autoGenerateMusic: true,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toContain('requires motion');
+    }
+  });
+
+  it('accepts music when motion is enabled', () => {
+    const result = createSequenceSchema.safeParse({
+      script: 'A valid length script here.',
+      styleId: 'style_1',
+      aspectRatio: '16:9',
+      autoGenerateMotion: true,
+      autoGenerateMusic: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/lib/schemas/sequence.schemas.test.ts
+++ b/src/lib/schemas/sequence.schemas.test.ts
@@ -12,7 +12,10 @@ describe('createSequenceSchema', () => {
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.message).toContain('requires motion');
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === 'autoGenerateMusic'
+      );
+      expect(issue?.message).toContain('requires motion');
     }
   });
 

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -32,6 +32,9 @@ const validAudioModelKeys = Object.keys(
   AUDIO_MODELS
 ) satisfies readonly string[];
 
+const MUSIC_REQUIRES_MOTION_ERROR =
+  'Music generation currently requires motion. Turn on motion or disable music.';
+
 export const createSequenceSchema = createInsertSchema(sequences, {
   title: (schema) => schema.min(1).optional(), // Optional - defaults to 'Untitled Sequence' in hook
   script: z.string().min(10), // Override to make it required with business rules
@@ -147,6 +150,15 @@ export const createSequenceSchema = createInsertSchema(sequences, {
     // When regenerating from an existing sequence, copy its elements onto the
     // newly created sequence so the user doesn't have to re-upload references.
     sourceSequenceId: ulidSchemaOptional,
+  })
+  .superRefine((data, ctx) => {
+    if (data.autoGenerateMusic && !data.autoGenerateMotion) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['autoGenerateMusic'],
+        message: MUSIC_REQUIRES_MOTION_ERROR,
+      });
+    }
   });
 
 export const updateSequenceSchema = createUpdateSchema(sequences, {

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -32,7 +32,7 @@ const validAudioModelKeys = Object.keys(
   AUDIO_MODELS
 ) satisfies readonly string[];
 
-const MUSIC_REQUIRES_MOTION_ERROR =
+export const MUSIC_REQUIRES_MOTION_ERROR =
   'Music generation currently requires motion. Turn on motion or disable music.';
 
 export const createSequenceSchema = createInsertSchema(sequences, {
@@ -151,14 +151,9 @@ export const createSequenceSchema = createInsertSchema(sequences, {
     // newly created sequence so the user doesn't have to re-upload references.
     sourceSequenceId: ulidSchemaOptional,
   })
-  .superRefine((data, ctx) => {
-    if (data.autoGenerateMusic && !data.autoGenerateMotion) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['autoGenerateMusic'],
-        message: MUSIC_REQUIRES_MOTION_ERROR,
-      });
-    }
+  .refine((data) => !data.autoGenerateMusic || data.autoGenerateMotion, {
+    path: ['autoGenerateMusic'],
+    message: MUSIC_REQUIRES_MOTION_ERROR,
   });
 
 export const updateSequenceSchema = createUpdateSchema(sequences, {


### PR DESCRIPTION
## Summary

This makes the create path reject `music: true` when `motion: false` instead of silently skipping music generation.

### Why

The current workflow only starts music generation inside the motion branch, so a music-only request becomes a silent no-op. This change makes that limitation explicit at validation time so callers get a clear error instead of a completed sequence with `musicStatus: pending`.

### What changed

- Added a `superRefine` guard to `apiCreateSequenceSchema`
- Added the same guard to `createSequenceSchema`
- Added regression tests for both schemas

### Notes

I kept this scoped to validation so we can make the current behavior legible first. If the preferred product direction is to support music-only generation, I can follow up with a standalone music path.

Closes #823

