### PR TITLE
fix(#1059): skip Auto Progress Issues in forks without PROJECT_TOKEN

### DIFF
--- a/.github/workflows/auto-progress-issues.yml
+++ b/.github/workflows/auto-progress-issues.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   progress-issue:
-    if: github.event.ref_type == 'branch'
+    # Forks can't read PROJECT_TOKEN and must never mutate the upstream org
+    # project, so branch creation there is a no-op instead of a failed run.
+    if: github.event.ref_type == 'branch' && github.repository == 'openstory-so/openstory'
     runs-on: ubuntu-latest
     permissions:
       issues: read
@@ -28,8 +30,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
           REPO: ${{ github.repository }}
+          # Passed as an env var rather than interpolated into the script, so a
+          # future loosening of the extract regex can't turn this into a shell
+          # injection sink.
+          ISSUE_NUMBER: ${{ steps.extract.outputs.issue_number }}
         run: |
-          ISSUE_NUMBER=${{ steps.extract.outputs.issue_number }}
           PROJECT_NUMBER=1
           ORG="openstory-so"
           STATUS_FIELD_ID="PVTSSF_lADODacWQM4BBrgJzg0HVm4"


### PR DESCRIPTION
## Problem

`Auto Progress Issues` fails on every fork branch that follows the required `<issue-number>-name` convention. The `create` event fires in the fork, but `secrets.PROJECT_TOKEN` is intentionally unavailable there, so `gh project item-edit` runs with an empty token and the run goes red. Contributors see a failed Action on a branch they named correctly.

## Fix

Guard the job to the canonical upstream repository:

```yaml
if: github.event.ref_type == 'branch' && github.repository == 'openstory-so/openstory'
```

Upstream behaviour is unchanged — branch creation still moves the linked issue to **In Progress**. In a fork (or a Deploy-button clone, which is also a differently-named repo) the job is skipped entirely, so the run is green and the upstream org project is never touched.

`PROJECT_TOKEN` is deliberately kept for the org-project mutation. Swapping it for `GITHUB_TOKEN` would risk breaking the existing automation, since the default token lacks organization-project write.

## Hardening (defense in depth)

The issue number was interpolated straight into the shell script:

```
ISSUE_NUMBER=${{ steps.extract.outputs.issue_number }}
```

That is safe today because the extract step narrows the branch name to `^([0-9]+)-`, but its safety depends on a regex three steps away — loosening that pattern later (e.g. to support `feat/999-name`) would silently turn this into a command-injection sink. It now moves through the step `env:` block instead, which removes the shape entirely. No behavioural change: the value still resolves at all three use sites.

## Risk notes

- `on: create` fires only in the repo where the branch is created and requires push access, so this was never a fork-PR secret-exfiltration vector — only a noisy-failure one.
- The workflow reads an issue *number* only; issue titles and bodies are never evaluated, so third-party issue content is not a surface here.
- Pre-existing and out of scope: `PROJECT_TOKEN` is a PAT with org-project write readable by any workflow in this repo. Tightening that (e.g. a per-run scoped GitHub App token) is worth its own issue.

## Verification

- Workflow YAML parses; job `if` resolves to the intended expression.
- `$ISSUE_NUMBER` still resolves at every use site (jq filter, not-found echo, success echo).
- No app behaviour or deployment credentials change — workflow-only.

Closes #1059
