### PR TITLE
feat(#1079): editable element names, filename-derived tokens, draft mention pills

### DIFF
--- a/e2e/fixtures/recorded/openrouter/element-vision/element-vision.json
+++ b/e2e/fixtures/recorded/openrouter/element-vision/element-vision.json
@@ -2,7 +2,7 @@
   "fixtures": [
     {
       "match": {
-        "userMessage": "Uploaded filename (hint only — may be meaningless): broadcast-mic.jpg\n\nDescribe the element in the image below and suggest a token.",
+        "userMessage": "Uploaded filename: broadcast-mic.jpg\n\nDescribe the element in the image below and suggest a token.",
         "model": "anthropic/claude-sonnet-5",
         "turnIndex": 0,
         "hasToolResult": false

--- a/e2e/mocks/aimock-server.ts
+++ b/e2e/mocks/aimock-server.ts
@@ -67,7 +67,7 @@ const STAGE_PREFIXES: ReadonlyArray<readonly [string, string]> = [
   ['Generate the visual prompt for the starting frame', 'visual-prompts'],
   ['Generate the motion prompt for this scene', 'motion-prompts'],
   ['Classify music design for each scene', 'music-design'],
-  ['Uploaded filename (hint only', 'element-vision'],
+  ['Uploaded filename:', 'element-vision'],
 ];
 
 // Diagnostic dump for unmatched requests — written on shutdown so we can diff

--- a/src/components/element/element-selector.tsx
+++ b/src/components/element/element-selector.tsx
@@ -2,11 +2,15 @@
  * Element selector for the sequence creation + edit forms.
  *
  * Two modes:
- *  - draft (default): files upload to a temp R2 path and emit DraftElementUpload
- *    entries via onDraftElementsChange. Used on new-sequence creation before
- *    the sequence exists.
+ *  - draft (default): files upload to a temp R2 path and land in the parent's
+ *    `draftElements` list via onDraftElementsChange. The parent list is the
+ *    canonical state (it's what localStorage draft persistence restores after
+ *    a reload — #1079); local entries here only track in-flight uploads and
+ *    errors. Used on new-sequence creation before the sequence exists.
  *  - persisted: when a sequenceId is provided, files upload directly into that
  *    sequence's elements (useSequenceElements) and can be deleted.
+ *
+ * Both modes let the user rename an element's token in place (#1079).
  *
  * Exposes an imperative ref so external drop targets (ScriptView) can inject
  * files.
@@ -19,8 +23,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { ElementTokenButton } from '@/components/element/element-token-button';
 import {
   useDeleteSequenceElement,
+  useRenameSequenceElementToken,
   useSequenceElements,
   useUploadDraftElement,
   useUploadElementToSequence,
@@ -74,12 +80,19 @@ type DraftModeProps = BaseProps & {
   sequenceId?: undefined;
   draftElements: DraftElementUpload[];
   onDraftElementsChange: (next: DraftElementUpload[]) => void;
+  /**
+   * Fires after a draft element's token is renamed so the parent can rewrite
+   * references in the script text (the persisted path does the same
+   * server-side via cascadeRename).
+   */
+  onDraftTokenRename?: (oldToken: string, newToken: string) => void;
 };
 
 type PersistedModeProps = BaseProps & {
   sequenceId: string;
   draftElements?: undefined;
   onDraftElementsChange?: undefined;
+  onDraftTokenRename?: undefined;
 };
 
 type ElementSelectorProps = DraftModeProps | PersistedModeProps;
@@ -90,7 +103,6 @@ type LocalEntry = {
   file: File;
   previewUrl: string;
   status: 'uploading' | 'analyzing' | 'done' | 'error';
-  uploaded?: DraftElementUpload;
   errorMessage?: string;
 };
 
@@ -107,7 +119,9 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
     ref,
     disabled = false,
     sequenceId,
+    draftElements,
     onDraftElementsChange,
+    onDraftTokenRename,
     onElementBusyChange,
   } = props;
   const isPersisted = !!sequenceId;
@@ -121,16 +135,23 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
   const draftUpload = useUploadDraftElement();
   const sequenceUpload = useUploadElementToSequence();
   const deleteElement = useDeleteSequenceElement();
+  const renameToken = useRenameSequenceElementToken();
   const { data: persistedElements = [] } = useSequenceElements(
     isPersisted ? sequenceId : undefined
   );
 
-  const uploaded = useMemo(
-    () =>
-      Array.from(entries.values())
-        .map((e) => e.uploaded)
-        .filter((u): u is DraftElementUpload => !!u),
-    [entries]
+  // Mirror of the parent's canonical draft list, updated synchronously on our
+  // own emissions so two uploads completing in the same tick don't lose the
+  // first append (the prop only catches up on the parent's next render).
+  const draftElementsRef = useRef<DraftElementUpload[]>(draftElements ?? []);
+  draftElementsRef.current = draftElements ?? [];
+
+  const emitDraftElements = useCallback(
+    (next: DraftElementUpload[]) => {
+      draftElementsRef.current = next;
+      onDraftElementsChange?.(next);
+    },
+    [onDraftElementsChange]
   );
 
   const hasInflightLocalEntry = useMemo(
@@ -159,12 +180,10 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
   const entriesRef = useRef(entries);
   entriesRef.current = entries;
 
+  // Persisted mode: once an upload's element row lands in the query data,
+  // drop the transient local entry (its tile is superseded by the real one).
   useEffect(() => {
-    if (!isPersisted) {
-      onDraftElementsChange?.(uploaded);
-      return;
-    }
-    if (persistedElements.length === 0) return;
+    if (!isPersisted || persistedElements.length === 0) return;
     const persistedFilenames = new Set(
       persistedElements.map((el) => el.uploadedFilename)
     );
@@ -183,7 +202,7 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
       }
       return changed ? next : prev;
     });
-  }, [isPersisted, uploaded, persistedElements, onDraftElementsChange]);
+  }, [isPersisted, persistedElements]);
 
   useEffect(() => {
     return () => {
@@ -195,7 +214,18 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
 
   const currentCount = isPersisted
     ? persistedElements.length + entries.size
-    : entries.size;
+    : (draftElements?.length ?? 0) + entries.size;
+
+  const removeLocalEntry = useCallback((key: string) => {
+    setEntries((prev) => {
+      const current = prev.get(key);
+      if (!current) return prev;
+      URL.revokeObjectURL(current.previewUrl);
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
 
   const processFiles = useCallback(
     async (newFiles: File[]) => {
@@ -212,7 +242,7 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
         const next = new Map(prev);
         const existingCount = isPersisted
           ? persistedElements.length + next.size
-          : next.size;
+          : draftElementsRef.current.length + next.size;
         let remaining = MAX_ELEMENTS - existingCount;
         for (const file of images) {
           if (remaining <= 0) break;
@@ -266,17 +296,13 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
                   });
                 },
               });
-              setEntries((prev) => {
-                const current = prev.get(key);
-                if (!current) return prev;
-                const next = new Map(prev);
-                next.set(key, {
-                  ...current,
-                  status: 'done',
-                  uploaded: result,
-                });
-                return next;
-              });
+              // Promote into the parent's canonical draft list and drop the
+              // transient local entry — unless the user removed it mid-upload,
+              // in which case the result is discarded.
+              if (entriesRef.current.has(key)) {
+                removeLocalEntry(key);
+                emitDraftElements([...draftElementsRef.current, result]);
+              }
             }
           } catch (err) {
             const message =
@@ -311,19 +337,10 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
       sequenceId,
       draftUpload,
       sequenceUpload,
+      removeLocalEntry,
+      emitDraftElements,
     ]
   );
-
-  const removeLocalEntry = useCallback((key: string) => {
-    setEntries((prev) => {
-      const current = prev.get(key);
-      if (!current) return prev;
-      URL.revokeObjectURL(current.previewUrl);
-      const next = new Map(prev);
-      next.delete(key);
-      return next;
-    });
-  }, []);
 
   const removePersistedElement = useCallback(
     (element: SequenceElement) => {
@@ -331,6 +348,68 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
       deleteElement.mutate({ elementId: element.id, sequenceId });
     },
     [deleteElement, isPersisted, sequenceId]
+  );
+
+  const removeDraftElement = useCallback(
+    (tempPath: string) => {
+      emitDraftElements(
+        draftElementsRef.current.filter((el) => el.tempPath !== tempPath)
+      );
+    },
+    [emitDraftElements]
+  );
+
+  // Rename a draft (pre-sequence) element in the parent's canonical list; the
+  // parent rewrites script references through onDraftTokenRename. Uniqueness
+  // is checked locally — promoteTempElements would silently suffix a
+  // collision, but a user-typed name should be rejected loudly instead
+  // (matching the persisted rename server fn).
+  const renameDraftElement = useCallback(
+    // oxlint-disable-next-line require-await -- ElementTokenButton takes an async commit; rejections surface inline
+    async (tempPath: string, nextToken: string) => {
+      const current = draftElementsRef.current;
+      const target = current.find((el) => el.tempPath === tempPath);
+      if (!target || nextToken === target.token) return;
+      const duplicate = current.some(
+        (el) => el.tempPath !== tempPath && el.token === nextToken
+      );
+      if (duplicate) {
+        throw new Error(
+          `Another element is already named "${nextToken}". Pick a different name.`
+        );
+      }
+      emitDraftElements(
+        current.map((el) =>
+          el.tempPath === tempPath ? { ...el, token: nextToken } : el
+        )
+      );
+      onDraftTokenRename?.(target.token, nextToken);
+    },
+    [emitDraftElements, onDraftTokenRename]
+  );
+
+  // Rename a persisted element — the server fn cascades the new token through
+  // the sequence script and every shot that references it.
+  const renamePersistedElement = useCallback(
+    async (element: SequenceElement, nextToken: string) => {
+      if (!isPersisted) return;
+      const result = await renameToken.mutateAsync({
+        sequenceId,
+        elementId: element.id,
+        token: nextToken,
+      });
+      const updates: string[] = [];
+      if (result.scriptUpdated) updates.push('script');
+      if (result.shotsUpdated > 0) {
+        updates.push(
+          `${result.shotsUpdated} shot${result.shotsUpdated === 1 ? '' : 's'}`
+        );
+      }
+      const suffix =
+        updates.length > 0 ? ` — updated ${updates.join(' + ')}` : '';
+      toast.success(`Renamed to ${nextToken}${suffix}`);
+    },
+    [isPersisted, renameToken, sequenceId]
   );
 
   useImperativeHandle(
@@ -384,11 +463,28 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
     [processFiles]
   );
 
-  // Build the display list
+  // Build the display list: canonical elements first (persisted rows or the
+  // parent's draft list), then transient local entries (in-flight / errored).
   const displayItems: Array<
     | { kind: 'persisted'; item: DisplayItem; source: SequenceElement }
+    | { kind: 'draft'; item: DisplayItem; source: DraftElementUpload }
     | { kind: 'local'; item: DisplayItem; key: string }
   > = [];
+
+  if (!isPersisted) {
+    for (const el of draftElements ?? []) {
+      displayItems.push({
+        kind: 'draft',
+        source: el,
+        item: {
+          key: `draft-${el.tempPath}`,
+          imageUrl: el.tempPublicUrl,
+          token: el.token,
+          status: 'done',
+        },
+      });
+    }
+  }
 
   if (isPersisted) {
     for (const el of persistedElements) {
@@ -419,14 +515,15 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
       item: {
         key: `local-${key}`,
         imageUrl: entry.previewUrl,
-        token: entry.uploaded?.token,
         status: entry.status,
         errorMessage: entry.errorMessage,
       },
     });
   }
 
-  const count = isPersisted ? persistedElements.length : uploaded.length;
+  const count = isPersisted
+    ? persistedElements.length
+    : (draftElements?.length ?? 0);
 
   return (
     <>
@@ -556,11 +653,21 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
                           {item.errorMessage ?? 'Failed'}
                         </div>
                       )}
-                      {item.status === 'done' && item.token && (
-                        <div className="absolute bottom-0 left-0 right-0 bg-background/90 px-1.5 py-0.5 text-[10px] font-mono truncate">
-                          {item.token}
-                        </div>
-                      )}
+                      {item.status === 'done' &&
+                        item.token &&
+                        entry.kind !== 'local' && (
+                          <ElementTokenButton
+                            token={item.token}
+                            onRename={(next) =>
+                              entry.kind === 'persisted'
+                                ? renamePersistedElement(entry.source, next)
+                                : renameDraftElement(
+                                    entry.source.tempPath,
+                                    next
+                                  )
+                            }
+                          />
+                        )}
                       <Button
                         type="button"
                         variant="destructive"
@@ -568,6 +675,8 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
                         onClick={() => {
                           if (entry.kind === 'persisted') {
                             removePersistedElement(entry.source);
+                          } else if (entry.kind === 'draft') {
+                            removeDraftElement(entry.source.tempPath);
                           } else {
                             removeLocalEntry(entry.key);
                           }

--- a/src/components/element/element-token-button.tsx
+++ b/src/components/element/element-token-button.tsx
@@ -1,0 +1,126 @@
+/**
+ * The token bar on an element tile: shows the element's UPPERCASE token and
+ * opens a small popover to rename it (#1079). The caller supplies the commit —
+ * draft mode rewrites local state, persisted mode calls the rename server fn
+ * (which cascades through script + shots). Rejections from `onRename` are
+ * surfaced inline in the popover.
+ */
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { deriveTokenFromFilename } from '@/lib/sequence-elements/derive-token';
+import { Pencil } from 'lucide-react';
+import { useRef, useState } from 'react';
+
+export const ElementTokenButton: React.FC<{
+  token: string;
+  /** Commit the (already normalized) new token. Reject to show the error inline. */
+  onRename: (nextToken: string) => Promise<void>;
+}> = ({ token, onRename }) => {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState(token);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Same normalization the rename server fn applies, previewed live.
+  const normalized = deriveTokenFromFilename(value);
+  const isUnchanged = normalized === token;
+
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      setValue(token);
+      setError(null);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isUnchanged) {
+      setOpen(false);
+      return;
+    }
+    setError(null);
+    setIsSaving(true);
+    try {
+      await onRename(normalized);
+      setOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to rename');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Rename ${token}`}
+          className="absolute bottom-0 left-0 right-0 flex min-h-6 cursor-pointer items-center gap-1 bg-background/90 px-1.5 py-0.5 text-left transition-colors hover:bg-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <span className="min-w-0 flex-1 truncate font-mono text-[10px]">
+            {token}
+          </span>
+          <Pencil className="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-72"
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          inputRef.current?.focus();
+          inputRef.current?.select();
+        }}
+      >
+        <form
+          onSubmit={(e) => void handleSubmit(e)}
+          className="flex flex-col gap-2"
+        >
+          <p className="text-sm font-medium">Rename element</p>
+          <Input
+            ref={inputRef}
+            value={value}
+            onChange={(e) => {
+              setValue(e.currentTarget.value);
+              if (error) setError(null);
+            }}
+            maxLength={100}
+            placeholder="ELEMENT_NAME"
+            className="font-mono"
+            aria-invalid={!!error}
+            aria-describedby={
+              error ? 'token-rename-error' : 'token-rename-hint'
+            }
+          />
+          <p id="token-rename-hint" className="text-xs text-muted-foreground">
+            Saved as <span className="font-mono">{normalized}</span>
+          </p>
+          {error && (
+            <p
+              id="token-rename-error"
+              className="text-xs text-destructive"
+              role="alert"
+            >
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end">
+            <Button type="submit" size="sm" disabled={isSaving || isUnchanged}>
+              {isSaving ? 'Renaming…' : 'Save'}
+            </Button>
+          </div>
+        </form>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/script/script-editor.tsx
+++ b/src/components/script/script-editor.tsx
@@ -17,8 +17,8 @@ type ScriptEditorProps = {
   /**
    * Sequence cast/elements/locations. When provided, their canonical tags in
    * the script render as @-mention pills (and `@` autocompletes them) — same
-   * behaviour as the scene prompt editors. Omit on the pre-analysis create
-   * screen where no canonical tags exist yet.
+   * behaviour as the scene prompt editors. The create screen passes the draft
+   * elements' tokens (#1079); pass the full sequence sets once analysed.
    */
   mentionItems?: MentionItem[];
 };

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -70,6 +70,7 @@ import {
   aspectRatioSchema,
   type AspectRatio,
 } from '@/lib/constants/aspect-ratios';
+import { replaceTokenInText } from '@/lib/sequence-elements/cascade-rename';
 import { cn } from '@/lib/utils';
 import {
   dataTransferHasImages,
@@ -80,7 +81,14 @@ import {
 import type { Sequence } from '@/types/database';
 import { usePostHog } from '@posthog/react';
 import { ImagePlus, Loader2, Sparkles, Square, Undo2 } from 'lucide-react';
-import React, { useEffect, useMemo, useRef, useState, type FC } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FC,
+} from 'react';
 import { ScriptEditor } from './script-editor';
 
 const DURATION_PRESETS = [
@@ -315,9 +323,11 @@ export const ScriptView: FC<{
   const styleName = selectedStyle?.name ?? undefined;
 
   // Sequence cast/elements/locations drive @-mention pills in the script
-  // editor — same canonical tags the scene prompt editors use. Only an existing
-  // (analysed) sequence has these; on the create screen there are no canonical
-  // tags yet, so we pass `undefined` to keep mentions off there.
+  // editor — same canonical tags the scene prompt editors use. An existing
+  // (analysed) sequence has all three; on the create screen only the uploaded
+  // draft elements exist, so their tokens pill (and `@`-complete) from local
+  // state instead (#1079). Always defined — the editor's mention extension is
+  // registered at init and can't be enabled later.
   const mentionSequenceId = sequence?.id;
   const { data: mentionElements } = useSequenceElements(mentionSequenceId);
   const { data: mentionCharacters } = useSequenceCharacters(
@@ -334,8 +344,38 @@ export const ScriptView: FC<{
             elements: mentionElements ?? [],
             locations: mentionLocations ?? [],
           })
-        : undefined,
-    [mentionSequenceId, mentionCharacters, mentionElements, mentionLocations]
+        : buildMentionItems({
+            characters: [],
+            elements: draftElements.map((el) => ({
+              id: el.tempPath,
+              token: el.token,
+              description: el.description,
+              imageUrl: el.tempPublicUrl,
+              consistencyTag: el.consistencyTag,
+            })),
+            locations: [],
+          }),
+    [
+      mentionSequenceId,
+      mentionCharacters,
+      mentionElements,
+      mentionLocations,
+      draftElements,
+    ]
+  );
+
+  // Renaming a draft element rewrites its token references in the script so
+  // the tile name and what the analyser will see stay in sync (the persisted
+  // path does the same server-side via cascadeRename).
+  const handleDraftTokenRename = useCallback(
+    (oldToken: string, newToken: string) => {
+      setContentState((s) => {
+        if (!s.script) return s;
+        const rewritten = replaceTokenInText(s.script, oldToken, newToken);
+        return rewritten === s.script ? s : { ...s, script: rewritten };
+      });
+    },
+    []
   );
   const recommendedImageModel = selectedStyle?.recommendedImageModel ?? null;
   const recommendedVideoModel = selectedStyle?.recommendedVideoModel ?? null;
@@ -918,6 +958,7 @@ export const ScriptView: FC<{
                 ref={elementSelectorRef}
                 draftElements={draftElements}
                 onDraftElementsChange={setDraftElements}
+                onDraftTokenRename={handleDraftTokenRename}
                 disabled={loading}
                 onElementBusyChange={setIsElementBusy}
               />

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -93,8 +93,9 @@ type MarkdownEditorProps = {
    * When provided, enables @-mention autocomplete. Tags found in the incoming
    * markdown (by canonical slug match against the items list) are rendered as
    * coloured pills via the Mention extension. Pass `undefined` (default) on
-   * surfaces where mentions don't apply (e.g. the pre-analysis script editor,
-   * where no canonical tags exist yet).
+   * surfaces where mentions don't apply. Enablement is captured at editor
+   * init — pass an (empty) array from the first render, not `undefined` that
+   * later becomes a list, or the extension never registers.
    */
   mentionItems?: MentionItem[];
 };

--- a/src/hooks/use-sequence-elements.ts
+++ b/src/hooks/use-sequence-elements.ts
@@ -17,6 +17,7 @@ import type {
 } from '@/lib/realtime';
 import { useRealtime } from '@/lib/realtime/client';
 import { putToR2 } from '@/lib/utils/upload';
+import { sceneKeys } from '@/hooks/use-scenes';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
@@ -204,6 +205,11 @@ export function useRenameSequenceElementToken() {
     onSuccess: (result, variables) => {
       void queryClient.invalidateQueries({
         queryKey: sequenceElementKeys.bySequence(variables.sequenceId),
+      });
+      // cascadeRename rewrites the sequence script and selected scene-script
+      // versions — refresh the composed script so editors showing it update.
+      void queryClient.invalidateQueries({
+        queryKey: sceneKeys.composedScript(variables.sequenceId),
       });
       // Shots now contain the new token in metadata / prompts. Refresh
       // anything that renders shot text or counts.

--- a/src/lib/ai/element-vision.ts
+++ b/src/lib/ai/element-vision.ts
@@ -63,11 +63,11 @@ function buildVisionMessages(
 Your output MUST be strict JSON with three fields:
 - "description": 60-120 words. Describe shape, proportions, colors, text rendered on the element (verbatim), finish/material, any distinguishing marks, and how it is oriented. Do NOT describe background, lighting, camera angle, or the overall photograph — only the element itself.
 - "consistencyTag": A lowercase slug (3-6 words joined by hyphens) capturing the element's visual identity for reuse in prompts (e.g. "red-hex-brand-logo", "silver-metal-water-bottle").
-- "suggestedToken": A short UPPERCASE_SNAKE_CASE identifier (1-3 words, joined by underscores, max 30 characters) naming the element so a screenwriter can reference it. Prefer brand/product names visible in the image (e.g. "PEPSI_LOGO", "IPHONE", "STARBUCKS_CUP"); if no brand text is visible, name the object descriptively (e.g. "RED_BOTTLE", "OFFICE_CHAIR"). Letters and digits only; no spaces, dashes, or punctuation.
+- "suggestedToken": A short UPPERCASE_SNAKE_CASE identifier (1-3 words, joined by underscores, max 30 characters) naming the element so a screenwriter can reference it. If the uploaded filename looks deliberately named by a person, derive the token from it (e.g. "acme-logo.png" → "ACME_LOGO", "red water bottle.jpg" → "RED_WATER_BOTTLE"). Ignore auto-generated filenames (e.g. "IMG_1234.jpg", "Screenshot 2026-05-01.png", "image.png", "download.jpg", random hashes) — for those, prefer brand/product names visible in the image (e.g. "PEPSI_LOGO", "IPHONE", "STARBUCKS_CUP"); if no brand text is visible, name the object descriptively (e.g. "RED_BOTTLE", "OFFICE_CHAIR"). Letters and digits only; no spaces, dashes, or punctuation.
 
 Return ONLY the JSON object. No prose, no markdown fences.`;
 
-  const userText = `Uploaded filename (hint only — may be meaningless): ${filename}
+  const userText = `Uploaded filename: ${filename}
 
 Describe the element in the image below and suggest a token.`;
 


### PR DESCRIPTION
Closes #1079

## What

Three fixes to the element-upload flow on the new-script composer:

1. **Filename-derived tokens** — the element-vision prompt now derives the token from a deliberate, human-chosen filename (`acme-logo.png` → `ACME_LOGO`) and only names from the image when the filename is auto-generated (`IMG_1234.jpg`, screenshots, hashes). Verified live: a plain red square uploaded as `acme-logo.png` came back `ACME_LOGO`.
2. **Editable element names** — the token bar on each element tile is now a button that opens a rename popover (new `ElementTokenButton`, following the `RenameElementDialog` pattern removed in #986) with a live "Saved as `X`" normalization preview. Draft mode renames the draft and rewrites every token reference in the script text via `replaceTokenInText`; persisted mode wires up the retained `renameSequenceElementTokenFn` cascade (script + shots), and the composed-script query is now invalidated on rename so the editor refreshes.
3. **Element tokens highlight before generate** — the create screen passed `mentionItems: undefined`, so uploaded elements never pilled in the script. `ScriptView` now builds mention items from `draftElements`; the token pills amber the moment vision analysis lands, and `@` autocomplete offers the uploaded elements.

## Bug fixed along the way

Draft elements did not survive a page reload: `ElementSelector` kept uploads only in local `entries` state and pushed that list up on every render (the `persistedElements = []` default-param identity re-fired the effect), so the localStorage-restored `draftElements` were immediately clobbered back to `[]` and permanently dropped from the saved draft — and restored elements never displayed in the popover. Draft mode now treats the parent's `draftElements` list as canonical: the selector renders it and appends/renames/deletes through it, with local entries only tracking in-flight/errored uploads.

## E2E

The aimock element-vision fixture matches on the vision user-prompt text, so `match.userMessage` and the `STAGE_PREFIXES` entry are updated to the new `Uploaded filename:` prefix (recorded response unchanged). Note for the next re-record: `broadcast-mic.jpg` will now yield `BROADCAST_MIC` instead of `PHANTOM_CLASSIC_MIC`, which will ripple into the script-analyze fixture.

## Verification

- `bun typecheck`, `bun lint`, `bun dead-code` clean; 1950 unit tests pass.
- Browser-verified end-to-end with real vision calls: upload → filename-derived token → live pill highlighting in the script → reload persistence (script + element + pill restored) → rename `GREEN_ICON` → `CITY_BEACON` rewrote the script text and re-labelled the pill.
