### PR TITLE
chore(models): bump Claude Opus 4.8 → Claude Opus 5

### DIFF
--- a/src/lib/ai/create-adapter.ts
+++ b/src/lib/ai/create-adapter.ts
@@ -78,6 +78,10 @@ export const CATALOG_LAG_MODELS = [
     input: ['text', 'image'],
     features: ['reasoning', 'structured_outputs'],
   }),
+  createModel('anthropic/claude-opus-5', {
+    input: ['text', 'image'],
+    features: ['reasoning', 'structured_outputs'],
+  }),
 ] as const;
 
 const openRouterTextExtended = extendAdapter(

--- a/src/lib/ai/models.config.ts
+++ b/src/lib/ai/models.config.ts
@@ -49,8 +49,8 @@ export const SCRIPT_ANALYSIS_MODELS = [
     description: 'Lowest hallucination rate, flagship agentic model',
   },
   {
-    id: 'anthropic/claude-opus-4.8',
-    name: 'Claude Opus 4.8',
+    id: 'anthropic/claude-opus-5',
+    name: 'Claude Opus 5',
     provider: 'Anthropic',
     license: 'proprietary' as const,
     qualityRank: 5,


### PR DESCRIPTION
## Model bump

| | |
| --- | --- |
| **Class** | Text (OpenRouter) — `SCRIPT_ANALYSIS_MODELS` |
| **Registry key / name** | Opus analysis-model entry (`qualityRank: 5`) — **key unchanged** |
| **Old id** | `anthropic/claude-opus-4.8` |
| **New id** | `anthropic/claude-opus-5` |

### Why this is a genuine successor

- **Same product line & tier.** Opus → Opus, one version newer (4.8 → 5). The new id is the **standard** Opus tier (`claude-opus-5`), *not* the `-fast` variant (`claude-opus-5-fast` exists but is deliberately not adopted — that would be a tier change).
- **Resolves on OpenRouter.** `anthropic/claude-opus-5` is live on `https://openrouter.ai/api/v1/models`, name "Claude Opus 5".
- **Same capabilities as the entry it replaces.** 1M context window (unchanged), input modalities `text`/`image`/`file` → `vision: true` retained.
- Detected by `bun models:check` (daily model-freshness routine); the only flagged upgrade this run. No fal image/video/audio or `@tanstack/ai*` updates were outstanding.

### Pricing delta

None. Both bill **$5.00 / M input, $25.00 / M output** on OpenRouter — a like-for-like swap.

### Changes

- `src/lib/ai/models.config.ts` — updated `id` and `name`; `provider`, `qualityRank`, `contextWindow` (1M), `vision`, `description` unchanged.
- `src/lib/ai/create-adapter.ts` — the installed `@tanstack/ai-openrouter` catalog snapshot doesn't yet know `anthropic/claude-opus-5`, so added a `CATALOG_LAG_MODELS` entry (`input: ['text','image']`, `features: ['reasoning','structured_outputs']`) to keep the typed model union compiling until a package bump ships the id upstream (per the skill's catalog-lag guidance). Prune it when `catalog-lag.test.ts` flags it.

No motion codegen or fal-pricing regeneration applies (text/OpenRouter model).

### Quality gates — all green

- `bun typecheck` ✓
- `bun lint` ✓ (0 errors)
- `bun run test src/lib/ai src/lib/motion` ✓ (435 passed)

Fal pricing unchanged (not a fal model), so `src/lib/billing` tests not required.

🤖 Opened by the daily model-freshness routine (#792). Verify pricing & quality before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XocqcyC17zhrJ8W8HsCKUw)_