### PR TITLE
feat(#1088): PostHog Slack alerts for signup, films, errors

### DIFF
--- a/scripts/setup-posthog-slack-alerts.ts
+++ b/scripts/setup-posthog-slack-alerts.ts
@@ -1,0 +1,350 @@
+/**
+ * #1088 — Wire PostHog → Slack destinations/alerts.
+ *
+ * Creates (idempotent by name) the product-activity Slack destinations and the
+ * error-tracking spike alert described in issue #1088.
+ *
+ * Prerequisites:
+ * 1. Slack is connected in PostHog → Settings → Integrations
+ * 2. The PostHog Slack app is invited to `#product-alerts` and `#ops-alerts`
+ * 3. A personal API key with `hog_function:write` (+ integrations read):
+ *    https://us.posthog.com/settings/user-api-keys
+ *
+ * Usage:
+ *   POSTHOG_PERSONAL_API_KEY=phx_… \
+ *   POSTHOG_PROJECT_ID=… \
+ *   bun scripts/setup-posthog-slack-alerts.ts
+ *
+ * Optional overrides:
+ *   POSTHOG_HOST=https://us.posthog.com
+ *   PRODUCT_CHANNEL=#product-alerts
+ *   OPS_CHANNEL=#ops-alerts
+ *   DRY_RUN=1   # print planned creates only
+ */
+
+import { z } from 'zod';
+
+const HOST = (process.env.POSTHOG_HOST ?? 'https://us.posthog.com').replace(
+  /\/$/,
+  ''
+);
+const API_KEY = process.env.POSTHOG_PERSONAL_API_KEY;
+const PROJECT_ID = process.env.POSTHOG_PROJECT_ID;
+const PRODUCT_CHANNEL = process.env.PRODUCT_CHANNEL ?? '#product-alerts';
+const OPS_CHANNEL = process.env.OPS_CHANNEL ?? '#ops-alerts';
+const DRY_RUN = process.env.DRY_RUN === '1' || process.env.DRY_RUN === 'true';
+
+if (!API_KEY || !PROJECT_ID) {
+  console.error(
+    'Required: POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID\n' +
+      '  Create a personal API key at https://us.posthog.com/settings/user-api-keys\n' +
+      '  Project ID is in Project settings (numeric).'
+  );
+  process.exit(1);
+}
+
+const hogFunctionSchema = z.object({
+  id: z.string(),
+  name: z.string().nullable().optional(),
+  type: z.string(),
+  enabled: z.boolean().optional(),
+  deleted: z.boolean().optional(),
+});
+
+const hogFunctionListSchema = z.object({
+  results: z.array(hogFunctionSchema).default([]),
+  next: z.string().nullable().optional(),
+});
+
+const integrationSchema = z.object({
+  id: z.number(),
+  kind: z.string(),
+});
+
+const integrationListSchema = z.object({
+  results: z.array(integrationSchema).default([]),
+});
+
+const createdHogFunctionSchema = z.object({
+  id: z.string(),
+});
+
+type HogFunctionSummary = z.infer<typeof hogFunctionSchema>;
+
+async function phFetch(
+  path: string,
+  options?: { method?: string; body?: string }
+): Promise<unknown> {
+  const headers = new Headers({
+    Authorization: `Bearer ${API_KEY}`,
+    Accept: 'application/json',
+  });
+  if (options?.body) {
+    headers.set('Content-Type', 'application/json');
+  }
+  const res = await fetch(`${HOST}${path}`, {
+    method: options?.method,
+    body: options?.body,
+    headers,
+  });
+  const text = await res.text();
+  let data: unknown = {};
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { raw: text };
+    }
+  }
+  if (!res.ok) {
+    throw new Error(
+      `${options?.method ?? 'GET'} ${path} → ${res.status}: ${text.slice(0, 800)}`
+    );
+  }
+  return data;
+}
+
+async function listHogFunctions(): Promise<HogFunctionSummary[]> {
+  const out: HogFunctionSummary[] = [];
+  let offset = 0;
+  const limit = 100;
+  for (;;) {
+    const page = hogFunctionListSchema.parse(
+      await phFetch(
+        `/api/projects/${PROJECT_ID}/hog_functions/?limit=${limit}&offset=${offset}`
+      )
+    );
+    out.push(...page.results.filter((r) => !r.deleted));
+    if (!page.next || page.results.length < limit) break;
+    offset += limit;
+  }
+  return out;
+}
+
+async function listSlackIntegrations(): Promise<
+  Array<{ id: number; kind: string }>
+> {
+  const data = integrationListSchema.parse(
+    await phFetch(`/api/projects/${PROJECT_ID}/integrations/`)
+  );
+  return data.results.filter((i) => i.kind === 'slack');
+}
+
+function eventFilter(eventName: string) {
+  return {
+    source: 'events',
+    events: [
+      {
+        id: eventName,
+        name: eventName,
+        type: 'events',
+        order: 0,
+      },
+    ],
+    filter_test_accounts: true,
+  };
+}
+
+function productBlocks(title: string, detail: string) {
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: title },
+    },
+    {
+      type: 'section',
+      text: { type: 'mrkdwn', text: detail },
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'mrkdwn',
+          text: 'Person: {person.properties.email ?? event.distinct_id}',
+        },
+        { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
+      ],
+    },
+  ];
+}
+
+function spikeBlocks() {
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: '📈 Issue spiking' },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '```{event.properties.name}: {substring(event.properties.description, 1, 1000)}```',
+      },
+    },
+    {
+      type: 'context',
+      elements: [
+        {
+          type: 'plain_text',
+          text: "Exceptions in last 5 minutes: {event.properties.current_bucket_value} ({event.properties.computed_baseline > 0 ? concat(round(event.properties.current_bucket_value / event.properties.computed_baseline), 'x over baseline') : 'no baseline yet'})",
+        },
+        { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
+        { type: 'mrkdwn', text: 'Alert: <{source.url}|{source.name}>' },
+      ],
+    },
+    { type: 'divider' },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'View Issue' },
+          url: '{project.url}/error_tracking/fingerprint/{encodeURLComponent(event.properties.fingerprint)}?timestamp={event.properties.exception_timestamp}&utm_source=alert&utm_campaign=error_tracking_alert&utm_medium=slack',
+        },
+      ],
+    },
+  ];
+}
+
+type DestinationSpec = {
+  name: string;
+  type: 'destination' | 'internal_destination';
+  event: string;
+  channel: string;
+  text: string;
+  blocks: unknown[];
+};
+
+function specs(): DestinationSpec[] {
+  return [
+    {
+      name: `Product · user_signed_up · ${PRODUCT_CHANNEL} (#1088)`,
+      type: 'destination',
+      event: 'user_signed_up',
+      channel: PRODUCT_CHANNEL,
+      text: 'New signup: {person.properties.email ?? event.distinct_id}',
+      blocks: productBlocks(
+        '🎉 New signup',
+        '*{person.properties.email ?? event.distinct_id}* just created an account'
+      ),
+    },
+    {
+      name: `Product · user_signed_in · ${PRODUCT_CHANNEL} (#1088)`,
+      type: 'destination',
+      event: 'user_signed_in',
+      channel: PRODUCT_CHANNEL,
+      text: 'Sign-in: {person.properties.email ?? event.distinct_id}',
+      blocks: productBlocks(
+        '👋 User signed in',
+        '*{person.properties.email ?? event.distinct_id}* signed in ({event.properties.path ?? "session"})'
+      ),
+    },
+    {
+      name: `Product · sequence_generated · ${PRODUCT_CHANNEL} (#1088)`,
+      type: 'destination',
+      event: 'sequence_generated',
+      channel: PRODUCT_CHANNEL,
+      text: 'Film started: {person.properties.email ?? event.distinct_id}',
+      blocks: productBlocks(
+        '🎬 Film / sequence created',
+        '*{person.properties.email ?? event.distinct_id}* created a sequence ({event.properties.source ?? "create"}, {event.properties.sequence_count ?? 1} seq, style `{event.properties.style_id}`)'
+      ),
+    },
+    {
+      name: `Issue spiking · ${OPS_CHANNEL} (#1088)`,
+      type: 'internal_destination',
+      event: '$error_tracking_issue_spiking',
+      channel: OPS_CHANNEL,
+      text: 'Issue spiking: {event.properties.name}',
+      blocks: spikeBlocks(),
+    },
+  ];
+}
+
+async function ensureDestination(
+  existing: HogFunctionSummary[],
+  slackWorkspaceId: number,
+  spec: DestinationSpec
+): Promise<'created' | 'exists' | 'dry-run'> {
+  const match = existing.find((f) => f.name === spec.name);
+  if (match) {
+    console.log(`  ✓ exists: ${spec.name} (${match.id})`);
+    return 'exists';
+  }
+
+  const payload = {
+    type: spec.type,
+    template_id: 'template-slack',
+    name: spec.name,
+    description: 'Created by scripts/setup-posthog-slack-alerts.ts for #1088',
+    enabled: true,
+    filters: eventFilter(spec.event),
+    inputs: {
+      slack_workspace: { value: slackWorkspaceId },
+      channel: { value: spec.channel },
+      text: { value: spec.text },
+      blocks: { value: spec.blocks },
+    },
+  };
+
+  if (DRY_RUN) {
+    console.log(`  · dry-run create: ${spec.name}`);
+    console.log(JSON.stringify(payload, null, 2));
+    return 'dry-run';
+  }
+
+  const created = createdHogFunctionSchema.parse(
+    await phFetch(`/api/projects/${PROJECT_ID}/hog_functions/`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  );
+  console.log(`  + created: ${spec.name} (${created.id})`);
+  return 'created';
+}
+
+async function main() {
+  console.log(`PostHog project ${PROJECT_ID} @ ${HOST}`);
+  if (DRY_RUN) console.log('DRY_RUN=1 — no writes');
+
+  const slack = await listSlackIntegrations();
+  const primarySlack = slack[0];
+  if (!primarySlack) {
+    console.error(
+      'No Slack integration found. Connect Slack in PostHog → Settings → Integrations first,\n' +
+        'then invite the PostHog app to #product-alerts and #ops-alerts.'
+    );
+    process.exit(1);
+  }
+  const slackWorkspaceId = primarySlack.id;
+  console.log(`Using Slack integration id=${slackWorkspaceId}`);
+
+  const existing = await listHogFunctions();
+  console.log(`Found ${existing.length} existing hog functions`);
+
+  let created = 0;
+  let skipped = 0;
+  for (const spec of specs()) {
+    const result = await ensureDestination(existing, slackWorkspaceId, spec);
+    if (result === 'created') created += 1;
+    if (result === 'exists') skipped += 1;
+  }
+
+  console.log('\nDone.');
+  console.log(`  created=${created} already_existed=${skipped}`);
+  console.log(`
+Manual follow-ups (not automated — needs baseline tuning):
+  1. Invite the PostHog Slack app to ${PRODUCT_CHANNEL} and ${OPS_CHANNEL}
+     (channel details → Integrations → Add apps → PostHog)
+  2. Logs ERROR alert → PostHog Logs → Alerts:
+     severity error/fatal → destination Slack ${OPS_CHANNEL}
+     Simulate against -7d history before enabling (see authoring-log-alerts skill).
+  3. Confirm error-tracking spike detection is enabled for the project.
+  4. Fire a test: sign up / create a sequence in prod (or capture with posthog-node).
+`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -114,7 +114,7 @@ export function AuthForm({
           otp: DEV_OTP_CODE,
         });
         if (!signIn.error) {
-          posthog.capture('user_signed_in', { method: 'email_otp_dev' });
+          // user_signed_in is captured server-side on session create (#1088).
           await navigate({ to: redirectTo });
           return;
         }

--- a/src/components/auth/verify-form.tsx
+++ b/src/components/auth/verify-form.tsx
@@ -19,7 +19,6 @@ import {
 } from '@/components/ui/input-otp';
 import { useHydrated } from '@/hooks/use-hydrated';
 import { authClient } from '@/lib/auth/client';
-import { usePostHog } from '@posthog/react';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useCallback, useEffect, useState, useTransition } from 'react';
 
@@ -38,7 +37,6 @@ export function VerifyForm({
 }: VerifyFormProps) {
   const navigate = useNavigate();
   const hydrated = useHydrated();
-  const posthog = usePostHog();
   const [otp, setOtp] = useState('');
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string | null>(null);
@@ -61,8 +59,7 @@ export function VerifyForm({
             return;
           }
 
-          posthog.capture('user_signed_in', { method: 'email_otp' });
-
+          // user_signed_in is captured server-side on session create (#1088).
           await navigate({ to: redirectTo });
         } catch (err) {
           logger.error('Verify OTP error:', { err });
@@ -70,7 +67,7 @@ export function VerifyForm({
         }
       });
     },
-    [email, navigate, posthog, redirectTo]
+    [email, navigate, redirectTo]
   );
 
   // Auto-verify when OTP is complete (6 digits)

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -680,17 +680,8 @@ export const ScriptView: FC<{
   const handleCancel = onCancel;
 
   const executeRegeneration = () => {
-    posthog.capture('sequence_generated', {
-      is_editing: isEditing,
-      aspect_ratio: aspectRatio,
-      image_models: imageModels,
-      video_models: videoModels,
-      audio_models: audioModels,
-      auto_generate_motion: autoGenerateMotion,
-      auto_generate_music: autoGenerateMusic,
-      analysis_model_count: analysisModels.length,
-      script_length: (script ?? baseScript ?? '').length,
-    });
+    // sequence_generated is captured server-side in createSequences (#1088)
+    // so dashboard + public API both feed #product-alerts once.
     createSequenceMutation.mutate(
       {
         title: undefined,

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -33,6 +33,7 @@ import {
 import { apiKey } from '@better-auth/api-key';
 import { passkey as passkeyPlugin } from '@better-auth/passkey';
 
+import { captureProductEvent } from '@/lib/observability/product-events';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'auth', 'config']);
@@ -269,6 +270,32 @@ function createAuth() {
                 metadata: { signupGrant: true },
               }
             );
+
+            // First-time account only — drives #product-alerts via PostHog (#1088).
+            captureProductEvent({
+              distinctId: user.id,
+              event: 'user_signed_up',
+              properties: {
+                email: user.email,
+                name: user.name,
+                team_id: team.id,
+              },
+            });
+          },
+        },
+      },
+      // Real session rows only (API-key auth uses an in-memory session and
+      // does not hit this hook). Covers email OTP, Google, and passkeys.
+      session: {
+        create: {
+          after: async (session, context) => {
+            captureProductEvent({
+              distinctId: session.userId,
+              event: 'user_signed_in',
+              properties: {
+                path: context?.path,
+              },
+            });
           },
         },
       },

