### PR TITLE
fix(#1074): aspect-fit 9:16 canvas media

### DIFF
--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -301,7 +301,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
     : (overrideVideoUrl ?? currentShot.videoUrl ?? '');
 
   return (
-    <div className={cn('flex w-full flex-col', wrapperClassName)}>
+    <div className={cn('relative flex w-full flex-col', wrapperClassName)}>
       {hasFailedVideo ? (
         <div
           className={cn(
@@ -432,7 +432,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
             src={playbackVideoUrl}
             posterSrc={displayImage}
             aspectRatio={aspectRatio}
-            className="w-full"
+            className="h-full w-full"
             autoPlay={shouldAutoPlay}
             onTimeUpdate={onTimeUpdate}
             onPause={handlePause}
@@ -469,9 +469,11 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
           {frameOverlay}
         </div>
       )}
+      {/* Sits just under the frame; CanvasMediaStage reserves a caption band
+          so this is not clipped when 9:16 fills the stage (#1074). */}
       <p
         className={cn(
-          'text-xs italic py-1 transition-opacity duration-300',
+          'pointer-events-none absolute inset-x-0 top-full pt-1 text-center text-xs italic transition-opacity duration-300',
           isPreviewImage
             ? 'text-muted-foreground opacity-100'
             : 'opacity-0 select-none'

--- a/src/components/scenes/canvas-media-stage.tsx
+++ b/src/components/scenes/canvas-media-stage.tsx
@@ -1,0 +1,59 @@
+/**
+ * Centres media in the Scenes canvas and sizes it to the largest aspect-
+ * correct rectangle that fits the available stage (#1074).
+ *
+ * Uses a size container (`cqw`/`cqh`) so 9:16 fills height without overflowing
+ * the overflow-hidden sequence layout, and shot view uses the full stage
+ * instead of a fixed 50vh cap.
+ *
+ * A bottom caption band is always reserved so the ScenePlayer "Fast preview"
+ * note (positioned just under the frame) is never clipped when the media
+ * fills the stage height.
+ */
+
+import { getCanvasFitClassName } from '@/lib/constants/aspect-ratios';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import { cn } from '@/lib/utils';
+import type { ReactNode } from 'react';
+
+/** Space under the fit frame for the preview caption line (text-xs + py-1). */
+const CAPTION_BAND = 'h-6';
+
+type CanvasMediaStageProps = {
+  aspectRatio: AspectRatio;
+  children: ReactNode;
+  className?: string;
+};
+
+export const CanvasMediaStage: React.FC<CanvasMediaStageProps> = ({
+  aspectRatio,
+  children,
+  className,
+}) => (
+  <div
+    data-testid="canvas-media-stage"
+    className={cn(
+      'flex min-h-0 flex-1 flex-col px-4 pt-4 pb-4 md:px-8',
+      className
+    )}
+  >
+    {/* Size container is only the media band — caption band is a sibling so
+        cqh never includes it, and full-height 9:16 still leaves room below. */}
+    <div className="flex min-h-0 flex-1 items-center justify-center [container-type:size]">
+      <div
+        data-testid="canvas-media-frame"
+        className={cn(
+          'relative max-h-full max-w-full',
+          getCanvasFitClassName(aspectRatio)
+        )}
+      >
+        {children}
+      </div>
+    </div>
+    <div
+      data-testid="canvas-media-caption-band"
+      className={cn('shrink-0', CAPTION_BAND)}
+      aria-hidden
+    />
+  </div>
+);

--- a/src/components/scenes/scene-canvas.tsx
+++ b/src/components/scenes/scene-canvas.tsx
@@ -1,4 +1,5 @@
 import { ScenePlayer } from '@/components/motion/scene-player';
+import { CanvasMediaStage } from '@/components/scenes/canvas-media-stage';
 import { StartingFrameVariants } from '@/components/scenes/starting-frame-variants';
 import { SequencePlayer } from '@/components/theatre/sequence-player';
 import { useSequenceExport } from '@/components/theatre/use-sequence-export';
@@ -42,8 +43,6 @@ type SceneCanvasProps = {
   modelMismatchLabel?: string | null;
   progressMessage?: string;
   retry?: { attempt: number; maxAttempts?: number };
-  playerClassName?: string;
-  playerWrapperClassName?: string;
   onSelectShot?: (shotId: string) => void;
   /** Scene-level image model (#909) used to generate starting-frame variants. */
   sceneImageModel?: TextToImageModel;
@@ -163,8 +162,6 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
   modelMismatchLabel,
   progressMessage,
   retry,
-  playerClassName,
-  playerWrapperClassName,
   onSelectShot,
   sceneImageModel,
   regeneratingSceneVariants,
@@ -188,7 +185,7 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
 
   if (loadError) {
     return (
-      <div className="flex flex-1 items-center justify-center p-8">
+      <div className="flex min-h-0 flex-1 items-center justify-center p-8">
         <p
           role="alert"
           className="max-w-md text-center text-sm text-destructive"
@@ -201,9 +198,9 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
 
   if (!shots) {
     return (
-      <div className="flex flex-1 items-center justify-center p-8">
-        <Skeleton className="aspect-video w-full max-w-2xl" />
-      </div>
+      <CanvasMediaStage aspectRatio={aspectRatio}>
+        <Skeleton className="h-full w-full rounded-lg" />
+      </CanvasMediaStage>
     );
   }
 
@@ -222,7 +219,7 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
         />
       ) : undefined;
     return (
-      <div className="flex flex-1 flex-col items-center gap-4 px-4 py-4 md:px-8">
+      <CanvasMediaStage aspectRatio={aspectRatio}>
         <ScenePlayer
           shots={playerShots}
           selectedShotId={selection.shotId}
@@ -236,17 +233,17 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
           progressMessage={progressMessage}
           retry={retry}
           posterUrl={sequence?.posterUrl ?? undefined}
-          className={playerClassName}
-          wrapperClassName={playerWrapperClassName}
+          className="h-full max-h-none w-full"
+          wrapperClassName="h-full w-full"
           frameOverlay={frameOverlay}
         />
-      </div>
+      </CanvasMediaStage>
     );
   }
 
   if (playbackScenes.length === 0) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center gap-4 py-16">
+      <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 py-16">
         <Film className="h-8 w-8 text-muted-foreground" />
         <p className="text-muted-foreground">No scenes ready to play yet</p>
         <p className="max-w-md text-center text-sm text-muted-foreground">
@@ -256,25 +253,26 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
     );
   }
 
+  if (!sequence) {
+    return null;
+  }
+
   return (
-    <div className="flex flex-1 flex-col items-center gap-4 px-4 py-4 md:px-8">
-      {sequence && (
-        <div className="w-full max-w-4xl">
-          <SequencePlayer
-            scenes={playbackScenes}
-            musicUrl={scope === 'sequence' ? (sequence.musicUrl ?? null) : null}
-            musicLoudnessGainDb={null}
-            musicEnabled={scope === 'sequence' ? sequence.includeMusic : false}
-            onMusicEnabledChange={(enabled) => setMusicEnabled.mutate(enabled)}
-            aspectRatio={aspectRatio}
-            overlayActions={
-              scope === 'sequence' ? (
-                <TheatreShareOverlay sequence={sequence} />
-              ) : undefined
-            }
-          />
-        </div>
-      )}
-    </div>
+    <CanvasMediaStage aspectRatio={aspectRatio}>
+      <SequencePlayer
+        scenes={playbackScenes}
+        musicUrl={scope === 'sequence' ? (sequence.musicUrl ?? null) : null}
+        musicLoudnessGainDb={null}
+        musicEnabled={scope === 'sequence' ? sequence.includeMusic : false}
+        onMusicEnabledChange={(enabled) => setMusicEnabled.mutate(enabled)}
+        aspectRatio={aspectRatio}
+        className="h-full max-h-none w-full"
+        overlayActions={
+          scope === 'sequence' ? (
+            <TheatreShareOverlay sequence={sequence} />
+          ) : undefined
+        }
+      />
+    </CanvasMediaStage>
   );
 };

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -62,10 +62,7 @@ import {
   resolveImageModel,
   resolveVideoModel,
 } from '@/lib/ai/resolve-asset-models';
-import {
-  DEFAULT_ASPECT_RATIO,
-  type AspectRatio,
-} from '@/lib/constants/aspect-ratios';
+import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
 import type { FrameVariant, SceneRow, ShotVariant } from '@/lib/db/schema';
 import type { ShotWithImage } from '@/lib/shots/shot-with-image';
 import { analyzeFailures } from '@/lib/failures/failure-analysis';
@@ -177,15 +174,6 @@ const CompareWithPromptDiff: React.FC<{
     />
   );
 };
-
-// Full class names required for Tailwind JIT to detect at build time
-// Split into max-width (for the wrapper, enables centering) and max-height (for the player div)
-const PLAYER_MAX_W_BY_RATIO: Record<AspectRatio, string> = {
-  '16:9': 'max-w-[calc(50vh*1.7777777777777777)]',
-  '9:16': 'max-w-[calc(50vh*0.5625)]',
-  '1:1': 'max-w-[50vh]',
-};
-const PLAYER_MAX_H = 'max-h-[50vh]';
 
 type RegenerationType = 'image' | 'motion' | 'scene-variants';
 
@@ -1342,8 +1330,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
                     ?.phaseName
                 }
                 retry={selectedShotRetry}
-                playerClassName={PLAYER_MAX_H}
-                playerWrapperClassName={PLAYER_MAX_W_BY_RATIO[aspectRatio]}
                 onSelectShot={handleSelectShot}
                 sceneImageModel={resolvedImageModel}
                 regeneratingSceneVariants={regeneratingSceneVariants}

--- a/src/lib/constants/aspect-ratios.test.ts
+++ b/src/lib/constants/aspect-ratios.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  aspectRatioValue,
+  fitAspectRatioInBox,
+  getCanvasFitClassName,
+} from './aspect-ratios';
+
+describe('aspectRatioValue', () => {
+  it('returns width÷height for each supported ratio', () => {
+    expect(aspectRatioValue('16:9')).toBeCloseTo(16 / 9);
+    expect(aspectRatioValue('9:16')).toBeCloseTo(9 / 16);
+    expect(aspectRatioValue('1:1')).toBe(1);
+  });
+});
+
+describe('fitAspectRatioInBox', () => {
+  it('returns zero when the box has no area', () => {
+    expect(fitAspectRatioInBox(0, 100, '9:16')).toEqual({
+      width: 0,
+      height: 0,
+    });
+    expect(fitAspectRatioInBox(100, 0, '16:9')).toEqual({
+      width: 0,
+      height: 0,
+    });
+  });
+
+  it('fills width for landscape when height allows', () => {
+    // Wide stage: 1600×900 is exactly 16:9
+    expect(fitAspectRatioInBox(1600, 900, '16:9')).toEqual({
+      width: 1600,
+      height: 900,
+    });
+  });
+
+  it('height-limits landscape when the stage is short', () => {
+    // 1600×500 stage: 16:9 at full width would be 900 tall → cap to height
+    const { width, height } = fitAspectRatioInBox(1600, 500, '16:9');
+    expect(height).toBe(500);
+    expect(width).toBeCloseTo(500 * (16 / 9));
+  });
+
+  it('fills height for portrait when width allows', () => {
+    // Stage wider than 9:16 at full height → height is the binding constraint
+    const { width, height } = fitAspectRatioInBox(1000, 1600, '9:16');
+    expect(height).toBe(1600);
+    expect(width).toBeCloseTo(1600 * (9 / 16));
+  });
+
+  it('width-limits portrait so 9:16 is not cropped', () => {
+    // Narrow stage: full-height 9:16 would be wider than available
+    const { width, height } = fitAspectRatioInBox(400, 900, '9:16');
+    expect(width).toBe(400);
+    expect(height).toBeCloseTo(400 / (9 / 16));
+  });
+
+  it('fits square into the smaller side', () => {
+    expect(fitAspectRatioInBox(1000, 600, '1:1')).toEqual({
+      width: 600,
+      height: 600,
+    });
+    expect(fitAspectRatioInBox(500, 800, '1:1')).toEqual({
+      width: 500,
+      height: 500,
+    });
+  });
+});
+
+describe('getCanvasFitClassName', () => {
+  it('returns a full class string per ratio for Tailwind JIT', () => {
+    expect(getCanvasFitClassName('9:16')).toContain('aspect-[9/16]');
+    expect(getCanvasFitClassName('9:16')).toContain('cqh');
+    expect(getCanvasFitClassName('16:9')).toContain('aspect-video');
+    expect(getCanvasFitClassName('1:1')).toContain('aspect-square');
+  });
+});

--- a/src/lib/constants/aspect-ratios.ts
+++ b/src/lib/constants/aspect-ratios.ts
@@ -87,3 +87,51 @@ export const getAspectRatioClassName = (aspectRatio: AspectRatio): string => {
   };
   return mapping[aspectRatio];
 };
