### PR TITLE
feat(#1090): live-update credit balance pill via billing SSE

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -100,7 +100,6 @@ export function AppSidebar() {
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
-              <CreditBalancePill />
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
@@ -145,6 +144,8 @@ export function AppSidebar() {
           </SidebarMenuItem>
         </SidebarMenu>
         <SidebarSeparator />
+        {/* Quiet status chip — not a nav peer of Sequences/Gallery (#1090). */}
+        <CreditBalancePill />
         <SidebarMenu>
           <UserSidebarFooter />
         </SidebarMenu>

--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -1,24 +1,32 @@
 /**
- * Quiet credit-balance chip in the sidebar footer (above the user menu).
+ * Quiet credit-balance control in the sidebar footer (below the social
+ * separator, above the user menu) — account chrome, not product nav (#1090).
  *
  * Visible when:
  * 1. Low balance with no safety net (amber)
  * 2. Balance topped up — brief green flash
  * 3. User toggled "always show" on the credits page (muted)
  *
- * While visible, subscribes to team billing SSE so generation / enhance
- * deductions update the amount live (#1090). Intentionally not a nav row —
- * dollars are status chrome, not a peer of Sequences/Gallery.
+ * Expanded: wallet + $amount as muted text (no badge chrome).
+ * Collapsed (icon rail): wallet icon only + tooltip with amount — never the
+ * dollar string, so it cannot overlap the avatar.
+ *
+ * Subscribes to team billing SSE only while visible.
  */
 
 import { cn } from '@/lib/utils';
-import { Badge } from '@/components/ui/badge';
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '@/components/ui/sidebar';
 import { useBalanceFlash } from '@/hooks/use-balance-flash';
 import { useBillingBalance } from '@/hooks/use-billing-balance';
 import { useBillingBalanceRealtime } from '@/hooks/use-billing-balance-realtime';
 import { useBillingGateQuery } from '@/hooks/use-billing-gate';
 import { useShowBalance } from '@/hooks/use-show-balance';
 import { Link } from '@tanstack/react-router';
+import { Wallet } from 'lucide-react';
 
 export const CreditBalancePill: React.FC = () => {
   const { balance, teamId, isLowBalance } = useBillingBalance();
@@ -33,44 +41,47 @@ export const CreditBalancePill: React.FC = () => {
   const isLowBalanceVisible = isLowBalance && !hasSafetyNet;
   const isVisible = isLowBalanceVisible || showBalance || isFlashing;
 
-  // Subscribe only while the chip would render — no SSE when hidden.
   useBillingBalanceRealtime(teamId, isVisible);
 
   if (!isVisible) return null;
 
-  // Flash (green) takes priority, then low-balance (amber), then muted.
-  const badgeTone = isFlashing
-    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
+  // Flash (green) > low (amber) > muted account chrome.
+  const toneClass = isFlashing
+    ? 'text-emerald-600 dark:text-emerald-400'
     : isLowBalanceVisible
-      ? 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400'
-      : 'border-border/50 bg-transparent text-muted-foreground';
+      ? 'text-amber-600 dark:text-amber-400'
+      : 'text-muted-foreground';
 
   const amount = `$${balance?.toFixed(2) ?? '0.00'}`;
+  const tooltip = `Credits · ${amount}`;
 
   return (
-    <div className="px-2 py-1 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
-      <Link
-        to="/credits"
-        search={{ tab: 'balance' }}
-        title={`Credits ${amount}`}
-        aria-label={`Credit balance ${amount}. Open credits.`}
-        className={cn(
-          'flex w-full items-center justify-start rounded-md outline-none',
-          'focus-visible:ring-2 focus-visible:ring-ring',
-          'group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center'
-        )}
-      >
-        <Badge
-          variant="outline"
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          asChild
+          tooltip={tooltip}
           className={cn(
-            'max-w-full truncate font-normal tabular-nums',
             'animate-[balance-flash-in_300ms_ease-out_both]',
-            badgeTone
+            toneClass,
+            // Keep hover/active readable without fighting the tone tint.
+            'hover:text-sidebar-accent-foreground data-active:text-sidebar-accent-foreground'
           )}
         >
-          {amount}
-        </Badge>
-      </Link>
-    </div>
+          <Link
+            to="/credits"
+            search={{ tab: 'balance' }}
+            aria-label={`Credit balance ${amount}. Open credits.`}
+          >
+            <Wallet />
+            {/* Amount hides in icon mode via SidebarMenuButton truncation
+                (span:last-child); tooltip carries the full amount. */}
+            <span className="tabular-nums" aria-live="polite">
+              {amount}
+            </span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
   );
 };

--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -4,9 +4,13 @@
  * 1. Low balance with no safety net (amber warning)
  * 2. Balance topped up — stays until credits are drawn down (green)
  * 3. User toggled "always show" in credits page (neutral)
+ *
+ * While visible, subscribes to team billing SSE so generation deductions
+ * update the amount live (#1090).
  */
 
 import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
 import {
   SidebarMenuBadge,
   SidebarMenuButton,
@@ -14,13 +18,14 @@ import {
 } from '@/components/ui/sidebar';
 import { useBalanceFlash } from '@/hooks/use-balance-flash';
 import { useBillingBalance } from '@/hooks/use-billing-balance';
+import { useBillingBalanceRealtime } from '@/hooks/use-billing-balance-realtime';
 import { useBillingGateQuery } from '@/hooks/use-billing-gate';
 import { useShowBalance } from '@/hooks/use-show-balance';
 import { Link } from '@tanstack/react-router';
 import { Wallet } from 'lucide-react';
 
 export const CreditBalancePill: React.FC = () => {
-  const { balance, isLowBalance } = useBillingBalance();
+  const { balance, teamId, isLowBalance } = useBillingBalance();
   const { data: gateStatus } = useBillingGateQuery();
   const { showBalance } = useShowBalance();
   const { isFlashing } = useBalanceFlash();
@@ -32,14 +37,17 @@ export const CreditBalancePill: React.FC = () => {
   const isLowBalanceVisible = isLowBalance && !hasSafetyNet;
   const isVisible = isLowBalanceVisible || showBalance || isFlashing;
 
+  // Subscribe only while the pill would render — no SSE when hidden.
+  useBillingBalanceRealtime(teamId, isVisible);
+
   if (!isVisible) return null;
 
-  // Flash (green) takes priority, then low-balance (amber), then neutral
-  const colorClass = isFlashing
-    ? 'text-emerald-600 dark:text-emerald-400'
+  // Flash (green) takes priority, then low-balance (amber), then neutral.
+  const badgeTone = isFlashing
+    ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-transparent'
     : isLowBalanceVisible
-      ? 'text-amber-600 dark:text-amber-400'
-      : '';
+      ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-transparent'
+      : undefined;
 
   return (
     <SidebarMenuItem>
@@ -49,13 +57,17 @@ export const CreditBalancePill: React.FC = () => {
           <span>Credits</span>
         </Link>
       </SidebarMenuButton>
-      <SidebarMenuBadge
-        className={cn(
-          'tabular-nums animate-[balance-flash-in_300ms_ease-out_both]',
-          colorClass
-        )}
-      >
-        ${balance?.toFixed(2) ?? '0.00'}
+      {/* SidebarMenuBadge is only the absolute positioner; Badge is the pill. */}
+      <SidebarMenuBadge className="h-auto min-w-0 p-0 peer-hover/menu-button:text-inherit peer-data-active/menu-button:text-inherit">
+        <Badge
+          variant="secondary"
+          className={cn(
+            'tabular-nums animate-[balance-flash-in_300ms_ease-out_both]',
+            badgeTone
+          )}
+        >
+          ${balance?.toFixed(2) ?? '0.00'}
+        </Badge>
       </SidebarMenuBadge>
     </SidebarMenuItem>
   );

--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -1,28 +1,24 @@
 /**
- * Credit Balance Sidebar Row
- * Shows credit balance as a sidebar nav row. Visible when:
- * 1. Low balance with no safety net (amber warning)
- * 2. Balance topped up — stays until credits are drawn down (green)
- * 3. User toggled "always show" in credits page (neutral)
+ * Quiet credit-balance chip in the sidebar footer (above the user menu).
  *
- * While visible, subscribes to team billing SSE so generation deductions
- * update the amount live (#1090).
+ * Visible when:
+ * 1. Low balance with no safety net (amber)
+ * 2. Balance topped up — brief green flash
+ * 3. User toggled "always show" on the credits page (muted)
+ *
+ * While visible, subscribes to team billing SSE so generation / enhance
+ * deductions update the amount live (#1090). Intentionally not a nav row —
+ * dollars are status chrome, not a peer of Sequences/Gallery.
  */
 
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
-import {
-  SidebarMenuBadge,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@/components/ui/sidebar';
 import { useBalanceFlash } from '@/hooks/use-balance-flash';
 import { useBillingBalance } from '@/hooks/use-billing-balance';
 import { useBillingBalanceRealtime } from '@/hooks/use-billing-balance-realtime';
 import { useBillingGateQuery } from '@/hooks/use-billing-gate';
 import { useShowBalance } from '@/hooks/use-show-balance';
 import { Link } from '@tanstack/react-router';
-import { Wallet } from 'lucide-react';
 
 export const CreditBalancePill: React.FC = () => {
   const { balance, teamId, isLowBalance } = useBillingBalance();
@@ -37,38 +33,44 @@ export const CreditBalancePill: React.FC = () => {
   const isLowBalanceVisible = isLowBalance && !hasSafetyNet;
   const isVisible = isLowBalanceVisible || showBalance || isFlashing;
 
-  // Subscribe only while the pill would render — no SSE when hidden.
+  // Subscribe only while the chip would render — no SSE when hidden.
   useBillingBalanceRealtime(teamId, isVisible);
 
   if (!isVisible) return null;
 
-  // Flash (green) takes priority, then low-balance (amber), then neutral.
+  // Flash (green) takes priority, then low-balance (amber), then muted.
   const badgeTone = isFlashing
-    ? 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-transparent'
+    ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-400'
     : isLowBalanceVisible
-      ? 'bg-amber-500/15 text-amber-700 dark:text-amber-400 border-transparent'
-      : undefined;
+      ? 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-400'
+      : 'border-border/50 bg-transparent text-muted-foreground';
+
+  const amount = `$${balance?.toFixed(2) ?? '0.00'}`;
 
   return (
-    <SidebarMenuItem>
-      <SidebarMenuButton asChild tooltip="Credits">
-        <Link to="/credits">
-          <Wallet />
-          <span>Credits</span>
-        </Link>
-      </SidebarMenuButton>
-      {/* SidebarMenuBadge is only the absolute positioner; Badge is the pill. */}
-      <SidebarMenuBadge className="h-auto min-w-0 p-0 peer-hover/menu-button:text-inherit peer-data-active/menu-button:text-inherit">
+    <div className="px-2 py-1 group-data-[collapsible=icon]:flex group-data-[collapsible=icon]:justify-center">
+      <Link
+        to="/credits"
+        search={{ tab: 'balance' }}
+        title={`Credits ${amount}`}
+        aria-label={`Credit balance ${amount}. Open credits.`}
+        className={cn(
+          'flex w-full items-center justify-start rounded-md outline-none',
+          'focus-visible:ring-2 focus-visible:ring-ring',
+          'group-data-[collapsible=icon]:w-auto group-data-[collapsible=icon]:justify-center'
+        )}
+      >
         <Badge
-          variant="secondary"
+          variant="outline"
           className={cn(
-            'tabular-nums animate-[balance-flash-in_300ms_ease-out_both]',
+            'max-w-full truncate font-normal tabular-nums',
+            'animate-[balance-flash-in_300ms_ease-out_both]',
             badgeTone
           )}
         >
-          ${balance?.toFixed(2) ?? '0.00'}
+          {amount}
         </Badge>
-      </SidebarMenuBadge>
-    </SidebarMenuItem>
+      </Link>
+    </div>
   );
 };

--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -7,7 +7,7 @@
  * 2. Balance topped up — brief green flash
  * 3. User toggled "always show" on the credits page (muted)
  *
- * Expanded: wallet + $amount as muted text (no badge chrome).
+ * Expanded: wallet + $amount at normal sidebar foreground weight.
  * Collapsed (icon rail): wallet icon only + tooltip with amount — never the
  * dollar string, so it cannot overlap the avatar.
  *
@@ -45,12 +45,12 @@ export const CreditBalancePill: React.FC = () => {
 
   if (!isVisible) return null;
 
-  // Flash (green) > low (amber) > muted account chrome.
+  // Flash / low only — default inherits sidebar menu foreground (not muted).
   const toneClass = isFlashing
-    ? 'text-emerald-600 dark:text-emerald-400'
+    ? 'text-emerald-600 dark:text-emerald-400 hover:text-emerald-600 dark:hover:text-emerald-400'
     : isLowBalanceVisible
-      ? 'text-amber-600 dark:text-amber-400'
-      : 'text-muted-foreground';
+      ? 'text-amber-600 dark:text-amber-400 hover:text-amber-600 dark:hover:text-amber-400'
+      : undefined;
 
   const amount = `$${balance?.toFixed(2) ?? '0.00'}`;
   const tooltip = `Credits · ${amount}`;
@@ -63,9 +63,7 @@ export const CreditBalancePill: React.FC = () => {
           tooltip={tooltip}
           className={cn(
             'animate-[balance-flash-in_300ms_ease-out_both]',
-            toneClass,
-            // Keep hover/active readable without fighting the tone tint.
-            'hover:text-sidebar-accent-foreground data-active:text-sidebar-accent-foreground'
+            toneClass
           )}
         >
           <Link

--- a/src/components/layout/user-sidebar-footer.tsx
+++ b/src/components/layout/user-sidebar-footer.tsx
@@ -127,7 +127,7 @@ export function UserSidebarFooter() {
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
-            <Link to="/credits">
+            <Link to="/credits" search={{ tab: 'balance' }}>
               <Wallet className="mr-2 h-4 w-4" />
               Credits
             </Link>

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -33,6 +33,8 @@ import {
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { enhanceScriptStreamFn } from '@/functions/ai';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
+import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
+import { BILLING_TRANSACTIONS_KEY } from '@/hooks/use-billing-balance-realtime';
 import { useBillingGate } from '@/hooks/use-billing-gate';
 import { useGenerationSettings } from '@/hooks/use-generation-settings';
 import { useComposedScript } from '@/hooks/use-scenes';
@@ -46,6 +48,7 @@ import { useSequenceLocations } from '@/hooks/use-sequence-locations';
 import { useCreateSequence } from '@/hooks/use-sequences';
 import { useRecommendedStyles, useStyles } from '@/hooks/use-styles';
 import { toEnhanceInputs } from '@/lib/ai/enhance-inputs';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_MUSIC_MODEL,
@@ -141,6 +144,7 @@ export const ScriptView: FC<{
   onStyleChange,
   allowScriptEdit = false,
 }) => {
+  const queryClient = useQueryClient();
   const isEditing = !!sequence?.id;
   const { data: composedScriptData } = useComposedScript(sequence?.id);
   const composedScript = composedScriptData?.script;
@@ -808,6 +812,14 @@ export const ScriptView: FC<{
         setScript(accumulated);
       }
       setEnhance('canUndoEnhance', true);
+      // Charge lands when the stream finishes — keep the credit chip in sync
+      // even if the billing SSE is delayed or dropped on this request path.
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_BALANCE_KEY],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_TRANSACTIONS_KEY],
+      });
       // Pre-warm the style shortlist off the freshly enhanced script so the
       // picker is ready the moment the user looks for it.
       // Billing is already gated above (handleEnhance returns early when

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -533,9 +533,9 @@ function ShowBalanceToggle() {
   return (
     <div className="flex items-center justify-between border-t pt-4">
       <div>
-        <p className="text-sm font-medium">Show balance in header</p>
+        <p className="text-sm font-medium">Show balance in sidebar</p>
         <p className="text-xs text-muted-foreground">
-          Always display your credit balance
+          Always display your credit balance above your account
         </p>
       </div>
       <Switch checked={showBalance} onCheckedChange={setShowBalance} />

--- a/src/components/settings/transaction-settings.tsx
+++ b/src/components/settings/transaction-settings.tsx
@@ -6,6 +6,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getTransactionsFn } from '@/functions/billing';
+import { BILLING_TRANSACTIONS_KEY } from '@/hooks/use-billing-balance-realtime';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { CreditCard, ExternalLink } from 'lucide-react';
 import React from 'react';
@@ -73,7 +74,7 @@ export function TransactionSettings() {
     hasNextPage,
     isFetchingNextPage,
   } = useInfiniteQuery({
-    queryKey: ['billing-transactions'],
+    queryKey: [...BILLING_TRANSACTIONS_KEY],
     queryFn: ({ pageParam }) =>
       getTransactionsFn({
         data: { limit: PAGE_SIZE, offset: pageParam },

--- a/src/functions/billing.ts
+++ b/src/functions/billing.ts
@@ -59,6 +59,7 @@ export const getBillingBalanceFn = createServerFn({ method: 'GET' })
     ]);
 
     return {
+      teamId: context.teamId,
       balance: microsToUsd(balance),
       stripeEnabled: isStripeEnabled(),
       autoTopUp: {

--- a/src/hooks/use-billing-balance-realtime.ts
+++ b/src/hooks/use-billing-balance-realtime.ts
@@ -1,0 +1,77 @@
+/**
+ * Live credit-balance updates over SSE (#1090).
+ *
+ * Subscribes to `billing:${teamId}` only while the credit pill is visible so
+ * idle sessions pay no realtime cost. On `billing.balance:updated`, optimistically
+ * patches the balance query and invalidates transactions for the ledger tab.
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
+import { billingChannelId } from '@/lib/realtime';
+import { useRealtime } from '@/lib/realtime/client';
+
+export const BILLING_TRANSACTIONS_KEY = ['billing-transactions'] as const;
+
+type BalanceQueryData = {
+  teamId?: string;
+  balance: number;
+  stripeEnabled: boolean;
+  autoTopUp: {
+    enabled: boolean;
+    thresholdUsd: number | null;
+    amountUsd: number | null;
+  };
+  hasPaymentMethod: boolean;
+};
+
+/**
+ * @param teamId - Active team; subscription is a no-op while undefined
+ * @param enabled - True only while the credit pill is on-screen
+ */
+export function useBillingBalanceRealtime(
+  teamId: string | undefined,
+  enabled: boolean
+) {
+  const queryClient = useQueryClient();
+
+  const onData = useCallback(
+    (msg: {
+      event: 'billing.balance:updated';
+      data: {
+        teamId: string;
+        balanceUsd: number;
+        amountUsd: number;
+        transactionId: string;
+        type:
+          | 'credit_purchase'
+          | 'credit_usage'
+          | 'credit_refund'
+          | 'credit_adjustment';
+      };
+    }) => {
+      const { balanceUsd } = msg.data;
+
+      queryClient.setQueryData<BalanceQueryData>(
+        [...BILLING_BALANCE_KEY],
+        (prev) => (prev ? { ...prev, balance: balanceUsd } : prev)
+      );
+
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_BALANCE_KEY],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...BILLING_TRANSACTIONS_KEY],
+      });
+    },
+    [queryClient]
+  );
+
+  useRealtime({
+    channels: teamId ? [billingChannelId(teamId)] : [],
+    events: ['billing.balance:updated'] as const,
+    enabled: Boolean(enabled && teamId),
+    onData,
+  });
+}

--- a/src/hooks/use-billing-balance.ts
+++ b/src/hooks/use-billing-balance.ts
@@ -30,6 +30,7 @@ export function useBillingBalance() {
   return {
     ...query,
     balance,
+    teamId: query.data?.teamId,
     stripeEnabled: query.data?.stripeEnabled ?? false,
     isLowBalance:
       balance !== null && balance > 0 && balance <= lowBalanceThreshold,

--- a/src/hooks/use-show-balance.ts
+++ b/src/hooks/use-show-balance.ts
@@ -1,24 +1,77 @@
 /**
  * Show Balance Preference Hook
- * localStorage-backed toggle for always showing credit balance in the header
+ *
+ * localStorage-backed toggle for always showing the credit balance in the
+ * sidebar. Module store + useSyncExternalStore so the credits-page switch and
+ * CreditBalancePill stay in sync without a reload (same pattern as
+ * useActiveVideoModel).
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 
 const STORAGE_KEY = 'openstory:show-balance';
 
-export function useShowBalance() {
-  const [show, setShow] = useState(false);
+/** `undefined` = not yet hydrated from localStorage. */
+let cached: boolean | undefined;
+const listeners = new Set<() => void>();
 
-  // Hydration-safe: load real value in useEffect
-  useEffect(() => {
-    setShow(localStorage.getItem(STORAGE_KEY) === 'true');
-  }, []);
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+let storageListenerAttached = false;
+function ensureStorageListener() {
+  if (storageListenerAttached || typeof window === 'undefined') return;
+  storageListenerAttached = true;
+  window.addEventListener('storage', (event) => {
+    if (event.key !== STORAGE_KEY) return;
+    cached = event.newValue === 'true';
+    emit();
+  });
+}
+
+function subscribe(listener: () => void) {
+  ensureStorageListener();
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function hydrate(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function read(): boolean {
+  if (cached !== undefined) return cached;
+  const value = hydrate();
+  cached = value;
+  return value;
+}
+
+function write(value: boolean) {
+  cached = value;
+  if (typeof window !== 'undefined') {
+    try {
+      localStorage.setItem(STORAGE_KEY, String(value));
+    } catch {
+      // private mode / quota — keep in-memory value
+    }
+  }
+  emit();
+}
+
+export function useShowBalance() {
+  const showBalance = useSyncExternalStore(subscribe, read, () => false);
 
   const setShowBalance = useCallback((value: boolean) => {
-    setShow(value);
-    localStorage.setItem(STORAGE_KEY, String(value));
+    write(value);
   }, []);
 
-  return { showBalance: show, setShowBalance };
+  return { showBalance, setShowBalance };
 }

--- a/src/lib/db/scoped/billing-balance-emit.test.ts
+++ b/src/lib/db/scoped/billing-balance-emit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * #1090 — `deductCredits` / `addCredits` emit `billing.balance:updated` only for
+ * new ledger rows (not idempotent workflow replays).
+ */
+
+import { micros } from '@/lib/billing/money';
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import { credits, teams, transactions, user } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
+
+const emitMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/realtime', () => ({
+  getBillingChannel: () => ({
+    emit: emitMock,
+    history: async () => [],
+  }),
+  billingChannelId: (teamId: string) => `billing:${teamId}`,
+}));
+
+// Dynamic import so the mock applies (vi.mock is hoisted; static import of
+// createBillingMethods would bind before the mock in some bundlers — follow
+// the project doMock pattern via mocked module + static import is fine with
+// vi.mock hoisting in Vitest).
+import { createBillingMethods } from './billing';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let userId = '';
+
+const STARTING_BALANCE = 100_000_000; // $100
+
+async function seed() {
+  await db.delete(transactions);
+  await db.delete(credits);
+  await db.delete(teams);
+  await db.delete(user);
+
+  teamId = generateId();
+  userId = generateId();
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  await db
+    .insert(user)
+    .values({ id: userId, name: 'U', email: `${userId}@example.com` });
+  await db.insert(credits).values({ teamId, balance: STARTING_BALANCE });
+  emitMock.mockClear();
+}
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await seed();
+});
+
+describe('billing.balance:updated emit (#1090)', () => {
+  const rawCost = micros(1_000_000); // $1
+
+  it('emits once on a new deductCredits charge', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    const result = await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-1:image',
+    });
+
+    // void emit — microtask; flush
+    await Promise.resolve();
+
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith('billing.balance:updated', {
+      teamId,
+      balanceUsd: 99,
+      amountUsd: -1,
+      transactionId: result.transactionId,
+      type: 'credit_usage',
+    });
+  });
+
+  it('does not re-emit on idempotent deductCredits replay', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-1:image',
+    });
+    await Promise.resolve();
+    emitMock.mockClear();
+
+    await billing.deductCredits(rawCost, {
+      idempotencyKey: 'wf-1:image',
+    });
+    await Promise.resolve();
+
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it('emits on addCredits', async () => {
+    const billing = createBillingMethods(db, teamId, userId);
+    const result = await billing.addCredits(micros(5_000_000), {
+      description: 'test top-up',
+    });
+    await Promise.resolve();
+
+    expect(result).not.toBeNull();
+    if (!result) return;
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock).toHaveBeenCalledWith('billing.balance:updated', {
+      teamId,
+      balanceUsd: 105,
+      amountUsd: 5,
+      transactionId: result.transactionId,
+      type: 'credit_purchase',
+    });
+  });
+});

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -41,19 +41,23 @@ import { giftTokenRedemptions, giftTokens } from '../schema';
 import { getLogger } from '@/lib/observability/logger';
 
 /**
- * Best-effort live balance push for the credit pill (#1090). Never throws —
- * realtime is progress signalling; the ledger write already committed.
- * Call only after a *new* transaction row was inserted (not on idempotent replay).
+ * Best-effort live balance push for the credit pill (#1090).
+ *
+ * **Awaited** (emit itself never throws): request-scoped paths like enhance
+ * script finish the streaming response right after `deductCredits`, and a
+ * fire-and-forget DO fetch can be dropped when the isolate tears down.
+ * Call only after a *new* transaction row was inserted (not on idempotent
+ * replay).
  */
-function emitBalanceUpdated(opts: {
+async function emitBalanceUpdated(opts: {
   teamId: string;
   newBalance: Microdollars;
   /** Signed ledger amount (negative for usage). */
   amountMicros: Microdollars;
   transactionId: string;
   type: TransactionType;
-}): void {
-  void getBillingChannel(opts.teamId).emit('billing.balance:updated', {
+}): Promise<void> {
+  await getBillingChannel(opts.teamId).emit('billing.balance:updated', {
     teamId: opts.teamId,
     balanceUsd: microsToUsd(opts.newBalance),
     amountUsd: microsToUsd(opts.amountMicros),
@@ -281,7 +285,7 @@ export function createBillingMethods(
     });
 
     const newBalance = micros(updated.balance);
-    emitBalanceUpdated({
+    await emitBalanceUpdated({
       teamId,
       newBalance,
       amountMicros,
@@ -452,7 +456,7 @@ export function createBillingMethods(
     }
 
     if (isNewCharge) {
-      emitBalanceUpdated({
+      await emitBalanceUpdated({
         teamId,
         newBalance,
         amountMicros: negateMicros(chargedAmount),

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -33,11 +33,34 @@ import type {
   TransactionType,
 } from '@/lib/db/schema/credits';
 import { ValidationError } from '@/lib/errors';
+import { getBillingChannel } from '@/lib/realtime';
 import { and, count, desc, eq, notExists, sql } from 'drizzle-orm';
 import { generateId } from '../id';
 import { giftTokenRedemptions, giftTokens } from '../schema';
 
 import { getLogger } from '@/lib/observability/logger';
+
+/**
+ * Best-effort live balance push for the credit pill (#1090). Never throws —
+ * realtime is progress signalling; the ledger write already committed.
+ * Call only after a *new* transaction row was inserted (not on idempotent replay).
+ */
+function emitBalanceUpdated(opts: {
+  teamId: string;
+  newBalance: Microdollars;
+  /** Signed ledger amount (negative for usage). */
+  amountMicros: Microdollars;
+  transactionId: string;
+  type: TransactionType;
+}): void {
+  void getBillingChannel(opts.teamId).emit('billing.balance:updated', {
+    teamId: opts.teamId,
+    balanceUsd: microsToUsd(opts.newBalance),
+    amountUsd: microsToUsd(opts.amountMicros),
+    transactionId: opts.transactionId,
+    type: opts.type,
+  });
+}
 
 const logger = getLogger(['openstory', 'db', 'billing']);
 
@@ -257,7 +280,16 @@ export function createBillingMethods(
       expiresAt: calculateExpiryDate(),
     });
 
-    return { newBalance: micros(updated.balance), transactionId };
+    const newBalance = micros(updated.balance);
+    emitBalanceUpdated({
+      teamId,
+      newBalance,
+      amountMicros,
+      transactionId,
+      type: txType,
+    });
+
+    return { newBalance, transactionId };
   }
 
   async function saveStripeCustomerId(stripeCustomerId: string): Promise<void> {
@@ -390,6 +422,9 @@ export function createBillingMethods(
     const newBalance = micros(balanceRow.balance);
 
     let transactionId = insertedRows[0]?.id;
+    // True only when this call wrote the ledger row — not an idempotent replay.
+    // Don't fire "charged $X" side effects (realtime) on replay.
+    const isNewCharge = Boolean(transactionId);
     if (!transactionId) {
       if (!idempotencyKey) {
         throw new Error(
@@ -414,6 +449,16 @@ export function createBillingMethods(
         );
       }
       transactionId = existing.id;
+    }
+
+    if (isNewCharge) {
+      emitBalanceUpdated({
+        teamId,
+        newBalance,
+        amountMicros: negateMicros(chargedAmount),
+        transactionId,
+        type: 'credit_usage',
+      });
     }
 
     void maybeAutoTopUp(newBalance).catch((err) => {

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -37,6 +37,27 @@ export const realtimeSchema = {
     }),
   },
 
+  // Team billing ledger updates (#1090). Channel `billing:${teamId}`; the
+  // credit-balance pill subscribes only while visible so idle sessions pay no
+  // SSE cost. Payload is enough to patch the pill optimistically; clients also
+  // invalidate the balance + transactions queries.
+  billing: {
+    'balance:updated': z.object({
+      teamId: z.string(),
+      /** Post-mutation balance in USD. */
+      balanceUsd: z.number(),
+      /** Signed ledger amount in USD (negative for usage, positive for top-ups). */
+      amountUsd: z.number(),
+      transactionId: z.string(),
+      type: z.enum([
+        'credit_purchase',
+        'credit_usage',
+        'credit_refund',
+        'credit_adjustment',
+      ]),
+    }),
+  },
+
   // Per-shot prompt regeneration events. Lives on its own channel
   // (`shot-prompt:${shotId}`) so a client only pays the realtime cost while
   // it's actually viewing the shot, and history replay rebuilds the
@@ -520,4 +541,17 @@ export function getShotPromptChannel(shotId?: string): RealtimeChannelApi {
   return shotId
     ? realtimeChannel(`shot-prompt:${shotId}`)
     : noopChannel('shot-prompt');
+}
+
+/**
+ * Team-scoped billing channel for live credit-balance updates (#1090).
+ * Channel id: `billing:${teamId}`.
+ */
+export function getBillingChannel(teamId?: string): RealtimeChannelApi {
+  return teamId ? realtimeChannel(`billing:${teamId}`) : noopChannel('billing');
+}
+
+/** Stable channel id for a team's billing events (client subscribe + history). */
+export function billingChannelId(teamId: string): string {
+  return `billing:${teamId}`;
 }


### PR DESCRIPTION
## Summary

- Emit `billing.balance:updated` on team channel `billing:${teamId}` from central `deductCredits` / `addCredits` (new ledger rows only — not idempotent workflow replays).
- Credit balance pill subscribes **only while visible** and optimistically patches balance + invalidates transactions.
- Fix “Show balance in header” so the credits switch and sidebar share one `useSyncExternalStore` store (was broken across components).
- Render the amount as a shadcn `Badge` pill.

Closes #1090

## Test plan

- [ ] Turn on **Show balance in header** on `/credits` — pill appears in the left sidebar under Gallery without reload
- [ ] With pill visible, run an image/video/LLM generation that charges credits — amount updates live
- [ ] Open Transactions tab mid-generation — new usage rows appear after invalidate
- [ ] With pill hidden (toggle off, healthy balance), confirm no `billing:…` EventSource in Network
- [ ] `bun run test src/lib/db/scoped/billing-balance-emit.test.ts`
- [ ] `bun typecheck`