--- a/src/lib/observability/product-events.test.ts
+++ b/src/lib/observability/product-events.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const capture = vi.fn();
+vi.doMock('@/lib/posthog-server', () => ({
+  getPostHogClient: () => ({ capture }),
+}));
+
+const { captureProductEvent } = await import('./product-events');
+
+describe('captureProductEvent', () => {
+  it('forwards to posthog-node with distinctId + event', () => {
+    capture.mockClear();
+    captureProductEvent({
+      distinctId: 'user_1',
+      event: 'user_signed_up',
+      properties: { email: 'a@b.com' },
+    });
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: 'user_1',
+      event: 'user_signed_up',
+      properties: { email: 'a@b.com' },
+    });
+  });
+});

--- a/src/lib/observability/product-events.ts
+++ b/src/lib/observability/product-events.ts
@@ -1,0 +1,44 @@
+/**
+ * Product analytics events that drive PostHog → Slack alerts (#1088).
+ *
+ * Prefer server-side capture so OAuth redirects, passkeys, and the public API
+ * all emit the same events. Failures must never break the critical path.
+ */
+
+import { getPostHogClient } from '@/lib/posthog-server';
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'observability', 'product-events']);
+
+type ProductEventName =
+  | 'user_signed_up'
+  | 'user_signed_in'
+  | 'sequence_generated';
+
+export type CaptureProductEventArgs = {
+  distinctId: string;
+  event: ProductEventName;
+  properties?: Record<string, unknown>;
+};
+
+/**
+ * Fire-and-forget PostHog product event. Never throws.
+ */
+export function captureProductEvent(args: CaptureProductEventArgs): void {
+  try {
+    const posthog = getPostHogClient();
+    if (!posthog) return;
+    posthog.capture({
+      distinctId: args.distinctId,
+      event: args.event,
+      properties: args.properties,
+    });
+  } catch (err) {
+    logger.error('captureProductEvent failed', {
+      event: args.event,
+      distinctId: args.distinctId,
+      err,
+    });
+  }
+}