+
+/**
+ * Width ÷ height for layout math (fit-in-box, canvas sizing).
+ */
+export const aspectRatioValue = (aspectRatio: AspectRatio): number => {
+  const data = getAspectRatioData(aspectRatio);
+  if (!data) return 16 / 9;
+  return data.width / data.height;
+};
+
+/**
+ * Largest box of `aspectRatio` that fits inside `boxWidth` × `boxHeight`.
+ * Used by the Scenes canvas so 9:16 fills available height without overflowing,
+ * and 16:9 fills width without exceeding the stage.
+ */
+export const fitAspectRatioInBox = (
+  boxWidth: number,
+  boxHeight: number,
+  aspectRatio: AspectRatio
+): { width: number; height: number } => {
+  if (boxWidth <= 0 || boxHeight <= 0) {
+    return { width: 0, height: 0 };
+  }
+  const ar = aspectRatioValue(aspectRatio);
+  let width = boxWidth;
+  let height = width / ar;
+  if (height > boxHeight) {
+    height = boxHeight;
+    width = height * ar;
+  }
+  return { width, height };
+};
+
+/**
+ * Tailwind classes that size a frame to the largest aspect-correct rectangle
+ * inside a `container-type: size` parent (uses cqw/cqh). Full class names so
+ * Tailwind JIT always sees them.
+ */
+export const getCanvasFitClassName = (aspectRatio: AspectRatio): string => {
+  const mapping: Record<AspectRatio, string> = {
+    '16:9':
+      'aspect-video w-[min(100cqw,calc(100cqh*16/9))] h-[min(100cqh,calc(100cqw*9/16))]',
+    '9:16':
+      'aspect-[9/16] w-[min(100cqw,calc(100cqh*9/16))] h-[min(100cqh,calc(100cqw*16/9))]',
+    '1:1': 'aspect-square w-[min(100cqw,100cqh)] h-[min(100cqh,100cqw)]',
+  };
+  return mapping[aspectRatio];
+};


### PR DESCRIPTION
## Summary
- Size shot and sequence/scene players to the largest aspect-correct rectangle that fits the Scenes canvas stage (`cqw`/`cqh`), so 9:16 is no longer cropped by the overflow-hidden sequence shell.
- Remove the fixed `50vh` player caps so shot view fills available canvas height.
- Reserve a bottom caption band so the “Fast preview…” note is not clipped under a full-height frame.

## Test plan
- [ ] Open a **9:16** sequence on Scenes → Canvas (sequence or scene selected): merged playback fills the stage without bottom crop.
- [ ] Select a **shot** on the same sequence: player uses the full centre-column height (not a short 50vh box).
- [ ] Confirm **16:9** and **1:1** still fit and centre correctly.
- [ ] With a fast-preview thumbnail, confirm “Fast preview — may not match the final image.” is fully visible under the frame.
- [ ] `bun run test src/lib/constants/aspect-ratios.test.ts`