### PR TITLE
fix(#1087): branch on error codes across the server-fn boundary

### DIFF
--- a/src/components/error/route-error-fallback.tsx
+++ b/src/components/error/route-error-fallback.tsx
@@ -5,6 +5,7 @@ import { useRouter } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { AlertCircle } from 'lucide-react';
 
+import { errorCode } from '@/lib/errors';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'ui', 'error', 'route-error-fallback']);
@@ -14,6 +15,9 @@ type RouteErrorFallbackProps = ErrorComponentProps & {
 };
 
 function isNotFoundError(error: unknown): boolean {
+  // Prefer the stable code that survives the server-fn boundary (#1087).
+  if (errorCode(error) === 'NOT_FOUND') return true;
+  // Router `notFound()` / residual plain Errors without a code.
   if (error instanceof Error) {
     const message = error.message.toLowerCase();
     return (

--- a/src/components/models/model-detail-view.tsx
+++ b/src/components/models/model-detail-view.tsx
@@ -67,18 +67,15 @@ import { toast } from 'sonner';
 // ---------------------------------------------------------------------------
 
 /**
- * Server-fn errors arrive as plain `Error`s (CatalogApiError's status/code
- * don't survive serialization), so "this endpoint has no schema" is detected
- * by message — same approach as `isInsufficientCreditsError`. Anchored to the
- * exact message `getModelDetail` throws: a looser match (e.g. on the upstream
- * `unknown_schema` code) would swallow a modelschemas outage into the
- * friendly "not runnable" empty state.
+ * `getModelDetail` throws CatalogApiError(404, 'unknown_schema') when the
+ * endpoint has no input schema. Seroval preserves own props across the
+ * server-fn boundary (#1087), so we match on status+code — not message prose.
+ * A modelschemas outage is 5xx and will not match.
  */
 function isNoSchemaError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.message.includes('No input schema for endpoint')
-  );
+  if (typeof error !== 'object' || error === null) return false;
+  const { status, code } = error as { status?: unknown; code?: unknown };
+  return status === 404 && code === 'unknown_schema';
 }
 
 /**

--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -348,20 +348,29 @@ export const stripeWebhookMiddleware = createMiddleware().server(
         typeof obj.metadata !== 'object' ||
         obj.metadata === null
       ) {
-        throw new Error(`Stripe event ${event.id} missing metadata`);
+        throw Response.json(
+          { error: `Stripe event ${event.id} missing metadata` },
+          { status: 400 }
+        );
       }
       const metadata = obj.metadata;
       if (!('teamId' in metadata && 'userId' in metadata)) {
-        throw new Error(
-          `Stripe event ${event.id} missing teamId or userId in metadata`
+        throw Response.json(
+          {
+            error: `Stripe event ${event.id} missing teamId or userId in metadata`,
+          },
+          { status: 400 }
         );
       }
 
       const teamId = metadata.teamId;
       const userId = metadata.userId;
       if (typeof teamId !== 'string' || typeof userId !== 'string') {
-        throw new Error(
-          `Stripe event ${event.id} missing teamId or userId in metadata`
+        throw Response.json(
+          {
+            error: `Stripe event ${event.id} missing teamId or userId in metadata`,
+          },
+          { status: 400 }
         );
       }
       return next({
@@ -373,9 +382,9 @@ export const stripeWebhookMiddleware = createMiddleware().server(
         },
       });
     } catch (error) {
-      if (error instanceof Error && error.message.includes('missing teamId')) {
-        throw Response.json({ error: error.message }, { status: 400 });
-      }
+      // Metadata validation throws Response above; rethrow as-is. Anything
+      // else (signature verify failure, malformed body) is an invalid webhook.
+      if (error instanceof Response) throw error;
       throw Response.json({ error: 'Invalid signature' }, { status: 400 });
     }
   }

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -3,6 +3,7 @@ import {
   ConfigurationError,
   ConnectionError,
   DatabaseError,
+  errorCode,
   errorMessage,
   handleApiError,
   InsufficientCreditsError,
@@ -165,14 +166,32 @@ describe('handleApiError', () => {
   });
 });
 
-describe('isInsufficientCreditsError', () => {
-  it('matches our error across the server-fn boundary but not a provider’s', () => {
+describe('errorCode / isInsufficientCreditsError', () => {
+  it('reads code from a live OpenStoryError', () => {
     const ours = new InsufficientCreditsError('Insufficient credits for image');
-    // Only the message survives the boundary, so re-throw as a plain Error.
-    expect(isInsufficientCreditsError(new Error(ours.message))).toBe(true);
+    expect(errorCode(ours)).toBe('INSUFFICIENT_CREDITS');
+    expect(isInsufficientCreditsError(ours)).toBe(true);
+    expect(ours.message).toBe('Insufficient credits for image');
+  });
+
+  it('matches our error across the server-fn boundary but not a provider’s', () => {
+    // Seroval reconstitutes a thrown OpenStoryError as a plain Error with the
+    // same own props (code/statusCode/details) — not the original class.
+    // See #1087 / seroval Error own-property serialization.
+    const acrossBoundary = Object.assign(
+      new Error('Insufficient credits for image'),
+      {
+        name: 'InsufficientCreditsError',
+        code: 'INSUFFICIENT_CREDITS',
+        statusCode: 402,
+      }
+    );
+    expect(isInsufficientCreditsError(acrossBoundary)).toBe(true);
+    expect(errorCode(acrossBoundary)).toBe('INSUFFICIENT_CREDITS');
 
     // OpenRouter's own balance — pinned in llm-client.test.ts. Routing this to
     // our billing dialog sends the user to top up an account that is fine.
+    // Message prose alone must never open the dialog.
     expect(
       isInsufficientCreditsError(
         new Error(
@@ -180,10 +199,44 @@ describe('isInsufficientCreditsError', () => {
         )
       )
     ).toBe(false);
+    expect(
+      errorCode(
+        new Error(
+          'Insufficient credits. Add more using https://openrouter.ai/settings/credits'
+        )
+      )
+    ).toBeUndefined();
   });
 
-  it('keeps the wire marker out of displayed text', () => {
+  it('preserves code/statusCode/details through a seroval round-trip (server-fn wire)', async () => {
+    // TanStack Start serializes server-fn errors with seroval's toCrossJSONAsync
+    // / fromCrossJSON (see start-server-core server-functions-handler). This is
+    // the empirical check for #1087: own props survive; the class does not.
+    const { toCrossJSONAsync, fromCrossJSON } = await import('seroval');
+    const original = new InsufficientCreditsError(
+      'Insufficient credits for image',
+      { needed: 10 }
+    );
+    const wire = await toCrossJSONAsync(original, { refs: new Map() });
+    const restored: unknown = fromCrossJSON(wire, { refs: new Map() });
+
+    expect(restored).toBeInstanceOf(Error);
+    expect(restored).not.toBeInstanceOf(InsufficientCreditsError);
+    // Own props survive; narrow via errorCode / property access after guards.
+    expect(restored).toMatchObject({
+      name: 'InsufficientCreditsError',
+      message: 'Insufficient credits for image',
+      code: 'INSUFFICIENT_CREDITS',
+      statusCode: 402,
+      details: { needed: 10 },
+    });
+    expect(isInsufficientCreditsError(restored)).toBe(true);
+    expect(errorCode(restored)).toBe('INSUFFICIENT_CREDITS');
+  });
+
+  it('surfaces the plain message for display', () => {
     const ours = new InsufficientCreditsError('Insufficient credits for image');
+    expect(errorMessage(ours)).toBe('Insufficient credits for image');
     expect(errorMessage(new Error(ours.message))).toBe(
       'Insufficient credits for image'
     );

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,5 +1,11 @@
 /**
- * Custom error classes for better error handling and categorization
+ * Custom error classes for better error handling and categorization.
+ *
+ * Server-fn boundary: TanStack Start serializes thrown errors with seroval,
+ * which preserves own enumerable properties on `Error` instances. A thrown
+ * `OpenStoryError` arrives on the client as a plain `Error` with the same
+ * `name`/`message`/`code`/`statusCode`/`details` — so branch on `errorCode()`,
+ * never on message prose. See #1087.
  */
 
 export class OpenStoryError extends Error {
@@ -79,45 +85,40 @@ export class NotFoundError extends OpenStoryError {
   }
 }
 
-/**
- * Stamped into the message because only the message survives the server-fn
- * boundary — `code` does not. The prose alone can't carry this: providers
- * throw "Insufficient credits…" about THEIR balance (OpenRouter's is pinned in
- * `llm-client.test.ts`), and routing that to our billing dialog sends the user
- * to top up an account that is already fine.
- */
-const INSUFFICIENT_CREDITS_MARKER = '[INSUFFICIENT_CREDITS]';
-
 export class InsufficientCreditsError extends OpenStoryError {
   constructor(
     message: string = 'Insufficient credits',
     details?: Record<string, unknown>
   ) {
-    super(
-      `${INSUFFICIENT_CREDITS_MARKER} ${message}`,
-      'INSUFFICIENT_CREDITS',
-      402,
-      details
-    );
+    super(message, 'INSUFFICIENT_CREDITS', 402, details);
   }
+}
+
+/**
+ * Stable machine-readable code from a thrown value.
+ *
+ * Works for live `OpenStoryError` instances on the server and for the plain
+ * `Error` objects seroval reconstitutes on the client after a server-fn throw
+ * (own props `code`/`statusCode`/`details` survive; the prototype does not).
+ */
+export function errorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
 }
 
 /** Is this OUR insufficient-credits failure? Callers gate the billing dialog on it. */
 export function isInsufficientCreditsError(error: unknown): boolean {
-  if (error instanceof InsufficientCreditsError) return true;
-  return (
-    error instanceof Error &&
-    error.message.includes(INSUFFICIENT_CREDITS_MARKER)
-  );
+  return errorCode(error) === 'INSUFFICIENT_CREDITS';
 }
 
