### PR TITLE
fix(#1076): canvas variant select + stuck video version chips

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,8 +28,8 @@
     }
   },
   "editor.formatOnSave": true,
-  "typescript.preferences.importModuleSpecifier": "non-relative",
-  "typescript.preferences.includePackageJsonAutoImports": "auto",
+  "js/ts.preferences.importModuleSpecifier": "non-relative",
+  "js/ts.preferences.includePackageJsonAutoImports": "auto",
   "editor.codeActionsOnSave": {
     "source.organizeImports": "explicit"
   },
@@ -66,10 +66,6 @@
   "editor.defaultFormatter": "oxc.oxc-vscode",
   "oxc.fixKind": "dangerous_fix_or_suggestion",
   "oxc.fmt.configPath": ".oxfmtrc.json",
-  "javascript.updateImportsOnFileMove.enabled": "always",
-  "typescript.updateImportsOnFileMove.enabled": "always",
+  "js/ts.updateImportsOnFileMove.enabled": "always",
   "workbench.editor.closeOnFileDelete": false,
-  "bun.test.filePattern": "src/**/*.{test,spec}.{ts,tsx,js,jsx}",
-  "bun.diagnosticsSocket.enabled": true,
-  "typescript.native-preview.goMemLimit": "4GiB",
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -28,6 +28,7 @@ pre-commit:
         - public/mockServiceWorker.js
         - worker-configuration.d.ts
         - gen.types.ts
+        - .vscode/settings.json
       run: bun run --bun oxfmt --write {staged_files}
       stage_fixed: true
     typecheck:

