### PR TITLE
fix(#1062): honest fal preflight estimates for gpt-image-2

### DIFF
--- a/scripts/fal-endpoints.ts
+++ b/scripts/fal-endpoints.ts
@@ -6,6 +6,7 @@ import {
   EDIT_ENDPOINTS,
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
+  MOTION_REFERENCE_ENDPOINTS,
 } from '@/lib/ai/models';
 
 export function getFalEndpointIds(): string[] {
@@ -13,6 +14,9 @@ export function getFalEndpointIds(): string[] {
   const image = Object.values(IMAGE_MODELS).map((m) => m.id);
   const audio = Object.values(AUDIO_MODELS).map((m) => m.id);
   const edit = Object.values(EDIT_ENDPOINTS);
+  const motionRef = Object.values(MOTION_REFERENCE_ENDPOINTS).map(
+    (m) => m.endpointId
+  );
 
-  return [...new Set([...video, ...image, ...edit, ...audio])];
+  return [...new Set([...video, ...image, ...edit, ...audio, ...motionRef])];
 }

--- a/scripts/update-fal-pricing.ts
+++ b/scripts/update-fal-pricing.ts
@@ -3,13 +3,19 @@
  * Usage (Bun autoloads .env.local; use --env-file= to override):
  *   bun scripts/update-fal-pricing.ts
  *
- * The output is a single flat map of `endpointId -> { unitPrice, unit }` taken
- * verbatim from fal's pricing API. Actual credit deduction multiplies fal's
- * reported `unitsBilled` by `unitPrice` (see `falCostFromUnits` in
- * `src/lib/ai/fal-cost.ts`), so no per-model multipliers/matrices are needed —
- * fal already accounts for resolution/audio/duration in `unitsBilled`. The
- * `unit` field is only used by pre-flight cost ESTIMATION to predict a unit
- * count before a generation runs.
+ * The output is a flat map of `endpointId -> { unitPrice, unit, typicalUnitsPerCall? }`
+ * taken from fal's pricing APIs:
+ *
+ * 1. GET /v1/models/pricing — unit_price + unit (billing denominator)
+ * 2. POST /v1/models/pricing/estimate (historical_api_price) — typical cost
+ *    per generation call, converted to typicalUnitsPerCall = cost / unit_price
+ *
+ * Actual credit deduction multiplies fal's reported `unitsBilled` by `unitPrice`
+ * (see `falCostFromUnits` in `src/lib/ai/fal-cost.ts`). Pre-flight estimation
+ * uses `typicalUnitsPerCall` for image/flat models so endpoints that report
+ * ambiguous unit `"units"` with unit_price=$1 (e.g. openai/gpt-image-2) are
+ * not treated as $1/image. Duration-based models still use parametric
+ * estimates from request params.
  */
 import { writeFile } from 'node:fs/promises';
 import { getFalEndpointIds } from './fal-endpoints';
@@ -36,7 +42,12 @@ type FalUnit =
   | 'tokens'
   | 'flat';
 
-type BuilderFalPricing = { unitPrice: MicrosValue; unit: FalUnit };
+type BuilderFalPricing = {
+  unitPrice: MicrosValue;
+  unit: FalUnit;
+  /** From fal historical estimate; omitted when fal has no usable history. */
+  typicalUnitsPerCall?: number;
+};
 
 const apiKey = requireFalPricingKey();
 
@@ -48,11 +59,15 @@ const endpoints = getFalEndpointIds();
 // The pricing API reports the ambiguous unit `"units"` for several distinct
 // billing kinds (e.g. flat-per-video, per-1000-token, per-image, and per-second
 // all show up as "units"). Tag the known ones so pre-flight ESTIMATION can
-// predict a unit count. This never affects an actual charge — billing always
-// multiplies fal's reported `unitsBilled` by `unitPrice` regardless of `unit`.
+// predict a unit count when historical data is missing. This never affects an
+// actual charge — billing always multiplies fal's reported `unitsBilled` by
+// `unitPrice` regardless of `unit`.
 // ============================================================================
 
 const UNITS_KIND: Record<string, FalUnit> = {
+  // Image models with unit "units": unit_price is the billable-unit size, not
+  // a flat per-image dollar price. typicalUnitsPerCall (from historical) is
+  // what makes preflight honest for these (e.g. gpt-image-2 ≈ 0.22 units).
   'openai/gpt-image-2': 'images',
   'openai/gpt-image-2/edit': 'images',
   'fal-ai/phota': 'images',
@@ -60,6 +75,7 @@ const UNITS_KIND: Record<string, FalUnit> = {
   'fal-ai/ace-step-1.5': 'seconds',
   'fal-ai/minimax/hailuo-2.3/pro/image-to-video': 'flat',
   'bytedance/seedance-2.0/enterprise/v2/image-to-video': 'tokens',
+  'bytedance/seedance-2.0/enterprise/v2/reference-to-video': 'tokens',
 };
 
 function normalizeUnit(apiUnit: string, endpointId: string): FalUnit {
@@ -89,7 +105,7 @@ function normalizeUnit(apiUnit: string, endpointId: string): FalUnit {
 }
 
 // ============================================================================
-// Fetch pricing from API
+// Fetch unit pricing from API
 // ============================================================================
 
 const url = new URL('https://api.fal.ai/v1/models/pricing');
@@ -123,13 +139,75 @@ if (missing.length > 0) {
 }
 
 // ============================================================================
+// Fetch historical per-call cost → typicalUnitsPerCall
+//
+// fal's estimate API only returns a single total_cost, so we request one
+// endpoint at a time. Concurrency is kept low to avoid rate limits.
+// ============================================================================
+
+type EstimateResponse = {
+  estimate_type: string;
+  total_cost: number;
+  currency: string;
+};
+
+const ESTIMATE_CONCURRENCY = 5;
+const ESTIMATE_CHUNK_DELAY_MS = 150;
+
+async function fetchHistoricalCostUsd(
+  endpointId: string
+): Promise<number | null> {
+  const resp = await fetch('https://api.fal.ai/v1/models/pricing/estimate', {
+    method: 'POST',
+    headers: {
+      Authorization: `Key ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      estimate_type: 'historical_api_price',
+      endpoints: { [endpointId]: { call_quantity: 1 } },
+    }),
+  });
+  if (!resp.ok) {
+    console.warn(
+      `  ? ${endpointId}: historical estimate HTTP ${resp.status} — skipping typicalUnitsPerCall`
+    );
+    return null;
+  }
+  const body: EstimateResponse = await resp.json();
+  if (!Number.isFinite(body.total_cost) || body.total_cost <= 0) {
+    // No usage history (or free) — leave typicalUnitsPerCall unset so
+    // estimateFalCost falls back to parametric unit math.
+    return null;
+  }
+  return body.total_cost;
+}
+
+const historicalByEndpoint = new Map<string, number>();
+for (let i = 0; i < endpoints.length; i += ESTIMATE_CONCURRENCY) {
+  const chunk = endpoints.slice(i, i + ESTIMATE_CONCURRENCY);
+  const costs = await Promise.all(chunk.map(fetchHistoricalCostUsd));
+  for (let j = 0; j < chunk.length; j++) {
+    const id = chunk[j];
+    const cost = costs[j];
+    if (id != null && cost != null) historicalByEndpoint.set(id, cost);
+  }
+  if (i + ESTIMATE_CONCURRENCY < endpoints.length) {
+    await new Promise((r) => setTimeout(r, ESTIMATE_CHUNK_DELAY_MS));
+  }
+}
+
+// ============================================================================
 // Read existing file for a price-change diff
 // ============================================================================
 
 const outPath = new URL('../src/lib/ai/fal-pricing-data.ts', import.meta.url)
   .pathname;
 
-let oldPricing: Record<string, { unitPrice?: number }> = {};
+let oldPricing: Record<
+  string,
+  { unitPrice?: number; typicalUnitsPerCall?: number }
+> = {};
 try {
   const existing = await import(outPath);
   oldPricing = existing.FAL_PRICING ?? {};
@@ -141,14 +219,30 @@ try {
 // Build the flat pricing map (prices wrapped in MicrosValue for serialization)
 // ============================================================================
 
+/** Stable serialization precision for typical units (avoids float noise). */
+function roundTypicalUnits(n: number): number {
+  return Math.round(n * 1_000_000) / 1_000_000;
+}
+
 const pricing: Record<string, BuilderFalPricing> = {};
 for (const p of data.prices.sort((a, b) =>
   a.endpoint_id.localeCompare(b.endpoint_id)
 )) {
-  pricing[p.endpoint_id] = {
+  const entry: BuilderFalPricing = {
     unitPrice: m(p.unit_price),
     unit: normalizeUnit(p.unit, p.endpoint_id),
   };
+
+  const historicalUsd = historicalByEndpoint.get(p.endpoint_id);
+  if (
+    historicalUsd != null &&
+    Number.isFinite(p.unit_price) &&
+    p.unit_price > 0
+  ) {
+    entry.typicalUnitsPerCall = roundTypicalUnits(historicalUsd / p.unit_price);
+  }
+
+  pricing[p.endpoint_id] = entry;
 }
 
 // ============================================================================
@@ -166,6 +260,20 @@ for (const [id, entry] of Object.entries(pricing)) {
   } else if (old.unitPrice !== newPrice) {
     console.log(`  ~ ${id}: ${old.unitPrice} → ${newPrice} micros`);
     changes++;
+  }
+  const newTypical = entry.typicalUnitsPerCall;
+  const oldTypical = old?.typicalUnitsPerCall;
+  if (newTypical !== oldTypical) {
+    console.log(
+      `  ~ ${id}: typicalUnitsPerCall ${oldTypical ?? '—'} → ${newTypical ?? '—'}`
+    );
+    changes++;
+  }
+  if (newTypical != null) {
+    const estUsd = (newTypical * newPrice) / 1_000_000;
+    console.log(
+      `    hist ≈ $${estUsd.toFixed(4)}/call (${newTypical} units × $${(newPrice / 1_000_000).toFixed(6)})`
+    );
   }
 }
 for (const id of Object.keys(oldPricing)) {
@@ -189,11 +297,21 @@ function formatMicros(value: number): string {
   return str;
 }
 
+function formatTypicalUnitsLiteral(value: number): string {
+  // Prefer short decimals when exact (0.22, 1.5); otherwise full rounded form.
+  if (Number.isInteger(value)) return String(value);
+  const asFixed = value.toFixed(6).replace(/\.?0+$/, '');
+  return asFixed;
+}
+
 const entries = Object.entries(pricing)
-  .map(
-    ([id, p]) =>
-      `  '${id}': { unitPrice: micros(${formatMicros(p.unitPrice.value)}), unit: '${p.unit}' },`
-  )
+  .map(([id, p]) => {
+    const typical =
+      p.typicalUnitsPerCall != null
+        ? `, typicalUnitsPerCall: ${formatTypicalUnitsLiteral(p.typicalUnitsPerCall)}`
+        : '';
+    return `  '${id}': { unitPrice: micros(${formatMicros(p.unitPrice.value)}), unit: '${p.unit}'${typical} },`;
+  })
   .join('\n');
 
 const now = new Date().toISOString();
@@ -207,7 +325,11 @@ import { type Microdollars, micros } from '@/lib/billing/money';
 //
 // \`unitPrice\` is fal's per-unit price, taken verbatim from the pricing API.
 // Actual cost = unitsBilled (from the adapter) * unitPrice. \`unit\` is the
-// billed unit, used only by pre-flight cost estimation.
+// billed unit kind, used by pre-flight estimation when historical data is
+// missing. \`typicalUnitsPerCall\` is fal's historical_api_price estimate
+// converted to units (cost / unit_price) — preferred for image/flat preflight
+// so models like openai/gpt-image-2 (unit_price=$1, ~0.22 units/call) are not
+// estimated at $1/image.
 // ============================================================================
 
 export type FalUnit =
@@ -222,6 +344,12 @@ export type FalUnit =
 export type FalPricing = {
   unitPrice: Microdollars;
   unit: FalUnit;
+  /**
+   * Typical unitsBilled for one generation call, from fal historical estimate
+   * (total_cost / unit_price). Preflight only — actual charges use the
+   * unitsBilled fal reports on the completed request.
+   */
+  typicalUnitsPerCall?: number;
 };
 
 export const FAL_PRICING: Record<string, FalPricing> = {
@@ -235,4 +363,7 @@ await writeFile(outPath, output);
 
 console.log(
   `\nWrote ${Object.keys(pricing).length} endpoints to fal-pricing-data.ts (${changes} changes)`
+);
+console.log(
+  `Historical estimates: ${historicalByEndpoint.size}/${endpoints.length} endpoints`
 );

--- a/src/lib/ai/fal-cost.test.ts
+++ b/src/lib/ai/fal-cost.test.ts
@@ -6,6 +6,7 @@ import {
   EDIT_ENDPOINTS,
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
+  MOTION_REFERENCE_ENDPOINTS,
 } from '@/lib/ai/models';
 import { micros, usdToMicros, ZERO_MICROS } from '@/lib/billing/money';
 
@@ -54,13 +55,29 @@ describe('falCostFromUnits', () => {
 });
 
 describe('estimateFalCost', () => {
-  test('per-image scales by numImages', () => {
+  test('per-image uses typicalUnitsPerCall × numImages (nano-banana historical 1.5×)', () => {
+    // unitPrice $0.08, typicalUnitsPerCall 1.5 → $0.12 each, $0.24 for 2.
     expect(estimateFalCost('fal-ai/nano-banana-2', { numImages: 2 })).toBe(
-      micros(160_000)
+      micros(240_000)
     );
   });
 
-  test('per-second scales by duration', () => {
+  test('gpt-image-2 is not estimated at $1/image (unit_price is $1 per unit, ~0.22 units/call)', () => {
+    // fal historical_api_price ≈ $0.22/call; unit_price=$1 → 0.22 units.
+    // Treating unitPrice as a flat per-image dollar cost was the #1062 bug.
+    expect(estimateFalCost('openai/gpt-image-2', { numImages: 1 })).toBe(
+      micros(220_000)
+    );
+    expect(estimateFalCost('openai/gpt-image-2', { numImages: 14 })).toBe(
+      micros(3_080_000)
+    );
+    // Must stay well under the $1×N overestimate that blocked first storyboards.
+    expect(
+      Number(estimateFalCost('openai/gpt-image-2', { numImages: 1 }))
+    ).toBeLessThan(Number(usd(1)));
+  });
+
+  test('per-second scales by duration (ignores historical typical duration)', () => {
     expect(
       estimateFalCost('fal-ai/veo3.1/image-to-video', { durationSeconds: 8 })
     ).toBe(usd(3.2));
@@ -72,8 +89,9 @@ describe('estimateFalCost', () => {
     ).toBe(usd(1.6));
   });
 
-  test('compute-seconds uses a fixed estimate', () => {
+  test('compute-seconds uses a fixed estimate when historical is absent', () => {
     // grok-imagine-image = $0.00017/compute-second, 3s default * 2 images.
+    // fal historical is $0 for this endpoint, so typicalUnitsPerCall is omitted.
     expect(
       estimateFalCost('xai/grok-imagine-image/quality/text-to-image', {
         numImages: 2,
@@ -81,7 +99,7 @@ describe('estimateFalCost', () => {
     ).toBe(micros(1_020));
   });
 
-  test('tokens estimate from resolution', () => {
+  test('tokens estimate from resolution (parametric, not historical)', () => {
     expect(
       estimateFalCost('bytedance/seedance-2.0/enterprise/v2/image-to-video', {
         durationSeconds: 5,
@@ -96,7 +114,6 @@ describe('estimateFalCost', () => {
     );
   });
 });
-
 describe('FAL_PRICING coverage', () => {
   // Every model we can generate with must have pricing, or it bills $0 at
   // runtime (a loud error, but only after free generations). This turns a
@@ -106,9 +123,20 @@ describe('FAL_PRICING coverage', () => {
     ...Object.values(IMAGE_TO_VIDEO_MODELS).map((m) => m.id),
     ...Object.values(AUDIO_MODELS).map((m) => m.id),
     ...Object.values(EDIT_ENDPOINTS).filter((id): id is string => !!id),
+    ...Object.values(MOTION_REFERENCE_ENDPOINTS).map((m) => m.endpointId),
   ];
 
   test.each([...new Set(endpointIds)])('has pricing for %s', (id) => {
     expect(FAL_PRICING[id]).toBeDefined();
+  });
+
+  test('gpt-image-2 carries a sub-1 typicalUnitsPerCall from fal historical', () => {
+    // Guards the regression where unit_price=$1 was treated as $1/image.
+    const pricing = FAL_PRICING['openai/gpt-image-2'];
+    expect(pricing?.unitPrice).toBe(micros(1_000_000));
+    const typical = pricing?.typicalUnitsPerCall;
+    expect(typical).toBeDefined();
+    expect(typical ?? 0).toBeGreaterThan(0);
+    expect(typical ?? 1).toBeLessThan(1);
   });
 });

--- a/src/lib/ai/fal-cost.ts
+++ b/src/lib/ai/fal-cost.ts
@@ -11,7 +11,10 @@ const logger = getLogger(['openstory', 'ai', 'fal-cost']);
  * duration, etc. in the unit count, so no per-model multipliers are needed.
  *
  * `estimateFalCost` predicts a cost BEFORE a generation runs (no `unitsBilled`
- * yet) for the pre-flight credit gate. It is deliberately rough.
+ * yet) for the pre-flight credit gate. For image/flat models it prefers
+ * `typicalUnitsPerCall` from fal's historical estimate (baked into
+ * fal-pricing-data.ts by `bun scripts/update-fal-pricing.ts`). Duration-based
+ * models still use parametric math from request params.
  */
 
 import { FAL_PRICING } from '@/lib/ai/fal-pricing-data';
@@ -78,11 +81,35 @@ export type FalCostEstimateParams = {
 };
 
 /**
+ * Predicted unitsBilled for one generation call of an image/flat model.
+ * Prefers fal historical average; falls back to 1 unit per call.
+ */
+function typicalImageUnitsPerCall(
+  typicalUnitsPerCall: number | undefined
+): number {
+  if (
+    typicalUnitsPerCall != null &&
+    Number.isFinite(typicalUnitsPerCall) &&
+    typicalUnitsPerCall > 0
+  ) {
+    return typicalUnitsPerCall;
+  }
+  return 1;
+}
+
+/**
  * Rough pre-flight cost estimate, used only for the credit-availability gate
- * before a generation runs. Predicts the billed unit count from the requested
- * parameters, then multiplies by `unitPrice`. Audio/resolution premiums are
- * intentionally ignored — the exact charge comes from `falCostFromUnits` once
- * fal reports `unitsBilled`.
+ * before a generation runs. Predicts the billed unit count, then multiplies
+ * by `unitPrice`. The exact charge comes from `falCostFromUnits` once fal
+ * reports `unitsBilled`.
+ *
+ * Image / flat models: use `typicalUnitsPerCall` from fal historical estimates
+ * (not unitPrice alone — openai/gpt-image-2 has unit_price=$1 with ~0.22
+ * units per high-quality image, so assuming 1 unit would over-gate ~5×).
+ *
+ * Duration models (seconds / minutes / tokens): parametric from request
+ * params — historical averages encode a random past duration and would be
+ * wrong for the requested length.
  */
 export function estimateFalCost(
   endpointId: string,
@@ -98,9 +125,22 @@ export function estimateFalCost(
   const duration = params.durationSeconds ?? 0;
 
   switch (pricing.unit) {
-    case 'images':
-    case 'flat':
-      return multiplyMicros(pricing.unitPrice, numImages);
+    case 'images': {
+      // One billable generation per image. Historical units capture quality /
+      // resolution premiums (e.g. nano-banana 1.5× at 2K, gpt-image-2 ≈ 0.22).
+      const unitsPerImage = typicalImageUnitsPerCall(
+        pricing.typicalUnitsPerCall
+      );
+      return multiplyMicros(pricing.unitPrice, unitsPerImage * numImages);
+    }
+
+    case 'flat': {
+      // Flat-rate video: one unit set per generation, not per "image".
+      const unitsPerCall = typicalImageUnitsPerCall(
+        pricing.typicalUnitsPerCall
+      );
+      return multiplyMicros(pricing.unitPrice, unitsPerCall);
+    }
 
     case 'megapixels': {
       const w = params.widthPx ?? 1024;
@@ -109,11 +149,15 @@ export function estimateFalCost(
       return multiplyMicros(pricing.unitPrice, megapixels * numImages);
     }
 
-    case 'compute_seconds':
-      return multiplyMicros(
-        pricing.unitPrice,
-        DEFAULT_COMPUTE_SECONDS * numImages
-      );
+    case 'compute_seconds': {
+      // Prefer historical compute time when fal has usage data; otherwise a
+      // fixed default (several compute-second models report $0 historical).
+      const secondsPerImage =
+        pricing.typicalUnitsPerCall != null && pricing.typicalUnitsPerCall > 0
+          ? pricing.typicalUnitsPerCall
+          : DEFAULT_COMPUTE_SECONDS;
+      return multiplyMicros(pricing.unitPrice, secondsPerImage * numImages);
+    }
 
     case 'seconds':
       return multiplyMicros(pricing.unitPrice, duration);

--- a/src/lib/ai/fal-pricing-data.ts
+++ b/src/lib/ai/fal-pricing-data.ts
@@ -8,7 +8,11 @@ import { type Microdollars, micros } from '@/lib/billing/money';
 //
 // `unitPrice` is fal's per-unit price, taken verbatim from the pricing API.
 // Actual cost = unitsBilled (from the adapter) * unitPrice. `unit` is the
-// billed unit, used only by pre-flight cost estimation.
+// billed unit kind, used by pre-flight estimation when historical data is
+// missing. `typicalUnitsPerCall` is fal's historical_api_price estimate
+// converted to units (cost / unit_price) — preferred for image/flat preflight
+// so models like openai/gpt-image-2 (unit_price=$1, ~0.22 units/call) are not
+// estimated at $1/image.
 // ============================================================================
 
 export type FalUnit =
@@ -23,41 +27,76 @@ export type FalUnit =
 export type FalPricing = {
   unitPrice: Microdollars;
   unit: FalUnit;
+  /**
+   * Typical unitsBilled for one generation call, from fal historical estimate
+   * (total_cost / unit_price). Preflight only — actual charges use the
+   * unitsBilled fal reports on the completed request.
+   */
+  typicalUnitsPerCall?: number;
 };
 
 export const FAL_PRICING: Record<string, FalPricing> = {
   'bytedance/seedance-2.0/enterprise/v2/image-to-video': {
     unitPrice: micros(14_000),
     unit: 'tokens',
+    typicalUnitsPerCall: 4.08,
   },
   'bytedance/seedance-2.0/enterprise/v2/reference-to-video': {
     unitPrice: micros(14_000),
     unit: 'tokens',
+    typicalUnitsPerCall: 6.496429,
   },
-  'fal-ai/ace-step-1.5': { unitPrice: micros(300), unit: 'seconds' },
+  'fal-ai/ace-step-1.5': {
+    unitPrice: micros(300),
+    unit: 'seconds',
+    typicalUnitsPerCall: 180,
+  },
   'fal-ai/ace-step/prompt-to-audio': {
     unitPrice: micros(200),
     unit: 'seconds',
+    typicalUnitsPerCall: 20,
   },
   'fal-ai/bytedance/seedream/v5/lite/edit': {
     unitPrice: micros(35_000),
     unit: 'images',
+    typicalUnitsPerCall: 1,
   },
   'fal-ai/bytedance/seedream/v5/lite/text-to-image': {
     unitPrice: micros(35_000),
     unit: 'images',
+    typicalUnitsPerCall: 1,
   },
-  'fal-ai/elevenlabs/music': { unitPrice: micros(800_000), unit: 'minutes' },
+  'fal-ai/elevenlabs/music': {
+    unitPrice: micros(800_000),
+    unit: 'minutes',
+    typicalUnitsPerCall: 3,
+  },
   'fal-ai/flux-2': { unitPrice: micros(1_670), unit: 'compute_seconds' },
-  'fal-ai/flux-2-max': { unitPrice: micros(70_000), unit: 'megapixels' },
-  'fal-ai/flux-2-max/edit': { unitPrice: micros(70_000), unit: 'megapixels' },
+  'fal-ai/flux-2-max': {
+    unitPrice: micros(70_000),
+    unit: 'megapixels',
+    typicalUnitsPerCall: 1.428571,
+  },
+  'fal-ai/flux-2-max/edit': {
+    unitPrice: micros(70_000),
+    unit: 'megapixels',
+    typicalUnitsPerCall: 4.001429,
+  },
   'fal-ai/flux-2/edit': { unitPrice: micros(1_670), unit: 'compute_seconds' },
-  'fal-ai/flux-2/turbo': { unitPrice: micros(8_000), unit: 'megapixels' },
+  'fal-ai/flux-2/turbo': {
+    unitPrice: micros(8_000),
+    unit: 'megapixels',
+    typicalUnitsPerCall: 1,
+  },
   'fal-ai/flux-2/turbo/edit': {
     unitPrice: micros(1_670),
     unit: 'compute_seconds',
   },
-  'fal-ai/hidream-i1-full': { unitPrice: micros(50_000), unit: 'megapixels' },
+  'fal-ai/hidream-i1-full': {
+    unitPrice: micros(50_000),
+    unit: 'megapixels',
+    typicalUnitsPerCall: 1,
+  },
   'fal-ai/hunyuan-image/v3/instruct/edit': {
     unitPrice: micros(1_670),
     unit: 'compute_seconds',
@@ -65,36 +104,78 @@ export const FAL_PRICING: Record<string, FalPricing> = {
   'fal-ai/hunyuan-image/v3/text-to-image': {
     unitPrice: micros(100_000),
     unit: 'megapixels',
+    typicalUnitsPerCall: 1,
   },
   'fal-ai/kling-video/v3/pro/image-to-video': {
     unitPrice: micros(140_000),
     unit: 'seconds',
+    typicalUnitsPerCall: 12,
   },
   'fal-ai/ltx-2.3/image-to-video': {
     unitPrice: micros(80_000),
     unit: 'seconds',
+    typicalUnitsPerCall: 12,
   },
   'fal-ai/minimax/hailuo-2.3/pro/image-to-video': {
     unitPrice: micros(490_000),
     unit: 'flat',
+    typicalUnitsPerCall: 1,
   },
-  'fal-ai/nano-banana-2': { unitPrice: micros(80_000), unit: 'images' },
-  'fal-ai/nano-banana-2/edit': { unitPrice: micros(80_000), unit: 'images' },
-  'fal-ai/nano-banana-pro': { unitPrice: micros(150_000), unit: 'images' },
-  'fal-ai/nano-banana-pro/edit': { unitPrice: micros(150_000), unit: 'images' },
-  'fal-ai/phota': { unitPrice: micros(90_000), unit: 'images' },
-  'fal-ai/phota/edit': { unitPrice: micros(90_000), unit: 'images' },
-  'fal-ai/qwen-image-2/pro/edit': { unitPrice: micros(75_000), unit: 'images' },
+  'fal-ai/nano-banana-2': {
+    unitPrice: micros(80_000),
+    unit: 'images',
+    typicalUnitsPerCall: 1.5,
+  },
+  'fal-ai/nano-banana-2/edit': {
+    unitPrice: micros(80_000),
+    unit: 'images',
+    typicalUnitsPerCall: 1.5,
+  },
+  'fal-ai/nano-banana-pro': {
+    unitPrice: micros(150_000),
+    unit: 'images',
+    typicalUnitsPerCall: 2,
+  },
+  'fal-ai/nano-banana-pro/edit': {
+    unitPrice: micros(150_000),
+    unit: 'images',
+    typicalUnitsPerCall: 2,
+  },
+  'fal-ai/phota': {
+    unitPrice: micros(90_000),
+    unit: 'images',
+    typicalUnitsPerCall: 2,
+  },
+  'fal-ai/phota/edit': {
+    unitPrice: micros(90_000),
+    unit: 'images',
+    typicalUnitsPerCall: 3,
+  },
+  'fal-ai/qwen-image-2/pro/edit': {
+    unitPrice: micros(75_000),
+    unit: 'images',
+    typicalUnitsPerCall: 1,
+  },
   'fal-ai/qwen-image-2/pro/text-to-image': {
     unitPrice: micros(75_000),
     unit: 'images',
+    typicalUnitsPerCall: 1,
   },
   'fal-ai/veo3.1/image-to-video': {
     unitPrice: micros(400_000),
     unit: 'seconds',
+    typicalUnitsPerCall: 8,
   },
-  'openai/gpt-image-2': { unitPrice: micros(1_000_000), unit: 'images' },
-  'openai/gpt-image-2/edit': { unitPrice: micros(1_000_000), unit: 'images' },
+  'openai/gpt-image-2': {
+    unitPrice: micros(1_000_000),
+    unit: 'images',
+    typicalUnitsPerCall: 0.22,
+  },
+  'openai/gpt-image-2/edit': {
+    unitPrice: micros(1_000_000),
+    unit: 'images',
+    typicalUnitsPerCall: 0.22,
+  },
   'xai/grok-imagine-image/quality/edit': {
     unitPrice: micros(170),
     unit: 'compute_seconds',
@@ -109,4 +190,4 @@ export const FAL_PRICING: Record<string, FalPricing> = {
   },
 };
 
-export const PRICING_LAST_UPDATED = '2026-06-18T02:03:11.319Z';
+export const PRICING_LAST_UPDATED = '2026-07-22T08:25:50.090Z';

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -260,7 +260,7 @@ function createAuth() {
               role: 'owner',
             });
 
-            // Grant every new team a one-time welcome credit (#1047).
+            // Grant every new team a one-time welcome credit (#1047; preflight fixed in #1062).
             await createBillingMethods(db, team.id, user.id).addCredits(
               SIGNUP_GRANT_MICROS,
               {

--- a/src/lib/billing/__tests__/constants.test.ts
+++ b/src/lib/billing/__tests__/constants.test.ts
@@ -1,12 +1,16 @@
-import { micros, usdToMicros } from '../money';
+import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
+import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
 import { describe, expect, it } from 'vitest';
 import {
+  SIGNUP_GRANT_MICROS,
   formatProcessingFeePercent,
   processingFeeUsd,
   splitCheckoutAmounts,
   totalCheckoutCents,
   totalCheckoutUsd,
 } from '../constants';
+import { estimateStoryboardCost } from '../cost-estimation';
+import { micros, microsToUsd, usdToMicros } from '../money';
 
 describe('billing constants', () => {
   it('applies processing fee only at purchase', () => {
@@ -44,5 +48,23 @@ describe('billing constants', () => {
     expect(totalCheckoutCents(usdToMicros(10))).toBe(1_050);
     expect(totalCheckoutCents(micros(10_500_000))).toBe(1_103);
     expect(Number.isInteger(totalCheckoutCents(micros(10_010_000)))).toBe(true);
+  });
+
+  /**
+   * #1062: new users must be able to generate a storyboard on first try with
+   * product defaults (DEFAULT_IMAGE_MODEL, images only — motion/music off).
+   * If this fails, either raise SIGNUP_GRANT_USD or re-check default model
+   * pricing / storyboard cost assumptions.
+   */
+  it('signup grant covers a default storyboard pre-flight estimate', () => {
+    const defaultStoryboardCost = estimateStoryboardCost({
+      imageModel: DEFAULT_IMAGE_MODEL,
+      aspectRatio: DEFAULT_ASPECT_RATIO,
+    });
+
+    expect(
+      SIGNUP_GRANT_MICROS,
+      `SIGNUP_GRANT ($${microsToUsd(SIGNUP_GRANT_MICROS)}) must be ≥ default storyboard estimate ($${microsToUsd(defaultStoryboardCost).toFixed(2)} with ${DEFAULT_IMAGE_MODEL})`
+    ).toBeGreaterThanOrEqual(defaultStoryboardCost);
   });
 });

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -14,7 +14,15 @@ export function isStripeEnabled(): boolean {
 /** Processing fee applied when purchasing credits (e.g., 0.05 = 5%). Not charged on usage. */
 export const PROCESSING_FEE_PERCENT = 0.05;
 
-/** Free credit granted to every new team on signup, in USD */
+/**
+ * Free credit granted to every new team on signup, in USD.
+ *
+ * Must cover at least one default storyboard (DEFAULT_IMAGE_MODEL, ~8 scenes,
+ * images only — motion/music off). Guarded by the "signup grant covers
+ * default storyboard" test in constants.test.ts. Preflight uses fal
+ * historical typicalUnitsPerCall (not raw unitPrice alone) so gpt-image-2
+ * estimates ~$0.22/image, not $1 (#1062).
+ */
 const SIGNUP_GRANT_USD = 10;
 
 /** Free credit granted to every new team on signup, in microdollars */

--- a/src/lib/billing/pricing-catalog.ts
+++ b/src/lib/billing/pricing-catalog.ts
@@ -62,10 +62,30 @@ function formatFalPrice(endpointId: string): {
     return { price: 'Contact support', detail: 'Pricing unavailable' };
   }
 
-  const usd = microsToUsd(pricing.unitPrice);
+  const unitUsd = microsToUsd(pricing.unitPrice);
   const unitLabel = FAL_UNIT_LABELS[pricing.unit];
+
+  // Prefer typical per-call cost when fal historical units differ from 1
+  // (e.g. gpt-image-2: unit_price=$1 but ~0.22 units → ~$0.22/image).
+  const typical =
+    pricing.typicalUnitsPerCall != null &&
+    pricing.typicalUnitsPerCall > 0 &&
+    (pricing.unit === 'images' || pricing.unit === 'flat')
+      ? unitUsd * pricing.typicalUnitsPerCall
+      : null;
+
+  if (typical != null && Math.abs(typical - unitUsd) > unitUsd * 0.05) {
+    return {
+      price: `~${formatUsd(typical)} / ${unitLabel}`,
+      detail:
+        pricing.unit === 'flat'
+          ? 'Typical cost per generation (billed from provider units)'
+          : 'Typical cost per image (billed from provider units)',
+    };
+  }
+
   return {
-    price: `${formatUsd(usd)} / ${unitLabel}`,
+    price: `${formatUsd(unitUsd)} / ${unitLabel}`,
     detail:
       pricing.unit === 'flat'
         ? 'Flat rate per video'


### PR DESCRIPTION
## Summary

- Root cause of #1062: preflight estimated `openai/gpt-image-2` at **$1/image** because fal reports `unit_price: 1` / `unit: "units"`. Actual charges use `unitsBilled × unitPrice` (~**$0.22**/high-quality image).
- `update-fal-pricing.ts` now also fetches fal `historical_api_price` and stores `typicalUnitsPerCall` (cost / unit_price).
- `estimateFalCost` uses that for image/flat models; duration models stay parametric.
- Signup grant stays **$10** (default storyboard preflight ~$3.14). Regression test: grant ≥ default storyboard estimate.
- Pricing page shows typical per-image cost when it diverges from raw unit price.

## Test plan

- [x] `bun run test src/lib/ai/fal-cost.test.ts src/lib/billing`
- [x] Live `bun scripts/update-fal-pricing.ts` (gpt-image-2 → 0.22 units)
- [ ] Confirm a new signup can start a default storyboard without topping up
- [ ] Spot-check /pricing for gpt-image-2 (~$0.22, not $1)

Closes #1062