-/** Display text for an arbitrary thrown value, minus any internal wire marker. */
+/** Display text for an arbitrary thrown value. */
 export function errorMessage(
   error: unknown,
   fallback = 'Unknown error'
 ): string {
   if (!(error instanceof Error)) return fallback;
-  return error.message.replace(INSUFFICIENT_CREDITS_MARKER, '').trim();
+  return error.message;
 }
 
 /**

--- a/src/lib/models/catalog.ts
+++ b/src/lib/models/catalog.ts
@@ -121,10 +121,10 @@ export type ModelDetail = {
 };
 
 /**
- * @public Typed upstream failure. `status`/`code` are branched on INSIDE this
- * module (e.g. `fetchSchema` maps 404 → null); they do NOT survive server-fn
- * serialization, so client code matches on `message` instead (see
- * `isNoSchemaError` in model-detail-view.tsx).
+ * @public Typed upstream failure. Own props (`status`/`code`) survive the
+ * server-fn boundary via seroval (#1087), so client code can branch on them
+ * (see `isNoSchemaError` in model-detail-view.tsx). Inside this module,
+ * `fetchSchema` still maps 404 → null before rethrowing a richer error.
  */
 export class CatalogApiError extends Error {
   readonly status: number;


### PR DESCRIPTION
## Summary

- Confirmed seroval already carries `code`/`statusCode`/`details` across the server-fn boundary (class is lost; own props survive) — evidence on #1087
- Drop the `[INSUFFICIENT_CREDITS]` marker and message-sniffing; add `errorCode()` and match on stable codes
- Migrate `isNoSchemaError` and Stripe webhook metadata validation off prose matching; prefer `NOT_FOUND` code in route error fallback

## Test plan

- [x] `bun run test src/lib/errors.test.ts` — includes seroval round-trip + OpenRouter false-positive regression
- [x] `bun typecheck`
- [ ] Manually: exhaust credits → billing dialog still opens from a real `InsufficientCreditsError`
- [ ] Manually: provider-style "Insufficient credits. Add more using…" does not open billing
- [ ] Catalog model with no schema still shows the friendly empty state

Closes #1087