--- a/src/lib/sequences/create-sequences.ts
+++ b/src/lib/sequences/create-sequences.ts
@@ -32,6 +32,7 @@ import type { Sequence } from '@/types/database';
 import type { CreateSequenceInput } from '@/lib/schemas/sequence.schemas';
 import { copySequenceElements } from '@/lib/sequence-elements/copy-sequence-elements';
 import { promoteTempElements } from '@/lib/sequence-elements/promote-temp-elements';
+import { captureProductEvent } from '@/lib/observability/product-events';
 import { bumpStylePopularity } from '@/lib/style/bump-style-popularity';
 import { triggerStoryboard } from '@/lib/workflow/launchers';
 import type { StoryboardWorkflowInput } from '@/lib/workflow/types';
@@ -247,12 +248,34 @@ export const createSequences = createServerOnlyFn(
 
     // One click = one popularity bump + one analytics event, regardless of how
     // many analysis models the caller picked. Fire-and-forget — never block.
+    const sequenceIds = created.map((c) => c.sequence.id);
     bumpStylePopularity({
       scopedDb: context.scopedDb,
       styleId,
-      sequenceIds: created.map((c) => c.sequence.id),
+      sequenceIds,
       teamId,
       userId: context.user.id,
+    });
+
+    // Server-side so dashboard + public API both feed #product-alerts (#1088).
+    captureProductEvent({
+      distinctId: context.user.id,
+      event: 'sequence_generated',
+      properties: {
+        team_id: teamId,
+        style_id: styleId,
+        aspect_ratio: aspectRatio,
+        sequence_ids: sequenceIds,
+        sequence_count: sequenceIds.length,
+        analysis_model_count: analysisModels.length,
+        image_models: imageModels,
+        video_models: videoModels,
+        audio_models: audioModels,
+        auto_generate_motion: autoGenerateMotion,
+        auto_generate_music: autoGenerateMusic,
+        script_length: data.script.length,
+        source: sourceSequenceId ? 'regenerate' : 'create',
+      },
     });
 
     return {


### PR DESCRIPTION
## Summary
- Server-side `user_signed_up` / `user_signed_in` / `sequence_generated` events for reliable PostHog capture (covers Google, passkeys, public API)
- Removes duplicate client captures that would double-fire Slack
- `scripts/setup-posthog-slack-alerts.ts` for idempotent destination setup
- PostHog Production already wired: product events → `#product-alerts`, error spikes + ERROR logs → `#ops-alerts`

## Test plan
- [ ] Deploy PR preview / merge; confirm events appear in PostHog after a real signup, sign-in, and sequence create
- [ ] Confirm `#product-alerts` receives messages (non-`@openstory.so` / non-test accounts)
- [ ] Confirm `#ops-alerts` has spike + log destinations enabled in PostHog
- [ ] `bun run test src/lib/observability/product-events.test.ts`

Closes #1088