--- a/src/components/scenes/segment-video-panel.tsx
+++ b/src/components/scenes/segment-video-panel.tsx
@@ -16,6 +16,20 @@ type SegmentVideoPanelProps = {
 };
 
 /**
+ * Versions the Video tab chips surface: active model only, no failed rows
+ * (#1076 — failed re-rolls stay in history, not as permanent chips).
+ */
+function visibleSegmentVersions(
+  segment: SequenceSegment
+): SegmentVideoVersion[] {
+  return segment.versions.filter(
+    (v) =>
+      (segment.model === null || v.model === segment.model) &&
+      v.status !== 'failed'
+  );
+}
+
+/**
  * Whether the segment panel adds anything the plain (per-shot) Video tab
  * doesn't: a multi-shot span, a re-roll history to switch between, or a stale
  * render. In the all-ones / single-version / fresh case it stays hidden so
@@ -26,7 +40,9 @@ export function segmentPanelIsInformative(
 ): segment is SequenceSegment {
   if (!segment) return false;
   return (
-    segment.shotIds.length > 1 || segment.versions.length > 1 || segment.stale
+    segment.shotIds.length > 1 ||
+    visibleSegmentVersions(segment).length > 1 ||
+    segment.stale
   );
 }
 
@@ -55,9 +71,7 @@ export const SegmentVideoPanel: React.FC<SegmentVideoPanelProps> = ({
   const label = segment.model ? videoModelDisplayName(segment.model) : null;
   // Re-roll history for the segment's active model (a "variant" is per
   // (segment, model)); each is one render you can point the selection at.
-  const versions = segment.versions.filter(
-    (v) => segment.model === null || v.model === segment.model
-  );
+  const versions = visibleSegmentVersions(segment);
 
   return (
     <div className="space-y-2 rounded-md border bg-muted/40 p-3">

--- a/src/lib/cron/reconcile-all.test.ts
+++ b/src/lib/cron/reconcile-all.test.ts
@@ -157,10 +157,10 @@ describe('reconcileAllStuckJobs — run-id-verified passes', () => {
   test('caps stuck-row selection at MAX_ROWS_PER_PASS (100) per verified pass', async () => {
     const { reconcileAllStuckJobs } = await import('./reconcile-all');
     await reconcileAllStuckJobs();
-    // 8 verified (run-id) passes: frames.image + shots.video/audio +
-    // frame_variants.status + 2 shot_variants + sequences.status (#989) +
-    // generated_assets.status (#458).
-    expect(limitArgs.filter((n) => n === 100)).toHaveLength(8);
+    // 9 verified (run-id) passes: frames.image + shots.video/audio +
+    // frame_variants.status + video_variants.status (#1076) + 2 shot_variants +
+    // sequences.status (#989) + generated_assets.status (#458).
+    expect(limitArgs.filter((n) => n === 100)).toHaveLength(9);
   });
 
   test('in-flight instance (resolveRunState null) → no per-row update on verified tables', async () => {

--- a/src/lib/cron/reconcile-all.ts
+++ b/src/lib/cron/reconcile-all.ts
@@ -22,10 +22,12 @@ import {
   frameVariants,
   frames,
   generatedAssets,
+  renderSegments,
   shots,
   shotVariants,
   sequenceElements,
   sequences,
+  videoVariants,
 } from '@/lib/db/schema';
 import { resolveRunState, STALE_THRESHOLD_MS } from '@/lib/workflow/reconcile';
 import { and, eq, inArray, isNotNull, isNull, lt } from 'drizzle-orm';
@@ -63,6 +65,10 @@ export async function reconcileAllStuckJobs(): Promise<ReconcileCounts> {
     ['frames.image', () => reconcileFramesImagePass(db)],
     ['shots.video', () => reconcileShotsPass(db, 'video')],
     ['frame_variants.status', () => reconcileFrameVariantsPass(db)],
+    // Video versions live on video_variants now (#990) — without this pass a
+    // dead motion run leaves a permanent "generating" chip on the Video tab
+    // (#1076).
+    ['video_variants.status', () => reconcileVideoVariantsPass(db)],
     ['shots.audio', () => reconcileShotsPass(db, 'audio')],
     ['shot_variants.status', () => reconcileShotVariantsPass(db, 'primary')],
     [
@@ -193,6 +199,45 @@ async function reconcileFrameVariantsPass(db: Database): Promise<number> {
         .update(frames)
         .set({ pendingPromoteVersionId: null, updatedAt: new Date() })
         .where(eq(frames.pendingPromoteVersionId, row.id));
+    }
+    updated++;
+  }
+  return updated;
+}
+
+/**
+ * Reconcile stuck `video_variants` versions (#990 / #1076) — the motion analog
+ * of {@link reconcileFrameVariantsPass}. Dead motion runs that never hit
+ * `onFailure` left permanent "generating" chips on the Video tab; heal them
+ * from the workflow instance status and drop a failed version's auto-promote
+ * claim on its render segment.
+ */
+async function reconcileVideoVariantsPass(db: Database): Promise<number> {
+  const staleCutoff = new Date(Date.now() - STALE_THRESHOLD_MS);
+  const stuck = await db
+    .select({ id: videoVariants.id, runId: videoVariants.workflowRunId })
+    .from(videoVariants)
+    .where(
+      and(
+        eq(videoVariants.status, 'generating'),
+        lt(videoVariants.updatedAt, staleCutoff)
+      )
+    )
+    .limit(MAX_ROWS_PER_PASS);
+  let updated = 0;
+  for (const row of stuck) {
+    const next = await resolveRunState(row.runId ?? '');
+    if (next === null || next === 'unknown') continue;
+    await db
+      .update(videoVariants)
+      .set({ status: next })
+      .where(eq(videoVariants.id, row.id));
+    // Drop auto-promote claim if this stuck version held it (#1070).
+    if (next === 'failed') {
+      await db
+        .update(renderSegments)
+        .set({ pendingPromoteVersionId: null, updatedAt: new Date() })
+        .where(eq(renderSegments.pendingPromoteVersionId, row.id));
     }
     updated++;
   }

--- a/src/lib/image/image-crop.test.ts
+++ b/src/lib/image/image-crop.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { parseImageDimensions } from './image-crop';
+
+/** Minimal valid PNG header (IHDR only — enough for dimension parse). */
+function makePng(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(24);
+  // PNG signature
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  // IHDR length (13) + type
+  bytes.set([0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52], 8);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width, false);
+  view.setUint32(20, height, false);
+  return bytes;
+}
+
+/** Minimal JPEG with APP0 + SOF0 carrying dimensions. */
+function makeJpeg(width: number, height: number): Uint8Array {
+  const bytes: number[] = [
+    0xff,
+    0xd8, // SOI
+    // APP0 (JFIF) — length 16
+    0xff,
+    0xe0,
+    0x00,
+    0x10,
+    0x4a,
+    0x46,
+    0x49,
+    0x46,
+    0x00,
+    0x01,
+    0x01,
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    // SOF0 — length 11, precision 8, height, width, 1 component
+    0xff,
+    0xc0,
+    0x00,
+    0x0b,
+    0x08,
+    (height >> 8) & 0xff,
+    height & 0xff,
+    (width >> 8) & 0xff,
+    width & 0xff,
+    0x01,
+    0x11,
+    0x00,
+    // EOI
+    0xff,
+    0xd9,
+  ];
+  return new Uint8Array(bytes);
+}
+
+/** Minimal VP8X WebP with canvas size fields. */
+function makeWebpVp8x(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(30);
+  // RIFF....WEBP
+  bytes.set([0x52, 0x49, 0x46, 0x46], 0);
+  bytes.set([0x16, 0x00, 0x00, 0x00], 4); // chunk size (dummy)
+  bytes.set([0x57, 0x45, 0x42, 0x50], 8);
+  bytes.set([0x56, 0x50, 0x38, 0x58], 12); // VP8X
+  bytes.set([0x0a, 0x00, 0x00, 0x00], 16); // chunk size 10
+  bytes.set([0x00, 0x00, 0x00, 0x00], 20); // flags + reserved
+  const w = width - 1;
+  const h = height - 1;
+  bytes[24] = w & 0xff;
+  bytes[25] = (w >> 8) & 0xff;
+  bytes[26] = (w >> 16) & 0xff;
+  bytes[27] = h & 0xff;
+  bytes[28] = (h >> 8) & 0xff;
+  bytes[29] = (h >> 16) & 0xff;
+  return bytes;
+}
+
+describe('parseImageDimensions (#1076)', () => {
+  it('reads PNG IHDR width/height', () => {
+    expect(parseImageDimensions(makePng(1920, 1080))).toEqual({
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it('reads JPEG SOF0 width/height (model grids are often JPEG)', () => {
+    expect(parseImageDimensions(makeJpeg(1536, 1536))).toEqual({
+      width: 1536,
+      height: 1536,
+    });
+  });
+
+  it('reads WebP VP8X canvas width/height', () => {
+    expect(parseImageDimensions(makeWebpVp8x(1024, 576))).toEqual({
+      width: 1024,
+      height: 576,
+    });
+  });
+
+  it('returns null for unknown / truncated bytes', () => {
+    expect(parseImageDimensions(new Uint8Array([0x00, 0x01, 0x02]))).toBeNull();
+    expect(parseImageDimensions(new Uint8Array(0))).toBeNull();
+  });
+});

--- a/src/lib/image/image-crop.ts
+++ b/src/lib/image/image-crop.ts
@@ -23,25 +23,221 @@ type CropTileResult = {
   url: string;
 };
 
+type ImageDimensions = { width: number; height: number };
+
 /**
- * Read the pixel dimensions from a PNG header (bytes 16-23 of IHDR chunk).
- * Stored `/r2/` URLs read the header straight from the R2 binding; external
- * URLs fetch only the first 30 bytes via Range request — no full download.
+ * Bytes to read for format headers. PNG/WebP fit in <40B; JPEG SOF often
+ * sits after EXIF/APP markers so we pull a larger prefix.
  */
-async function getImageDimensions(
-  imageUrl: string
-): Promise<{ width: number; height: number }> {
+const HEADER_BYTES = 64 * 1024;
+
+/** Read one byte or null if out of range (avoids non-null assertions). */
+function at(bytes: Uint8Array, i: number): number | null {
+  const value = bytes.at(i);
+  return value === undefined ? null : value;
+}
+
+/** Big-endian u16 from two known-in-range bytes. */
+function be16(hi: number, lo: number): number {
+  return (hi << 8) | lo;
+}
+
+/** Little-endian u16. */
+function le16(lo: number, hi: number): number {
+  return lo | (hi << 8);
+}
+
+/** Parse PNG IHDR (bytes 16–23). */
+function parsePngDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.length < 24) return null;
+  // PNG magic: 89 50 4E 47
+  if (at(bytes, 0) !== 0x89 || at(bytes, 1) !== 0x50) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return {
+    width: view.getUint32(16, false),
+    height: view.getUint32(20, false),
+  };
+}
+
+/**
+ * Scan JPEG for the first SOF0/SOF1/SOF2 marker and read height/width.
+ * Markers: FF C0 / FF C1 / FF C2 … (baseline / extended / progressive).
+ */
+function parseJpegDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.length < 4) return null;
+  // JPEG SOI: FF D8
+  if (at(bytes, 0) !== 0xff || at(bytes, 1) !== 0xd8) return null;
+
+  let i = 2;
+  while (i + 9 < bytes.length) {
+    if (at(bytes, i) !== 0xff) {
+      i += 1;
+      continue;
+    }
+    // Skip fill bytes (FF FF …)
+    while (i < bytes.length && at(bytes, i) === 0xff) i += 1;
+    if (i >= bytes.length) break;
+
+    const marker = at(bytes, i);
+    if (marker === null) break;
+    i += 1;
+
+    // Standalone markers without a length field
+    if (marker === 0xd9 /* EOI */ || marker === 0xda /* SOS */) break;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd7)) continue;
+
+    const lenHi = at(bytes, i);
+    const lenLo = at(bytes, i + 1);
+    if (lenHi === null || lenLo === null) break;
+    const segmentLength = be16(lenHi, lenLo);
+    if (segmentLength < 2) break;
+
+    // SOF0–SOF3, SOF5–SOF7, SOF9–SOF11, SOF13–SOF15 carry dimensions
+    const isSof =
+      (marker >= 0xc0 && marker <= 0xc3) ||
+      (marker >= 0xc5 && marker <= 0xc7) ||
+      (marker >= 0xc9 && marker <= 0xcb) ||
+      (marker >= 0xcd && marker <= 0xcf);
+    if (isSof) {
+      // segment: len(2) precision(1) height(2) width(2)
+      const hHi = at(bytes, i + 3);
+      const hLo = at(bytes, i + 4);
+      const wHi = at(bytes, i + 5);
+      const wLo = at(bytes, i + 6);
+      if (hHi === null || hLo === null || wHi === null || wLo === null) {
+        return null;
+      }
+      const height = be16(hHi, hLo);
+      const width = be16(wHi, wLo);
+      if (width === 0 || height === 0) return null;
+      return { width, height };
+    }
+
+    i += segmentLength;
+  }
+  return null;
+}
+
+/** Parse WebP VP8X / VP8 / VP8L headers. */
+function parseWebpDimensions(bytes: Uint8Array): ImageDimensions | null {
+  if (bytes.length < 30) return null;
+  // RIFF....WEBP
+  if (
+    at(bytes, 0) !== 0x52 ||
+    at(bytes, 1) !== 0x49 ||
+    at(bytes, 2) !== 0x46 ||
+    at(bytes, 3) !== 0x46
+  ) {
+    return null;
+  }
+  if (
+    at(bytes, 8) !== 0x57 ||
+    at(bytes, 9) !== 0x45 ||
+    at(bytes, 10) !== 0x42 ||
+    at(bytes, 11) !== 0x50
+  ) {
+    return null;
+  }
+
+  const c0 = at(bytes, 12);
+  const c1 = at(bytes, 13);
+  const c2 = at(bytes, 14);
+  const c3 = at(bytes, 15);
+  if (c0 === null || c1 === null || c2 === null || c3 === null) return null;
+  const fourCC = String.fromCharCode(c0, c1, c2, c3);
+
+  if (fourCC === 'VP8X') {
+    // Canvas width/height are 24-bit little-endian, stored as size-1
+    const w0 = at(bytes, 24);
+    const w1 = at(bytes, 25);
+    const w2 = at(bytes, 26);
+    const h0 = at(bytes, 27);
+    const h1 = at(bytes, 28);
+    const h2 = at(bytes, 29);
+    if (
+      w0 === null ||
+      w1 === null ||
+      w2 === null ||
+      h0 === null ||
+      h1 === null ||
+      h2 === null
+    ) {
+      return null;
+    }
+    const width = 1 + (w0 | (w1 << 8) | (w2 << 16));
+    const height = 1 + (h0 | (h1 << 8) | (h2 << 16));
+    return { width, height };
+  }
+
+  if (fourCC === 'VP8 ') {
+    // Lossy: frame tag (3) + start code 9d 01 2a, then 16-bit LE width/height
+    // with 2 high bits as scale. Chunk data starts at offset 20.
+    const dataStart = 20;
+    if (
+      at(bytes, dataStart + 3) === 0x9d &&
+      at(bytes, dataStart + 4) === 0x01 &&
+      at(bytes, dataStart + 5) === 0x2a
+    ) {
+      const wLo = at(bytes, dataStart + 6);
+      const wHi = at(bytes, dataStart + 7);
+      const hLo = at(bytes, dataStart + 8);
+      const hHi = at(bytes, dataStart + 9);
+      if (wLo === null || wHi === null || hLo === null || hHi === null) {
+        return null;
+      }
+      return {
+        width: le16(wLo, wHi) & 0x3fff,
+        height: le16(hLo, hHi) & 0x3fff,
+      };
+    }
+  }
+
+  if (fourCC === 'VP8L') {
+    // Lossless signature 0x2f, then 14-bit width-1 / height-1 packed
+    if (at(bytes, 20) !== 0x2f) return null;
+    const b0 = at(bytes, 21);
+    const b1 = at(bytes, 22);
+    const b2 = at(bytes, 23);
+    const b3 = at(bytes, 24);
+    if (b0 === null || b1 === null || b2 === null || b3 === null) return null;
+    const width = 1 + (((b1 & 0x3f) << 8) | b0);
+    const height = 1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6));
+    return { width, height };
+  }
+
+  return null;
+}
+
+/**
+ * Read width/height from PNG, JPEG, or WebP headers. Stored `/r2/` URLs
+ * read a prefix from the R2 binding; external URLs use a Range request —
+ * no full download.
+ */
+export function parseImageDimensions(
+  bytes: Uint8Array
+): ImageDimensions | null {
+  return (
+    parsePngDimensions(bytes) ??
+    parseJpegDimensions(bytes) ??
+    parseWebpDimensions(bytes)
+  );
+}
+
+async function getImageDimensions(imageUrl: string): Promise<ImageDimensions> {
   const key = r2KeyFromUrl(imageUrl);
   let bytes: Uint8Array;
   if (key !== null) {
-    const object = await readStorageObject(key, { offset: 0, length: 30 });
+    const object = await readStorageObject(key, {
+      offset: 0,
+      length: HEADER_BYTES,
+    });
     if (!object) {
       throw new Error(`Grid image not found in storage: ${key}`);
     }
     bytes = object.bytes;
   } else {
     const response = await fetch(imageUrl, {
-      headers: { Range: 'bytes=0-29' },
+      headers: { Range: `bytes=0-${HEADER_BYTES - 1}` },
     });
     if (!response.ok) {
       throw new Error(
@@ -51,30 +247,21 @@ async function getImageDimensions(
     bytes = new Uint8Array(await response.arrayBuffer());
   }
 
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
-
-  // PNG: bytes 16-19 = width, 20-23 = height (big-endian uint32)
-  // PNG magic: 0x89504E47
-  if (view.getUint8(0) === 0x89 && view.getUint8(1) === 0x50) {
-    return {
-      width: view.getUint32(16, false),
-      height: view.getUint32(20, false),
-    };
+  const dims = parseImageDimensions(bytes);
+  if (!dims || dims.width <= 0 || dims.height <= 0) {
+    throw new Error(
+      'Could not read image dimensions — supported formats: PNG, JPEG, WebP'
+    );
   }
-
-  // JPEG: need to scan for SOF marker — more complex, fall back to full HEAD
-  // For now, throw and let the caller handle it
-  throw new Error(
-    'Could not read image dimensions — only PNG headers are supported'
-  );
+  return dims;
 }
 
 /**
  * Crop a tile from a grid image using Cloudflare Image Resizing.
  * Returns a cdn-cgi/image/trim= URL instead of downloading and processing in-memory.
  *
- * Reads actual image dimensions from the PNG header (30 bytes) to calculate
- * accurate trim values, rather than assuming fixed tile sizes.
+ * Reads actual image dimensions from the file header to calculate accurate
+ * trim values, rather than assuming fixed tile sizes.
  *
  * KNOWN LIMITATION: with locally-served storage (no R2_PUBLIC_STORAGE_DOMAIN)
  * there is no Cloudflare edge, so the returned origin-relative trim URL won't

--- a/src/lib/realtime/__tests__/query-cache-updater.test.ts
+++ b/src/lib/realtime/__tests__/query-cache-updater.test.ts
@@ -222,6 +222,31 @@ describe('updateQueryCacheFromEvent — variant-only guard (#547)', () => {
       const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
       expect(invalidatedKeys).toContainEqual(['sequence-video-variants', SEQ]);
       expect(invalidatedKeys).toContainEqual(['sequence-video-models', SEQ]);
+      // Video tab version chips read segments — must refresh with history (#1076).
+      expect(invalidatedKeys).toContainEqual(['segments', 'list', SEQ]);
+    });
+
+    it('primary completion refreshes segments so version chips leave the spinning state (#1076)', () => {
+      const invalidate = vi.spyOn(qc, 'invalidateQueries');
+      qc.setQueryData(shotKeys.list(SEQ), [
+        makeShot({ videoStatus: 'generating', videoError: null }),
+      ]);
+
+      updateQueryCacheFromEvent(qc, SEQ, 'generation.video:progress', {
+        shotId: 'shot-1',
+        status: 'completed',
+        videoUrl: NEW_URL,
+        model: 'veo3',
+      });
+
+      expect(getCachedShot(qc)?.videoStatus).toBe('completed');
+
+      vi.advanceTimersByTime(200);
+      const invalidatedKeys = invalidate.mock.calls.map((c) => c[0]?.queryKey);
+      expect(invalidatedKeys).toContainEqual(['segments', 'list', SEQ]);
+      expect(invalidatedKeys).toContainEqual([
+        ...shotKeys.videoVersions('shot-1'),
+      ]);
     });
 
     it('variant-only failure does not flip the primary video to failed', () => {

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -1,6 +1,7 @@
 import { characterSheetVariantKeys } from '@/hooks/use-character-sheet-variants';
 import { promptVariantKeys } from '@/hooks/use-prompt-variants';
 import { sceneKeys } from '@/hooks/use-scenes';
+import { segmentKeys } from '@/hooks/use-segments';
 import { shotKeys } from '@/hooks/use-shots';
 import { locationSheetVariantKeys } from '@/hooks/use-location-sheet-variants';
 import { sequenceCharacterKeys } from '@/hooks/use-sequence-characters';
@@ -306,6 +307,17 @@ export function updateQueryCacheFromEvent(
             `video-versions:${shotId}`
           );
         }
+        // Version chips on the Video tab read `segments`, not history and not
+        // the shots list. History was invalidated above (#1070) but segments
+        // were not — after primary completion we also flip `shots.videoStatus`
+        // off `generating`, which stops the 2s segment poll, so a chip can
+        // stay on the pre-complete "generating" snapshot forever while history
+        // already shows completed (#1076).
+        debouncedInvalidate(
+          queryClient,
+          segmentKeys.list(sequenceId),
+          `segments:${sequenceId}`
+        );
       }
       break;
     }


### PR DESCRIPTION
## Summary

- **Variant select:** crop tile dimension probing supports PNG, JPEG, and WebP (model grids are often not PNG), fixing the “only PNG headers are supported” toast.
- **Video version chips:** invalidate `segments` on `generation.video:progress` completed/failed so chips don’t stay spinning after history already shows completed (SSE arrived; wrong query was refreshed).
- **Stuck rows:** cron reconciles `video_variants` generating status (missed after #990).
- **UX:** failed re-rolls stay in history but are hidden from Video tab chips.

Closes #1076

## Test plan

- [ ] Select a framing variant from a JPEG/WebP grid sheet — no dimension error; upscale kicks off
- [ ] Re-roll video with v1 selected; when v2 completes (history shows completed), Video tab chips update without a full page reload
- [ ] Confirm failed video versions appear in history sheet but not as permanent chips
- [ ] Unit: `bun run test src/lib/image/image-crop.test.ts src/lib/realtime/__tests__/query-cache-updater.test.ts src/lib/cron/reconcile-all.test.ts`