### PR TITLE
fix: skip protected realtime reads for anonymous viewers

### DIFF
--- a/src/hooks/use-library-location-sheet-variants.ts
+++ b/src/hooks/use-library-location-sheet-variants.ts
@@ -5,6 +5,7 @@ import {
   undiscardLibraryLocationSheetVariantFn,
 } from '@/functions/library-location-sheet-variants';
 import { libraryLocationKeys } from '@/hooks/use-sequence-locations';
+import { useUser } from '@/hooks/use-user';
 import type { LocationSheetVariant } from '@/lib/db/schema';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -22,11 +23,14 @@ export const libraryLocationSheetVariantKeys = {
 export function useLibraryLocationDivergentVariants(options?: {
   refetchInterval?: number | false;
 }) {
+  const { data: user } = useUser();
+
   return useQuery<LocationSheetVariant[]>({
     queryKey: libraryLocationSheetVariantKeys.divergent(),
     queryFn: () => getLibraryLocationDivergentVariantsFn(),
     staleTime: 30_000,
     refetchInterval: options?.refetchInterval ?? false,
+    enabled: !!user,
   });
 }
 

--- a/src/hooks/use-location-realtime.ts
+++ b/src/hooks/use-location-realtime.ts
@@ -1,4 +1,5 @@
 import { getChannelHistoryFn } from '@/functions/realtime-history';
+import { useUser } from '@/hooks/use-user';
 import { useRealtime } from '@/lib/realtime/client';
 import type { StaleDetectedPayload } from '@/lib/realtime';
 import { useQueryClient } from '@tanstack/react-query';
@@ -53,12 +54,13 @@ function resolveStatusFromHistory(
  */
 export function useLocationSheetRealtime(locationId?: string) {
   const queryClient = useQueryClient();
+  const { data: user } = useUser();
   const [isGenerating, setIsGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Replay channel history on mount
   useEffect(() => {
-    if (!locationId) return;
+    if (!locationId || !user) return;
 
     getChannelHistoryFn({ data: { channel: `location:${locationId}` } })
       .then((events) => {
@@ -72,7 +74,7 @@ export function useLocationSheetRealtime(locationId?: string) {
           err,
         });
       });
-  }, [locationId]);
+  }, [locationId, user]);
 
   const handleEvent = useCallback(
     (event: LocationRealtimeEvent) => {

--- a/src/hooks/use-location-sheets-realtime.ts
+++ b/src/hooks/use-location-sheets-realtime.ts
@@ -1,4 +1,5 @@
 import { getChannelHistoryFn } from '@/functions/realtime-history';
+import { useUser } from '@/hooks/use-user';
 import { useRealtime } from '@/lib/realtime/client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -25,6 +26,7 @@ type SheetProgressEvent = {
  */
 export function useLocationSheetsRealtime(locationIds: string[] = []) {
   const queryClient = useQueryClient();
+  const { data: user } = useUser();
   const [generatingStatus, setGeneratingStatus] = useState<
     Map<string, boolean>
   >(new Map());
@@ -38,6 +40,8 @@ export function useLocationSheetsRealtime(locationIds: string[] = []) {
 
   // Replay channel history for newly added location IDs
   useEffect(() => {
+    if (!user) return;
+
     const newIds = locationIds.filter((id) => !checkedIds.current.has(id));
     if (newIds.length === 0) return;
 
@@ -70,7 +74,7 @@ export function useLocationSheetsRealtime(locationIds: string[] = []) {
           logger.error(`Failed to fetch history for location:${id}:`, { err });
         });
     }
-  }, [locationIds]);
+  }, [locationIds, user]);
 
   const handleEvent = useCallback(
     (event: SheetProgressEvent) => {

--- a/src/hooks/use-talent-realtime.ts
+++ b/src/hooks/use-talent-realtime.ts
@@ -1,4 +1,5 @@
 import { getChannelHistoryFn } from '@/functions/realtime-history';
+import { useUser } from '@/hooks/use-user';
 import { useRealtime } from '@/lib/realtime/client';
 import type { StaleDetectedPayload } from '@/lib/realtime';
 import { useQueryClient } from '@tanstack/react-query';
@@ -66,13 +67,14 @@ function resolveStatusFromHistory(
  */
 export function useTalentSheetRealtime(talentId?: string) {
   const queryClient = useQueryClient();
+  const { data: user } = useUser();
   const [isGenerating, setIsGenerating] = useState(false);
   const [phase, setPhase] = useState<GenerationPhase>('sheet');
   const [error, setError] = useState<string | null>(null);
 
   // Replay channel history on mount to catch in-flight generation
   useEffect(() => {
-    if (!talentId) return;
+    if (!talentId || !user) return;
 
     getChannelHistoryFn({ data: { channel: `talent:${talentId}` } })
       .then((events) => {
@@ -94,7 +96,7 @@ export function useTalentSheetRealtime(talentId?: string) {
           err,
         });
       });
-  }, [talentId, queryClient]);
+  }, [talentId, queryClient, user]);
 
   const handleEvent = useCallback(
     (event: TalentRealtimeEvent) => {

--- a/src/hooks/use-talent-sheet-variants.ts
+++ b/src/hooks/use-talent-sheet-variants.ts
@@ -6,6 +6,7 @@ import {
   undiscardTalentSheetVariantFn,
 } from '@/functions/talent-sheet-variants';
 import { talentKeys } from '@/hooks/use-talent';
+import { useUser } from '@/hooks/use-user';
 import type { TalentSheetVariant } from '@/lib/db/schema';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -23,11 +24,14 @@ export const talentSheetVariantKeys = {
 export function useTeamTalentDivergentVariants(options?: {
   refetchInterval?: number | false;
 }) {
+  const { data: user } = useUser();
+
   return useQuery<TalentSheetVariant[]>({
     queryKey: talentSheetVariantKeys.divergentTeam(),
     queryFn: () => getTeamTalentDivergentVariantsFn(),
     staleTime: 30_000,
     refetchInterval: options?.refetchInterval ?? false,
+    enabled: !!user,
   });
 }
 

--- a/src/hooks/use-talent-sheets-realtime.ts
+++ b/src/hooks/use-talent-sheets-realtime.ts
@@ -1,4 +1,5 @@
 import { getChannelHistoryFn } from '@/functions/realtime-history';
+import { useUser } from '@/hooks/use-user';
 import { useRealtime } from '@/lib/realtime/client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -30,6 +31,7 @@ type SheetProgressEvent = {
  */
 export function useTalentSheetsRealtime(talentIds: string[] = []) {
   const queryClient = useQueryClient();
+  const { data: user } = useUser();
   const [generatingStatus, setGeneratingStatus] = useState<
     Map<string, boolean>
   >(new Map());
@@ -45,6 +47,8 @@ export function useTalentSheetsRealtime(talentIds: string[] = []) {
 
   // Replay channel history for newly added talent IDs
   useEffect(() => {
+    if (!user) return;
+
     const newIds = talentIds.filter((id) => !checkedIds.current.has(id));
     if (newIds.length === 0) return;
 
@@ -78,7 +82,7 @@ export function useTalentSheetsRealtime(talentIds: string[] = []) {
           logger.error(`Failed to fetch history for talent:${id}:`, { err });
         });
     }
-  }, [talentIds]);
+  }, [talentIds, user]);
 
   const handleEvent = useCallback(
     (event: SheetProgressEvent) => {

--- a/src/lib/realtime/use-generation-stream.ts
+++ b/src/lib/realtime/use-generation-stream.ts
@@ -1,4 +1,5 @@
 import { getChannelHistoryFn } from '@/functions/realtime-history';
+import { useUser } from '@/hooks/use-user';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useReducer } from 'react';
 import { useRealtime } from './client';
@@ -263,6 +264,7 @@ export function useGenerationStream(
     createInitialState
   );
   const replayHistory = options?.replayHistory ?? true;
+  const { data: user } = useUser();
 
   // Handle incoming events
   const handleEvent = useCallback(
@@ -287,7 +289,7 @@ export function useGenerationStream(
   // Skipped when replayHistory is false (e.g., sequence already complete) to
   // avoid briefly flashing progress UI from old events on tab re-mount.
   useEffect(() => {
-    if (!replayHistory) return;
+    if (!replayHistory || !user) return;
     getChannelHistoryFn({ data: { channel: sequenceId } })
       .then((events: { event: string; data: string }[]) => {
         for (const evt of events) {
@@ -307,7 +309,7 @@ export function useGenerationStream(
           err: error,
         });
       });
-  }, [sequenceId, replayHistory]);
+  }, [sequenceId, replayHistory, user]);
 
   // Subscribe to realtime events for live updates.
   const { status } = useRealtime({

--- a/src/lib/realtime/use-shot-prompt-stream.ts
+++ b/src/lib/realtime/use-shot-prompt-stream.ts
@@ -1,4 +1,5 @@
 import { getChannelHistoryFn } from '@/functions/realtime-history';
+import { useUser } from '@/hooks/use-user';
 import { useCallback, useEffect, useReducer } from 'react';
 import { z } from 'zod';
 import { useRealtime } from './client';
@@ -100,14 +101,16 @@ export function useShotPromptStream(
   enabled: boolean = true
 ) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  const { data: user } = useUser();
   const channelId = shotId ? `shot-prompt:${shotId}` : undefined;
   const active = enabled && Boolean(channelId);
+  const canReplayHistory = active && Boolean(user);
 
   // Replay history on mount so a user who navigates back mid-regen sees the
   // accumulated text and the right status. Re-keys on shotId so switching
   // shots clears and re-fetches.
   useEffect(() => {
-    if (!active || !channelId) {
+    if (!canReplayHistory || !channelId) {
       dispatch({ type: 'RESET' });
       return;
     }
@@ -156,7 +159,7 @@ export function useShotPromptStream(
     return () => {
       cancelled = true;
     };
-  }, [active, channelId]);
+  }, [canReplayHistory, channelId]);
 
   const handleEvent = useCallback(
     (msg: {


### PR DESCRIPTION
## Related Issue

Closes #840

## Summary of Changes

- Skip authenticated channel-history replays for anonymous visitors.
- Disable team-only divergent-variant queries until a user session exists.
- Keep realtime subscriptions intact and preserve server-side authentication, so anonymous browsing no longer generates authentication errors without exposing private channel history.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes

Authenticated users retain history replay and divergent-variant indicators. Anonymous users continue to receive existing live realtime updates, but do not request protected replay/history data.

## Screenshots (if applicable)

Not applicable — behavior-only change.