### PR TITLE
fix(#1052): delete PR-preview container apps on cleanup

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -331,6 +331,51 @@ jobs:
           done
           echo "Deleted $deleted preview workflow(s) with suffix $SUFFIX"
 
+      # Container applications are account-level resources tied to a worker's
+      # DO namespace — they outlive the worker delete above. Leaving them
+      # blocks reopened/redeployed PRs ("already an application with the name
+      # pr-<n>-videoexportcontainer … associated with a different durable
+      # object namespace") and accrues provisioned instances. See #1052.
+      - name: Delete container application
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Naming: wrangler deploys the container as `<worker>-<class>` lowercased
+          # — worker is `pr-<n>`, class is VideoExportContainer →
+          # `pr-<n>-videoexportcontainer`. Same list-then-delete pattern as
+          # workflows; tolerate not-found (PRs that never got a container).
+          APP_NAME="pr-${PR_NUMBER}-videoexportcontainer"
+          resp=$(curl -sf \
+            -H "Authorization: Bearer $CF_API_TOKEN" \
+            "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/containers/applications?name=$APP_NAME") || {
+              echo "::warning::Failed to list container applications — skipping container cleanup"
+              exit 0
+            }
+
+          # Response may be a bare array (Cloudchamber OpenAPI) or the usual
+          # `{ success, result: [...] }` envelope — accept both.
+          ids=$(echo "$resp" | jq -r '
+            if type == "array" then .[]?.id
+            elif .result | type == "array" then .result[]?.id
+            else empty
+            end
+          ')
+
+          if [ -z "$ids" ]; then
+            echo "Container application $APP_NAME not found (already deleted or never deployed)"
+            exit 0
+          fi
+
+          for id in $ids; do
+            status=$(curl -sw '%{http_code}' -o /dev/null \
+              -X DELETE \
+              -H "Authorization: Bearer $CF_API_TOKEN" \
+              "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/containers/applications/$id")
+            echo "Delete container application $APP_NAME ($id) response: $status"
+          done
+
       - name: Delete D1 database
         env:
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -373,4 +418,4 @@ jobs:
             <!-- cf-preview -->
             **Cloudflare Preview** torn down
 
-            Worker `pr-${{ github.event.pull_request.number }}` and D1 database `openstory-pr-${{ github.event.pull_request.number }}` have been deleted.
+            Worker `pr-${{ github.event.pull_request.number }}`, D1 database `openstory-pr-${{ github.event.pull_request.number }}`, preview workflows, and container application `pr-${{ github.event.pull_request.number }}-videoexportcontainer` have been deleted.

--- a/docs/deployment/cloudflare.md
+++ b/docs/deployment/cloudflare.md
@@ -187,8 +187,8 @@ reopen the PR to get a fresh, wrangler-tracked preview database.
 
 Production pushes to `main` deploy via Workers Builds (see [Build & Deploy](#build--deploy) above). [`deploy-cloudflare.yml`](https://github.com/openstory-so/openstory/blob/main/.github/workflows/deploy-cloudflare.yml) handles the PR previews, which stay on GitHub Actions because Workers Builds branch previews share production bindings — no per-PR D1 provisioning, no workflow-name namespacing, no teardown on close:
 
-- **PR previews**: each PR gets its own Worker (`pr-<number>`) and D1 database (`openstory-pr-<number>`), with secrets pushed and the preview URL posted as a PR comment.
-- **Cleanup**: closing a PR deletes both the Worker and the D1 database.
+- **PR previews**: each PR gets its own Worker (`pr-<number>`) and D1 database (`openstory-pr-<number>`), with secrets pushed and the preview URL posted as a PR comment. Previews also get namespaced workflows (`*-pr-<number>`) and a video-export container application (`pr-<number>-videoexportcontainer`).
+- **Cleanup**: closing a PR deletes the Worker, namespaced workflows, container application, and D1 database. Container apps are account-level and outlive the worker — skipping them blocks reopened-PR redeploys and accrues provisioned instances (see #1052).
 
 ## Platform Detection
 


### PR DESCRIPTION
## Summary

- **Problem:** `cleanup-preview` tore down the worker, workflows, and D1 on PR close, but never the account-level container application (`pr-<n>-videoexportcontainer`). Stale apps blocked reopened-PR redeploys and accrued provisioned instances.
- **Fix:** Add a list-then-delete step for `pr-<n>-videoexportcontainer` (tolerate not-found), and document the full preview teardown surface.
- **One-off:** Stale closed-PR container apps were swept via `wrangler containers delete`; `pr-1043`'s stale app was removed and its deploy re-run to unblock.

Closes #1052

## Test plan

- [ ] Merge lands the workflow change on `main`
- [ ] Close a PR that has deployed a preview with video-export container → `cleanup-preview` log shows delete for `pr-<n>-videoexportcontainer` (or not-found if never deployed)
- [ ] Reopen that PR (or push to a reopened PR) → preview deploy succeeds without “already an application… different durable object namespace”
- [ ] Confirm `wrangler containers list` only shows production + live open-PR apps after close cleanup