### PR TITLE
fix(billing): provider-cost usage, purchase fee, pricing page, and missing deductions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ BETTER_AUTH_SECRET=
 # =============================================================================
 
 # FAL_KEY=           # https://fal.ai - image, video & audio; also covers LLM calls via fal's OpenRouter endpoint
+# FAL_PRICING_KEY=   # fal admin key — pricing sync (update-fal-pricing.ts) and usage comparison (verify-fal-costs.ts --compare)
 # OPENROUTER_KEY=    # https://openrouter.ai - LLM access for script analysis (optional with FAL_KEY set)
 
 # =============================================================================

--- a/scripts/check-fal-estimate.ts
+++ b/scripts/check-fal-estimate.ts
@@ -4,20 +4,15 @@
  *
  * Note: the --individual flag hits the API once per model and may get rate-limited.
  *
- * Usage:
+ * Usage (Bun autoloads .env.local; use --env-file= to override):
  *   bun scripts/check-fal-estimate.ts              # Total estimate
  *   bun scripts/check-fal-estimate.ts --individual  # Per-model breakdown
  */
-import { getEnv } from '#env';
 import { getFalEndpointIds } from './fal-endpoints';
+import { requireFalPricingKey } from './env-file';
 
 const allIds = getFalEndpointIds();
-
-const apiKey = getEnv().FAL_KEY;
-if (!apiKey) {
-  console.error('FAL_KEY not set');
-  process.exit(1);
-}
+const apiKey = requireFalPricingKey();
 
 type EstimateResponse = {
   estimate_type: string;

--- a/scripts/check-fal-pricing.ts
+++ b/scripts/check-fal-pricing.ts
@@ -1,17 +1,13 @@
 /**
  * Check fal.ai pricing for all supported models
  * Usage: bun scripts/check-fal-pricing.ts
+ * (Bun autoloads .env.local; use --env-file= to override)
  */
-import { getEnv } from '#env';
 import { getFalEndpointIds } from './fal-endpoints';
+import { requireFalPricingKey } from './env-file';
 
 const endpoints = getFalEndpointIds();
-
-const apiKey = getEnv().FAL_KEY;
-if (!apiKey) {
-  console.error('FAL_KEY not set');
-  process.exit(1);
-}
+const apiKey = requireFalPricingKey();
 
 const url = new URL('https://api.fal.ai/v1/models/pricing');
 url.searchParams.set('endpoint_id', endpoints.join(','));

--- a/scripts/env-file.ts
+++ b/scripts/env-file.ts
@@ -113,6 +113,20 @@ export function ensureLocalEnv(): string[] {
   return added;
 }
 
+/** Admin key for fal's pricing & usage APIs (distinct from FAL_KEY for generation). */
+export function getFalPricingKey(): string | undefined {
+  return process.env.FAL_PRICING_KEY;
+}
+
+export function requireFalPricingKey(): string {
+  const key = getFalPricingKey();
+  if (!key) {
+    console.error('FAL_PRICING_KEY not set (add to .env.local)');
+    process.exit(1);
+  }
+  return key;
+}
+
 export function generateSecret(): string {
   try {
     return execFileSync('openssl', ['rand', '-hex', '32'], {

--- a/scripts/update-fal-pricing.ts
+++ b/scripts/update-fal-pricing.ts
@@ -1,6 +1,6 @@
 /**
  * Fetch live pricing from fal.ai and write src/lib/ai/fal-pricing-data.ts
- * Usage:
+ * Usage (Bun autoloads .env.local; use --env-file= to override):
  *   bun scripts/update-fal-pricing.ts
  *
  * The output is a single flat map of `endpointId -> { unitPrice, unit }` taken
@@ -12,8 +12,8 @@
  * count before a generation runs.
  */
 import { writeFile } from 'node:fs/promises';
-import { getEnv } from '#env';
 import { getFalEndpointIds } from './fal-endpoints';
+import { requireFalPricingKey } from './env-file';
 
 /**
  * Wrapper to tag numeric values that should be serialized as `micros(X)` in the
@@ -38,11 +38,7 @@ type FalUnit =
 
 type BuilderFalPricing = { unitPrice: MicrosValue; unit: FalUnit };
 
-const apiKey = getEnv().FAL_KEY;
-if (!apiKey) {
-  console.error('FAL_KEY not set');
-  process.exit(1);
-}
+const apiKey = requireFalPricingKey();
 
 const endpoints = getFalEndpointIds();
 

--- a/scripts/update-openrouter-pricing.ts
+++ b/scripts/update-openrouter-pricing.ts
@@ -1,0 +1,91 @@
+/**
+ * Fetch live pricing from OpenRouter and write src/lib/ai/openrouter-pricing-data.ts
+ * Usage:
+ *   bun scripts/update-openrouter-pricing.ts
+ *
+ * Only syncs models in SCRIPT_ANALYSIS_MODELS — the LLM models OpenStory uses.
+ * Actual billing uses OpenRouter's per-request `usage.cost`; this file powers
+ * the public pricing page and pre-flight estimates.
+ */
+import { writeFile } from 'node:fs/promises';
+import { SCRIPT_ANALYSIS_MODELS } from '../src/lib/ai/models.config';
+
+type OpenRouterModel = {
+  id: string;
+  name: string;
+  pricing?: {
+    prompt?: string;
+    completion?: string;
+    web_search?: string;
+  };
+};
+
+type OpenRouterModelsResponse = {
+  data: OpenRouterModel[];
+};
+
+const MODEL_IDS = SCRIPT_ANALYSIS_MODELS.map((m) => m.id);
+
+const response = await fetch('https://openrouter.ai/api/v1/models');
+if (!response.ok) {
+  console.error(`OpenRouter models API failed: ${response.status}`);
+  process.exit(1);
+}
+
+const payload: OpenRouterModelsResponse = await response.json();
+const byId = new Map(payload.data.map((m) => [m.id, m]));
+
+const missing: string[] = [];
+const entries: string[] = [];
+
+for (const modelId of MODEL_IDS) {
+  const model = byId.get(modelId);
+  if (!model?.pricing?.prompt || !model.pricing.completion) {
+    missing.push(modelId);
+    continue;
+  }
+
+  const promptPerM = Number(model.pricing.prompt) * 1_000_000;
+  const completionPerM = Number(model.pricing.completion) * 1_000_000;
+  const webSearch = model.pricing.web_search
+    ? Number(model.pricing.web_search)
+    : null;
+
+  entries.push(`  '${modelId}': {
+    name: ${JSON.stringify(model.name)},
+    promptPerMillionTokens: ${promptPerM},
+    completionPerMillionTokens: ${completionPerM},${
+      webSearch != null ? `\n    webSearchPerQuery: ${webSearch},` : ''
+    }
+  },`);
+}
+
+if (missing.length > 0) {
+  console.warn('Missing pricing for models:', missing.join(', '));
+}
+
+const timestamp = new Date().toISOString();
+const output = `// AUTO-GENERATED — do not edit manually. Run: bun scripts/update-openrouter-pricing.ts
+
+export type OpenRouterPricing = {
+  name: string;
+  /** USD per 1M input tokens */
+  promptPerMillionTokens: number;
+  /** USD per 1M output tokens */
+  completionPerMillionTokens: number;
+  /** USD per web search query, when supported */
+  webSearchPerQuery?: number;
+};
+
+export const OPENROUTER_PRICING: Record<string, OpenRouterPricing> = {
+${entries.join('\n')}
+};
+
+export const OPENROUTER_PRICING_LAST_UPDATED = '${timestamp}';
+`;
+
+await writeFile('src/lib/ai/openrouter-pricing-data.ts', output);
+console.log(
+  `Wrote ${entries.length} model prices to src/lib/ai/openrouter-pricing-data.ts`
+);
+if (missing.length > 0) process.exit(1);

--- a/scripts/verify-fal-costs.ts
+++ b/scripts/verify-fal-costs.ts
@@ -9,9 +9,9 @@
  *
  * Falls back to single FAL_KEY when per-tier keys are not set.
  *
- * Usage:
- *   FAL_KEY=... bun scripts/verify-fal-costs.ts
- *   FAL_KEY_LOW=... FAL_KEY_HIGH=... bun scripts/verify-fal-costs.ts
+ * Usage (Bun autoloads .env.local; use --env-file= to override):
+ *   bun scripts/verify-fal-costs.ts
+ *   bun scripts/verify-fal-costs.ts --dry-run
  *   bun scripts/verify-fal-costs.ts --image-url https://example.com/test.jpg
  *   bun scripts/verify-fal-costs.ts --dry-run
  *   bun scripts/verify-fal-costs.ts --retry              # rerun only errored tasks
@@ -32,7 +32,6 @@ import { typedEntries } from '@/lib/utils/typed-object';
 import { createFalClient } from '@fal-ai/client';
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-
 // ============================================================================
 // Configuration
 // ============================================================================
@@ -44,13 +43,13 @@ const FAL_KEY_HIGH = process.env.FAL_KEY_HIGH ?? process.env.FAL_KEY;
 
 if (!FAL_KEY_LOW || !FAL_KEY_HIGH) {
   console.error(
-    'Set FAL_KEY_LOW + FAL_KEY_HIGH (or FAL_KEY for single-key mode)'
+    'Set FAL_KEY in .env.local (or FAL_KEY_LOW + FAL_KEY_HIGH for two-key mode)'
   );
   process.exit(1);
 }
 
 const twoKeyMode = FAL_KEY_LOW !== FAL_KEY_HIGH;
-const FAL_ADMIN_KEY = process.env.FAL_ADMIN_KEY;
+const FAL_PRICING_KEY = process.env.FAL_PRICING_KEY;
 
 const MAX_CONCURRENT = 20;
 const TEST_PROMPT =
@@ -434,7 +433,7 @@ async function runTask(task: Task, semaphore: Semaphore): Promise<Result> {
 }
 
 // ============================================================================
-// Usage API (requires FAL_ADMIN_KEY)
+// Usage API (requires FAL_PRICING_KEY)
 // ============================================================================
 
 type UsageEntry = {
@@ -599,8 +598,10 @@ async function main() {
 
   // --compare: skip generation, load previous results and fetch usage
   if (compareOnly) {
-    if (!FAL_ADMIN_KEY) {
-      console.error('FAL_ADMIN_KEY is required for --compare');
+    if (!FAL_PRICING_KEY) {
+      console.error(
+        'FAL_PRICING_KEY is required for --compare (set in .env.local)'
+      );
       process.exit(1);
     }
     const csvPath = path.join(
@@ -675,7 +676,7 @@ async function main() {
     ];
 
     const usage = await fetchUsage(
-      FAL_ADMIN_KEY,
+      FAL_PRICING_KEY,
       startTime,
       endTime,
       uniqueEndpoints
@@ -809,8 +810,8 @@ async function main() {
   await writeFile(csvPath, csv);
   console.error(`\nCSV saved to: ${csvPath}`);
 
-  // Fetch usage data (requires FAL_ADMIN_KEY, skip in dry-run)
-  if (!dryRun && FAL_ADMIN_KEY) {
+  // Fetch usage data (requires FAL_PRICING_KEY, skip in dry-run)
+  if (!dryRun && FAL_PRICING_KEY) {
     const successfulResults = results.filter((r) => r.status === 'completed');
     const uniqueEndpoints = [
       ...new Set(successfulResults.map((r) => r.endpointId)),
@@ -823,7 +824,7 @@ async function main() {
       console.error('Fetching usage data from fal API…');
       try {
         const usage = await fetchUsage(
-          FAL_ADMIN_KEY,
+          FAL_PRICING_KEY,
           startTime,
           endTime,
           uniqueEndpoints
@@ -862,8 +863,10 @@ async function main() {
         );
       }
     }
-  } else if (!dryRun && !FAL_ADMIN_KEY) {
-    console.error('\nSkipping usage comparison (set FAL_ADMIN_KEY to enable)');
+  } else if (!dryRun && !FAL_PRICING_KEY) {
+    console.error(
+      '\nSkipping usage comparison (set FAL_PRICING_KEY in .env.local to enable)'
+    );
   }
 
   // Summary

--- a/src/components/marketing/site-footer.tsx
+++ b/src/components/marketing/site-footer.tsx
@@ -72,6 +72,12 @@ export function SiteFooter() {
 
           <div className="flex items-center gap-4">
             <Link
+              to="/pricing"
+              className="text-xs text-background/40 transition-colors hover:text-background"
+            >
+              Pricing
+            </Link>
+            <Link
               to="/docs"
               className="text-xs text-background/40 transition-colors hover:text-background"
             >

--- a/src/components/marketing/site-header.tsx
+++ b/src/components/marketing/site-header.tsx
@@ -22,6 +22,7 @@ function GitHubIcon({ className }: { className?: string }) {
 }
 
 const navLinks = [
+  { href: '/pricing', label: 'Pricing', external: false },
   { href: '/docs', label: 'Docs', external: false },
   { href: SITE_CONFIG.githubHref, label: 'GitHub', external: true, icon: true },
 ] as const;

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -42,8 +42,10 @@ import {
 import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
 import { useShowBalance } from '@/hooks/use-show-balance';
 import {
+  formatProcessingFeePercent,
   MIN_TOPUP_AMOUNT_USD,
   PRESET_TOPUP_AMOUNTS_USD,
+  splitCheckoutAmounts,
 } from '@/lib/billing/constants';
 import { usePostHog } from '@posthog/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -219,6 +221,10 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
   const effectiveAmount = selectedAmount ?? parseFloat(customAmount);
   const isValidAmount =
     !isNaN(effectiveAmount) && effectiveAmount >= MIN_TOPUP_AMOUNT_USD;
+  const checkoutBreakdown = isValidAmount
+    ? splitCheckoutAmounts(effectiveAmount)
+    : null;
+  const feePercent = formatProcessingFeePercent();
   const autoTopUpThreshold =
     autoTopUpPrompt !== null ? Math.ceil((autoTopUpPrompt * 0.1) / 5) * 5 : 5;
 
@@ -300,7 +306,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
           <SectionHeader
             icon={Wallet}
             title="Credit Balance"
-            description="Credits are used for image and video generation"
+            description="Pay-as-you-go wallet for AI generation at provider cost"
           />
         </CardHeader>
         <CardContent className="space-y-4">
@@ -342,7 +348,7 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
               <SectionHeader
                 icon={DollarSign}
                 title="Add Credits"
-                description="Choose an amount or enter a custom value"
+                description={`Credits are billed at provider cost. A ${feePercent} processing fee applies at purchase — not on usage.`}
               />
             </CardHeader>
             <CardContent className="space-y-4">
@@ -386,6 +392,25 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
                 />
               </div>
 
+              {checkoutBreakdown && (
+                <div className="rounded-lg border bg-muted/30 px-4 py-3 text-sm">
+                  <div className="flex justify-between tabular-nums">
+                    <span className="text-muted-foreground">Credits</span>
+                    <span>${checkoutBreakdown.creditUsd.toFixed(2)}</span>
+                  </div>
+                  <div className="flex justify-between tabular-nums">
+                    <span className="text-muted-foreground">
+                      Processing fee ({feePercent})
+                    </span>
+                    <span>${checkoutBreakdown.feeUsd.toFixed(2)}</span>
+                  </div>
+                  <div className="mt-2 flex justify-between border-t pt-2 font-medium tabular-nums">
+                    <span>Total charged</span>
+                    <span>${checkoutBreakdown.totalUsd.toFixed(2)}</span>
+                  </div>
+                </div>
+              )}
+
               <Button
                 onClick={handleTopUp}
                 disabled={!isValidAmount || checkoutMutation.isPending}
@@ -393,10 +418,16 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
               >
                 {checkoutMutation.isPending
                   ? 'Loading…'
-                  : isValidAmount
-                    ? `Top up $${effectiveAmount}`
+                  : checkoutBreakdown
+                    ? `Pay $${checkoutBreakdown.totalUsd.toFixed(2)}`
                     : 'Top up'}
               </Button>
+
+              <p className="text-center text-xs text-muted-foreground">
+                <Link to="/pricing" className="underline hover:text-foreground">
+                  View full model pricing
+                </Link>
+              </p>
 
               {!balanceLoading && !balanceData?.hasPaymentMethod && (
                 <p className="text-xs text-muted-foreground">

--- a/src/functions/ai.ts
+++ b/src/functions/ai.ts
@@ -21,6 +21,7 @@ import {
   RateLimiter,
   scriptEnhancementRateLimiter,
 } from '@/lib/ai/script-enhancer';
+import { reportMissingBillingCost } from '@/lib/billing/billing-observability';
 import { estimateLLMCost } from '@/lib/billing/cost-estimation';
 import type { Microdollars } from '@/lib/billing/money';
 import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
@@ -111,7 +112,13 @@ async function prepareBilling(
           description,
           metadata,
         });
+        return;
       }
+      reportMissingBillingCost({
+        source: 'server-fn-deduct',
+        description,
+        metadata,
+      });
     },
   };
 }
@@ -156,8 +163,6 @@ export const shortenPromptFn = createServerFn({ method: 'POST' })
       if (chunk.done) usage = chunk.usage;
     }
 
-    await deduct?.(llmCostFromUsage(usage, model));
-
     if (!shortenedPrompt) {
       throw new Error('No response received from AI service');
     }
@@ -166,6 +171,8 @@ export const shortenPromptFn = createServerFn({ method: 'POST' })
     if (trimmedPrompt.length < 20) {
       throw new Error('Shortened prompt is too short. Please try again.');
     }
+
+    await deduct?.(llmCostFromUsage(usage, model));
 
     return {
       originalPrompt: data.prompt,

--- a/src/functions/ai.ts
+++ b/src/functions/ai.ts
@@ -6,8 +6,8 @@
 import { getEnv } from '#env';
 import { mediaUrlSchema } from '@/lib/schemas/media-url.schemas';
 import {
-  callLLM,
   callLLMStream,
+  llmCostFromUsage,
   PROMPT_REASONING,
   RECOMMENDED_MODELS,
 } from '@/lib/ai/llm-client';
@@ -22,6 +22,7 @@ import {
   scriptEnhancementRateLimiter,
 } from '@/lib/ai/script-enhancer';
 import { estimateLLMCost } from '@/lib/billing/cost-estimation';
+import type { Microdollars } from '@/lib/billing/money';
 import { aspectRatioSchema } from '@/lib/constants/aspect-ratios';
 import { StyleConfigSchema } from '@/lib/db/schema/libraries';
 import type { ScopedDb } from '@/lib/db/scoped';
@@ -87,12 +88,15 @@ async function prepareBilling(
   scopedDb: ScopedDb,
   description: string,
   metadata?: Record<string, unknown>
-): Promise<{ llmKey: ResolvedLlmKey; deduct?: () => Promise<void> }> {
+): Promise<{
+  llmKey: ResolvedLlmKey;
+  deduct?: (actualCost: Microdollars) => Promise<void>;
+}> {
   const llmKey = await scopedDb.apiKeys.resolveLlmKey();
   if (llmKey.source === 'team') return { llmKey };
 
-  const cost = estimateLLMCost(1);
-  const canAfford = await scopedDb.billing.hasEnoughCredits(cost);
+  const estimatedCost = estimateLLMCost(1);
+  const canAfford = await scopedDb.billing.hasEnoughCredits(estimatedCost);
   if (!canAfford) {
     throw new InsufficientCreditsError(
       `Insufficient credits for ${description.toLowerCase()}`
@@ -101,9 +105,9 @@ async function prepareBilling(
 
   return {
     llmKey,
-    deduct: async () => {
-      if (cost > 0) {
-        await scopedDb.billing.deductCredits(cost, {
+    deduct: async (actualCost) => {
+      if (actualCost > 0) {
+        await scopedDb.billing.deductCredits(actualCost, {
           description,
           metadata,
         });
@@ -133,8 +137,11 @@ export const shortenPromptFn = createServerFn({ method: 'POST' })
       { model: RECOMMENDED_MODELS.fast }
     );
 
-    const shortenedPrompt = await callLLM({
-      model: RECOMMENDED_MODELS.fast,
+    const model = RECOMMENDED_MODELS.fast;
+    let shortenedPrompt = '';
+    let usage;
+    for await (const chunk of callLLMStream({
+      model,
       messages: [
         { role: 'system' as const, content: SHORTEN_PROMPT_SYSTEM },
         { role: 'user' as const, content: data.prompt },
@@ -144,9 +151,12 @@ export const shortenPromptFn = createServerFn({ method: 'POST' })
       observationName: 'shortenPrompt',
       userId: context.user.id,
       apiKey: llmKey,
-    });
+    })) {
+      shortenedPrompt = chunk.accumulated;
+      if (chunk.done) usage = chunk.usage;
+    }
 
-    await deduct?.();
+    await deduct?.(llmCostFromUsage(usage, model));
 
     if (!shortenedPrompt) {
       throw new Error('No response received from AI service');
@@ -238,7 +248,9 @@ export const estimateSceneDurationFn = createServerFn({ method: 'POST' })
       .filter(Boolean)
       .join('\n');
 
-    const response = await callLLM({
+    let response;
+    let usage;
+    for await (const chunk of callLLMStream({
       model: analysisModel,
       messages: [
         { role: 'system' as const, content: ESTIMATE_SCENE_DURATION_SYSTEM },
@@ -250,9 +262,18 @@ export const estimateSceneDurationFn = createServerFn({ method: 'POST' })
       userId: context.user.id,
       responseSchema: sceneDurationResponseSchema,
       apiKey: llmKey,
-    });
+    })) {
+      if (chunk.done) {
+        response = chunk.parsed;
+        usage = chunk.usage;
+      }
+    }
 
-    await deduct?.();
+    if (!response) {
+      throw new Error('No response received from AI service');
+    }
+
+    await deduct?.(llmCostFromUsage(usage, analysisModel));
 
     return { durationSeconds: clampDuration(response.durationSeconds) };
   });
@@ -390,6 +411,7 @@ export async function* streamScriptEnhancement(
   // is NOT gated — it's deterministic once recorded, so E2E records + replays
   // it like any other request.
   const useWebSearch = getEnv().E2E_TEST !== 'true';
+  let usage;
   for await (const chunk of callLLMStream({
     model,
     messages,
@@ -417,9 +439,10 @@ export async function* streamScriptEnhancement(
     if (chunk.delta) {
       yield { delta: chunk.delta };
     }
+    if (chunk.done) usage = chunk.usage;
   }
 
-  await deduct?.();
+  await deduct?.(llmCostFromUsage(usage, model));
 }
 
 /**

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -4,6 +4,9 @@ import {
   describeElementImage,
   ELEMENT_VISION_MODEL,
 } from '@/lib/ai/element-vision';
+import { reportMissingBillingCost } from '@/lib/billing/billing-observability';
+import { estimateLLMCost } from '@/lib/billing/cost-estimation';
+import { InsufficientCreditsError } from '@/lib/errors';
 import { DEFAULT_VIDEO_MODEL, safeImageToVideoModel } from '@/lib/ai/models';
 import { resolveMotionPromptFromVersion } from '@/lib/motion/resolve-motion-prompt';
 import { generateId } from '@/lib/db/id';
@@ -140,16 +143,36 @@ export const analyzeDraftElementFn = createServerFn({ method: 'POST' })
   .handler(async ({ context, data }) => {
     const { scopedDb } = context;
     const llmKeyInfo = await scopedDb.apiKeys.resolveLlmKey();
+    if (llmKeyInfo.source !== 'team') {
+      const estimatedCost = estimateLLMCost(1);
+      const canAfford = await scopedDb.billing.hasEnoughCredits(estimatedCost);
+      if (!canAfford) {
+        throw new InsufficientCreditsError(
+          'Insufficient credits for element vision'
+        );
+      }
+    }
+
     const result = await describeElementImage({
       imageUrl: data.publicUrl,
       filename: data.filename,
       llmKey: llmKeyInfo,
     });
-    if (result.costMicros > 0 && !result.usedOwnKey) {
-      await scopedDb.billing.deductCredits(result.costMicros, {
-        description: `Element vision (${ELEMENT_VISION_MODEL})`,
-        metadata: { model: ELEMENT_VISION_MODEL, draft: true },
-      });
+
+    if (!result.usedOwnKey) {
+      if (result.costMicros > 0) {
+        await scopedDb.billing.deductCredits(result.costMicros, {
+          description: `Element vision (${ELEMENT_VISION_MODEL})`,
+          metadata: { model: ELEMENT_VISION_MODEL, draft: true },
+          idempotencyKey: `draft-vision:${data.publicUrl}`,
+        });
+      } else {
+        reportMissingBillingCost({
+          source: 'draft-element-vision',
+          modelId: ELEMENT_VISION_MODEL,
+          metadata: { draft: true, publicUrl: data.publicUrl },
+        });
+      }
     }
     return {
       description: result.description,

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -1,6 +1,9 @@
 import { mediaUrlSchema } from '@/lib/schemas/media-url.schemas';
 import { getSignedUploadUrl } from '#storage';
-import { describeElementImage } from '@/lib/ai/element-vision';
+import {
+  describeElementImage,
+  ELEMENT_VISION_MODEL,
+} from '@/lib/ai/element-vision';
 import { DEFAULT_VIDEO_MODEL, safeImageToVideoModel } from '@/lib/ai/models';
 import { resolveMotionPromptFromVersion } from '@/lib/motion/resolve-motion-prompt';
 import { generateId } from '@/lib/db/id';
@@ -135,12 +138,19 @@ export const analyzeDraftElementFn = createServerFn({ method: 'POST' })
     )
   )
   .handler(async ({ context, data }) => {
-    const llmKeyInfo = await context.scopedDb.apiKeys.resolveLlmKey();
+    const { scopedDb } = context;
+    const llmKeyInfo = await scopedDb.apiKeys.resolveLlmKey();
     const result = await describeElementImage({
       imageUrl: data.publicUrl,
       filename: data.filename,
       llmKey: llmKeyInfo,
     });
+    if (result.costMicros > 0 && !result.usedOwnKey) {
+      await scopedDb.billing.deductCredits(result.costMicros, {
+        description: `Element vision (${ELEMENT_VISION_MODEL})`,
+        metadata: { model: ELEMENT_VISION_MODEL, draft: true },
+      });
+    }
     return {
       description: result.description,
       consistencyTag: result.consistencyTag,

--- a/src/lib/ai/element-vision.ts
+++ b/src/lib/ai/element-vision.ts
@@ -5,13 +5,16 @@
  * @tanstack/ai's OpenRouter adapter.
  */
 
+import type { Microdollars } from '@/lib/billing/money';
+import type { ResolvedLlmKey } from '@/lib/db/scoped/api-keys';
 import type { ChatMessage, ChatMessageImagePart } from '@/lib/prompts';
 import { toVisionImageSource } from '@/lib/storage/external-url';
-import { chat } from '@tanstack/ai';
+import { chat, type TokenUsage } from '@tanstack/ai';
 import { z } from 'zod';
-import { createAdapter, type LlmKeyInfo } from './create-adapter';
+import { createAdapter } from './create-adapter';
+import { llmCostFromUsage } from './llm-client';
 
-const VISION_MODEL = 'anthropic/claude-sonnet-4.6';
+export const ELEMENT_VISION_MODEL = 'anthropic/claude-sonnet-4.6' as const;
 
 const responseSchema = z.object({
   description: z.string().min(1),
@@ -19,13 +22,18 @@ const responseSchema = z.object({
   suggestedToken: z.string().min(1),
 });
 
-export type ElementDescription = z.infer<typeof responseSchema>;
+type ElementDescription = z.infer<typeof responseSchema>;
 
 export type DescribeElementInput = {
   imageUrl: string;
   filename: string;
   /** Resolved LLM key (team OpenRouter, team fal, or platform) */
-  llmKey?: LlmKeyInfo;
+  llmKey?: ResolvedLlmKey;
+};
+
+export type ElementVisionResult = ElementDescription & {
+  costMicros: Microdollars;
+  usedOwnKey: boolean;
 };
 
 /**
@@ -76,7 +84,7 @@ Describe the element in the image below and suggest a token.`;
 
 export async function describeElementImage(
   input: DescribeElementInput
-): Promise<ElementDescription> {
+): Promise<ElementVisionResult> {
   // Local /r2/ URLs aren't reachable by real OpenRouter — inline the image
   // bytes as a data part instead (no-op in prod and e2e replay).
   const imageSource = await toVisionImageSource(input.imageUrl);
@@ -96,8 +104,9 @@ export async function describeElementImage(
     }
   }
 
-  const adapter = createAdapter(VISION_MODEL, input.llmKey);
+  const adapter = createAdapter(ELEMENT_VISION_MODEL, input.llmKey);
 
+  let capturedUsage: TokenUsage | undefined;
   const result = await chat({
     adapter,
     systemPrompts,
@@ -105,6 +114,13 @@ export async function describeElementImage(
     stream: false,
     modelOptions: { temperature: 0.3 },
     outputSchema: responseSchema,
+    middleware: [
+      {
+        onFinish: (_ctx, info) => {
+          capturedUsage = info.usage;
+        },
+      },
+    ],
     debug: false,
   });
 
@@ -112,5 +128,7 @@ export async function describeElementImage(
   return {
     ...parsed,
     suggestedToken: normalizeSuggestedToken(parsed.suggestedToken),
+    costMicros: llmCostFromUsage(capturedUsage, ELEMENT_VISION_MODEL),
+    usedOwnKey: input.llmKey?.source === 'team',
   };
 }

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -24,7 +24,7 @@ const logger = getLogger(['openstory', 'ai', 'llm-client']);
 /**
  * Convert a completed LLM call's usage into a charge. OpenRouter reports an
  * authoritative per-request `cost` (USD) on every response; we charge that raw
- * cost (markup is applied downstream in `deductCredits`). Logs and charges
+ * cost at face value in `deductCredits`. Logs and charges
  * nothing when no cost was reported, surfacing the gap rather than guessing.
  */
 export function llmCostFromUsage(

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TextModel } from '@/lib/ai/models';
+import { reportMissingBillingCost } from '@/lib/billing/billing-observability';
 import {
   usdToMicros,
   ZERO_MICROS,
@@ -36,10 +37,11 @@ export function llmCostFromUsage(
     typeof usage.cost !== 'number' ||
     !Number.isFinite(usage.cost)
   ) {
-    logger.error(
-      `No usage cost reported for LLM call (${modelId}) — charging nothing`,
-      { usage }
-    );
+    reportMissingBillingCost({
+      source: 'llm-cost-from-usage',
+      modelId,
+      metadata: { usage },
+    });
     return ZERO_MICROS;
   }
   return usdToMicros(usage.cost);

--- a/src/lib/ai/openrouter-pricing-data.ts
+++ b/src/lib/ai/openrouter-pricing-data.ts
@@ -1,0 +1,90 @@
+// AUTO-GENERATED — do not edit manually. Run: bun scripts/update-openrouter-pricing.ts
+
+export type OpenRouterPricing = {
+  name: string;
+  /** USD per 1M input tokens */
+  promptPerMillionTokens: number;
+  /** USD per 1M output tokens */
+  completionPerMillionTokens: number;
+  /** USD per web search query, when supported */
+  webSearchPerQuery?: number;
+};
+
+export const OPENROUTER_PRICING: Record<string, OpenRouterPricing> = {
+  'x-ai/grok-4.3': {
+    name: 'xAI: Grok 4.3',
+    promptPerMillionTokens: 1.25,
+    completionPerMillionTokens: 2.5,
+    webSearchPerQuery: 0.005,
+  },
+  'anthropic/claude-sonnet-4.6': {
+    name: 'Anthropic: Claude Sonnet 4.6',
+    promptPerMillionTokens: 3,
+    completionPerMillionTokens: 15,
+    webSearchPerQuery: 0.01,
+  },
+  'x-ai/grok-4.20': {
+    name: 'xAI: Grok 4.20',
+    promptPerMillionTokens: 1.25,
+    completionPerMillionTokens: 2.5,
+    webSearchPerQuery: 0.005,
+  },
+  'anthropic/claude-opus-4.8': {
+    name: 'Anthropic: Claude Opus 4.8',
+    promptPerMillionTokens: 5,
+    completionPerMillionTokens: 25,
+    webSearchPerQuery: 0.01,
+  },
+  'mistralai/mistral-small-2603': {
+    name: 'Mistral: Mistral Small 4',
+    promptPerMillionTokens: 0.15,
+    completionPerMillionTokens: 0.6,
+  },
+  'deepseek/deepseek-v3.2': {
+    name: 'DeepSeek: DeepSeek V3.2',
+    promptPerMillionTokens: 0.2145,
+    completionPerMillionTokens: 0.32175,
+  },
+  'z-ai/glm-5.2': {
+    name: 'Z.ai: GLM 5.2',
+    promptPerMillionTokens: 0.42,
+    completionPerMillionTokens: 1.32,
+  },
+  'google/gemini-3.1-pro-preview': {
+    name: 'Google: Gemini 3.1 Pro Preview',
+    promptPerMillionTokens: 2,
+    completionPerMillionTokens: 12,
+    webSearchPerQuery: 0.014,
+  },
+  'openai/gpt-5.5': {
+    name: 'OpenAI: GPT-5.5',
+    promptPerMillionTokens: 5,
+    completionPerMillionTokens: 30,
+    webSearchPerQuery: 0.01,
+  },
+  'google/gemini-3-flash-preview': {
+    name: 'Google: Gemini 3 Flash Preview',
+    promptPerMillionTokens: 0.5,
+    completionPerMillionTokens: 3,
+    webSearchPerQuery: 0.014,
+  },
+  'openai/gpt-5.4-mini': {
+    name: 'OpenAI: GPT-5.4 Mini',
+    promptPerMillionTokens: 0.75,
+    completionPerMillionTokens: 4.5,
+    webSearchPerQuery: 0.01,
+  },
+  'bytedance-seed/seed-2.0-mini': {
+    name: 'ByteDance Seed: Seed-2.0-Mini',
+    promptPerMillionTokens: 0.09999999999999999,
+    completionPerMillionTokens: 0.39999999999999997,
+  },
+  'openai/gpt-5.4-nano': {
+    name: 'OpenAI: GPT-5.4 Nano',
+    promptPerMillionTokens: 0.19999999999999998,
+    completionPerMillionTokens: 1.25,
+    webSearchPerQuery: 0.01,
+  },
+};
+
+export const OPENROUTER_PRICING_LAST_UPDATED = '2026-07-13T02:18:19.339Z';

--- a/src/lib/billing/__tests__/billing-observability.test.ts
+++ b/src/lib/billing/__tests__/billing-observability.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const loggerWarn = vi.fn();
+vi.doMock('@/lib/observability/logger', () => ({
+  getLogger: () => ({ warn: loggerWarn, error: vi.fn(), info: vi.fn() }),
+}));
+
+const capture = vi.fn();
+vi.doMock('@/lib/posthog-server', () => ({
+  getPostHogClient: () => ({ capture }),
+}));
+
+const { reportMissingBillingCost } = await import('../billing-observability');
+
+describe('reportMissingBillingCost', () => {
+  it('logs and captures a billing_missing_cost event', () => {
+    loggerWarn.mockClear();
+    capture.mockClear();
+
+    reportMissingBillingCost({
+      source: 'workflow-deduction',
+      workflowName: 'StoryboardWorkflow',
+      modelId: 'fal/flux',
+      teamId: 'team_1',
+    });
+
+    expect(loggerWarn).toHaveBeenCalledWith(
+      'Completed AI generation with no billable cost reported',
+      expect.objectContaining({
+        source: 'workflow-deduction',
+        workflowName: 'StoryboardWorkflow',
+      })
+    );
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: 'team_1',
+      event: 'billing_missing_cost',
+      properties: expect.objectContaining({
+        source: 'workflow-deduction',
+        workflow_name: 'StoryboardWorkflow',
+        model_id: 'fal/flux',
+      }),
+    });
+  });
+});

--- a/src/lib/billing/__tests__/checkout.test.ts
+++ b/src/lib/billing/__tests__/checkout.test.ts
@@ -1,0 +1,61 @@
+import type { ScopedDb } from '@/lib/db/scoped';
+import { describe, expect, it, vi } from 'vitest';
+
+const create = vi.fn();
+vi.doMock('../stripe', () => ({
+  getStripeOrThrow: () => ({
+    customers: {
+      retrieve: vi.fn().mockResolvedValue({ deleted: false }),
+      create: vi.fn().mockResolvedValue({ id: 'cus_new' }),
+    },
+    checkout: {
+      sessions: { create },
+    },
+  }),
+}));
+
+const { createCheckoutSession } = await import('../checkout');
+
+function makeScopedDb() {
+  const stub = {
+    billing: {
+      getBillingSettings: vi
+        .fn()
+        .mockResolvedValue({ stripeCustomerId: 'cus_1' }),
+      saveStripeCustomerId: vi.fn(),
+    },
+  };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal ScopedDb stub
+  return stub as unknown as ScopedDb;
+}
+
+describe('createCheckoutSession', () => {
+  it('charges credit + fee line items but metadata stores credit-only amountUsd', async () => {
+    create.mockResolvedValue({ url: 'https://checkout.stripe.com/test' });
+
+    await createCheckoutSession({
+      scopedDb: makeScopedDb(),
+      teamId: 'team_1',
+      amountUsd: 100,
+      userId: 'user_1',
+      userEmail: 'test@example.com',
+      successUrl: 'https://app/success',
+      cancelUrl: 'https://app/cancel',
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const session = create.mock.calls[0]?.[0];
+    expect(session.line_items).toEqual([
+      expect.objectContaining({
+        price_data: expect.objectContaining({ unit_amount: 10_000 }),
+      }),
+      expect.objectContaining({
+        price_data: expect.objectContaining({ unit_amount: 500 }),
+      }),
+    ]);
+    expect(session.metadata).toMatchObject({
+      amountUsd: '100',
+      type: 'credit_top_up',
+    });
+  });
+});

--- a/src/lib/billing/__tests__/constants.test.ts
+++ b/src/lib/billing/__tests__/constants.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatProcessingFeePercent,
+  processingFeeUsd,
+  splitCheckoutAmounts,
+  totalCheckoutUsd,
+} from '../constants';
+
+describe('billing constants', () => {
+  it('applies processing fee only at purchase', () => {
+    expect(processingFeeUsd(100)).toBe(5);
+    expect(totalCheckoutUsd(100)).toBe(105);
+    expect(formatProcessingFeePercent()).toBe('5%');
+  });
+
+  it('splits checkout into credit and fee line items', () => {
+    expect(splitCheckoutAmounts(100)).toEqual({
+      creditUsd: 100,
+      feeUsd: 5,
+      totalUsd: 105,
+    });
+  });
+
+  it('rounds fee to cents for Stripe', () => {
+    expect(splitCheckoutAmounts(10)).toEqual({
+      creditUsd: 10,
+      feeUsd: 0.5,
+      totalUsd: 10.5,
+    });
+  });
+});

--- a/src/lib/billing/__tests__/constants.test.ts
+++ b/src/lib/billing/__tests__/constants.test.ts
@@ -1,8 +1,10 @@
+import { micros, usdToMicros } from '../money';
 import { describe, expect, it } from 'vitest';
 import {
   formatProcessingFeePercent,
   processingFeeUsd,
   splitCheckoutAmounts,
+  totalCheckoutCents,
   totalCheckoutUsd,
 } from '../constants';
 
@@ -27,5 +29,20 @@ describe('billing constants', () => {
       feeUsd: 0.5,
       totalUsd: 10.5,
     });
+  });
+
+  it('rounds fee from credit cents, not float USD', () => {
+    expect(splitCheckoutAmounts(10.01)).toEqual({
+      creditUsd: 10.01,
+      feeUsd: 0.5,
+      totalUsd: 10.51,
+    });
+  });
+
+  it('totalCheckoutCents returns integer cents aligned with splitCheckoutAmounts', () => {
+    expect(totalCheckoutCents(usdToMicros(100))).toBe(10_500);
+    expect(totalCheckoutCents(usdToMicros(10))).toBe(1_050);
+    expect(totalCheckoutCents(micros(10_500_000))).toBe(1_103);
+    expect(Number.isInteger(totalCheckoutCents(micros(10_010_000)))).toBe(true);
   });
 });

--- a/src/lib/billing/__tests__/extract-image-cost.test.ts
+++ b/src/lib/billing/__tests__/extract-image-cost.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { micros, ZERO_MICROS } from '../money';
+import { extractImageCost } from '../workflow-deduction';
+
+describe('extractImageCost', () => {
+  it('returns metadata.cost when present', () => {
+    expect(extractImageCost({ cost: micros(500_000) })).toBe(micros(500_000));
+  });
+
+  it('returns ZERO_MICROS when cost is missing', () => {
+    expect(extractImageCost({})).toBe(ZERO_MICROS);
+  });
+});

--- a/src/lib/billing/billing-observability.ts
+++ b/src/lib/billing/billing-observability.ts
@@ -1,0 +1,35 @@
+/**
+ * Observability for billing gaps — when a completed AI call reports no cost.
+ */
+
+import { getPostHogClient } from '@/lib/posthog-server';
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'billing', 'missing-cost']);
+
+export type MissingBillingCostContext = {
+  source: string;
+  modelId?: string;
+  workflowName?: string;
+  description?: string;
+  teamId?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Log and emit analytics when a completed generation has nothing to bill. */
+export function reportMissingBillingCost(ctx: MissingBillingCostContext): void {
+  logger.warn('Completed AI generation with no billable cost reported', ctx);
+
+  const posthog = getPostHogClient();
+  posthog?.capture({
+    distinctId: ctx.teamId ?? 'system',
+    event: 'billing_missing_cost',
+    properties: {
+      source: ctx.source,
+      model_id: ctx.modelId,
+      workflow_name: ctx.workflowName,
+      description: ctx.description,
+      ...ctx.metadata,
+    },
+  });
+}

--- a/src/lib/billing/checkout.ts
+++ b/src/lib/billing/checkout.ts
@@ -4,7 +4,11 @@
  */
 
 import { ValidationError } from '@/lib/errors';
-import { MIN_TOPUP_AMOUNT_USD } from './constants';
+import {
+  formatProcessingFeePercent,
+  MIN_TOPUP_AMOUNT_USD,
+  splitCheckoutAmounts,
+} from './constants';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { getStripeOrThrow } from './stripe';
 
@@ -62,7 +66,10 @@ export async function createCheckoutSession(
     await scopedDb.billing.saveStripeCustomerId(customerId);
   }
 
-  const amountCents = Math.round(amountUsd * 100);
+  const { creditUsd, feeUsd } = splitCheckoutAmounts(amountUsd);
+  const creditCents = Math.round(creditUsd * 100);
+  const feeCents = Math.round(feeUsd * 100);
+  const feeLabel = formatProcessingFeePercent();
 
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
@@ -76,10 +83,21 @@ export async function createCheckoutSession(
       {
         price_data: {
           currency: 'usd',
-          unit_amount: amountCents,
+          unit_amount: creditCents,
           product_data: {
-            name: `Credits — $${amountUsd.toFixed(2)}`,
-            description: `Add $${amountUsd.toFixed(2)} to your team wallet`,
+            name: `Credits — $${creditUsd.toFixed(2)}`,
+            description: `Add $${creditUsd.toFixed(2)} to your team wallet`,
+          },
+        },
+        quantity: 1,
+      },
+      {
+        price_data: {
+          currency: 'usd',
+          unit_amount: feeCents,
+          product_data: {
+            name: `Processing fee (${feeLabel})`,
+            description: `One-time processing fee on credit purchases. AI usage is billed at provider cost with no additional fee.`,
           },
         },
         quantity: 1,

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -4,12 +4,7 @@
  */
 
 import { getEnv } from '#env';
-import {
-  type Microdollars,
-  usdToMicros,
-  multiplyMicros,
-  microsToUsdCents,
-} from './money';
+import { type Microdollars, usdToMicros, microsToUsd } from './money';
 
 /** Whether Stripe payment processing is available (checkout, webhooks, auto-top-up). */
 export function isStripeEnabled(): boolean {
@@ -77,7 +72,6 @@ export function splitCheckoutAmounts(creditAmountUsd: number): {
 
 /** Total Stripe charge in cents for a credit amount in microdollars */
 export function totalCheckoutCents(creditAmountMicros: Microdollars): number {
-  return microsToUsdCents(
-    multiplyMicros(creditAmountMicros, 1 + PROCESSING_FEE_PERCENT)
-  );
+  const { totalUsd } = splitCheckoutAmounts(microsToUsd(creditAmountMicros));
+  return Math.round(totalUsd * 100);
 }

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -4,15 +4,20 @@
  */
 
 import { getEnv } from '#env';
-import { type Microdollars, usdToMicros, multiplyMicros } from './money';
+import {
+  type Microdollars,
+  usdToMicros,
+  multiplyMicros,
+  microsToUsdCents,
+} from './money';
 
 /** Whether Stripe payment processing is available (checkout, webhooks, auto-top-up). */
 export function isStripeEnabled(): boolean {
   return !!getEnv().STRIPE_SECRET_KEY;
 }
 
-/** Markup percentage applied on top of provider costs (e.g., 0.05 = 5%) */
-const BILLING_MARKUP_PERCENT = 0.05;
+/** Processing fee applied when purchasing credits (e.g., 0.05 = 5%). Not charged on usage. */
+export const PROCESSING_FEE_PERCENT = 0.05;
 
 /** Minimum top-up amount in USD */
 export const MIN_TOPUP_AMOUNT_USD = 10;
@@ -40,11 +45,39 @@ export function calculateExpiryDate(from?: Date): Date {
   return date;
 }
 
-/**
- * Apply markup to a raw provider cost in microdollars
- * @param rawCostMicros - The raw cost from the provider in microdollars
- * @returns The cost with markup applied, in microdollars
- */
-export function applyMarkup(rawCostMicros: Microdollars): Microdollars {
-  return multiplyMicros(rawCostMicros, 1 + BILLING_MARKUP_PERCENT);
+/** Processing fee in USD for a credit purchase amount */
+export function processingFeeUsd(creditAmountUsd: number): number {
+  return creditAmountUsd * PROCESSING_FEE_PERCENT;
+}
+
+/** Total charged at checkout (credits + processing fee) */
+export function totalCheckoutUsd(creditAmountUsd: number): number {
+  return creditAmountUsd * (1 + PROCESSING_FEE_PERCENT);
+}
+
+/** Format processing fee percent for display (e.g. "5%") */
+export function formatProcessingFeePercent(): string {
+  return `${Math.round(PROCESSING_FEE_PERCENT * 100)}%`;
+}
+
+/** Split a credit purchase into credit + fee line items (USD, cents-rounded) */
+export function splitCheckoutAmounts(creditAmountUsd: number): {
+  creditUsd: number;
+  feeUsd: number;
+  totalUsd: number;
+} {
+  const creditCents = Math.round(creditAmountUsd * 100);
+  const feeCents = Math.round(creditCents * PROCESSING_FEE_PERCENT);
+  return {
+    creditUsd: creditCents / 100,
+    feeUsd: feeCents / 100,
+    totalUsd: (creditCents + feeCents) / 100,
+  };
+}
+
+/** Total Stripe charge in cents for a credit amount in microdollars */
+export function totalCheckoutCents(creditAmountMicros: Microdollars): number {
+  return microsToUsdCents(
+    multiplyMicros(creditAmountMicros, 1 + PROCESSING_FEE_PERCENT)
+  );
 }

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -18,7 +18,7 @@ import { aspectRatioToDimensions } from '@/lib/constants/aspect-ratios';
 import { type Microdollars, addMicros, micros, multiplyMicros } from './money';
 
 /**
- * Estimate the raw cost (before markup) of generating images. Rough pre-flight
+ * Estimate provider cost of generating images. Rough pre-flight
  * gate only — the exact charge comes from fal's reported units post-generation.
  */
 export function estimateImageCost(
@@ -38,7 +38,7 @@ export function estimateImageCost(
 }
 
 /**
- * Estimate the raw cost (before markup) of generating video.
+ * Estimate provider cost of generating video.
  */
 export function estimateVideoCost(
   model: ImageToVideoModel,
@@ -52,7 +52,7 @@ export function estimateVideoCost(
 }
 
 /**
- * Estimate the raw cost (before markup) of generating one music track.
+ * Estimate provider cost of generating one music track.
  */
 export function estimateAudioCost(
   model: AudioModel,

--- a/src/lib/billing/money.ts
+++ b/src/lib/billing/money.ts
@@ -12,7 +12,6 @@
 export type Microdollars = number & { readonly __brand: 'Microdollars' };
 
 const MICROS_PER_USD = 1_000_000;
-const MICROS_PER_CENT = 10_000;
 
 /** Brand a raw integer as Microdollars (no conversion, just type cast) */
 export function micros(value: number): Microdollars {
@@ -27,10 +26,6 @@ export function usdToMicros(usd: number): Microdollars {
 
 export function microsToUsd(micros: Microdollars): number {
   return micros / MICROS_PER_USD;
-}
-
-export function microsToUsdCents(micros: Microdollars): number {
-  return micros / MICROS_PER_CENT;
 }
 
 export function microsToDisplayUsd(micros: Microdollars): string {

--- a/src/lib/billing/pricing-catalog.ts
+++ b/src/lib/billing/pricing-catalog.ts
@@ -1,0 +1,199 @@
+/**
+ * Public model pricing catalog — single source for the /pricing page.
+ * Combines fal media pricing with OpenRouter LLM token rates.
+ */
+
+import {
+  FAL_PRICING,
+  PRICING_LAST_UPDATED as FAL_PRICING_LAST_UPDATED,
+  type FalUnit,
+} from '@/lib/ai/fal-pricing-data';
+import {
+  AUDIO_MODELS,
+  IMAGE_MODELS,
+  IMAGE_TO_VIDEO_MODELS,
+} from '@/lib/ai/models';
+import { SCRIPT_ANALYSIS_MODELS } from '@/lib/ai/models.config';
+import {
+  OPENROUTER_PRICING,
+  OPENROUTER_PRICING_LAST_UPDATED,
+} from '@/lib/ai/openrouter-pricing-data';
+import { microsToUsd } from '@/lib/billing/money';
+
+type PricingRow = {
+  name: string;
+  provider: string;
+  license?: 'open-source' | 'proprietary';
+  price: string;
+  detail?: string;
+};
+
+export type PricingSection = {
+  id: string;
+  title: string;
+  description: string;
+  rows: PricingRow[];
+};
+
+const FAL_UNIT_LABELS: Record<FalUnit, string> = {
+  images: 'image',
+  seconds: 'second',
+  minutes: 'minute',
+  megapixels: 'megapixel',
+  compute_seconds: 'compute second',
+  flat: 'generation',
+  tokens: '1K tokens',
+};
+
+function formatUsd(amount: number): string {
+  if (amount === 0) return 'Free';
+  if (amount >= 1) return `$${amount.toFixed(2)}`;
+  if (amount >= 0.01) return `$${amount.toFixed(2)}`;
+  if (amount >= 0.0001) return `$${amount.toFixed(4)}`;
+  return `$${amount.toFixed(6)}`;
+}
+
+function formatFalPrice(endpointId: string): {
+  price: string;
+  detail?: string;
+} {
+  const pricing = FAL_PRICING[endpointId];
+  if (!pricing) {
+    return { price: 'Contact support', detail: 'Pricing unavailable' };
+  }
+
+  const usd = microsToUsd(pricing.unitPrice);
+  const unitLabel = FAL_UNIT_LABELS[pricing.unit];
+  return {
+    price: `${formatUsd(usd)} / ${unitLabel}`,
+    detail:
+      pricing.unit === 'flat'
+        ? 'Flat rate per video'
+        : pricing.unit === 'tokens'
+          ? 'Billed per 1,000 video tokens'
+          : undefined,
+  };
+}
+
+function formatLlmPrice(modelId: string): { price: string; detail?: string } {
+  const pricing = OPENROUTER_PRICING[modelId];
+  if (!pricing) {
+    return { price: 'Per request', detail: 'Billed at provider cost' };
+  }
+
+  const input = formatUsd(pricing.promptPerMillionTokens);
+  const output = formatUsd(pricing.completionPerMillionTokens);
+  const detail =
+    pricing.webSearchPerQuery != null
+      ? `Web search: ${formatUsd(pricing.webSearchPerQuery)} / query`
+      : undefined;
+
+  return {
+    price: `${input} / M input · ${output} / M output`,
+    detail,
+  };
+}
+
+function visibleImageModels() {
+  return Object.values(IMAGE_MODELS).filter(
+    (model) => !('hidden' in model && model.hidden)
+  );
+}
+
+export function buildPricingCatalog(): {
+  sections: PricingSection[];
+  lastUpdated: string;
+} {
+  const imageRows: PricingRow[] = visibleImageModels()
+    .sort((a, b) => a.qualityRank - b.qualityRank)
+    .map((model) => {
+      const { price, detail } = formatFalPrice(model.id);
+      return {
+        name: model.name,
+        provider: model.provider,
+        license: model.license,
+        price,
+        detail,
+      };
+    });
+
+  const videoRows: PricingRow[] = Object.values(IMAGE_TO_VIDEO_MODELS)
+    .sort((a, b) => a.qualityRank - b.qualityRank)
+    .map((model) => {
+      const { price, detail } = formatFalPrice(model.id);
+      return {
+        name: model.name,
+        provider: model.provider,
+        license: model.license,
+        price,
+        detail,
+      };
+    });
+
+  const audioRows: PricingRow[] = Object.values(AUDIO_MODELS)
+    .sort((a, b) => a.qualityRank - b.qualityRank)
+    .map((model) => {
+      const { price, detail } = formatFalPrice(model.id);
+      return {
+        name: model.name,
+        provider: model.provider,
+        license: model.license,
+        price,
+        detail,
+      };
+    });
+
+  const llmRows: PricingRow[] = SCRIPT_ANALYSIS_MODELS.map((model) => {
+    const { price, detail } = formatLlmPrice(model.id);
+    return {
+      name: model.name,
+      provider: model.provider,
+      license: model.license,
+      price,
+      detail,
+    };
+  });
+
+  const falDate = new Date(FAL_PRICING_LAST_UPDATED).toLocaleDateString(
+    'en-US',
+    { month: 'short', day: 'numeric', year: 'numeric' }
+  );
+  const orDate = new Date(OPENROUTER_PRICING_LAST_UPDATED).toLocaleDateString(
+    'en-US',
+    { month: 'short', day: 'numeric', year: 'numeric' }
+  );
+
+  return {
+    sections: [
+      {
+        id: 'llm',
+        title: 'Script analysis (LLM)',
+        description:
+          'Script enhancement, scene splitting, character extraction, and motion prompts. Billed per request at OpenRouter provider cost — same model as openrouter.ai.',
+        rows: llmRows,
+      },
+      {
+        id: 'image',
+        title: 'Image generation',
+        description:
+          'Shots, character sheets, location sheets, and style previews. Billed per generation at fal.ai provider cost.',
+        rows: imageRows,
+      },
+      {
+        id: 'video',
+        title: 'Video / motion',
+        description:
+          'Image-to-video motion generation per shot. Billed per second (or flat rate where noted) at fal.ai provider cost.',
+        rows: videoRows,
+      },
+      {
+        id: 'audio',
+        title: 'Music & audio',
+        description:
+          'Background music and soundtracks per sequence. Billed per minute or second at fal.ai provider cost.',
+        rows: audioRows,
+      },
+    ],
+    lastUpdated: `Media models: ${falDate} · LLM models: ${orDate}`,
+  };
+}

--- a/src/lib/billing/workflow-deduction.test.ts
+++ b/src/lib/billing/workflow-deduction.test.ts
@@ -7,7 +7,11 @@
 import type { ScopedDb } from '@/lib/db/scoped';
 import { describe, expect, it, vi } from 'vitest';
 import { micros, ZERO_MICROS } from './money';
-import { deductWorkflowCredits } from './workflow-deduction';
+
+const reportMissingBillingCost = vi.fn();
+vi.doMock('./billing-observability', () => ({
+  reportMissingBillingCost,
+}));
 
 function makeScopedDb({ canAfford = true } = {}) {
   const deductCredits = vi.fn().mockResolvedValue({
@@ -25,11 +29,14 @@ function makeScopedDb({ canAfford = true } = {}) {
   return { scopedDb, deductCredits, hasEnoughCredits, checkAutoTopUp };
 }
 
+const { deductWorkflowCredits: deductWorkflowCreditsImpl } =
+  await import('./workflow-deduction');
+
 describe('deductWorkflowCredits', () => {
   it('forwards the idempotencyKey to deductCredits', async () => {
     const { scopedDb, deductCredits } = makeScopedDb();
 
-    await deductWorkflowCredits({
+    await deductWorkflowCreditsImpl({
       scopedDb,
       costMicros: micros(2_000_000),
       usedOwnKey: false,
@@ -49,7 +56,7 @@ describe('deductWorkflowCredits', () => {
   it('skips when the team used its own key', async () => {
     const { scopedDb, deductCredits } = makeScopedDb();
 
-    await deductWorkflowCredits({
+    await deductWorkflowCreditsImpl({
       scopedDb,
       costMicros: micros(2_000_000),
       usedOwnKey: true,
@@ -60,24 +67,32 @@ describe('deductWorkflowCredits', () => {
     expect(deductCredits).not.toHaveBeenCalled();
   });
 
-  it('skips for a zero cost', async () => {
+  it('reports missing cost and skips deduction for zero cost', async () => {
+    reportMissingBillingCost.mockClear();
     const { scopedDb, deductCredits } = makeScopedDb();
 
-    await deductWorkflowCredits({
+    await deductWorkflowCreditsImpl({
       scopedDb,
       costMicros: ZERO_MICROS,
       usedOwnKey: false,
       description: 'LLM analysis (model)',
       idempotencyKey: 'env_wf_abc123:llm-step',
+      workflowName: 'ImageWorkflow',
     });
 
     expect(deductCredits).not.toHaveBeenCalled();
+    expect(reportMissingBillingCost).toHaveBeenCalledWith({
+      source: 'workflow-deduction',
+      workflowName: 'ImageWorkflow',
+      description: 'LLM analysis (model)',
+      metadata: undefined,
+    });
   });
 
   it('skips without a scopedDb (anonymous workflow)', async () => {
     const { deductCredits } = makeScopedDb();
 
-    await deductWorkflowCredits({
+    await deductWorkflowCreditsImpl({
       scopedDb: undefined,
       costMicros: micros(2_000_000),
       usedOwnKey: false,
@@ -93,7 +108,7 @@ describe('deductWorkflowCredits', () => {
       canAfford: false,
     });
 
-    await deductWorkflowCredits({
+    await deductWorkflowCreditsImpl({
       scopedDb,
       costMicros: micros(2_000_000),
       usedOwnKey: false,

--- a/src/lib/billing/workflow-deduction.ts
+++ b/src/lib/billing/workflow-deduction.ts
@@ -9,6 +9,7 @@
  */
 
 import type { ScopedDb } from '@/lib/db/scoped';
+import { reportMissingBillingCost } from './billing-observability';
 import { type Microdollars, microsToUsd, ZERO_MICROS } from './money';
 
 import { getLogger } from '@/lib/observability/logger';
@@ -45,7 +46,17 @@ type WorkflowDeductionOpts = {
 export async function deductWorkflowCredits(
   opts: WorkflowDeductionOpts
 ): Promise<void> {
-  if (!opts.scopedDb || opts.costMicros <= 0 || opts.usedOwnKey) return;
+  if (!opts.scopedDb || opts.usedOwnKey) return;
+
+  if (opts.costMicros <= 0) {
+    reportMissingBillingCost({
+      source: 'workflow-deduction',
+      workflowName: opts.workflowName,
+      description: opts.description,
+      metadata: opts.metadata,
+    });
+    return;
+  }
 
   const { scopedDb } = opts;
   const canAfford = await scopedDb.billing.hasEnoughCredits(opts.costMicros);

--- a/src/lib/db/scoped/billing.test.ts
+++ b/src/lib/db/scoped/billing.test.ts
@@ -9,7 +9,6 @@
  * original transaction id instead of double-debiting the team.
  */
 
-import { applyMarkup } from '@/lib/billing/constants';
 import { micros, negateMicros } from '@/lib/billing/money';
 import type { Database } from '@/lib/db/client';
 import { generateId } from '@/lib/db/id';
@@ -59,18 +58,16 @@ beforeEach(async () => {
 });
 
 describe('deductCredits with an idempotencyKey', () => {
-  const rawCost = micros(1_000_000); // $1 raw
+  const rawCost = micros(1_000_000); // $1
 
   it('debits once and writes a single ledger row', async () => {
     const billing = createBillingMethods(db, teamId, userId);
-    const charged = applyMarkup(rawCost);
-
     const result = await billing.deductCredits(rawCost, {
       idempotencyKey: 'wf-instance-1:image',
     });
 
-    expect(result.chargedAmount).toBe(charged);
-    expect(result.newBalance).toBe(STARTING_BALANCE - charged);
+    expect(result.chargedAmount).toBe(rawCost);
+    expect(result.newBalance).toBe(STARTING_BALANCE - rawCost);
     expect(result.transactionId).not.toBe('');
 
     const rows = await db
@@ -78,16 +75,15 @@ describe('deductCredits with an idempotencyKey', () => {
       .from(transactions)
       .where(eq(transactions.teamId, teamId));
     expect(rows).toHaveLength(1);
-    expect(rows[0]?.amount).toBe(negateMicros(charged));
+    expect(rows[0]?.amount).toBe(negateMicros(rawCost));
     // The balanceAfter subquery must see the post-UPDATE balance (the batch
     // statements run sequentially inside one transaction).
-    expect(rows[0]?.balanceAfter).toBe(STARTING_BALANCE - charged);
+    expect(rows[0]?.balanceAfter).toBe(STARTING_BALANCE - rawCost);
     expect(rows[0]?.idempotencyKey).toBe('wf-instance-1:image');
   });
 
   it('replay with the same key is a no-op that returns the original transaction id', async () => {
     const billing = createBillingMethods(db, teamId, userId);
-    const charged = applyMarkup(rawCost);
 
     const first = await billing.deductCredits(rawCost, {
       idempotencyKey: 'wf-instance-1:image',
@@ -98,7 +94,7 @@ describe('deductCredits with an idempotencyKey', () => {
 
     // Must not throw, must not double-debit, must recover the original id.
     expect(replay.transactionId).toBe(first.transactionId);
-    expect(replay.newBalance).toBe(STARTING_BALANCE - charged);
+    expect(replay.newBalance).toBe(STARTING_BALANCE - rawCost);
 
     const rows = await db
       .select()
@@ -110,12 +106,11 @@ describe('deductCredits with an idempotencyKey', () => {
       .select({ balance: credits.balance })
       .from(credits)
       .where(eq(credits.teamId, teamId));
-    expect(credit?.balance).toBe(STARTING_BALANCE - charged);
+    expect(credit?.balance).toBe(STARTING_BALANCE - rawCost);
   });
 
   it('distinct keys are distinct charges', async () => {
     const billing = createBillingMethods(db, teamId, userId);
-    const charged = applyMarkup(rawCost);
 
     await billing.deductCredits(rawCost, {
       idempotencyKey: 'wf-instance-1:image',
@@ -138,14 +133,14 @@ describe('deductCredits with an idempotencyKey', () => {
     const motionRow = rows.find(
       (r) => r.idempotencyKey === 'wf-instance-1:motion'
     );
-    expect(imageRow?.balanceAfter).toBe(STARTING_BALANCE - charged);
-    expect(motionRow?.balanceAfter).toBe(STARTING_BALANCE - 2 * charged);
+    expect(imageRow?.balanceAfter).toBe(STARTING_BALANCE - rawCost);
+    expect(motionRow?.balanceAfter).toBe(STARTING_BALANCE - 2 * rawCost);
 
     const [credit] = await db
       .select({ balance: credits.balance })
       .from(credits)
       .where(eq(credits.teamId, teamId));
-    expect(credit?.balance).toBe(STARTING_BALANCE - 2 * charged);
+    expect(credit?.balance).toBe(STARTING_BALANCE - 2 * rawCost);
   });
 
   it('the same key under a different team charges both teams (key is team-scoped)', async () => {
@@ -166,9 +161,8 @@ describe('deductCredits with an idempotencyKey', () => {
     });
 
     expect(a.transactionId).not.toBe(b.transactionId);
-    const charged = applyMarkup(rawCost);
-    expect(a.newBalance).toBe(STARTING_BALANCE - charged);
-    expect(b.newBalance).toBe(STARTING_BALANCE - charged);
+    expect(a.newBalance).toBe(STARTING_BALANCE - rawCost);
+    expect(b.newBalance).toBe(STARTING_BALANCE - rawCost);
   });
 });
 
@@ -177,7 +171,6 @@ describe('deductCredits without an idempotencyKey (keyless path)', () => {
 
   it('charges on every call (HTTP single-shot semantics preserved)', async () => {
     const billing = createBillingMethods(db, teamId, userId);
-    const charged = applyMarkup(rawCost);
 
     const r1 = await billing.deductCredits(rawCost, {
       description: 'one',
@@ -187,7 +180,7 @@ describe('deductCredits without an idempotencyKey (keyless path)', () => {
     });
 
     expect(r1.transactionId).not.toBe(r2.transactionId);
-    expect(r2.newBalance).toBe(STARTING_BALANCE - 2 * charged);
+    expect(r2.newBalance).toBe(STARTING_BALANCE - 2 * rawCost);
 
     const rows = await db
       .select()

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -5,18 +5,17 @@
  */
 
 import {
-  applyMarkup,
   AUTO_TOPUP_COOLDOWN_MS,
   calculateExpiryDate,
   isStripeEnabled,
   MIN_TOPUP_AMOUNT_MICROS,
+  totalCheckoutCents,
 } from '@/lib/billing/constants';
 import {
   type Microdollars,
   micros,
   microsToDisplayUsd,
   microsToUsd,
-  microsToUsdCents,
   negateMicros,
   ZERO_MICROS,
 } from '@/lib/billing/money';
@@ -78,7 +77,7 @@ function createBillingReadMethods(db: Database, teamId: string) {
     estimatedCostMicros: Microdollars
   ): Promise<boolean> {
     const balance = await getBalance();
-    return balance >= applyMarkup(estimatedCostMicros);
+    return balance >= estimatedCostMicros;
   }
 
   async function getTransactionHistory(
@@ -275,7 +274,7 @@ export function createBillingMethods(
   }
 
   /**
-   * Applies markup automatically. Triggers auto-top-up if balance drops below
+   * Charges provider cost at face value (no usage fee). Triggers auto-top-up if balance drops below
    * threshold.
    *
    * Pass `opts.idempotencyKey` (convention: `${workflowInstanceId}:<charge-name>`)
@@ -308,7 +307,7 @@ export function createBillingMethods(
         transactionId: '',
       };
 
-    const chargedAmount = applyMarkup(rawCostMicros);
+    const chargedAmount = rawCostMicros;
     const { idempotencyKey } = opts;
 
     await db
@@ -316,7 +315,6 @@ export function createBillingMethods(
       .values({ teamId, balance: 0 })
       .onConflictDoNothing();
 
-    const rawUsd = microsToUsd(rawCostMicros);
     const chargedUsd = microsToUsd(chargedAmount);
 
     const updateBalance = db
@@ -356,12 +354,9 @@ export function createBillingMethods(
         type: 'credit_usage' as TransactionType,
         amount: negateMicros(chargedAmount),
         balanceAfter: sql`(select ${credits.balance} from ${credits} where ${credits.teamId} = ${teamId})`,
-        description:
-          opts.description ??
-          `Usage: $${chargedUsd.toFixed(4)} (raw: $${rawUsd.toFixed(4)})`,
+        description: opts.description ?? `Usage: $${chargedUsd.toFixed(4)}`,
         metadata: {
-          rawCostMicros,
-          chargedAmountMicros: chargedAmount,
+          costMicros: chargedAmount,
           ...opts.metadata,
         },
         idempotencyKey: idempotencyKey ?? null,
@@ -521,7 +516,7 @@ export function createBillingMethods(
     }
 
     const stripe = getStripeOrThrow();
-    const amountCents = microsToUsdCents(
+    const amountCents = totalCheckoutCents(
       micros(settings.autoTopUpAmountMicros)
     );
 

--- a/src/lib/marketing/constants.ts
+++ b/src/lib/marketing/constants.ts
@@ -122,7 +122,7 @@ export const FAQ_ITEMS = [
   {
     question: 'How does pricing work?',
     answer:
-      'There are no subscriptions and no margin on model costs. You pay exactly what the AI providers charge\u2009\u2014\u2009nothing more. Bring your own API keys or self-host for full control.',
+      'No subscriptions. AI usage is billed at exact provider cost — the same rates as OpenRouter and fal.ai. A small processing fee applies only when you buy credits, not on each generation. See openstory.so/pricing for the full model price list. Bring your own API keys to pay providers directly.',
   },
   {
     question: 'Can I use my own API keys?',
@@ -150,12 +150,12 @@ export const OPEN_FAIR_BENEFITS = [
   {
     title: 'Bring Your Own Keys',
     description:
-      'Use your own API keys or self-host entirely. Pay providers directly, no markup.',
+      'Use your own API keys or self-host entirely. Pay providers directly with no platform fees.',
   },
   {
     title: 'At Cost Pricing',
     description:
-      'No subscriptions. No margin on model costs. You pay what the AI providers charge.',
+      'No subscriptions. AI usage at provider cost. A small fee applies only when buying credits.',
   },
   {
     title: 'Export Everything',

--- a/src/lib/workflows/element-vision-workflow.ts
+++ b/src/lib/workflows/element-vision-workflow.ts
@@ -13,7 +13,11 @@
  *     `context.workflowRunId` (not needed for this workflow, but listed
  *     here for parity with the other CF ports). */
 
-import { describeElementImage } from '@/lib/ai/element-vision';
+import {
+  describeElementImage,
+  ELEMENT_VISION_MODEL,
+} from '@/lib/ai/element-vision';
+import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import type {
@@ -50,17 +54,31 @@ export class ElementVisionWorkflow extends OpenStoryWorkflowEntrypoint<ElementVi
     });
 
     // Step 3: vision call (also returns a vision-suggested token).
-    const { description, consistencyTag, suggestedToken } = await step.do(
-      'describe-element',
-      async () => {
-        const llmKeyInfo = await scopedDb.apiKeys.resolveLlmKey();
-        return await describeElementImage({
-          imageUrl,
-          filename,
-          llmKey: llmKeyInfo,
-        });
-      }
-    );
+    const vision = await step.do('describe-element', async () => {
+      const llmKeyInfo = await scopedDb.apiKeys.resolveLlmKey();
+      return await describeElementImage({
+        imageUrl,
+        filename,
+        llmKey: llmKeyInfo,
+      });
+    });
+
+    await step.do('deduct-vision-credits', async () => {
+      await deductWorkflowCredits({
+        scopedDb,
+        costMicros: vision.costMicros,
+        usedOwnKey: vision.usedOwnKey,
+        description: `Element vision (${ELEMENT_VISION_MODEL})`,
+        idempotencyKey: `${event.instanceId}:vision`,
+        metadata: {
+          model: ELEMENT_VISION_MODEL,
+          elementId,
+        },
+        workflowName: 'ElementVisionWorkflow',
+      });
+    });
+
+    const { description, consistencyTag, suggestedToken } = vision;
 
     // Step 4: persist description + consistencyTag.
     await step.do('persist-vision', async () => {

--- a/src/lib/workflows/replace-element-workflow.ts
+++ b/src/lib/workflows/replace-element-workflow.ts
@@ -21,7 +21,11 @@
  *     `context.workflowRunId` (not needed by this workflow, but included
  *     here for parity with other CF ports). */
 
-import { describeElementImage } from '@/lib/ai/element-vision';
+import {
+  describeElementImage,
+  ELEMENT_VISION_MODEL,
+} from '@/lib/ai/element-vision';
+import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
 import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_VIDEO_MODEL,
@@ -226,6 +230,22 @@ export class ReplaceElementWorkflow extends OpenStoryWorkflowEntrypoint<ReplaceE
         result.consistencyTag
       );
       return result;
+    });
+
+    await step.do('deduct-vision-credits', async () => {
+      await deductWorkflowCredits({
+        scopedDb,
+        costMicros: visionResult.costMicros,
+        usedOwnKey: visionResult.usedOwnKey,
+        description: `Element vision (${ELEMENT_VISION_MODEL})`,
+        idempotencyKey: `${event.instanceId}:vision`,
+        metadata: {
+          model: ELEMENT_VISION_MODEL,
+          elementId,
+          sequenceId,
+        },
+        workflowName: 'ReplaceElementWorkflow',
+      });
     });
 
     // Vision-driven auto-rename: if the new image suggests a meaningfully

--- a/src/lib/workflows/storyboard-workflow.ts
+++ b/src/lib/workflows/storyboard-workflow.ts
@@ -168,22 +168,22 @@ export class StoryboardWorkflow extends OpenStoryWorkflowEntrypoint<StoryboardWo
             { posterUrl }
           );
         });
-      }
 
-      await step.do('deduct-poster-credits', async () => {
-        await deductWorkflowCredits({
-          scopedDb,
-          costMicros: extractImageCost(posterResult.metadata),
-          usedOwnKey: posterResult.metadata.usedOwnKey,
-          description: `Sequence poster (${PREVIEW_IMAGE_MODEL})`,
-          idempotencyKey: `${event.instanceId}:poster`,
-          metadata: {
-            model: PREVIEW_IMAGE_MODEL,
-            sequenceId,
-          },
-          workflowName: 'StoryboardWorkflow',
+        await step.do('deduct-poster-credits', async () => {
+          await deductWorkflowCredits({
+            scopedDb,
+            costMicros: extractImageCost(posterResult.metadata),
+            usedOwnKey: posterResult.metadata.usedOwnKey,
+            description: `Sequence poster (${PREVIEW_IMAGE_MODEL})`,
+            idempotencyKey: `${event.instanceId}:poster`,
+            metadata: {
+              model: PREVIEW_IMAGE_MODEL,
+              sequenceId,
+            },
+            workflowName: 'StoryboardWorkflow',
+          });
         });
-      });
+      }
     }
 
     // Spawn the analyze-script child and block until it returns. Pattern 3.

--- a/src/lib/workflows/storyboard-workflow.ts
+++ b/src/lib/workflows/storyboard-workflow.ts
@@ -32,6 +32,10 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
+import {
+  deductWorkflowCredits,
+  extractImageCost,
+} from '@/lib/billing/workflow-deduction';
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { StyleConfigSchema } from '@/lib/db/schema';
@@ -134,30 +138,53 @@ export class StoryboardWorkflow extends OpenStoryWorkflowEntrypoint<StoryboardWo
     // state. Non-critical — failures are logged and swallowed so a poster
     // outage cannot block the storyboard. Mirrors the QStash original's
     // try/catch swallow inside the step.
-    await step.do('generate-poster', async () => {
+    const posterResult = await step.do('generate-poster', async () => {
       try {
         const prompt = buildPosterPrompt(title, script, styleConfig);
-        const result = await generateImageWithProvider({
-          model: PREVIEW_IMAGE_MODEL,
-          prompt,
-          imageSize: aspectRatioToImageSize(aspectRatio),
-          traceName: 'poster-image',
+        return await generateImageWithProvider(
+          {
+            model: PREVIEW_IMAGE_MODEL,
+            prompt,
+            imageSize: aspectRatioToImageSize(aspectRatio),
+            traceName: 'poster-image',
+          },
+          { scopedDb }
+        );
+      } catch (error) {
+        logger.warn('[StoryboardWorkflow:cf] Poster generation failed:', {
+          err: error,
         });
+        return null;
+      }
+    });
 
-        const posterUrl = result.imageUrls[0];
-        if (posterUrl) {
+    if (posterResult) {
+      const posterUrl = posterResult.imageUrls[0];
+      if (posterUrl) {
+        await step.do('save-poster', async () => {
           await scopedDb.sequences.update({ id: sequenceId, posterUrl });
           await getGenerationChannel(sequenceId).emit(
             'generation.poster:ready',
             { posterUrl }
           );
-        }
-      } catch (error) {
-        logger.warn('[StoryboardWorkflow:cf] Poster generation failed:', {
-          err: error,
         });
       }
-    });
+
+      await step.do('deduct-poster-credits', async () => {
+        await deductWorkflowCredits({
+          scopedDb,
+          costMicros: extractImageCost(posterResult.metadata),
+          usedOwnKey: posterResult.metadata.usedOwnKey,
+          description: `Sequence poster (${PREVIEW_IMAGE_MODEL})`,
+          idempotencyKey: `${event.instanceId}:poster`,
+          metadata: {
+            model: PREVIEW_IMAGE_MODEL,
+            sequenceId,
+          },
+          workflowName: 'StoryboardWorkflow',
+        });
+      });
+    }
 
     // Spawn the analyze-script child and block until it returns. Pattern 3.
     await spawnAndAwaitChild<AnalyzeScriptWorkflowInput, unknown>(step, {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as ApiRealtimeRouteImport } from './routes/api/realtime'
 import { Route as MarketingTermsRouteImport } from './routes/_marketing/terms'
 import { Route as MarketingPrivacyRouteImport } from './routes/_marketing/privacy'
+import { Route as MarketingPricingRouteImport } from './routes/_marketing/pricing'
 import { Route as AuthVerifyRouteImport } from './routes/_auth/verify'
 import { Route as AuthLoginRouteImport } from './routes/_auth/login'
 import { Route as AppCreditsRouteImport } from './routes/_app/credits'
@@ -176,6 +177,11 @@ const MarketingTermsRoute = MarketingTermsRouteImport.update({
 const MarketingPrivacyRoute = MarketingPrivacyRouteImport.update({
   id: '/privacy',
   path: '/privacy',
+  getParentRoute: () => MarketingRoute,
+} as any)
+const MarketingPricingRoute = MarketingPricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
   getParentRoute: () => MarketingRoute,
 } as any)
 const AuthVerifyRoute = AuthVerifyRouteImport.update({
@@ -449,6 +455,7 @@ export interface FileRoutesByFullPath {
   '/credits': typeof AppCreditsRoute
   '/login': typeof AuthLoginRoute
   '/verify': typeof AuthVerifyRoute
+  '/pricing': typeof MarketingPricingRoute
   '/privacy': typeof MarketingPrivacyRoute
   '/terms': typeof MarketingTermsRoute
   '/api/realtime': typeof ApiRealtimeRoute
@@ -517,6 +524,7 @@ export interface FileRoutesByTo {
   '/credits': typeof AppCreditsRoute
   '/login': typeof AuthLoginRoute
   '/verify': typeof AuthVerifyRoute
+  '/pricing': typeof MarketingPricingRoute
   '/privacy': typeof MarketingPrivacyRoute
   '/terms': typeof MarketingTermsRoute
   '/api/realtime': typeof ApiRealtimeRoute
@@ -590,6 +598,7 @@ export interface FileRoutesById {
   '/_app/credits': typeof AppCreditsRoute
   '/_auth/login': typeof AuthLoginRoute
   '/_auth/verify': typeof AuthVerifyRoute
+  '/_marketing/pricing': typeof MarketingPricingRoute
   '/_marketing/privacy': typeof MarketingPrivacyRoute
   '/_marketing/terms': typeof MarketingTermsRoute
   '/api/realtime': typeof ApiRealtimeRoute
@@ -663,6 +672,7 @@ export interface FileRouteTypes {
     | '/credits'
     | '/login'
     | '/verify'
+    | '/pricing'
     | '/privacy'
     | '/terms'
     | '/api/realtime'
@@ -731,6 +741,7 @@ export interface FileRouteTypes {
     | '/credits'
     | '/login'
     | '/verify'
+    | '/pricing'
     | '/privacy'
     | '/terms'
     | '/api/realtime'
@@ -803,6 +814,7 @@ export interface FileRouteTypes {
     | '/_app/credits'
     | '/_auth/login'
     | '/_auth/verify'
+    | '/_marketing/pricing'
     | '/_marketing/privacy'
     | '/_marketing/terms'
     | '/api/realtime'
@@ -1030,6 +1042,13 @@ declare module '@tanstack/react-router' {
       path: '/privacy'
       fullPath: '/privacy'
       preLoaderRoute: typeof MarketingPrivacyRouteImport
+      parentRoute: typeof MarketingRoute
+    }
+    '/_marketing/pricing': {
+      id: '/_marketing/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof MarketingPricingRouteImport
       parentRoute: typeof MarketingRoute
     }
     '/_auth/verify': {
@@ -1498,12 +1517,14 @@ const AuthRouteRouteWithChildren = AuthRouteRoute._addFileChildren(
 )
 
 interface MarketingRouteChildren {
+  MarketingPricingRoute: typeof MarketingPricingRoute
   MarketingPrivacyRoute: typeof MarketingPrivacyRoute
   MarketingTermsRoute: typeof MarketingTermsRoute
   MarketingIndexRoute: typeof MarketingIndexRoute
 }
 
 const MarketingRouteChildren: MarketingRouteChildren = {
+  MarketingPricingRoute: MarketingPricingRoute,
   MarketingPrivacyRoute: MarketingPrivacyRoute,
   MarketingTermsRoute: MarketingTermsRoute,
   MarketingIndexRoute: MarketingIndexRoute,

--- a/src/routes/_marketing/pricing.tsx
+++ b/src/routes/_marketing/pricing.tsx
@@ -1,0 +1,189 @@
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  formatProcessingFeePercent,
+  PROCESSING_FEE_PERCENT,
+} from '@/lib/billing/constants';
+import { buildPricingCatalog } from '@/lib/billing/pricing-catalog';
+import { SITE_CONFIG } from '@/lib/marketing/constants';
+import { ArrowRight, KeyRound, Wallet, Zap } from 'lucide-react';
+
+const title = `Pricing — ${SITE_CONFIG.name}`;
+const description =
+  'Transparent, provider-cost AI pricing. Pay what models charge — a small processing fee applies only when you buy credits.';
+
+export const Route = createFileRoute('/_marketing/pricing')({
+  component: PricingPage,
+  head: () => ({
+    meta: [
+      { title },
+      { name: 'description', content: description },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { property: 'og:url', content: `${SITE_CONFIG.url}/pricing` },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+    ],
+  }),
+});
+
+function PricingPage() {
+  const { sections, lastUpdated } = buildPricingCatalog();
+  const feePercent = formatProcessingFeePercent();
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 pb-24 pt-28">
+      <header className="max-w-3xl">
+        <p className="text-sm font-medium uppercase tracking-widest text-primary">
+          Pricing
+        </p>
+        <h1 className="font-heading mt-3 text-4xl font-bold tracking-tight md:text-5xl">
+          Pay provider cost. Nothing hidden.
+        </h1>
+        <p className="mt-4 text-lg leading-relaxed text-muted-foreground">
+          {description} Bring your own API keys to pay providers directly with
+          zero platform fees.
+        </p>
+      </header>
+
+      <div className="mt-10 grid gap-4 sm:grid-cols-3">
+        <Card className="border-primary/20 bg-primary/5">
+          <CardHeader className="gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+              <Zap className="h-5 w-5 text-primary" />
+            </div>
+            <CardTitle className="text-lg">At-cost usage</CardTitle>
+            <CardDescription>
+              Every generation is billed at the exact rate the AI provider
+              charges — the same pricing you see on OpenRouter and fal.ai.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+
+        <Card>
+          <CardHeader className="gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+              <Wallet className="h-5 w-5 text-foreground" />
+            </div>
+            <CardTitle className="text-lg">
+              {feePercent} processing fee
+            </CardTitle>
+            <CardDescription>
+              A {feePercent} fee applies when you buy credits via Stripe — not
+              on each generation. $
+              {(100 * (1 + PROCESSING_FEE_PERCENT)).toFixed(0)} charged → $100
+              in your wallet.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+
+        <Card>
+          <CardHeader className="gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+              <KeyRound className="h-5 w-5 text-foreground" />
+            </div>
+            <CardTitle className="text-lg">Bring your own keys</CardTitle>
+            <CardDescription>
+              Use your own fal.ai and OpenRouter keys to skip credits entirely.
+              You pay the provider directly with no OpenStory fees.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <div className="mt-16 flex flex-col gap-12">
+        {sections.map((section) => (
+          <section key={section.id} id={section.id}>
+            <div className="mb-4 max-w-2xl">
+              <h2 className="text-2xl font-semibold tracking-tight">
+                {section.title}
+              </h2>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {section.description}
+              </p>
+            </div>
+
+            <div className="overflow-hidden rounded-xl border">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/40">
+                    <th className="px-4 py-3 font-medium">Model</th>
+                    <th className="hidden px-4 py-3 font-medium sm:table-cell">
+                      Provider
+                    </th>
+                    <th className="px-4 py-3 font-medium text-right">Price</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {section.rows.map((row) => (
+                    <tr
+                      key={row.name}
+                      className="border-b last:border-b-0 hover:bg-muted/20"
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="font-medium">{row.name}</span>
+                          {row.license === 'open-source' && (
+                            <Badge variant="secondary" className="text-xs">
+                              Open source
+                            </Badge>
+                          )}
+                        </div>
+                        {row.detail && (
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {row.detail}
+                          </p>
+                        )}
+                        <p className="mt-1 text-xs text-muted-foreground sm:hidden">
+                          {row.provider}
+                        </p>
+                      </td>
+                      <td className="hidden px-4 py-3 text-muted-foreground sm:table-cell">
+                        {row.provider}
+                      </td>
+                      <td className="px-4 py-3 text-right font-mono text-xs tabular-nums sm:text-sm">
+                        {row.price}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        ))}
+      </div>
+
+      <p className="mt-10 text-center text-xs text-muted-foreground">
+        Prices synced from provider APIs. {lastUpdated}. Actual charges reflect
+        reported usage (tokens, seconds, images) and may vary slightly from
+        estimates.
+      </p>
+
+      <div className="mt-12 flex flex-col items-center gap-4 rounded-2xl border bg-muted/30 px-6 py-10 text-center">
+        <h2 className="text-xl font-semibold">Ready to start creating?</h2>
+        <p className="max-w-md text-sm text-muted-foreground">
+          Add credits from your dashboard, or connect API keys in Settings. No
+          subscriptions — pay only for what you use.
+        </p>
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Button asChild size="lg">
+            <Link to="/sequences/new">
+              Get started
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <Link to="/credits">Add credits</Link>
+          </Button>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Closes #1044

## Summary

Overhauls OpenStory billing to charge AI usage at exact provider cost and apply a 5% processing fee only when purchasing credits — not on each generation. Closes billing gaps for poster and element vision, adds a public pricing page, and hardens deduction paths found in review.

### Billing model
- **Remove usage markup** — `deductCredits` and `hasEnoughCredits` use raw provider cost (no 5% multiplier on generation)
- **Processing fee at purchase** — 5% fee on Stripe checkout and auto-top-up; wallet receives the credit amount only
- **Checkout transparency** — billing settings shows credits / fee / total breakdown; Stripe session uses separate line items
- **LLM actual-cost billing** — server functions and workflows bill OpenRouter's per-request `usage.cost` via `llmCostFromUsage`, not a flat estimate

### Missing credit deductions
- **Sequence poster** — `StoryboardWorkflow` deducts after successful poster save (gated on persisted `posterUrl`)
- **Element vision** — deducts in `ElementVisionWorkflow`, `ReplaceElementWorkflow`, and `analyzeDraftElementFn`
- **Draft element preflight** — draft vision checks `hasEnoughCredits` before the LLM call; deducts with idempotency key `draft-vision:{publicUrl}`

### Pricing & marketing
- **Public `/pricing` page** — model catalog from fal + OpenRouter pricing data
- **`pricing-catalog.ts`** — single source for the pricing page tables
- **`update-openrouter-pricing.ts`** — sync script for LLM rates
- Updated FAQ, marketing copy, nav links (header/footer), and billing settings descriptions

### Scripts & env
- **`FAL_PRICING_KEY`** — separate admin key for pricing sync and usage comparison (distinct from generation `FAL_KEY`)
- Fal pricing/verify scripts use `requireFalPricingKey()`; Bun autoloads `.env.local` (use `--env-file=` to override)

### Review hardening
- **`shortenPromptFn`** — deducts only after output validation (no charge on empty/too-short responses)
- **`totalCheckoutCents`** — integer-cent rounding aligned with `splitCheckoutAmounts` (fixes fractional cents on auto-top-up)
- **`reportMissingBillingCost`** — logs + PostHog `billing_missing_cost` when a completed AI call has no billable cost
- Removed unused `microsToUsdCents` after checkout refactor

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test src/lib/billing` (47 tests)
- [x] `bun run test src/lib/ai/llm-client.test.ts`
- [x] `bun run test src/lib/db/scoped/billing.test.ts`
- [ ] Run storyboard workflow — confirm poster credits deducted after save
- [ ] Run element vision workflow — confirm LLM credits deducted
- [ ] Manual checkout — confirm Stripe shows credit + fee line items, wallet credited with credit amount only