### PR TITLE
feat(#1091): progressive reveal — script view during split, canvas at first preview

### DIFF
--- a/e2e/mocks/aimock-server.ts
+++ b/e2e/mocks/aimock-server.ts
@@ -257,7 +257,9 @@ export async function startAimockServer(): Promise<string> {
     // (a 30s reasoning gap becomes 300ms) while still yielding between
     // chunks, so concurrent streams keep interleaving like production.
     // Recording is unaffected — record mode streams live from upstream.
-    replaySpeed: 100,
+    // AIMOCK_REPLAY_SPEED overrides for demo/video runs where streaming
+    // should be watchable (e.g. 10 keeps the script split visibly streaming).
+    replaySpeed: Number(process.env.AIMOCK_REPLAY_SPEED ?? 100),
     requestTransform: falRequestTransform,
     // Record only when E2E_RECORD=1 (real key from .env.local). Default is
     // strict replay against the recorded fixtures — CI runs without the flag

--- a/e2e/tests/full-sequence.spec.ts
+++ b/e2e/tests/full-sequence.spec.ts
@@ -292,6 +292,14 @@ SUPER:  CORAL.  OUT NOW.
       }
       createdSequenceId = sequenceId;
 
+      // Progressive reveal (#1091): analysis lands on the forced script view —
+      // the canvas has nothing to show until the first shot preview arrives.
+      // Assert immediately after the redirect, before any preview can land
+      // and auto-reveal the canvas.
+      await expect(
+        page.getByRole('radio', { name: 'Show the script' })
+      ).toHaveAttribute('data-state', 'on');
+
       // 9. Wait for storyboard + shot images to land in the DB.
       //
       // Content-flag retry coverage (#881): two recorded fixtures inject a
@@ -356,6 +364,15 @@ SUPER:  CORAL.  OUT NOW.
       //     each scene's player renders its <video>; that player video is
       //     ordered before the prefetch in the DOM, so `.first()` resolves to
       //     it.
+      // Progressive reveal (#1091): the first preview auto-revealed the canvas
+      // (no explicit view in the URL), so by now the toggle is enabled AND the
+      // canvas is the active view — the playback checks below depend on it.
+      const canvasToggle = page.getByRole('radio', {
+        name: 'Show the canvas',
+      });
+      await expect(canvasToggle).toBeEnabled();
+      await expect(canvasToggle).toHaveAttribute('data-state', 'on');
+
       const sceneItems = page.locator('[data-testid="scene-list-item"]');
       const sceneCount = await sceneItems.count();
       expect(sceneCount, 'sequence has at least one scene').toBeGreaterThan(0);

--- a/src/components/scenes/canvas-view-toggle.tsx
+++ b/src/components/scenes/canvas-view-toggle.tsx
@@ -14,6 +14,9 @@ import { FileText, Film } from 'lucide-react';
 type CanvasViewToggleProps = {
   view: CanvasView;
   onViewChange: (view: CanvasView) => void;
+  /** Progressive reveal (#1091): the canvas has nothing to show until the
+   *  first shot preview lands, so the item stays disabled during the split. */
+  canvasDisabled?: boolean;
   /** View-scoped action shown at the right of the row. Absolutely positioned so
    *  it can't push the toggle off centre. */
   trailing?: React.ReactNode;
@@ -22,6 +25,7 @@ type CanvasViewToggleProps = {
 export const CanvasViewToggle: React.FC<CanvasViewToggleProps> = ({
   view,
   onViewChange,
+  canvasDisabled,
   trailing,
 }) => (
   <div className="relative flex shrink-0 items-center justify-center pt-4">
@@ -36,7 +40,11 @@ export const CanvasViewToggle: React.FC<CanvasViewToggleProps> = ({
       variant="outline"
       size="sm"
     >
-      <ToggleGroupItem value="canvas" aria-label="Show the canvas">
+      <ToggleGroupItem
+        value="canvas"
+        aria-label="Show the canvas"
+        disabled={canvasDisabled}
+      >
         <Film className="mr-1.5 h-3.5 w-3.5" />
         Canvas
       </ToggleGroupItem>

--- a/src/components/scenes/scene-canvas.tsx
+++ b/src/components/scenes/scene-canvas.tsx
@@ -246,6 +246,28 @@ export const SceneCanvas: React.FC<SceneCanvasProps> = ({
   }
 
   if (playbackScenes.length === 0) {
+    // No video to play yet — fall back to a still of the selection's first
+    // shot (#1091). ScenePlayer owns the image ladder (final thumbnail → fast
+    // preview) plus the generating/failed overlays, so early scenes show
+    // something the moment their first preview lands.
+    const stillShot =
+      scopedShots.find((s) => s.thumbnailUrl || s.previewThumbnailUrl) ??
+      scopedShots[0];
+    if (stillShot) {
+      return (
+        <CanvasMediaStage aspectRatio={aspectRatio}>
+          <ScenePlayer
+            shots={playerShots}
+            selectedShotId={stillShot.id}
+            aspectRatio={aspectRatio}
+            progressMessage={progressMessage}
+            posterUrl={sequence?.posterUrl ?? undefined}
+            className="h-full max-h-none w-full"
+            wrapperClassName="h-full w-full"
+          />
+        </CanvasMediaStage>
+      );
+    }
     return (
       <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 py-16">
         <Film className="h-8 w-8 text-muted-foreground" />

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -310,6 +310,17 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
     shouldPoll ? { refetchInterval: 2000 } : undefined
   );
 
+  // Progressive reveal (#1091): while the script is being split the canvas has
+  // nothing to show, so the Script view is forced and the Canvas toggle stays
+  // disabled. When the first shot preview lands the override drops away and —
+  // unless the user explicitly chose the script view (URL `view=script`) —
+  // the derived view falls back to the canvas default, auto-revealing the
+  // first images as they arrive. No effect, no state: pure derivation.
+  const canvasReady =
+    !isProcessing ||
+    (shots?.some((s) => s.thumbnailUrl || s.previewThumbnailUrl) ?? false);
+  const effectiveView = canvasReady ? view : 'script';
+
   // Escape progressive zoom-out (#986):
   // 1) blur the focused editing field (exit typing)
   // 2) else yield to an open dialog/menu/popover
@@ -1325,15 +1336,16 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         <div className="flex flex-1 min-h-0 min-w-0 flex-col md:flex-row">
           <div className="flex flex-1 min-h-0 min-w-0 flex-col">
             <CanvasViewToggle
-              view={view}
+              view={effectiveView}
               onViewChange={setView}
+              canvasDisabled={!canvasReady}
               trailing={
-                view === 'script' ? (
+                effectiveView === 'script' ? (
                   <CopyScriptButton sequenceId={sequenceId} />
                 ) : null
               }
             />
-            {view === 'script' ? (
+            {effectiveView === 'script' ? (
               <SceneScriptDocument
                 sequenceId={sequenceId}
                 scenes={scenes}

--- a/src/routes/_app/sequences/$id/script.tsx
+++ b/src/routes/_app/sequences/$id/script.tsx
@@ -43,6 +43,8 @@ function ScriptPage() {
   const handleSuccess = (sequenceIds: string[]) => {
     const [firstId] = sequenceIds;
     if (firstId) {
+      // No explicit view: ScenesView forces the script view while the split
+      // streams, then auto-reveals the canvas at the first preview (#1091).
       void navigate({
         to: '/sequences/$id/scenes',
         params: { id: firstId },

--- a/src/routes/_app/sequences/new.tsx
+++ b/src/routes/_app/sequences/new.tsx
@@ -177,7 +177,8 @@ function NewSequencePage() {
     (sequenceIds: string[]) => {
       const [firstId] = sequenceIds;
       if (firstId) {
-        // Navigate to storyboard page after successful generation
+        // No explicit view: ScenesView forces the script view while the split
+        // streams, then auto-reveals the canvas at the first preview (#1091).
         void navigate({
           to: '/sequences/$id/scenes',
           params: { id: firstId },


### PR DESCRIPTION
Closes #1091

## Problem

When analysing a script, the canvas showed nothing while the script was being split — users landed on an empty canvas with no signal that anything was happening.

## Changes

**Progressive reveal (ScenesView, derived — no view state written):**
- While the sequence is `processing` and no shot has an image yet, the effective centre view is forced to **Script** so the streaming split is what's on screen, and the **Canvas toggle is disabled** (new `canvasDisabled` prop on `CanvasViewToggle`).
- The moment the first shot preview lands (`thumbnailUrl || previewThumbnailUrl` on any shot), the override drops away and the derived view falls back to the canvas default — the **canvas auto-reveals** showing the first images as they arrive. An explicit Script click writes `view=script` to the URL and sticks.
- Entry navigations (`sequences/new`, the `$id/script` composer) intentionally write no view param so the derivation owns the flow.

**First-shot still fallback (SceneCanvas):**
- Scene/sequence scope with no completed video now renders `ScenePlayer` on the selection's first shot with an image (else its first shot) instead of the "No scenes ready to play yet" empty state — reusing the existing image ladder (final thumbnail → fast preview), the "Preview" chip, and the generating/failed overlays. The empty state remains only when the scope has zero shots.

**E2E:**
- `full-sequence.spec.ts` asserts the forced script view immediately after Generate, and that the Canvas toggle is enabled **and** active (`data-state="on"`) before the playback checks — regression coverage for both the disabled window and the auto-reveal.
- `aimock-server.ts` `replaySpeed` is now overridable via `AIMOCK_REPLAY_SPEED` (default unchanged at 100) — `AIMOCK_REPLAY_SPEED=10 bun test:e2e:full` produces watchable demo recordings.

## Testing

- `bun typecheck`, `bun lint`, `bun format:check`, `bun run test` (1990 passing) all green.
- Full-pipeline e2e (`bun test:e2e:full`) passing at replay speed 100 and 10.
- Demo video recorded from the 10× run shows: forced script view with disabled Canvas toggle during "Analyzing script…" → canvas auto-reveals with scene 1's fast-preview still while later scenes are still splitting → images upgrade in place → motion/music/playback.

Note: in production the forced-script window lasts much longer than in the compressed-replay demo — the first preview takes real generation time, so users watch the script stream before the canvas reveals.
