### PR TITLE
feat(#1085): pending artifact records + Update all depth picker

### DIFF
--- a/drizzle/migrations/20260801225338_good_leech/migration.sql
+++ b/drizzle/migrations/20260801225338_good_leech/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `frame_prompt_versions` ADD `status` text DEFAULT 'completed' NOT NULL;--> statement-breakpoint
+ALTER TABLE `frame_prompt_versions` ADD `pending_input_hash` text;--> statement-breakpoint
+ALTER TABLE `frame_prompt_versions` ADD `workflow_run_id` text;--> statement-breakpoint
+ALTER TABLE `frame_variants` ADD `pending_input_hash` text;--> statement-breakpoint
+ALTER TABLE `frame_variants` ADD `depends_on_version_id` text;--> statement-breakpoint
+ALTER TABLE `shot_prompt_versions` ADD `status` text DEFAULT 'completed' NOT NULL;--> statement-breakpoint
+ALTER TABLE `shot_prompt_versions` ADD `pending_input_hash` text;--> statement-breakpoint
+ALTER TABLE `shot_prompt_versions` ADD `workflow_run_id` text;

--- a/drizzle/migrations/20260801225338_good_leech/snapshot.json
+++ b/drizzle/migrations/20260801225338_good_leech/snapshot.json
@@ -1,0 +1,9237 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "379234c5-2523-42a5-874a-83d49d2114bc",
+  "prevIds": ["53b35518-2c91-46cf-88cd-0ffbaba14b06"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "apikey",
+      "entityType": "tables"
+    },
+    {
+      "name": "app_metadata",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frames",
+      "entityType": "tables"
+    },
+    {
+      "name": "generated_assets",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "render_segments",
+      "entityType": "tables"
+    },
+    {
+      "name": "scene_script_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "scenes",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_exports",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "shots",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "name": "video_variants",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_interval",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_amount",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_refill_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "rate_limit_enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_time_window",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_max",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "request_count",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_request",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permissions",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text(255)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'completed'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'model'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_variant_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "depends_on_version_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_version_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'first'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'generated'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "image_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_image_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_image_prompt_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_promote_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(50)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(200)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(20)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(200)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model_name",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'queued'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outputs",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cost_micros",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_video_version_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_promote_version_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "story_beat",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "continuity",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_design",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_script",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_script_version_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_strategy",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_type",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'ready'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_shots_hash",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_music_variant_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "loudness_gain_db",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "include_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "dialogue",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'completed'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_input_hash",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_number",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_motion_prompt_version_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_segment_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sample_videos",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_image_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_video_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_aspect_ratio",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "use_cases",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_segment_id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "manifest",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_versions_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_versions_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frames_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frames_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_generated_assets_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "generated_assets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_generated_assets_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "generated_assets"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_render_segments_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "render_segments"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_render_segments_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "render_segments"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_scene_script_versions_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "scene_script_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_scene_script_versions_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "scene_script_versions"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_scenes_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "scenes"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_events_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_events"
+    },
+    {
+      "columns": ["actor_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_events_actor_id_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_events"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_sequence_exports_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shots_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shots_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["render_segment_id"],
+      "tableTo": "render_segments",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shots_render_segment_id_render_segments_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["render_segment_id"],
+      "tableTo": "render_segments",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_video_variants_render_segment_id_render_segments_id_fk",
+      "entityType": "fks",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_video_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "apikey_pk",
+      "table": "apikey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["key"],
+      "nameExplicit": false,
+      "name": "app_metadata_pk",
+      "table": "app_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_prompt_versions_pk",
+      "table": "frame_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_variants_pk",
+      "table": "frame_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frames_pk",
+      "table": "frames",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "generated_assets_pk",
+      "table": "generated_assets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "render_segments_pk",
+      "table": "render_segments",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "scene_script_versions_pk",
+      "table": "scene_script_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "scenes_pk",
+      "table": "scenes",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_events_pk",
+      "table": "sequence_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_exports_pk",
+      "table": "sequence_exports",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_variants_pk",
+      "table": "sequence_music_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_prompt_variants_pk",
+      "table": "shot_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_variants_pk",
+      "table": "shot_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shots_pk",
+      "table": "shots",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "video_variants_pk",
+      "table": "video_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_referenceId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_key_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_configId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_prompt_versions_frame_created",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_prompt_versions\".\"input_hash\" IS NOT NULL AND \"frame_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_frame_prompt_versions_frame_hash_ai",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "kind",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_group",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_sequence",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_shot_order",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_sequence_id",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "frames_shot_id_order_index_key",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_generated_assets_team",
+      "entityType": "indexes",
+      "table": "generated_assets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "endpoint_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_generated_assets_team_endpoint",
+      "entityType": "indexes",
+      "table": "generated_assets"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "scene_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_render_segments_scene",
+      "entityType": "indexes",
+      "table": "render_segments"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_render_segments_sequence",
+      "entityType": "indexes",
+      "table": "render_segments"
+    },
+    {
+      "columns": [
+        {
+          "value": "scene_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_scene_script_versions_scene_created",
+      "entityType": "indexes",
+      "table": "scene_script_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_scenes_sequence_order",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "scenes_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_events_sequence",
+      "entityType": "indexes",
+      "table": "sequence_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "target_type",
+          "isExpression": false
+        },
+        {
+          "value": "target_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_events_target",
+      "entityType": "indexes",
+      "table": "sequence_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_sequence",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_created_at",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_exports\".\"status\" = 'processing'",
+      "origin": "manual",
+      "name": "uq_sequence_exports_one_processing",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_prompt_versions\".\"input_hash\" IS NOT NULL AND \"sequence_music_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_sequence_music_prompt_variants_sequence_hash_ai",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_prompt_variants_shot_type_created",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_prompt_versions\".\"input_hash\" IS NOT NULL AND \"shot_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_shot_prompt_variants_shot_type_hash_ai",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_shot_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "shot_variants_primary_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "shot_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_order",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_sequence_id",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "shots_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"transactions\".\"idempotency_key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "idx_transactions_team_idempotency_key",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "render_segment_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_video_variants_group",
+      "entityType": "indexes",
+      "table": "video_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_video_variants_sequence",
+      "entityType": "indexes",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": []
+}

--- a/drizzle/migrations/20260801234203_glamorous_dagger/migration.sql
+++ b/drizzle/migrations/20260801234203_glamorous_dagger/migration.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX `uq_frame_prompt_versions_live_claim` ON `frame_prompt_versions` (`frame_id`,`pending_input_hash`) WHERE "frame_prompt_versions"."pending_input_hash" IS NOT NULL AND "frame_prompt_versions"."status" IN ('pending', 'generating');--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_frame_variants_live_claim` ON `frame_variants` (`frame_id`,`pending_input_hash`) WHERE "frame_variants"."pending_input_hash" IS NOT NULL AND "frame_variants"."status" IN ('pending', 'generating');--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_shot_prompt_versions_live_claim` ON `shot_prompt_versions` (`shot_id`,`prompt_type`,`pending_input_hash`) WHERE "shot_prompt_versions"."pending_input_hash" IS NOT NULL AND "shot_prompt_versions"."status" IN ('pending', 'generating');

--- a/drizzle/migrations/20260801234203_glamorous_dagger/snapshot.json
+++ b/drizzle/migrations/20260801234203_glamorous_dagger/snapshot.json
@@ -1,0 +1,9295 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "5c184dba-6988-4ab8-99c2-28b343fb69c9",
+  "prevIds": ["379234c5-2523-42a5-874a-83d49d2114bc"],
+  "ddl": [
+    {
+      "name": "account",
+      "entityType": "tables"
+    },
+    {
+      "name": "apikey",
+      "entityType": "tables"
+    },
+    {
+      "name": "app_metadata",
+      "entityType": "tables"
+    },
+    {
+      "name": "audio",
+      "entityType": "tables"
+    },
+    {
+      "name": "character_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "characters",
+      "entityType": "tables"
+    },
+    {
+      "name": "credit_batches",
+      "entityType": "tables"
+    },
+    {
+      "name": "credits",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "frame_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "frames",
+      "entityType": "tables"
+    },
+    {
+      "name": "generated_assets",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_token_redemptions",
+      "entityType": "tables"
+    },
+    {
+      "name": "gift_tokens",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_library",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "location_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "passkey",
+      "entityType": "tables"
+    },
+    {
+      "name": "render_segments",
+      "entityType": "tables"
+    },
+    {
+      "name": "scene_script_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "scenes",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_elements",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_events",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_exports",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_locations",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequence_music_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "sequences",
+      "entityType": "tables"
+    },
+    {
+      "name": "session",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_prompt_versions",
+      "entityType": "tables"
+    },
+    {
+      "name": "shot_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "shots",
+      "entityType": "tables"
+    },
+    {
+      "name": "styles",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_media",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheet_variants",
+      "entityType": "tables"
+    },
+    {
+      "name": "talent_sheets",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_api_keys",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_billing_settings",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_invitations",
+      "entityType": "tables"
+    },
+    {
+      "name": "team_members",
+      "entityType": "tables"
+    },
+    {
+      "name": "teams",
+      "entityType": "tables"
+    },
+    {
+      "name": "transactions",
+      "entityType": "tables"
+    },
+    {
+      "name": "user",
+      "entityType": "tables"
+    },
+    {
+      "name": "verification",
+      "entityType": "tables"
+    },
+    {
+      "name": "vfx",
+      "entityType": "tables"
+    },
+    {
+      "name": "video_variants",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "account_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id_token",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refresh_token_expires_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scope",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "password",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "account"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "start",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prefix",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "config_id",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_interval",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "refill_amount",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_refill_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "rate_limit_enabled",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_time_window",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "rate_limit_max",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "request_count",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_request",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "permissions",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "apikey"
+    },
+    {
+      "type": "text(255)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "app_metadata"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "file_url",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "audio"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "character_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "character_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "age",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gender",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ethnicity",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "physical_description",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "standard_clothing",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "distinguishing_features",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_url",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_image_path",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "sheet_status",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_generated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_error",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sheet_input_hash",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "characters"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "remaining_amount",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transaction_id",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "credit_batches"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "balance",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "credits"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'completed'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_input_hash",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "frame_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'model'",
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_variant_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_input_hash",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "depends_on_version_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_version_id",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frame_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'first'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'generated'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_image_url",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "image_status",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_workflow_run_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_generated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_error",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_prompt",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_image_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_image_prompt_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_promote_version_id",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "visual_prompt_input_hash",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "frames"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(50)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(200)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "endpoint_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(20)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "activity",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text(200)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model_name",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'queued'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outputs",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "cost_micros",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "generated_assets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "gift_token_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "redeemed_at",
+      "entityType": "columns",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "code",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount_micros",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "max_redemptions",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by_user_id",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "note",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "gift_tokens"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_library"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_type",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "location_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "public_key",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "credential_id",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "counter",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "device_type",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backed_up",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "transports",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "aaguid",
+      "entityType": "columns",
+      "table": "passkey"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_video_version_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_promote_version_id",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "render_segments"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "content",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "scene_script_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "story_beat",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "continuity",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_design",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "original_script",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_script_version_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_strategy",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "scenes"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "uploaded_filename",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "vision_status",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_error",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "vision_generated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_elements"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "actor_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "kind",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_type",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "target_id",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "summary",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "data",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_events"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'ready'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_shots_hash",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source_music_variant_id",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_exports"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "library_location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "location_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_of_day",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "architectural_style",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_features",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "color_palette",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "lighting_setup",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ambiance",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "consistency_tag",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_scene_id",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_text",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "first_mention_line",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_url",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_image_path",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "reference_status",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_generated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_error",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reference_input_hash",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_locations"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'music'",
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "real",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "loudness_gain_db",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_seconds",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequence_music_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(500)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "script",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'draft'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_by",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "style_id",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(10)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'16:9'",
+      "generated": null,
+      "name": "aspect_ratio",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'anthropic/claude-haiku-4.5'",
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "analysis_duration_ms",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'nano_banana_2'",
+      "generated": null,
+      "name": "image_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'kling_v3_pro'",
+      "generated": null,
+      "name": "video_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_path",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "music_status",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_generated_at",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_error",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_model",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_tags",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "music_prompt_input_hash",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "include_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "poster_url",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_motion",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_generate_music",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_talent_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "suggested_location_ids",
+      "entityType": "columns",
+      "table": "sequences"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "ip_address",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_agent",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "session"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_type",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "text",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "components",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parameters",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "dialogue",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "analysis_model",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'completed'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pending_input_hash",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant_type",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_url",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_path",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "shot_variant_status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_variant_workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "prompt_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shot_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scene_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "shot_number",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "order_index",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "3000",
+      "generated": null,
+      "name": "duration_ms",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "video_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "selected_motion_prompt_version_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_segment_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_url",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_path",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "audio_status",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_workflow_run_id",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_generated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_error",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_model",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "video_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "audio_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "motion_prompt_input_hash",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "shots"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "config",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text(100)",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "category",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "tags",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "1",
+      "generated": null,
+      "name": "version",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sample_videos",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_image_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "recommended_video_model",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_aspect_ratio",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "use_cases",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100",
+      "generated": null,
+      "name": "sort_order",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "usage_count",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "styles"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_favorite",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_human",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_in_team_library",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_public",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_template",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "path",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_media"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_sheet_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "talent_id",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_url",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image_path",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_default",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual_upload'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "diverged_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "talent_sheets"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "provider",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "encrypted_key",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_iv",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_tag",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key_hint",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'manual'",
+      "generated": null,
+      "name": "source",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "is_active",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "is_invalid",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invalid_reason",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "last_validated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "added_by",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_api_keys"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_customer_id",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_top_up_enabled",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "5000000",
+      "generated": null,
+      "name": "auto_top_up_threshold_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "100000000",
+      "generated": null,
+      "name": "auto_top_up_amount_micros",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_billing_settings"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "invited_by",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "token",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "accepted_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "declined_at",
+      "entityType": "columns",
+      "table": "team_invitations"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'member'",
+      "generated": null,
+      "name": "role",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "joined_at",
+      "entityType": "columns",
+      "table": "team_members"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "slug",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "teams"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "user_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "type",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "amount",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "balance_after",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "metadata",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "stripe_session_id",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "description",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "idempotency_key",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "transactions"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "email",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "email_verified",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "image",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "access_code",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "user"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "identifier",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "value",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "expires_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "(cast(unixepoch('subsecond') * 1000 as integer))",
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "verification"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "team_id",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text(255)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'{}'",
+      "generated": null,
+      "name": "preset_config",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_by",
+      "entityType": "columns",
+      "table": "vfx"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "render_segment_id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "sequence_id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text(100)",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "manifest",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "storage_path",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "preview_url",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'pending'",
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "generated_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "input_hash",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "discarded_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "account_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "account"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "audio_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "audio_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "audio"
+    },
+    {
+      "columns": ["character_id"],
+      "tableTo": "characters",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_character_sheet_variants_character_id_characters_id_fk",
+      "entityType": "fks",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "characters_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "characters_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "characters"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credit_batches_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["transaction_id"],
+      "tableTo": "transactions",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "credit_batches_transaction_id_transactions_id_fk",
+      "entityType": "fks",
+      "table": "credit_batches"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "credits_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "credits"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_versions_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_frame_prompt_versions_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": ["frame_id"],
+      "tableTo": "frames",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_variants_frame_id_frames_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frame_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frame_variants"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frames_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_frames_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "frames"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_generated_assets_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "generated_assets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_generated_assets_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "generated_assets"
+    },
+    {
+      "columns": ["gift_token_id"],
+      "tableTo": "gift_tokens",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_gift_token_id_gift_tokens_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": ["created_by_user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "gift_tokens_created_by_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_library_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "location_library_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "location_library"
+    },
+    {
+      "columns": ["location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "location_sheets_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "location_sheets"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "passkey_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "passkey"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_render_segments_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "render_segments"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_render_segments_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "render_segments"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_scene_script_versions_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "scene_script_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_scene_script_versions_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "scene_script_versions"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_scenes_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "scenes"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_elements_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_events_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_events"
+    },
+    {
+      "columns": ["actor_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_events_actor_id_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_events"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "RESTRICT",
+      "nameExplicit": false,
+      "name": "fk_sequence_exports_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequence_locations_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["library_location_id"],
+      "tableTo": "location_library",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequence_locations_library_location_id_location_library_id_fk",
+      "entityType": "fks",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_sequence_music_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "sequences_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["updated_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_updated_by_user_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["style_id"],
+      "tableTo": "styles",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "sequences_style_id_styles_id_fk",
+      "entityType": "fks",
+      "table": "sequences"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "session_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "session"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shot_prompt_variants_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": ["shot_id"],
+      "tableTo": "shots",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_shot_id_shots_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shot_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shot_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_shots_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["scene_id"],
+      "tableTo": "scenes",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shots_scene_id_scenes_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["render_segment_id"],
+      "tableTo": "render_segments",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_shots_render_segment_id_render_segments_id_fk",
+      "entityType": "fks",
+      "table": "shots"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "styles_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "styles_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "styles"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "talent_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "talent"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_media_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_media"
+    },
+    {
+      "columns": ["talent_sheet_id"],
+      "tableTo": "talent_sheets",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_talent_sheet_variants_talent_sheet_id_talent_sheets_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": ["talent_id"],
+      "tableTo": "talent",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "talent_sheets_talent_id_talent_id_fk",
+      "entityType": "fks",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["added_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_api_keys_added_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_billing_settings_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_billing_settings"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["invited_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_invitations_invited_by_user_id_fk",
+      "entityType": "fks",
+      "table": "team_invitations"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "team_members_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "transactions_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["user_id"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "transactions_user_id_user_id_fk",
+      "entityType": "fks",
+      "table": "transactions"
+    },
+    {
+      "columns": ["team_id"],
+      "tableTo": "teams",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "vfx_team_id_teams_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["created_by"],
+      "tableTo": "user",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "vfx_created_by_user_id_fk",
+      "entityType": "fks",
+      "table": "vfx"
+    },
+    {
+      "columns": ["render_segment_id"],
+      "tableTo": "render_segments",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_video_variants_render_segment_id_render_segments_id_fk",
+      "entityType": "fks",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["sequence_id"],
+      "tableTo": "sequences",
+      "columnsTo": ["id"],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_video_variants_sequence_id_sequences_id_fk",
+      "entityType": "fks",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["team_id", "user_id"],
+      "nameExplicit": false,
+      "name": "team_members_team_id_user_id_pk",
+      "entityType": "pks",
+      "table": "team_members"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "account_pk",
+      "table": "account",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "apikey_pk",
+      "table": "apikey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["key"],
+      "nameExplicit": false,
+      "name": "app_metadata_pk",
+      "table": "app_metadata",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "audio_pk",
+      "table": "audio",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "character_sheet_variants_pk",
+      "table": "character_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "characters_pk",
+      "table": "characters",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "credit_batches_pk",
+      "table": "credit_batches",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "credits_pk",
+      "table": "credits",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_prompt_versions_pk",
+      "table": "frame_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frame_variants_pk",
+      "table": "frame_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "frames_pk",
+      "table": "frames",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "generated_assets_pk",
+      "table": "generated_assets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_token_redemptions_pk",
+      "table": "gift_token_redemptions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "gift_tokens_pk",
+      "table": "gift_tokens",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_library_pk",
+      "table": "location_library",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheet_variants_pk",
+      "table": "location_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "location_sheets_pk",
+      "table": "location_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "passkey_pk",
+      "table": "passkey",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "render_segments_pk",
+      "table": "render_segments",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "scene_script_versions_pk",
+      "table": "scene_script_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "scenes_pk",
+      "table": "scenes",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_elements_pk",
+      "table": "sequence_elements",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_events_pk",
+      "table": "sequence_events",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_exports_pk",
+      "table": "sequence_exports",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_locations_pk",
+      "table": "sequence_locations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_prompt_variants_pk",
+      "table": "sequence_music_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequence_music_variants_pk",
+      "table": "sequence_music_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "sequences_pk",
+      "table": "sequences",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "session_pk",
+      "table": "session",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_prompt_variants_pk",
+      "table": "shot_prompt_versions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shot_variants_pk",
+      "table": "shot_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "shots_pk",
+      "table": "shots",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "styles_pk",
+      "table": "styles",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_pk",
+      "table": "talent",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_media_pk",
+      "table": "talent_media",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheet_variants_pk",
+      "table": "talent_sheet_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "talent_sheets_pk",
+      "table": "talent_sheets",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_api_keys_pk",
+      "table": "team_api_keys",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["team_id"],
+      "nameExplicit": false,
+      "name": "team_billing_settings_pk",
+      "table": "team_billing_settings",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "team_invitations_pk",
+      "table": "team_invitations",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "teams_pk",
+      "table": "teams",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "transactions_pk",
+      "table": "transactions",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "user_pk",
+      "table": "user",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "verification_pk",
+      "table": "verification",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "vfx_pk",
+      "table": "vfx",
+      "entityType": "pks"
+    },
+    {
+      "columns": ["id"],
+      "nameExplicit": false,
+      "name": "video_variants_pk",
+      "table": "video_variants",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "account_userId_idx",
+      "entityType": "indexes",
+      "table": "account"
+    },
+    {
+      "columns": [
+        {
+          "value": "reference_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_referenceId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_key_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "config_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "apikey_configId_idx",
+      "entityType": "indexes",
+      "table": "apikey"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_name",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_audio_team_id",
+      "entityType": "indexes",
+      "table": "audio"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_character_sheet_variants_character",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "character_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"character_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "character_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "character_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_sequence_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_characters_talent_id",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "character_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "characters_sequence_character_key",
+      "entityType": "indexes",
+      "table": "characters"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_id",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "remaining_amount",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_team_remaining_created",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_credit_batches_expires_at",
+      "entityType": "indexes",
+      "table": "credit_batches"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_prompt_versions_frame_created",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_prompt_versions\".\"input_hash\" IS NOT NULL AND \"frame_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_frame_prompt_versions_frame_hash_ai",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "pending_input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_prompt_versions\".\"pending_input_hash\" IS NOT NULL AND \"frame_prompt_versions\".\"status\" IN ('pending', 'generating')",
+      "origin": "manual",
+      "name": "uq_frame_prompt_versions_live_claim",
+      "entityType": "indexes",
+      "table": "frame_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "kind",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_group",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frame_variants_sequence",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "frame_id",
+          "isExpression": false
+        },
+        {
+          "value": "pending_input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"frame_variants\".\"pending_input_hash\" IS NOT NULL AND \"frame_variants\".\"status\" IN ('pending', 'generating')",
+      "origin": "manual",
+      "name": "uq_frame_variants_live_claim",
+      "entityType": "indexes",
+      "table": "frame_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_shot_order",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_frames_sequence_id",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "frames_shot_id_order_index_key",
+      "entityType": "indexes",
+      "table": "frames"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_generated_assets_team",
+      "entityType": "indexes",
+      "table": "generated_assets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "endpoint_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_generated_assets_team_endpoint",
+      "entityType": "indexes",
+      "table": "generated_assets"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        },
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "gift_token_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_token",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_token_redemptions_team",
+      "entityType": "indexes",
+      "table": "gift_token_redemptions"
+    },
+    {
+      "columns": [
+        {
+          "value": "code",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_code",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_by_user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_gift_tokens_created_by",
+      "entityType": "indexes",
+      "table": "gift_tokens"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_team_id",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_library_name",
+      "entityType": "indexes",
+      "table": "location_library"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheet_variants_parent",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "parent_type",
+          "isExpression": false
+        },
+        {
+          "value": "parent_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"location_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "location_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "location_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_location_id",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_location_sheets_is_default",
+      "entityType": "indexes",
+      "table": "location_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_userId_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "credential_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "passkey_credentialID_idx",
+      "entityType": "indexes",
+      "table": "passkey"
+    },
+    {
+      "columns": [
+        {
+          "value": "scene_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_render_segments_scene",
+      "entityType": "indexes",
+      "table": "render_segments"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_render_segments_sequence",
+      "entityType": "indexes",
+      "table": "render_segments"
+    },
+    {
+      "columns": [
+        {
+          "value": "scene_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_scene_script_versions_scene_created",
+      "entityType": "indexes",
+      "table": "scene_script_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_scenes_sequence_order",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "scenes_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "scenes"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_elements_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_elements_sequence_token_key",
+      "entityType": "indexes",
+      "table": "sequence_elements"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_events_sequence",
+      "entityType": "indexes",
+      "table": "sequence_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "target_type",
+          "isExpression": false
+        },
+        {
+          "value": "target_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_events_target",
+      "entityType": "indexes",
+      "table": "sequence_events"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_sequence",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_exports_created_at",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_exports\".\"status\" = 'processing'",
+      "origin": "manual",
+      "name": "uq_sequence_exports_one_processing",
+      "entityType": "indexes",
+      "table": "sequence_exports"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_sequence_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "library_location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_locations_library_location_id",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "location_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "sequence_locations_sequence_location_key",
+      "entityType": "indexes",
+      "table": "sequence_locations"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_prompt_variants_sequence_created",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_prompt_versions\".\"input_hash\" IS NOT NULL AND \"sequence_music_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_sequence_music_prompt_variants_sequence_hash_ai",
+      "entityType": "indexes",
+      "table": "sequence_music_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequence_music_variants_sequence",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_primary_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"sequence_music_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "sequence_music_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "sequence_music_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_created_at",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_status",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "style_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_style_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_sequences_team_id",
+      "entityType": "indexes",
+      "table": "sequences"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "session_userId_idx",
+      "entityType": "indexes",
+      "table": "session"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_prompt_variants_shot_type_created",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_prompt_versions\".\"input_hash\" IS NOT NULL AND \"shot_prompt_versions\".\"source\" != 'restored'",
+      "origin": "manual",
+      "name": "uq_shot_prompt_variants_shot_type_hash_ai",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "prompt_type",
+          "isExpression": false
+        },
+        {
+          "value": "pending_input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_prompt_versions\".\"pending_input_hash\" IS NOT NULL AND \"shot_prompt_versions\".\"status\" IN ('pending', 'generating')",
+      "origin": "manual",
+      "name": "uq_shot_prompt_versions_live_claim",
+      "entityType": "indexes",
+      "table": "shot_prompt_versions"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_shot_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shot_variants_sequence_type",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "shot_variants_primary_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "shot_id",
+          "isExpression": false
+        },
+        {
+          "value": "variant_type",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"shot_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "shot_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "shot_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_order",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_shots_sequence_id",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        },
+        {
+          "value": "order_index",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "shots_sequence_id_order_index_key",
+      "entityType": "indexes",
+      "table": "shots"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_styles_team_id",
+      "entityType": "indexes",
+      "table": "styles"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_team_id",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_name",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_favorite",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_favorite",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_in_team_library",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_is_in_team_library",
+      "entityType": "indexes",
+      "table": "talent"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_talent_id",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_media_type",
+      "entityType": "indexes",
+      "table": "talent_media"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheet_variants_talent_sheet",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_primary_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_sheet_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        },
+        {
+          "value": "input_hash",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"talent_sheet_variants\".\"diverged_at\" IS NOT NULL",
+      "origin": "manual",
+      "name": "talent_sheet_variants_divergent_key",
+      "entityType": "indexes",
+      "table": "talent_sheet_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "talent_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_talent_id",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "is_default",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_talent_sheets_is_default",
+      "entityType": "indexes",
+      "table": "talent_sheets"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "provider",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_provider",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_api_keys_team_id",
+      "entityType": "indexes",
+      "table": "team_api_keys"
+    },
+    {
+      "columns": [
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_email",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "expires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_expires_at",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_status",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_team_id",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "token",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_token",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "email",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_invitations_unique_pending",
+      "entityType": "indexes",
+      "table": "team_invitations"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_team_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_team_members_user_id",
+      "entityType": "indexes",
+      "table": "team_members"
+    },
+    {
+      "columns": [
+        {
+          "value": "slug",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_teams_slug",
+      "entityType": "indexes",
+      "table": "teams"
+    },
+    {
+      "columns": [
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_created_at",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "type",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_type",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_team_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "user_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_user_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "stripe_session_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_transactions_stripe_session_id",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        },
+        {
+          "value": "idempotency_key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"transactions\".\"idempotency_key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "idx_transactions_team_idempotency_key",
+      "entityType": "indexes",
+      "table": "transactions"
+    },
+    {
+      "columns": [
+        {
+          "value": "identifier",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "verification_identifier_idx",
+      "entityType": "indexes",
+      "table": "verification"
+    },
+    {
+      "columns": [
+        {
+          "value": "name",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_name",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "team_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_vfx_team_id",
+      "entityType": "indexes",
+      "table": "vfx"
+    },
+    {
+      "columns": [
+        {
+          "value": "render_segment_id",
+          "isExpression": false
+        },
+        {
+          "value": "model",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_video_variants_group",
+      "entityType": "indexes",
+      "table": "video_variants"
+    },
+    {
+      "columns": [
+        {
+          "value": "sequence_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "idx_video_variants_sequence",
+      "entityType": "indexes",
+      "table": "video_variants"
+    },
+    {
+      "columns": ["token"],
+      "nameExplicit": false,
+      "name": "session_token_unique",
+      "entityType": "uniques",
+      "table": "session"
+    },
+    {
+      "columns": ["email"],
+      "nameExplicit": false,
+      "name": "user_email_unique",
+      "entityType": "uniques",
+      "table": "user"
+    },
+    {
+      "value": "\"balance\" >= 0",
+      "name": "positive_balance",
+      "entityType": "checks",
+      "table": "credits"
+    }
+  ],
+  "renames": []
+}

--- a/src/components/prompts/prompt-history-sheet.tsx
+++ b/src/components/prompts/prompt-history-sheet.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/sheet';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
+  useCancelPendingArtifact,
   useRestoreMusicPromptVariant,
   useRestoreShotPromptVariant,
   useSequenceMusicPromptVariants,
@@ -29,11 +30,12 @@ import {
   isValidTextToImageModel,
   videoModelDisplayName,
 } from '@/lib/ai/models';
-import type { PromptVariantSource } from '@/lib/db/schema';
+import type { PromptVariantSource, PromptVersionStatus } from '@/lib/db/schema';
 import { cn } from '@/lib/utils';
 import {
   AlertCircle,
   AlertTriangle,
+  Ban,
   Check,
   Image as ImageIcon,
   Loader2,
@@ -97,7 +99,14 @@ type PromptRow = {
   createdAt: Date;
   createdByName: string | null;
   inputHash: string | null;
+  /** Lifecycle (#1085): non-'completed' rows are in-flight placeholders or
+   * their terminal failures — greyed, no diff/restore, cancellable while
+   * live. Music history predates the column and always reads 'completed'. */
+  status: PromptVersionStatus;
 };
+
+const isLiveStatus = (status: string): boolean =>
+  status === 'pending' || status === 'generating';
 
 type MediaRow = {
   id: string;
@@ -146,9 +155,11 @@ function MediaStatusIcon({ status }: { status: string }) {
     return <Check className="h-3 w-3 text-muted-foreground" aria-hidden />;
   if (status === 'failed')
     return <AlertTriangle className="h-3 w-3 text-destructive" aria-hidden />;
+  if (status === 'cancelled')
+    return <Ban className="h-3 w-3 text-muted-foreground" aria-hidden />;
   return (
     <Loader2
-      className="h-3 w-3 animate-spin text-muted-foreground"
+      className="h-3 w-3 animate-spin text-muted-foreground motion-reduce:animate-none"
       aria-hidden
     />
   );
@@ -162,6 +173,9 @@ type MediaHistoryListProps = {
   onRetry: () => void;
   selecting: boolean;
   onSelect: (versionId: string) => void;
+  /** Cancel an in-flight generation (#1085) — image versions only today. */
+  cancelling?: boolean;
+  onCancel?: (versionId: string) => void;
 };
 
 /**
@@ -176,6 +190,8 @@ const MediaHistoryList: React.FC<MediaHistoryListProps> = ({
   onRetry,
   selecting,
   onSelect,
+  cancelling = false,
+  onCancel,
 }) => {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const emptyLabel =
@@ -310,13 +326,36 @@ const MediaHistoryList: React.FC<MediaHistoryListProps> = ({
                 {row.status === 'failed' && (
                   <span className="text-xs text-destructive">Failed</span>
                 )}
-                {row.status === 'generating' && (
+                {row.status === 'cancelled' && (
+                  <span className="text-xs text-muted-foreground">
+                    Cancelled
+                  </span>
+                )}
+                {isLiveStatus(row.status) && (
                   <span className="text-xs text-muted-foreground">
                     Generating…
                   </span>
                 )}
               </div>
             </button>
+
+            {onCancel && isLiveStatus(row.status) && (
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={cancelling}
+                  onClick={() => onCancel(row.id)}
+                  aria-label={`Cancel this ${kind} generation`}
+                >
+                  {cancelling && (
+                    <Loader2 className="mr-2 h-3 w-3 animate-spin motion-reduce:animate-none" />
+                  )}
+                  Cancel
+                </Button>
+              </div>
+            )}
 
             {expanded && (
               <section
@@ -384,6 +423,9 @@ type PromptHistoryListProps = {
   onRetry: () => void;
   restorePending: boolean;
   onRestore: (variantId: string) => void;
+  /** Cancel an in-flight prompt generation (#1085). */
+  cancelling?: boolean;
+  onCancel?: (variantId: string) => void;
 };
 
 const PromptHistoryList: React.FC<PromptHistoryListProps> = ({
@@ -394,6 +436,8 @@ const PromptHistoryList: React.FC<PromptHistoryListProps> = ({
   onRetry,
   restorePending,
   onRestore,
+  cancelling = false,
+  onCancel,
 }) => {
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
@@ -439,6 +483,64 @@ const PromptHistoryList: React.FC<PromptHistoryListProps> = ({
   return (
     <ul className="flex flex-col gap-2 pt-2">
       {rows.map((row) => {
+        // In-flight placeholders and their terminal failures (#1085): no
+        // text to diff or restore — a quiet status row, cancellable while
+        // the generation is still live.
+        if (row.status !== 'completed') {
+          const live = isLiveStatus(row.status);
+          return (
+            <li
+              key={row.id}
+              className="flex flex-col gap-2 rounded-md border border-dashed p-3 text-muted-foreground"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  {live ? (
+                    <Loader2
+                      className="h-3 w-3 animate-spin motion-reduce:animate-none"
+                      aria-hidden
+                    />
+                  ) : row.status === 'failed' ? (
+                    <AlertTriangle
+                      className="h-3 w-3 text-destructive"
+                      aria-hidden
+                    />
+                  ) : (
+                    <Ban className="h-3 w-3" aria-hidden />
+                  )}
+                  <span className="text-sm">
+                    {live
+                      ? 'Generating…'
+                      : row.status === 'failed'
+                        ? 'Generation failed'
+                        : 'Cancelled'}
+                  </span>
+                </div>
+                <span className="text-xs tabular-nums">
+                  {formatTimestamp(row.createdAt)}
+                </span>
+              </div>
+              {live && onCancel && (
+                <div className="flex justify-end">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={cancelling}
+                    onClick={() => onCancel(row.id)}
+                    aria-label="Cancel this prompt generation"
+                  >
+                    {cancelling && (
+                      <Loader2 className="mr-2 h-3 w-3 animate-spin motion-reduce:animate-none" />
+                    )}
+                    Cancel
+                  </Button>
+                </div>
+              )}
+            </li>
+          );
+        }
+
         const expanded = expandedId === row.id;
         const isCurrent = row.text === currentText;
         const panelId = `prompt-history-panel-${row.id}`;
@@ -546,6 +648,7 @@ export const PromptHistorySheet: React.FC<PromptHistorySheetProps> = (
         createdAt: v.createdAt,
         createdByName: v.createdByName,
         inputHash: v.inputHash,
+        status: 'completed' as const,
       }))
     : shotQuery.data?.map((v) => ({
         id: v.id,
@@ -554,6 +657,7 @@ export const PromptHistorySheet: React.FC<PromptHistorySheetProps> = (
         createdAt: v.createdAt,
         createdByName: v.createdByName,
         inputHash: v.inputHash,
+        status: v.status,
       }));
 
   const restoreShot = useRestoreShotPromptVariant({
@@ -563,6 +667,48 @@ export const PromptHistorySheet: React.FC<PromptHistorySheetProps> = (
   });
   const restoreMusic = useRestoreMusicPromptVariant(sequenceId);
   const restoreMutation = isMusic ? restoreMusic : restoreShot;
+
+  // Cancel an in-flight pending claim (#1085) — shot modes only.
+  const cancelPending = useCancelPendingArtifact({
+    sequenceId,
+    shotId: shotId ?? '',
+  });
+  const onCancelPrompt = isMusic
+    ? undefined
+    : (versionId: string) =>
+        cancelPending.mutate(
+          {
+            versionId,
+            artifact: mode === 'visual' ? 'visual-prompt' : 'motion-prompt',
+          },
+          {
+            onSuccess: ({ cancelled }) => {
+              if (!cancelled) toast.info('This generation already finished');
+            },
+            onError: (err) =>
+              toast.error('Cancel failed', {
+                description:
+                  err instanceof Error ? err.message : 'Unknown error',
+              }),
+          }
+        );
+  const onCancelImage =
+    isMusic || mode !== 'visual'
+      ? undefined
+      : (versionId: string) =>
+          cancelPending.mutate(
+            { versionId, artifact: 'image' },
+            {
+              onSuccess: ({ cancelled }) => {
+                if (!cancelled) toast.info('This generation already finished');
+              },
+              onError: (err) =>
+                toast.error('Cancel failed', {
+                  description:
+                    err instanceof Error ? err.message : 'Unknown error',
+                }),
+            }
+          );
 
   const imageQuery = useShotImageVersions(
     { sequenceId, shotId: shotId ?? '' },
@@ -666,6 +812,8 @@ export const PromptHistorySheet: React.FC<PromptHistorySheetProps> = (
                   onRetry={() => void refetch()}
                   restorePending={restoreMutation.isPending}
                   onRestore={onRestore}
+                  cancelling={cancelPending.isPending}
+                  onCancel={onCancelPrompt}
                 />
               </ScrollArea>
             </TabsContent>
@@ -682,6 +830,8 @@ export const PromptHistorySheet: React.FC<PromptHistorySheetProps> = (
                   onRetry={() => void mediaQuery.refetch()}
                   selecting={selectMutation.isPending}
                   onSelect={onSelectMedia}
+                  cancelling={cancelPending.isPending}
+                  onCancel={onCancelImage}
                 />
               </ScrollArea>
             </TabsContent>

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -93,6 +93,7 @@ import {
   type SelectionScope,
 } from '@/lib/scenes/scene-selection';
 import { errorMessage, isInsufficientCreditsError } from '@/lib/errors';
+import { useUpdateStaleShots } from '@/hooks/use-update-stale-shots';
 import { SceneCastTab } from './scene-cast-tab';
 import { SceneStaleShots } from './scene-stale-shots';
 import { SceneElementsTab } from './scene-elements-tab';
@@ -463,6 +464,38 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     sequenceId,
     shotId: shot?.id,
   });
+
+  // "Update all" (#1077) — enqueues the durable UpdateStaleShotsWorkflow,
+  // which recomputes staleness server-side and regenerates whatever reads
+  // stale then. This component only picks the scope; the hook polls the run
+  // and reports what it did.
+  const updateStaleShots = useUpdateStaleShots({ sequenceId });
+  const handleUpdateAll = useCallback(() => {
+    if (!shot?.id) return;
+    if (falNeedsBillingSetup) {
+      showFalGate();
+      return;
+    }
+    updateStaleShots.run({ shotId: shot.id });
+  }, [shot?.id, falNeedsBillingSetup, showFalGate, updateStaleShots]);
+  const handleScopeUpdateAll = useCallback(() => {
+    if (!scopeShots || !scopeStaleness) return;
+    if (falNeedsBillingSetup) {
+      showFalGate();
+      return;
+    }
+    updateStaleShots.run({
+      // Undefined at sequence scope → the workflow covers the whole sequence.
+      sceneId: scriptSceneId,
+    });
+  }, [
+    scopeShots,
+    scopeStaleness,
+    scriptSceneId,
+    falNeedsBillingSetup,
+    showFalGate,
+    updateStaleShots,
+  ]);
 
   const {
     items: mentionItems,
@@ -1279,6 +1312,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     !!shot &&
     !shotBusy &&
     (isStalenessError || shotStalenessUnknown(staleness));
+  const isUpdatingAll = updateStaleShots.isRunning;
 
   return (
     <Tabs
@@ -1291,11 +1325,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       className="w-full"
     >
       {/* Staleness status line (#1077) — one quiet summary under the scope
-          header instead of the old filled banners. Purely informational: each
-          artifact carries its own Regenerate control on its tab, so the
-          summary states the condition and the tabs own the action. */}
+          header instead of the old filled banners. "Update all" regenerates
+          only what is stale now — it doesn't cascade into artifacts the
+          regeneration outdates. Video stays a manual pick on its tab. */}
       {shotHasStale && (
-        <StalenessIndicator entityType="shot" density="status-line" />
+        <StalenessIndicator
+          entityType="shot"
+          density="status-line"
+          isRegenerating={isUpdatingAll}
+          onRegenerate={handleUpdateAll}
+        />
       )}
       {shotStaleUnknown && !shotHasStale && (
         <StalenessIndicator
@@ -1307,13 +1346,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       )}
 
       {/* Scene/sequence scope (#1077): same one-line pattern, ending in
-          shot-number chips that navigate down to shot scope. */}
+          shot-number chips that navigate down to shot scope, plus a
+          multi-shot Update all. */}
       {!shot && scopeShots && onSelectShot && (
         <SceneStaleShots
           shots={scopeShots}
           staleness={scopeStaleness}
           stalenessFailed={scopeStalenessFailed}
           onSelectShot={onSelectShot}
+          onUpdateAll={handleScopeUpdateAll}
+          isUpdating={updateStaleShots.isRunning}
         />
       )}
 

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -40,6 +40,8 @@ import {
   type ShotStaleness,
   markArtifactFresh,
   shotIsStale,
+  shotIsUpdating,
+  shotStalenessKey,
   shotStalenessNamespace,
   shotStalenessUnknown,
   useShotStaleness,
@@ -546,6 +548,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     onSuccess: (result, vars) => {
       if (result.alreadyUpToDate) {
         toast.info('Prompt is already up to date');
+      } else if (result.alreadyInFlight) {
+        // Server-side dedup hit (#1085): a run — this tab's, another tab's,
+        // or a teammate's — is already producing this prompt.
+        toast.info('This prompt is already being regenerated');
       } else {
         // Workflow is now enqueued; hold the busy state via the stream's
         // `'pending'` status until deltas start arriving. Naturally cleared
@@ -1306,6 +1312,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // so, and "out of date" over a regenerating still just reads as stuck.
   const shotBusy = isGenerating || isGeneratingMotion;
   const shotHasStale = !!shot && !shotBusy && shotIsStale(staleness);
+  // 'updating' (#1085): a server-side pending claim exists — some run (this
+  // tab's, another tab's, a teammate's) is already regenerating the artifact.
+  const shotHasUpdating = !!shot && !shotBusy && shotIsUpdating(staleness);
   // The comparison failed rather than came back clean — say so instead of
   // rendering the confident silence of an up-to-date shot.
   const shotStaleUnknown =
@@ -1313,6 +1322,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     !shotBusy &&
     (isStalenessError || shotStalenessUnknown(staleness));
   const isUpdatingAll = updateStaleShots.isRunning;
+  const visualBusy =
+    isRegeneratingVisualPrompt || staleness?.visualPrompt === 'updating';
+  const motionBusy =
+    isRegeneratingMotionPrompt || staleness?.motionPrompt === 'updating';
 
   return (
     <Tabs
@@ -1328,12 +1341,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           header instead of the old filled banners. "Update all" regenerates
           only what is stale now — it doesn't cascade into artifacts the
           regeneration outdates. Video stays a manual pick on its tab. */}
-      {shotHasStale && (
+      {(shotHasStale || shotHasUpdating) && (
         <StalenessIndicator
           entityType="shot"
           density="status-line"
-          isRegenerating={isUpdatingAll}
-          onRegenerate={handleUpdateAll}
+          message={shotHasStale ? undefined : 'Updating out-of-date artifacts…'}
+          // Busy while OUR run is in flight, or while everything left is
+          // already covered by a server-side claim (#1085) — clicking again
+          // would just no-op against the dedup.
+          isRegenerating={isUpdatingAll || !shotHasStale}
+          onRegenerate={shotHasStale ? handleUpdateAll : undefined}
         />
       )}
       {shotStaleUnknown && !shotHasStale && (
@@ -1389,21 +1406,23 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           <TabsTrigger key={t.value} value={t.value}>
             {t.label}
             {t.value === 'image-prompt' &&
-              staleness?.visualPrompt === 'stale' && (
+              (staleness?.visualPrompt === 'stale' ||
+                staleness?.visualPrompt === 'updating') && (
                 <StalenessIndicator
                   artifact="visual-prompt"
                   entityType="shot"
                   density="corner-dot"
-                  isRegenerating={isRegeneratingVisualPrompt}
+                  isRegenerating={visualBusy}
                 />
               )}
             {t.value === 'motion-prompt' &&
-              staleness?.motionPrompt === 'stale' && (
+              (staleness?.motionPrompt === 'stale' ||
+                staleness?.motionPrompt === 'updating') && (
                 <StalenessIndicator
                   artifact="motion-prompt"
                   entityType="shot"
                   density="corner-dot"
-                  isRegenerating={isRegeneratingMotionPrompt}
+                  isRegenerating={motionBusy}
                 />
               )}
           </TabsTrigger>
@@ -1456,12 +1475,13 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 {/* Quiet stale chip on the artifact itself (#1077); the
                     optimistic 'fresh' write clears it the moment Regenerate
                     is clicked. */}
-                {staleness?.visualPrompt === 'stale' && (
+                {(staleness?.visualPrompt === 'stale' ||
+                  staleness?.visualPrompt === 'updating') && (
                   <StalenessIndicator
                     artifact="visual-prompt"
                     entityType="shot"
                     density="header-chip"
-                    isRegenerating={isRegeneratingVisualPrompt}
+                    isRegenerating={visualBusy}
                     onRegenerate={() =>
                       regeneratePromptMutation.mutate({ promptType: 'visual' })
                     }
@@ -1726,12 +1746,13 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   Prompt
                 </label>
                 {/* Quiet stale chip — same pattern as the image tab (#1077). */}
-                {staleness?.motionPrompt === 'stale' && (
+                {(staleness?.motionPrompt === 'stale' ||
+                  staleness?.motionPrompt === 'updating') && (
                   <StalenessIndicator
                     artifact="motion-prompt"
                     entityType="shot"
                     density="header-chip"
-                    isRegenerating={isRegeneratingMotionPrompt}
+                    isRegenerating={motionBusy}
                     onRegenerate={() =>
                       regeneratePromptMutation.mutate({ promptType: 'motion' })
                     }

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -42,7 +42,6 @@ import {
   markArtifactFresh,
   shotIsStale,
   shotIsUpdating,
-  shotStalenessKey,
   shotStalenessNamespace,
   shotStalenessUnknown,
   useShotStaleness,

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -36,6 +36,7 @@ import {
   segmentPanelIsInformative,
 } from '@/components/scenes/segment-video-panel';
 import type { SequenceSegment } from '@/lib/scenes/scene-segments';
+import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
 import {
   type ShotStaleness,
   markArtifactFresh,
@@ -472,32 +473,39 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // stale then. This component only picks the scope; the hook polls the run
   // and reports what it did.
   const updateStaleShots = useUpdateStaleShots({ sequenceId });
-  const handleUpdateAll = useCallback(() => {
-    if (!shot?.id) return;
-    if (falNeedsBillingSetup) {
-      showFalGate();
-      return;
-    }
-    updateStaleShots.run({ shotId: shot.id });
-  }, [shot?.id, falNeedsBillingSetup, showFalGate, updateStaleShots]);
-  const handleScopeUpdateAll = useCallback(() => {
-    if (!scopeShots || !scopeStaleness) return;
-    if (falNeedsBillingSetup) {
-      showFalGate();
-      return;
-    }
-    updateStaleShots.run({
-      // Undefined at sequence scope → the workflow covers the whole sequence.
-      sceneId: scriptSceneId,
-    });
-  }, [
-    scopeShots,
-    scopeStaleness,
-    scriptSceneId,
-    falNeedsBillingSetup,
-    showFalGate,
-    updateStaleShots,
-  ]);
+  const handleUpdateAll = useCallback(
+    (depth: UpdateStaleDepth) => {
+      if (!shot?.id) return;
+      if (falNeedsBillingSetup) {
+        showFalGate();
+        return;
+      }
+      updateStaleShots.run({ shotId: shot.id, depth });
+    },
+    [shot?.id, falNeedsBillingSetup, showFalGate, updateStaleShots]
+  );
+  const handleScopeUpdateAll = useCallback(
+    (depth: UpdateStaleDepth) => {
+      if (!scopeShots || !scopeStaleness) return;
+      if (falNeedsBillingSetup) {
+        showFalGate();
+        return;
+      }
+      updateStaleShots.run({
+        // Undefined at sequence scope → the workflow covers the whole sequence.
+        sceneId: scriptSceneId,
+        depth,
+      });
+    },
+    [
+      scopeShots,
+      scopeStaleness,
+      scriptSceneId,
+      falNeedsBillingSetup,
+      showFalGate,
+      updateStaleShots,
+    ]
+  );
 
   const {
     items: mentionItems,
@@ -1350,10 +1358,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           // already covered by a server-side claim (#1085) — clicking again
           // would just no-op against the dedup.
           isRegenerating={isUpdatingAll || !shotHasStale}
-          onRegenerate={shotHasStale ? handleUpdateAll : undefined}
+          onRegenerateDepth={shotHasStale ? handleUpdateAll : undefined}
         />
       )}
-      {shotStaleUnknown && !shotHasStale && (
+      {shotStaleUnknown && !shotHasStale && !shotHasUpdating && (
         <StalenessIndicator
           entityType="shot"
           density="status-line"

--- a/src/components/scenes/scene-stale-shots.tsx
+++ b/src/components/scenes/scene-stale-shots.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/components/ui/button';
 import {
   type ShotStaleness,
   shotIsStale,
+  shotIsUpdating,
   shotStalenessUnknown,
 } from '@/hooks/use-shot-staleness';
 import type { ShotWithImage } from '@/lib/shots/shot-with-image';
@@ -58,18 +59,33 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
   }
 
   const staleShots = shots.filter((shot) => shotIsStale(staleness?.[shot.id]));
-  if (staleShots.length === 0) return null;
+  // Shots whose stale artifacts are all already covered by a live server-side
+  // claim (#1085) — a run (this tab's or someone else's) is fixing them now.
+  const updatingShots = shots.filter(
+    (shot) =>
+      !shotIsStale(staleness?.[shot.id]) && shotIsUpdating(staleness?.[shot.id])
+  );
+  if (staleShots.length === 0 && updatingShots.length === 0) return null;
+
+  // Nothing actionable left: everything in flight, clicking would no-op
+  // against the server-side dedup.
+  const busy = isUpdating || staleShots.length === 0;
 
   return (
     <StalenessIndicator
       entityType="sequence"
       density="status-line"
-      message="Out of date since your edit"
-      isRegenerating={isUpdating}
-      onRegenerate={onUpdateAll}
+      message={
+        staleShots.length > 0
+          ? 'Out of date since your edit'
+          : 'Updating out-of-date shots…'
+      }
+      isRegenerating={busy}
+      onRegenerate={staleShots.length > 0 ? onUpdateAll : undefined}
     >
-      {staleShots.map((shot) => {
+      {[...staleShots, ...updatingShots].map((shot) => {
         const number = shot.shotNumber ?? shot.orderIndex + 1;
+        const updating = updatingShots.includes(shot);
         return (
           <Button
             key={shot.id}
@@ -78,18 +94,22 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
             size="sm"
             className="h-6 rounded-full px-2 text-xs font-normal"
             onClick={() => onSelectShot(shot.id)}
-            aria-label={`Open shot ${number} — out of date`}
+            aria-label={
+              updating
+                ? `Open shot ${number} — updating`
+                : `Open shot ${number} — out of date`
+            }
           >
+            {updating && (
+              <Loader2
+                aria-hidden="true"
+                className="mr-1 h-2.5 w-2.5 animate-spin motion-reduce:animate-none"
+              />
+            )}
             Shot {number}
           </Button>
         );
       })}
-      {isUpdating && (
-        <Loader2
-          aria-hidden="true"
-          className="h-3 w-3 animate-spin motion-reduce:animate-none"
-        />
-      )}
     </StalenessIndicator>
   );
 };

--- a/src/components/scenes/scene-stale-shots.tsx
+++ b/src/components/scenes/scene-stale-shots.tsx
@@ -72,9 +72,13 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
   );
   if (staleShots.length === 0 && updatingShots.length === 0) return null;
 
-  // Nothing actionable left: everything in flight, clicking would no-op
-  // against the server-side dedup.
-  const busy = isUpdating || staleShots.length === 0;
+  const busy = isUpdating;
+
+  // Chip labels use the shot's position within the IN-SCOPE list, not
+  // `shotNumber`: shot numbers are per-scene, so at sequence scope every
+  // scene's first shot would read "Shot 1" (#1095 review). Positions match
+  // the rail's ordering because `shots` is documented as in-scope-in-order.
+  const numberByShotId = new Map(shots.map((s, index) => [s.id, index + 1]));
 
   return (
     <div
@@ -99,7 +103,7 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
       </span>
       <span aria-hidden="true">·</span>
       {[...staleShots, ...updatingShots].map((shot) => {
-        const number = shot.shotNumber ?? shot.orderIndex + 1;
+        const number = numberByShotId.get(shot.id) ?? shot.orderIndex + 1;
         const updating = updatingShots.includes(shot);
         return (
           <Button

--- a/src/components/scenes/scene-stale-shots.tsx
+++ b/src/components/scenes/scene-stale-shots.tsx
@@ -1,13 +1,14 @@
-import { StalenessIndicator } from '@/components/staleness/staleness-indicator';
+import { UpdateAllDialog } from '@/components/staleness/update-all-dialog';
 import { Button } from '@/components/ui/button';
 import {
   type ShotStaleness,
   shotIsStale,
   shotIsUpdating,
-  shotStalenessUnknown,
 } from '@/hooks/use-shot-staleness';
 import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
 import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
 
 type SceneStaleShotsProps = {
   /** The in-scope shots (a scene's, or the whole sequence's), in order. */
@@ -15,14 +16,17 @@ type SceneStaleShotsProps = {
   /** Batched staleness for those shots, keyed by shot id (#1077). */
   staleness: Record<string, ShotStaleness> | undefined;
   /**
-   * The staleness request failed. Without this, an errored request is
+   * The staleness check failed. Without this, an errored request is
    * indistinguishable from a clean scene — both render nothing.
    */
   stalenessFailed?: boolean;
   /** Same handler the left rail uses — lands at shot scope. */
   onSelectShot: (shotId: string) => void;
-  /** Regenerate every artifact that is stale right now across these shots. */
-  onUpdateAll?: () => void;
+  /**
+   * Regenerate out-of-date artifacts across these shots at the chosen
+   * cascade depth (#1085) — rendered as a depth menu on the action.
+   */
+  onUpdateAll?: (depth: UpdateStaleDepth) => void;
   isUpdating?: boolean;
 };
 
@@ -41,20 +45,21 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
   onUpdateAll,
   isUpdating = false,
 }) => {
-  // A shot whose comparison failed is reported the same way a failed request
-  // is: we don't know, and saying nothing would read as "up to date".
-  const uncheckable =
-    stalenessFailed ||
-    shots.some((shot) => shotStalenessUnknown(staleness?.[shot.id]));
-
-  if (uncheckable) {
+  // "Update all" opens the depth confirm dialog (#1085).
+  const [updateAllOpen, setUpdateAllOpen] = useState(false);
+  if (stalenessFailed) {
     return (
-      <StalenessIndicator
-        entityType="sequence"
-        density="status-line"
-        tone="unknown"
-        message="Couldn’t check whether these shots are up to date"
-      />
+      <div
+        data-testid="scene-stale-shots-error"
+        aria-live="polite"
+        className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
+      >
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 shrink-0 rounded-full bg-muted-foreground/50"
+        />
+        <span>Couldn’t check whether these shots are up to date</span>
+      </div>
     );
   }
 
@@ -72,17 +77,27 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
   const busy = isUpdating || staleShots.length === 0;
 
   return (
-    <StalenessIndicator
-      entityType="sequence"
-      density="status-line"
-      message={
-        staleShots.length > 0
-          ? 'Out of date since your edit'
-          : 'Updating out-of-date shots…'
-      }
-      isRegenerating={busy}
-      onRegenerate={staleShots.length > 0 ? onUpdateAll : undefined}
+    <div
+      data-testid="scene-stale-shots"
+      className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground"
     >
+      {staleShots.length > 0 ? (
+        <span
+          aria-hidden="true"
+          className="h-2 w-2 shrink-0 rounded-full bg-amber-500"
+        />
+      ) : (
+        <Loader2
+          aria-hidden="true"
+          className="h-3 w-3 shrink-0 animate-spin text-amber-600 motion-reduce:animate-none"
+        />
+      )}
+      <span>
+        {staleShots.length > 0
+          ? 'Out of date since your edit'
+          : 'Updating out-of-date shots…'}
+      </span>
+      <span aria-hidden="true">·</span>
       {[...staleShots, ...updatingShots].map((shot) => {
         const number = shot.shotNumber ?? shot.orderIndex + 1;
         const updating = updatingShots.includes(shot);
@@ -92,7 +107,7 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
             type="button"
             variant="outline"
             size="sm"
-            className="h-6 rounded-full px-2 text-xs font-normal"
+            className="h-5 rounded-full px-2 text-xs font-normal"
             onClick={() => onSelectShot(shot.id)}
             aria-label={
               updating
@@ -110,6 +125,37 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
           </Button>
         );
       })}
-    </StalenessIndicator>
+      {onUpdateAll && staleShots.length > 0 && (
+        <>
+          <span aria-hidden="true">·</span>
+          <Button
+            type="button"
+            variant="link"
+            size="sm"
+            className="h-auto p-0 text-xs"
+            onClick={() => setUpdateAllOpen(true)}
+            disabled={busy}
+            aria-busy={busy}
+            aria-label="Update all out-of-date shots"
+          >
+            {isUpdating && (
+              <Loader2
+                aria-hidden="true"
+                className="mr-1 h-3 w-3 animate-spin motion-reduce:animate-none"
+              />
+            )}
+            {isUpdating ? 'Updating…' : 'Update all'}
+          </Button>
+          <UpdateAllDialog
+            open={updateAllOpen}
+            onOpenChange={setUpdateAllOpen}
+            onConfirm={(depth: UpdateStaleDepth) => {
+              setUpdateAllOpen(false);
+              onUpdateAll(depth);
+            }}
+          />
+        </>
+      )}
+    </div>
   );
 };

--- a/src/components/scenes/scene-stale-shots.tsx
+++ b/src/components/scenes/scene-stale-shots.tsx
@@ -6,6 +6,7 @@ import {
   shotStalenessUnknown,
 } from '@/hooks/use-shot-staleness';
 import type { ShotWithImage } from '@/lib/shots/shot-with-image';
+import { Loader2 } from 'lucide-react';
 
 type SceneStaleShotsProps = {
   /** The in-scope shots (a scene's, or the whole sequence's), in order. */
@@ -19,6 +20,9 @@ type SceneStaleShotsProps = {
   stalenessFailed?: boolean;
   /** Same handler the left rail uses — lands at shot scope. */
   onSelectShot: (shotId: string) => void;
+  /** Regenerate every artifact that is stale right now across these shots. */
+  onUpdateAll?: () => void;
+  isUpdating?: boolean;
 };
 
 /**
@@ -33,6 +37,8 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
   staleness,
   stalenessFailed = false,
   onSelectShot,
+  onUpdateAll,
+  isUpdating = false,
 }) => {
   // A shot whose comparison failed is reported the same way a failed request
   // is: we don't know, and saying nothing would read as "up to date".
@@ -59,6 +65,8 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
       entityType="sequence"
       density="status-line"
       message="Out of date since your edit"
+      isRegenerating={isUpdating}
+      onRegenerate={onUpdateAll}
     >
       {staleShots.map((shot) => {
         const number = shot.shotNumber ?? shot.orderIndex + 1;
@@ -76,6 +84,12 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
           </Button>
         );
       })}
+      {isUpdating && (
+        <Loader2
+          aria-hidden="true"
+          className="h-3 w-3 animate-spin motion-reduce:animate-none"
+        />
+      )}
     </StalenessIndicator>
   );
 };

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -90,7 +90,9 @@ import { toast } from 'sonner';
  */
 type SceneModelVariant = {
   model: string;
-  status: ShotVariant['status'];
+  // FrameVariant's wider union (adds 'cancelled', #1085); shot-variant rows
+  // assign into it unchanged.
+  status: FrameVariant['status'];
   url: string | null;
   discardedAt: Date | null;
   divergedAt?: Date | null;
@@ -1376,9 +1378,13 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
                 staleLabel={
                   effectiveTab === 'image-prompt' &&
                   curSelectedShotId &&
-                  !regeneratingImages.has(curSelectedShotId) &&
-                  scopeStaleness?.[curSelectedShotId]?.thumbnail === 'stale'
-                    ? 'Out of date'
+                  !regeneratingImages.has(curSelectedShotId)
+                    ? scopeStaleness?.[curSelectedShotId]?.thumbnail === 'stale'
+                      ? 'Out of date'
+                      : scopeStaleness?.[curSelectedShotId]?.thumbnail ===
+                          'updating'
+                        ? 'Updating…'
+                        : null
                     : null
                 }
                 progressMessage={

--- a/src/components/staleness/staleness-indicator.tsx
+++ b/src/components/staleness/staleness-indicator.tsx
@@ -67,9 +67,9 @@ type StalenessIndicatorProps = StalenessIndicatorBaseProps &
         // Quiet one-line summary (#1077): dot + muted message + an optional
         // text action. Staleness is a routine editing state, not a failure —
         // no fill, no triangle. Omit `onRegenerate` for a purely informational
-        // line: the shot-scope summary does this, because each artifact
-        // carries its own Regenerate control on its tab. Covers any mix of
-        // artifacts, so it takes no `artifact`.
+        // line; the shot-scope summary may pass one to drive "Update all" for
+        // that shot (#1085). Covers any mix of artifacts, so it takes no
+        // `artifact`.
         density: 'status-line';
         artifact?: never;
         onRegenerate?: () => void;

--- a/src/components/staleness/staleness-indicator.tsx
+++ b/src/components/staleness/staleness-indicator.tsx
@@ -29,11 +29,17 @@ export type StalenessEntityType =
   | 'talent'
   | 'sequence';
 
-export type StalenessIndicatorDensity =
+type StalenessIndicatorDensity =
   | 'inline'
   | 'corner-dot'
   | 'status-line'
   | 'header-chip';
+
+/** The subset the divergent/sheet banners branch on; they render no others. */
+export type BannerDensity = Extract<
+  StalenessIndicatorDensity,
+  'inline' | 'corner-dot'
+>;
 
 type StalenessIndicatorBaseProps = {
   entityType: StalenessEntityType;
@@ -105,8 +111,7 @@ const ARTIFACT_LABEL: Record<StalenessArtifact, string> = {
 export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
   props
 ) => {
-  const { entityType, density = 'inline', isRegenerating = false, className } =
-    props;
+  const { entityType, isRegenerating = false, className } = props;
   const [dismissed, setDismissed] = useState(false);
   // Status-line "Update all" opens the depth confirm dialog (#1085).
   const [updateAllOpen, setUpdateAllOpen] = useState(false);
@@ -118,7 +123,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
     ? `Stale ${ARTIFACT_LABEL[artifact]} on this ${entityType} — inputs changed since it was generated`
     : `Stale artifacts on this ${entityType} — inputs changed since they were generated`;
 
-  if (density === 'corner-dot') {
+  if (props.density === 'corner-dot') {
     // Non-interactive: corner-dot is a presentational signal that nests inside
     // tab triggers and other interactive parents. Regeneration always happens
     // from the tab body's inline banner where there's room for proper UX.

--- a/src/components/staleness/staleness-indicator.tsx
+++ b/src/components/staleness/staleness-indicator.tsx
@@ -7,6 +7,8 @@ import {
   AlertTitle,
 } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { UpdateAllDialog } from '@/components/staleness/update-all-dialog';
+import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
 import { cn } from '@/lib/utils';
 
 export type StalenessArtifact =
@@ -27,17 +29,11 @@ export type StalenessEntityType =
   | 'talent'
   | 'sequence';
 
-type StalenessIndicatorDensity =
+export type StalenessIndicatorDensity =
   | 'inline'
   | 'corner-dot'
   | 'status-line'
   | 'header-chip';
-
-/** The subset the divergent/sheet banners branch on; they render no others. */
-export type BannerDensity = Extract<
-  StalenessIndicatorDensity,
-  'inline' | 'corner-dot'
->;
 
 type StalenessIndicatorBaseProps = {
   entityType: StalenessEntityType;
@@ -57,22 +53,24 @@ type StalenessIndicatorProps = StalenessIndicatorBaseProps &
     | {
         // Non-interactive: safe to nest inside other interactive parents
         // (e.g. TabsTrigger). No regenerate handler — drive that from the
-        // artifact's own control in the tab body.
+        // tab body's inline banner instead.
         density: 'corner-dot';
         artifact: StalenessArtifact;
         onRegenerate?: never;
         onDismiss?: never;
       }
     | {
-        // Quiet one-line summary (#1077): dot + muted message + an optional
-        // text action. Staleness is a routine editing state, not a failure —
-        // no fill, no triangle. Omit `onRegenerate` for a purely informational
-        // line; the shot-scope summary may pass one to drive "Update all" for
-        // that shot (#1085). Covers any mix of artifacts, so it takes no
-        // `artifact`.
+        // Quiet one-line summary (#1077): amber dot + muted message + an
+        // optional text action. Staleness is a routine editing state, not a
+        // failure — no fill, no triangle. Omit both handlers for a purely
+        // informational line. `onRegenerateDepth` renders the action as a
+        // depth menu (#1085: prompts / images / video / music) and takes
+        // precedence over the plain `onRegenerate` click. Covers any mix of
+        // artifacts, so `artifact` is optional.
         density: 'status-line';
-        artifact?: never;
+        artifact?: StalenessArtifact;
         onRegenerate?: () => void;
+        onRegenerateDepth?: (depth: UpdateStaleDepth) => void;
         /** Defaults to "Out of date since your last edit". */
         message?: string;
         /** Defaults to "Update all". */
@@ -107,69 +105,27 @@ const ARTIFACT_LABEL: Record<StalenessArtifact, string> = {
 export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
   props
 ) => {
-  const { entityType, isRegenerating = false, className } = props;
+  const { entityType, density = 'inline', isRegenerating = false, className } =
+    props;
   const [dismissed, setDismissed] = useState(false);
+  // Status-line "Update all" opens the depth confirm dialog (#1085).
+  const [updateAllOpen, setUpdateAllOpen] = useState(false);
 
   if (dismissed) return null;
 
-  if (props.density === 'status-line') {
-    const message = props.message ?? 'Out of date since your last edit';
-    const actionLabel = props.actionLabel ?? 'Update all';
-    const unknown = props.tone === 'unknown';
-    return (
-      <div
-        data-slot="staleness-indicator"
-        data-density="status-line"
-        data-tone={props.tone ?? 'stale'}
-        data-entity-type={entityType}
-        aria-live="polite"
-        className={cn(
-          'flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground',
-          className
-        )}
-      >
-        <span
-          aria-hidden="true"
-          className={cn(
-            'h-2 w-2 shrink-0 rounded-full',
-            unknown ? 'bg-muted-foreground/50' : 'bg-amber-500'
-          )}
-        />
-        <span className="min-w-0 truncate">{message}</span>
-        {props.children}
-        {props.onRegenerate && (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="h-6 shrink-0 px-2 text-xs"
-            onClick={props.onRegenerate}
-            disabled={isRegenerating}
-            aria-busy={isRegenerating}
-            aria-label={`${actionLabel} — this ${entityType} is out of date`}
-          >
-            {isRegenerating && (
-              <Loader2
-                aria-hidden="true"
-                className="mr-1 h-3 w-3 animate-spin motion-reduce:animate-none"
-              />
-            )}
-            {isRegenerating ? 'Updating…' : actionLabel}
-          </Button>
-        )}
-      </div>
-    );
-  }
-
-  const { artifact, density = 'inline' } = props;
-  const ariaLabel = `Stale ${ARTIFACT_LABEL[artifact]} on this ${entityType} — inputs changed since it was generated`;
+  const artifact = 'artifact' in props ? props.artifact : undefined;
+  const ariaLabel = artifact
+    ? `Stale ${ARTIFACT_LABEL[artifact]} on this ${entityType} — inputs changed since it was generated`
+    : `Stale artifacts on this ${entityType} — inputs changed since they were generated`;
 
   if (density === 'corner-dot') {
     // Non-interactive: corner-dot is a presentational signal that nests inside
     // tab triggers and other interactive parents. Regeneration always happens
-    // from the artifact's own control in the tab body.
+    // from the tab body's inline banner where there's room for proper UX.
+    // artifact is required on this density branch.
+    const cornerArtifact = props.artifact;
     const dotLabel = isRegenerating
-      ? `Regenerating ${ARTIFACT_LABEL[artifact]}…`
+      ? `Regenerating ${ARTIFACT_LABEL[cornerArtifact]}…`
       : ariaLabel;
     return (
       <span
@@ -178,7 +134,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
           isRegenerating ? 'Regenerating…' : 'Inputs changed since generation'
         }
         data-slot="staleness-indicator-dot"
-        data-artifact={artifact}
+        data-artifact={cornerArtifact}
         data-entity-type={entityType}
         className={cn(
           'inline-flex h-4 w-4 items-center justify-center',
@@ -198,6 +154,83 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
           />
         )}
       </span>
+    );
+  }
+
+  if (props.density === 'status-line') {
+    const message = props.message ?? 'Out of date since your last edit';
+    const actionLabel = props.actionLabel ?? 'Update all';
+    const unknown = props.tone === 'unknown';
+    return (
+      <div
+        data-slot="staleness-indicator"
+        data-density="status-line"
+        data-artifact={artifact}
+        data-entity-type={entityType}
+        className={cn(
+          'flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted-foreground',
+          className
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            'h-2 w-2 shrink-0 rounded-full',
+            unknown ? 'bg-muted-foreground/50' : 'bg-amber-500'
+          )}
+        />
+        <span className="min-w-0 truncate">{message}</span>
+        {props.children}
+        {props.onRegenerateDepth ? (
+          <>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-6 shrink-0 px-2 text-xs"
+              onClick={() => setUpdateAllOpen(true)}
+              disabled={isRegenerating}
+              aria-busy={isRegenerating}
+              aria-label={`${actionLabel} — ${ariaLabel}`}
+            >
+              {isRegenerating && (
+                <Loader2
+                  aria-hidden="true"
+                  className="mr-1 h-3 w-3 animate-spin motion-reduce:animate-none"
+                />
+              )}
+              {isRegenerating ? 'Updating…' : actionLabel}
+            </Button>
+            <UpdateAllDialog
+              open={updateAllOpen}
+              onOpenChange={setUpdateAllOpen}
+              onConfirm={(depth: UpdateStaleDepth) => {
+                setUpdateAllOpen(false);
+                props.onRegenerateDepth?.(depth);
+              }}
+            />
+          </>
+        ) : props.onRegenerate ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-6 shrink-0 px-2 text-xs"
+            onClick={props.onRegenerate}
+            disabled={isRegenerating}
+            aria-busy={isRegenerating}
+            aria-label={`${actionLabel} — ${ariaLabel}`}
+          >
+            {isRegenerating && (
+              <Loader2
+                aria-hidden="true"
+                className="mr-1 h-3 w-3 animate-spin motion-reduce:animate-none"
+              />
+            )}
+            {isRegenerating ? 'Updating…' : actionLabel}
+          </Button>
+        ) : null}
+      </div>
     );
   }
 
@@ -223,7 +256,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
           type="button"
           variant="link"
           size="sm"
-          className="h-6 p-0 text-xs"
+          className="h-auto p-0 text-xs"
           onClick={props.onRegenerate}
           disabled={isRegenerating}
           aria-busy={isRegenerating}
@@ -241,8 +274,8 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
     );
   }
 
-  // Inline density.
-  const { onRegenerate, onDismiss } = props;
+  // Inline density (artifact required on this branch).
+  const { onRegenerate, onDismiss, artifact: inlineArtifact } = props;
   const handleDismiss = () => {
     setDismissed(true);
     onDismiss?.();
@@ -251,7 +284,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
     <Alert
       data-slot="staleness-indicator"
       data-density="inline"
-      data-artifact={artifact}
+      data-artifact={inlineArtifact}
       data-entity-type={entityType}
       className={cn(
         'border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-50',
@@ -261,7 +294,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
       <AlertTriangle aria-hidden="true" />
       <AlertTitle>Inputs changed</AlertTitle>
       <AlertDescription>
-        This {ARTIFACT_LABEL[artifact]} was generated from earlier inputs.
+        This {ARTIFACT_LABEL[inlineArtifact]} was generated from earlier inputs.
       </AlertDescription>
       <AlertAction className="flex items-center gap-1">
         <Button

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -1,0 +1,98 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import {
+  UPDATE_STALE_DEPTH_DESCRIPTIONS,
+  UPDATE_STALE_DEPTH_LABELS,
+  UPDATE_STALE_DEPTHS,
+  type UpdateStaleDepth,
+} from '@/lib/shots/update-stale-depth';
+import { cn } from '@/lib/utils';
+import { useState } from 'react';
+
+type UpdateAllDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Confirm with the chosen cascade depth; the dialog closes itself. */
+  onConfirm: (depth: UpdateStaleDepth) => void;
+};
+
+/**
+ * "Update all" depth confirmation (#1085). One dialog per trigger site
+ * (shot status line, scene/sequence summary): pick how deep the update
+ * cascades — prompts → images → videos → music — then confirm. A dialog
+ * rather than a menu so each level's cost consequence is readable before
+ * anything is billed. Native radios for keyboard/AT semantics.
+ */
+export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
+  open,
+  onOpenChange,
+  onConfirm,
+}) => {
+  // 'images' is the middle-ground default — the closest match to what
+  // "Update all" did before depths existed.
+  const [depth, setDepth] = useState<UpdateStaleDepth>('images');
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Update out-of-date items</AlertDialogTitle>
+          <AlertDialogDescription>
+            Choose how deep the update goes. Only items that are already out of
+            date (or become out of date from this update) are regenerated —
+            nothing is ever created for the first time.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <fieldset className="flex flex-col gap-2">
+          <legend className="sr-only">Update depth</legend>
+          {UPDATE_STALE_DEPTHS.map((option) => (
+            <label
+              key={option}
+              htmlFor={`update-all-depth-${option}`}
+              className={cn(
+                'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
+                'has-focus-visible:ring-[3px] has-focus-visible:ring-ring/50',
+                depth === option
+                  ? 'border-primary/40 bg-primary/5'
+                  : 'hover:bg-muted/50'
+              )}
+            >
+              <input
+                id={`update-all-depth-${option}`}
+                type="radio"
+                name="update-all-depth"
+                value={option}
+                checked={depth === option}
+                onChange={() => setDepth(option)}
+                aria-label={UPDATE_STALE_DEPTH_LABELS[option]}
+                className="mt-1 accent-primary"
+              />
+              <span className="flex min-w-0 flex-col gap-0.5">
+                <span className="text-sm font-medium">
+                  {UPDATE_STALE_DEPTH_LABELS[option]}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {UPDATE_STALE_DEPTH_DESCRIPTIONS[option]}
+                </span>
+              </span>
+            </label>
+          ))}
+        </fieldset>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={() => onConfirm(depth)}>
+            Update
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -20,6 +20,7 @@ import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { simpleHash } from '@/lib/utils/hash';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
+import { terminateSingleArtifactRun } from '@/lib/workflow/run-outcome';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type {
   MotionPromptWorkflowInput,
@@ -86,7 +87,7 @@ export function isPromptUpToDate(
 // store-agnostic row so `listShotPromptVariantsFn` returns one shape.
 export type ShotPromptVariantWithAuthor = Pick<
   ShotPromptVersion,
-  'id' | 'source' | 'text' | 'inputHash' | 'createdAt'
+  'id' | 'source' | 'text' | 'inputHash' | 'createdAt' | 'status'
 > & {
   createdByName: string | null;
 };
@@ -120,6 +121,7 @@ export const listShotPromptVariantsFn = createServerFn({ method: 'GET' })
           inputHash: r.inputHash,
           createdAt: r.createdAt,
           createdByName: r.createdByName,
+          status: r.status,
         }));
       }
       const rows =
@@ -134,6 +136,7 @@ export const listShotPromptVariantsFn = createServerFn({ method: 'GET' })
         inputHash: r.inputHash,
         createdAt: r.createdAt,
         createdByName: r.createdByName,
+        status: r.status,
       }));
     }
   );
@@ -179,6 +182,10 @@ export const restoreShotPromptVariantFn = createServerFn({ method: 'POST' })
         context.frame.id
       );
     if (frameChosen) {
+      if (frameChosen.status !== 'completed') {
+        // In-flight/failed placeholders have no content to restore (#1085).
+        throw new Error('Cannot restore a prompt version that never completed');
+      }
       const inserted = await context.scopedDb.framePromptVersions.write({
         frameId: context.frame.id,
         text: frameChosen.text,
@@ -197,6 +204,9 @@ export const restoreShotPromptVariantFn = createServerFn({ method: 'POST' })
     );
     if (!chosen) {
       throw new Error('Prompt variant not found for this shot');
+    }
+    if (chosen.status !== 'completed') {
+      throw new Error('Cannot restore a prompt version that never completed');
     }
 
     const inserted = await context.scopedDb.shotPromptVersions.write({
@@ -343,6 +353,74 @@ export const saveShotPromptFn = createServerFn({ method: 'POST' })
     return { unchanged: false, versionId: inserted.id } as const;
   });
 
+/**
+ * Cancel an in-flight pending artifact claim (#1085): flip the row to
+ * 'cancelled' (a completion that races in afterwards is discarded against the
+ * status guard), cascade to dependent image claims, and best-effort terminate
+ * the producing workflow when it's a single-artifact run. Idempotent — a row
+ * that already went terminal reports `cancelled: false`.
+ */
+const cancelPendingInput = z.object({
+  sequenceId: ulidSchema,
+  shotId: ulidSchema,
+  versionId: ulidSchema,
+  artifact: z.enum(['visual-prompt', 'motion-prompt', 'image']),
+});
+
+export const cancelPendingArtifactFn = createServerFn({ method: 'POST' })
+  .middleware([shotAccessMiddleware])
+  .inputValidator(zodValidator(cancelPendingInput))
+  .handler(async ({ context, data }) => {
+    const { scopedDb, frame, shot } = context;
+
+    if (data.artifact === 'visual-prompt') {
+      const row = await scopedDb.framePromptVersions.getByIdForFrame(
+        data.versionId,
+        frame.id
+      );
+      if (!row) throw new Error('Prompt version not found for this shot');
+      const cancelled = await scopedDb.framePromptVersions.markTerminal(
+        row.id,
+        'cancelled'
+      );
+      if (!cancelled) return { cancelled: false } as const;
+      await scopedDb.frameVariants.cancelByDependency(
+        row.id,
+        'Upstream visual prompt was cancelled'
+      );
+      await terminateSingleArtifactRun(row.workflowRunId);
+      return { cancelled: true } as const;
+    }
+
+    if (data.artifact === 'motion-prompt') {
+      const row = await scopedDb.shotPromptVersions.getByIdForShot(
+        data.versionId,
+        shot.id
+      );
+      if (!row) throw new Error('Prompt version not found for this shot');
+      const cancelled = await scopedDb.shotPromptVersions.markTerminal(
+        row.id,
+        'cancelled'
+      );
+      if (!cancelled) return { cancelled: false } as const;
+      await terminateSingleArtifactRun(row.workflowRunId);
+      return { cancelled: true } as const;
+    }
+
+    const row = await scopedDb.frameVariants.getById(data.versionId);
+    if (!row || row.frameId !== frame.id) {
+      throw new Error('Image version not found for this shot');
+    }
+    const cancelled = await scopedDb.frameVariants.markTerminal(
+      row.id,
+      'cancelled',
+      'Cancelled by user'
+    );
+    if (!cancelled) return { cancelled: false } as const;
+    await terminateSingleArtifactRun(row.workflowRunId);
+    return { cancelled: true } as const;
+  });
+
 const shotRegenerateInput = z.object({
   sequenceId: ulidSchema,
   shotId: ulidSchema,
@@ -393,7 +471,63 @@ export const regenerateShotPromptFn = createServerFn({ method: 'POST' })
         ? frame.visualPromptInputHash
         : shot.motionPromptInputHash;
     if (!data.force && isPromptUpToDate(storedHash, liveHash)) {
-      return { workflowRunId: null, alreadyUpToDate: true } as const;
+      return {
+        workflowRunId: null,
+        alreadyUpToDate: true,
+        alreadyInFlight: false,
+      } as const;
+    }
+
+    // Server-side dedup (#1085): a live pending claim for exactly these
+    // inputs means a run is already producing this prompt — a second click,
+    // a second tab, or a teammate must no-op instead of double-spending.
+    // Applies to `force` too: force bypasses the up-to-date bail, not an
+    // in-flight run.
+    const existingClaim =
+      data.promptType === 'visual'
+        ? await scopedDb.framePromptVersions.getLivePending(frame.id, liveHash)
+        : await scopedDb.shotPromptVersions.getLivePending(shot.id, liveHash);
+    if (existingClaim) {
+      return {
+        workflowRunId: existingClaim.workflowRunId,
+        alreadyUpToDate: false,
+        alreadyInFlight: true,
+      } as const;
+    }
+
+    // Pre-create the pending version row (#1085) so in-flight work is
+    // representable: staleness reads 'updating', duplicate enqueues no-op,
+    // and the run completes this row in place. The partial unique index on
+    // live claims closes the check-then-insert race above — the loser lands
+    // here and reports in-flight instead of double-spending.
+    let claim;
+    try {
+      claim =
+        data.promptType === 'visual'
+          ? await scopedDb.framePromptVersions.createPending({
+              frameId: frame.id,
+              pendingInputHash: liveHash,
+              createdBy: user.id,
+            })
+          : await scopedDb.shotPromptVersions.createPending({
+              shotId: shot.id,
+              pendingInputHash: liveHash,
+              createdBy: user.id,
+            });
+    } catch (error) {
+      const racedClaim =
+        data.promptType === 'visual'
+          ? await scopedDb.framePromptVersions.getLivePending(
+              frame.id,
+              liveHash
+            )
+          : await scopedDb.shotPromptVersions.getLivePending(shot.id, liveHash);
+      if (!racedClaim) throw error;
+      return {
+        workflowRunId: racedClaim.workflowRunId,
+        alreadyUpToDate: false,
+        alreadyInFlight: true,
+      } as const;
     }
 
     // Always stream deltas for this endpoint — it's only invoked from the
@@ -454,32 +588,64 @@ export const regenerateShotPromptFn = createServerFn({ method: 'POST' })
       sceneAfter = nextShot?.metadata ?? undefined;
     }
 
-    const workflowRunId =
-      data.promptType === 'visual'
-        ? // `frameId` is REQUIRED on FramePromptWorkflowInput — the workflow
-          // never reads the DB (#991) and persists the visual prompt only when
-          // it's present, so resolving the anchor frame here (from the access
-          // middleware's `frame`) is mandatory, not optional.
-          await triggerWorkflow<FramePromptWorkflowInput>(
-            '/frame-prompt',
-            { ...commonInput, frameId: frame.id },
-            triggerOpts
-          )
-        : // Snapshot the rendered still at trigger time (#929) so the motion
-          // workflow never looks it up mid-run (a concurrent re-render could
-          // swap it). The still lives on the anchor frame now (#989).
-          await triggerWorkflow<MotionPromptWorkflowInput>(
-            '/motion-prompt',
-            {
-              ...commonInput,
-              startingFrameImageUrl: frame.imageUrl,
-              sceneBefore,
-              sceneAfter,
-            },
-            triggerOpts
-          );
+    let workflowRunId: string;
+    try {
+      workflowRunId =
+        data.promptType === 'visual'
+          ? // `frameId` is REQUIRED on FramePromptWorkflowInput — the workflow
+            // never reads the DB (#991) and persists the visual prompt only
+            // when it's present, so resolving the anchor frame here (from the
+            // access middleware's `frame`) is mandatory, not optional.
+            await triggerWorkflow<FramePromptWorkflowInput>(
+              '/frame-prompt',
+              {
+                ...commonInput,
+                frameId: frame.id,
+                targetVersionId: claim.id,
+              },
+              triggerOpts
+            )
+          : // Snapshot the rendered still at trigger time (#929) so the motion
+            // workflow never looks it up mid-run (a concurrent re-render could
+            // swap it). The still lives on the anchor frame now (#989).
+            await triggerWorkflow<MotionPromptWorkflowInput>(
+              '/motion-prompt',
+              {
+                ...commonInput,
+                startingFrameImageUrl: frame.imageUrl,
+                sceneBefore,
+                sceneAfter,
+                targetVersionId: claim.id,
+              },
+              triggerOpts
+            );
+    } catch (error) {
+      // The claim must not outlive a trigger that never happened.
+      if (data.promptType === 'visual') {
+        await scopedDb.framePromptVersions.markTerminal(claim.id, 'failed');
+      } else {
+        await scopedDb.shotPromptVersions.markTerminal(claim.id, 'failed');
+      }
+      throw error;
+    }
 
-    return { workflowRunId, alreadyUpToDate: false } as const;
+    // Stamp the producing instance so cancel + zombie reconciliation can
+    // verify the run. 'generating' from here on — the instance starts
+    // immediately.
+    if (data.promptType === 'visual') {
+      await scopedDb.framePromptVersions.markGenerating(
+        claim.id,
+        workflowRunId
+      );
+    } else {
+      await scopedDb.shotPromptVersions.markGenerating(claim.id, workflowRunId);
+    }
+
+    return {
+      workflowRunId,
+      alreadyUpToDate: false,
+      alreadyInFlight: false,
+    } as const;
   });
 
 const sequenceRegenerateInput = z.object({ sequenceId: ulidSchema });

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -423,6 +423,10 @@ export const cancelPendingArtifactFn = createServerFn({ method: 'POST' })
         'Upstream visual prompt was cancelled'
       );
       for (const dep of cascaded) {
+        // Terminate the image child (if it has a real single-artifact run id)
+        // before settling frame state — cancel should stop spend when possible.
+        // Status guards still discard any completion that races past this.
+        await terminateSingleArtifactRun(dep.workflowRunId);
         await settleFrameAfterImageCancel(scopedDb, dep.frameId, dep);
       }
       await terminateSingleArtifactRun(row.workflowRunId);

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -22,6 +22,7 @@ import { triggerWorkflow } from '@/lib/workflow/client';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { terminateSingleArtifactRun } from '@/lib/workflow/run-outcome';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import type { ScopedDb } from '@/lib/db/scoped';
 import type {
   MotionPromptWorkflowInput,
   MusicPromptWorkflowInput,
@@ -367,6 +368,39 @@ const cancelPendingInput = z.object({
   artifact: z.enum(['visual-prompt', 'motion-prompt', 'image']),
 });
 
+/**
+ * Settle the frame's primary in-flight state after an image claim cancel
+ * (#1095 review): the producing run may be terminated (or abandon the claim
+ * before its own settle path runs), which would leave `image_status` stuck
+ * 'generating' with nothing in flight. Only touches the frame when THIS
+ * cancelled row is what holds it — a newer kickoff's state is left alone.
+ */
+async function settleFrameAfterImageCancel(
+  scopedDb: ScopedDb,
+  frameId: string,
+  row: { id: string; workflowRunId: string | null }
+): Promise<void> {
+  const frameNow = await scopedDb.frames.getById(frameId);
+  if (!frameNow) return;
+  const heldByThisRow =
+    frameNow.pendingPromoteVersionId === row.id ||
+    (row.workflowRunId !== null &&
+      frameNow.imageWorkflowRunId === row.workflowRunId);
+  if (!heldByThisRow) return;
+  await scopedDb.frames.clearPendingPromoteVersionIdIf(frameId, row.id);
+  if (frameNow.imageStatus === 'generating') {
+    await scopedDb.frames.setImageGenerationStatus(
+      frameId,
+      {
+        imageStatus: frameNow.selectedImageVersionId ? 'completed' : 'pending',
+        imageWorkflowRunId: null,
+        imageError: null,
+      },
+      { throwOnMissing: false }
+    );
+  }
+}
+
 export const cancelPendingArtifactFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
   .inputValidator(zodValidator(cancelPendingInput))
@@ -384,10 +418,13 @@ export const cancelPendingArtifactFn = createServerFn({ method: 'POST' })
         'cancelled'
       );
       if (!cancelled) return { cancelled: false } as const;
-      await scopedDb.frameVariants.cancelByDependency(
+      const cascaded = await scopedDb.frameVariants.cancelByDependency(
         row.id,
         'Upstream visual prompt was cancelled'
       );
+      for (const dep of cascaded) {
+        await settleFrameAfterImageCancel(scopedDb, dep.frameId, dep);
+      }
       await terminateSingleArtifactRun(row.workflowRunId);
       return { cancelled: true } as const;
     }
@@ -418,6 +455,7 @@ export const cancelPendingArtifactFn = createServerFn({ method: 'POST' })
     );
     if (!cancelled) return { cancelled: false } as const;
     await terminateSingleArtifactRun(row.workflowRunId);
+    await settleFrameAfterImageCancel(scopedDb, row.frameId, row);
     return { cancelled: true } as const;
   });
 

--- a/src/functions/shot-image.ts
+++ b/src/functions/shot-image.ts
@@ -4,10 +4,7 @@ import {
   safeImageToVideoModel,
   safeTextToImageModel,
 } from '@/lib/ai/models';
-import {
-  resolveImageModel,
-  resolveUpscaleModel,
-} from '@/lib/ai/resolve-asset-models';
+import { resolveUpscaleModel } from '@/lib/ai/resolve-asset-models';
 import {
   estimateImageCost,
   estimateStoryboardCost,
@@ -15,64 +12,32 @@ import {
 } from '@/lib/billing/cost-estimation';
 import { getEffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
 import { requireCredits } from '@/lib/billing/preflight';
-import {
-  aspectRatioToImageSize,
-  getVariantGridConfig,
-} from '@/lib/constants/aspect-ratios';
-import { type SequenceLocation } from '@/lib/db/schema';
-import { locationMatchesTag } from '@/lib/db/scoped/sequence-locations';
+import { getVariantGridConfig } from '@/lib/constants/aspect-ratios';
 import { cropTileFromGrid } from '@/lib/image/image-crop';
 import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
-import { buildElementReferenceImages } from '@/lib/prompts/element-prompt';
-import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
-import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
 import {
   generateVariantSchema,
   regenerateShotSchema,
 } from '@/lib/schemas/shot.schemas';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import { rescanContinuityFromPrompt } from '@/lib/scenes/rescan-continuity-from-prompt';
+import {
+  getSceneLocationReferenceImages,
+  prepareShotImageWorkflowInput,
+} from '@/lib/shots/shot-image-input';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { triggerStoryboard } from '@/lib/workflow/launchers';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import type {
-  ShotImageSceneSnapshot,
-  ImageWorkflowInput,
   StoryboardWorkflowInput,
   ShotVariantWorkflowInput,
   UpscaleShotVariantWorkflowInput,
 } from '@/lib/workflow/types';
-import {
-  matchCharactersToScene,
-  matchElementsToScene,
-  matchLocationsToScene,
-} from '@/lib/workflows/scene-matching';
-import { computeShotImageSceneHash } from '@/lib/workflows/sheet-snapshots';
+import { matchCharactersToScene } from '@/lib/workflows/scene-matching';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 import { shotAccessMiddleware, sequenceAccessMiddleware } from './middleware';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** Match locations by environmentTag or scene location and return reference images. */
-function getSceneLocationReferenceImages(
-  allLocations: SequenceLocation[],
-  environmentTag: string,
-  sceneLocation?: string
-): ReferenceImageDescription[] {
-  if (!environmentTag && !sceneLocation) return [];
-
-  const matchedLocations = allLocations.filter(
-    (loc) =>
-      (environmentTag && locationMatchesTag(loc, environmentTag)) ||
-      (sceneLocation && locationMatchesTag(loc, sceneLocation))
-  );
-
-  return buildLocationReferenceImages(matchedLocations);
-}
 
 // ---------------------------------------------------------------------------
 // Generate Shots (Storyboard Workflow)
@@ -147,146 +112,40 @@ export const generateShotImageFn = createServerFn({ method: 'POST' })
       script,
     } = context;
 
-    // Priority: provided > stored anchor-frame mirror (#989/#713) > description.
-    // The visual prompt lives solely on `frame.imagePrompt` now (the old
-    // `metadata.prompts.visual` fallback is gone).
-    const prompt = data.prompt || frame.imagePrompt || shot.description;
-
-    if (!prompt) {
-      throw new Error('Shot has no prompt or description to regenerate from');
-    }
-
     // Auto-link any element/cast/location tags the user mentioned in their
     // edited prompt before computing reference attachment, so a freshly-
     // mentioned LOGO gets its reference image attached to THIS regeneration.
     // updateShotFn does the same rescan, but the UI never calls it — the
     // regenerate buttons are the only persistence path for prompts today.
     const userEditedPrompt = data.prompt !== undefined;
+    let shotForInput = shot;
     const baseContinuity = shot.metadata?.continuity;
-    let continuity = baseContinuity;
-    if (userEditedPrompt && shot.metadata && baseContinuity) {
+    if (userEditedPrompt && data.prompt && shot.metadata && baseContinuity) {
       const rescan = await rescanContinuityFromPrompt({
         scopedDb: context.scopedDb,
         sequenceId: sequence.id,
         existing: baseContinuity,
-        promptText: prompt,
+        promptText: data.prompt,
       });
       if (rescan.changed) {
-        continuity = rescan.continuity;
-        await context.scopedDb.shots.update(shot.id, {
-          metadata: { ...shot.metadata, continuity: rescan.continuity },
-        });
+        const metadata = { ...shot.metadata, continuity: rescan.continuity };
+        await context.scopedDb.shots.update(shot.id, { metadata });
+        shotForInput = { ...shot, metadata };
       }
     }
 
-    const allCharacters = await context.scopedDb.characters.listWithSheets(
-      sequence.id
-    );
-    const matchedCharacters = matchCharactersToScene(
-      allCharacters,
-      continuity?.characterTags ?? []
-    );
-    const characterReferences =
-      buildCharacterReferenceImages(matchedCharacters);
-
-    const allLocations =
-      await context.scopedDb.sequenceLocations.listWithReferences(sequence.id);
-    const matchedLocations = matchLocationsToScene(
-      allLocations,
-      continuity?.environmentTag ?? '',
-      shot.metadata?.metadata?.location ?? ''
-    );
-    const locationReferences = getSceneLocationReferenceImages(
-      allLocations,
-      continuity?.environmentTag ?? '',
-      shot.metadata?.metadata?.location ?? ''
-    );
-
-    const allElements = await context.scopedDb.sequenceElements.list(
-      sequence.id
-    );
-    const matchedElements = matchElementsToScene(
-      allElements,
-      continuity?.elementTags ?? [],
-      script?.extract ?? resolvedScene?.originalScript.extract ?? ''
-    );
-    const elementReferences = buildElementReferenceImages(matchedElements);
-
-    // Model identity lives on the version that produced the still (#1066): an
-    // explicit per-request model wins (one-off variant generation), else the
-    // model of a failed attempt still awaiting retry, else the frame's
-    // currently selected version, then the sequence default.
-    const [selectedVersion, lastFailed] = await Promise.all([
-      context.scopedDb.frameVariants.getSelected(frame.id),
-      context.scopedDb.frameVariants.getLastFailed(frame.id),
-    ]);
-    const model = resolveImageModel({
-      explicit: data.model,
-      lastFailedAttemptModel: lastFailed?.model,
-      selectedVersionModel: selectedVersion?.model,
-      sequenceModel: sequence.imageModel,
-    });
-
-    await requireCredits(
-      context.scopedDb,
-      gateEstimate(
-        estimateImageCost(model, sequence.aspectRatio, 1, {
-          pricing: await getEffectiveFalPricing(),
-        }),
-        { model, operation: 'shot-image' }
-      ),
-      { errorMessage: 'Insufficient credits for image generation' }
-    );
-
-    // Build a per-scene snapshot so the image workflow records a non-null
-    // `thumbnailInputHash`. Without this the convergent write path stores
-    // `null`, and the staleness check loses the ability to flip back to
-    // 'stale' on a future prompt regenerate. The sceneId fallback covers
-    // legacy shots generated before scene metadata was attached.
-    const sortedHashes = (
-      values: ReadonlyArray<string | null | undefined>
-    ): string[] =>
-      values
-        .filter((v): v is string => typeof v === 'string' && v.length > 0)
-        .sort();
-    const sceneSnapshot: ShotImageSceneSnapshot = {
-      sceneId: shot.metadata?.sceneId ?? shot.id,
-      visualPrompt: prompt,
-      characterSheetHashes: sortedHashes(
-        matchedCharacters.map((c) => c.sheetInputHash)
-      ),
-      locationSheetHashes: sortedHashes(
-        matchedLocations.map((l) => l.referenceInputHash)
-      ),
-      elementReferenceHashes: sortedHashes(
-        matchedElements.map((e) => e.imageUrl)
-      ),
-    };
-    const snapshotInputHash = await computeShotImageSceneHash(
-      sceneSnapshot,
-      model,
-      sequence.aspectRatio
-    );
-
-    const workflowInput: ImageWorkflowInput = {
+    const workflowInput = await prepareShotImageWorkflowInput({
+      scopedDb: context.scopedDb,
+      sequence,
+      shot: shotForInput,
+      frame,
+      scriptExtract:
+        script?.extract ?? resolvedScene?.originalScript.extract ?? '',
       userId: user.id,
-      teamId: sequence.teamId,
-      prompt,
-      model,
-      imageSize: aspectRatioToImageSize(sequence.aspectRatio),
-      numImages: 1,
-      shotId: shot.id,
-      sequenceId: sequence.id,
-      aspectRatio: sequence.aspectRatio,
-      sceneSnapshot,
-      snapshotInputHash,
-      referenceImages: [
-        ...characterReferences,
-        ...locationReferences,
-        ...elementReferences,
-      ],
+      promptOverride: data.prompt,
+      modelOverride: data.model,
       userEditedPrompt,
-    };
+    });
 
     const workflowRunId = await triggerWorkflow('/image', workflowInput, {
       deduplicationId: `image-${shot.id}-${Date.now()}`,

--- a/src/functions/shot-image.ts
+++ b/src/functions/shot-image.ts
@@ -147,12 +147,73 @@ export const generateShotImageFn = createServerFn({ method: 'POST' })
       userEditedPrompt,
     });
 
-    const workflowRunId = await triggerWorkflow('/image', workflowInput, {
-      deduplicationId: `image-${shot.id}-${Date.now()}`,
-      label: buildWorkflowLabel(sequence.id),
-    });
+    // Server-side dedup (#1085): a live claim for exactly this snapshot hash
+    // means a run is already producing this render — a second click, second
+    // tab, or teammate must no-op instead of double-spending credits.
+    const liveClaims = await context.scopedDb.frameVariants.listLiveClaims(
+      frame.id
+    );
+    const existingClaim = liveClaims.find(
+      (c) => c.pendingInputHash === workflowInput.snapshotInputHash
+    );
+    if (existingClaim) {
+      return {
+        workflowRunId: existingClaim.workflowRunId,
+        shotId: shot.id,
+        alreadyInFlight: true,
+      } as const;
+    }
 
-    return { workflowRunId, shotId: shot.id };
+    // Pre-create the claim row (#1085): in-flight work is representable
+    // (staleness reads 'updating'), and the workflow completes this row in
+    // place instead of appending its own. The partial unique index on live
+    // claims closes the check-then-insert race above — the loser lands in
+    // the catch and reports in-flight instead of double-billing.
+    let claim;
+    try {
+      claim = await context.scopedDb.frameVariants.createPendingClaim({
+        frameId: frame.id,
+        sequenceId: sequence.id,
+        model: workflowInput.model ?? DEFAULT_IMAGE_MODEL,
+        pendingInputHash: workflowInput.snapshotInputHash,
+      });
+    } catch (error) {
+      const raced = (
+        await context.scopedDb.frameVariants.listLiveClaims(frame.id)
+      ).find((c) => c.pendingInputHash === workflowInput.snapshotInputHash);
+      if (!raced) throw error;
+      return {
+        workflowRunId: raced.workflowRunId,
+        shotId: shot.id,
+        alreadyInFlight: true,
+      } as const;
+    }
+
+    let workflowRunId: string;
+    try {
+      workflowRunId = await triggerWorkflow(
+        '/image',
+        { ...workflowInput, targetVariantId: claim.id },
+        {
+          // Claim-scoped: stable across retries of THIS enqueue (CF collapses
+          // duplicate create()s), fresh per claim so a deliberate re-roll
+          // after completion still gets a new run.
+          deduplicationId: `image-${shot.id}-${claim.id}`,
+          label: buildWorkflowLabel(sequence.id),
+        }
+      );
+    } catch (error) {
+      // The claim must not outlive a trigger that never happened.
+      await context.scopedDb.frameVariants.markTerminal(
+        claim.id,
+        'failed',
+        error instanceof Error ? error.message : String(error)
+      );
+      throw error;
+    }
+    await context.scopedDb.frameVariants.update(claim.id, { workflowRunId });
+
+    return { workflowRunId, shotId: shot.id, alreadyInFlight: false } as const;
   });
 
 // ---------------------------------------------------------------------------

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -10,7 +10,7 @@ import { getWorkflowRunOutcome } from '@/lib/workflow/run-outcome';
 import type { ShotVariant, NewShot } from '@/lib/db/schema';
 import {
   computeShotStaleness,
-  UNKNOWN_STALENESS,
+  UNTRACKED_STALENESS,
   type ShotStalenessRefs,
   type ShotStalenessResult,
 } from '@/lib/shots/shot-staleness';
@@ -600,8 +600,20 @@ export const getShotStalenessFn = createServerFn({ method: 'GET' })
   .inputValidator(zodValidator(shotIdInputSchema))
   .handler(async ({ context }) => {
     const { shot, frame, sequence, scopedDb, scene } = context;
-    return computeShotStaleness({ scopedDb, sequence, shot, frame, scene });
+    return toWireStaleness(
+      await computeShotStaleness({ scopedDb, sequence, shot, frame, scene })
+    );
   });
+
+/**
+ * The client-facing slice of a staleness result. `liveHashes` is a server-side
+ * convenience for the enqueue paths (#1085) and stays off the wire.
+ */
+const toWireStaleness = ({
+  thumbnail,
+  visualPrompt,
+  motionPrompt,
+}: ShotStalenessResult) => ({ thumbnail, visualPrompt, motionPrompt });
 
 /**
  * Batched `getShotStalenessFn` (#1077): staleness for every shot in one scene
@@ -630,62 +642,56 @@ export const getShotStalenessBatchFn = createServerFn({ method: 'GET' })
     await scopedDb.shots.ensureAnchorFrames(targetShots);
     // Loaded once here and threaded into every shot's comparison as `refs`;
     // without that each shot would re-read all four for both prompt branches.
-    const [
-      anchorRows,
-      scriptBySceneId,
-      characters,
-      locations,
-      elements,
-      style,
-    ] = await Promise.all([
-      scopedDb.frames.listAnchorsBySequence(sequence.id),
-      loadSelectedScriptsBySequence(scopedDb, sequence.id),
-      scopedDb.characters.listWithSheets(sequence.id),
-      scopedDb.sequenceLocations.listWithReferences(sequence.id),
-      scopedDb.sequenceElements.list(sequence.id),
-      sequence.styleId
-        ? scopedDb.styles.getById(sequence.styleId)
-        : Promise.resolve(null),
-    ]);
+    const [anchorRows, scriptBySceneId, characters, locations, elements] =
+      await Promise.all([
+        scopedDb.frames.listAnchorsBySequence(sequence.id),
+        loadSelectedScriptsBySequence(scopedDb, sequence.id),
+        scopedDb.characters.listWithSheets(sequence.id),
+        scopedDb.sequenceLocations.listWithReferences(sequence.id),
+        scopedDb.sequenceElements.list(sequence.id),
+      ]);
     const anchorsByShot = new Map(anchorRows.map((f) => [f.shotId, f]));
-    const refs: ShotStalenessRefs = { characters, locations, elements, style };
+    const refs: ShotStalenessRefs = { characters, locations, elements };
 
     const entries = await Promise.all(
-      targetShots.map(async (shot): Promise<[string, ShotStalenessResult]> => {
-        const frame = anchorsByShot.get(shot.id);
-        if (!frame) {
-          // ensureAnchorFrames guarantees an anchor; if it's somehow absent we
-          // can't compare anything, so report the shot unknown rather than
-          // dropping it from the result or claiming it's up to date.
-          logger.error(
-            `getShotStalenessBatchFn: shot ${shot.id} has no anchor frame`
-          );
-          return [shot.id, { ...UNKNOWN_STALENESS }];
+      targetShots.map(
+        async (shot): Promise<[string, ReturnType<typeof toWireStaleness>]> => {
+          const frame = anchorsByShot.get(shot.id);
+          if (!frame) {
+            // ensureAnchorFrames guarantees an anchor; if it's somehow absent
+            // we have no image surface to compare, so report the shot
+            // untracked rather than dropping it from the result.
+            logger.error(
+              `getShotStalenessBatchFn: shot ${shot.id} has no anchor frame`
+            );
+            return [shot.id, toWireStaleness(UNTRACKED_STALENESS)];
+          }
+          const { scene } = resolveSceneForShot(shot, scriptBySceneId);
+          try {
+            return [
+              shot.id,
+              toWireStaleness(
+                await computeShotStaleness({
+                  scopedDb,
+                  sequence,
+                  shot,
+                  frame,
+                  scene,
+                  refs,
+                })
+              ),
+            ];
+          } catch (error) {
+            // Per-shot boundary: anything escaping computeShotStaleness must
+            // not reject the whole batch and blank the scene.
+            logger.error(
+              `getShotStalenessBatchFn: shot ${shot.id} staleness failed`,
+              { err: error }
+            );
+            return [shot.id, toWireStaleness(UNTRACKED_STALENESS)];
+          }
         }
-        const { scene } = resolveSceneForShot(shot, scriptBySceneId);
-        try {
-          return [
-            shot.id,
-            await computeShotStaleness({
-              scopedDb,
-              sequence,
-              shot,
-              frame,
-              scene,
-              refs,
-            }),
-          ];
-        } catch (error) {
-          // Per-shot boundary: computeShotStaleness catches its own artifact
-          // branches, but anything escaping it would otherwise reject the whole
-          // batch and blank the scene.
-          logger.error(
-            `getShotStalenessBatchFn: shot ${shot.id} staleness failed`,
-            { err: error }
-          );
-          return [shot.id, { ...UNKNOWN_STALENESS }];
-        }
-      })
+      )
     );
     return typedFromEntries(entries);
   });

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -15,7 +15,10 @@ import {
   type ShotStalenessRefs,
   type ShotStalenessResult,
 } from '@/lib/shots/shot-staleness';
-import { UPDATE_STALE_DEPTHS } from '@/lib/shots/update-stale-depth';
+import {
+  DEFAULT_UPDATE_STALE_DEPTH,
+  UPDATE_STALE_DEPTHS,
+} from '@/lib/shots/update-stale-depth';
 import {
   projectShotWithImage,
   projectShotMissingFrame,
@@ -727,7 +730,7 @@ export const updateStaleShotsFn = createServerFn({ method: 'POST' })
   )
   .handler(async ({ data, context }) => {
     const { sequence, teamId, user, scopedDb } = context;
-    const depth = data.depth ?? 'images';
+    const depth = data.depth ?? DEFAULT_UPDATE_STALE_DEPTH;
     // The plan isn't known yet, so this can't be the exact cost — it's a
     // floor: a run that can't afford even one artifact of its most expensive
     // level should never start. 'prompts' has no render cost; LLM spend is

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -7,6 +7,7 @@ import {
 import { estimateImageCost } from '@/lib/billing/cost-estimation';
 import { requireCredits } from '@/lib/billing/preflight';
 import { getWorkflowRunOutcome } from '@/lib/workflow/run-outcome';
+import { workflowNameFromRunId } from '@/lib/workflow/trigger-bindings';
 import type { ShotVariant, NewShot } from '@/lib/db/schema';
 import {
   computeShotStaleness,
@@ -698,12 +699,14 @@ export const getShotStalenessBatchFn = createServerFn({ method: 'GET' })
   });
 
 /**
- * "Update all" (#1077): enqueue the durable `UpdateStaleShotsWorkflow` for a
- * shot / scene / the whole sequence. The workflow recomputes staleness
- * server-side and regenerates only the artifacts that read stale right now —
- * no cascade into artifacts a regeneration outdates, and video never
- * auto-renders — so the payload is just the scope. Returns the run id;
- * progress surfaces through the staleness indicators as artifacts land.
+ * "Update all" (#1077, depth picker #1085): enqueue the durable
+ * `UpdateStaleShotsWorkflow` for a shot / scene / the whole sequence. The
+ * workflow recomputes staleness server-side and regenerates what reads stale
+ * up to the chosen `depth` cascade — at 'images' and above a regenerated
+ * prompt cascades into its still; at 'video'/'music' existing videos and
+ * music re-render behind their regenerated upstreams (never a FIRST render).
+ * Returns the run id; progress surfaces through the staleness indicators as
+ * artifacts land.
  *
  * Preflights credits before enqueuing. Inside the workflow an out-of-credits
  * failure can only land in the run result, where it reads as "nothing
@@ -750,7 +753,14 @@ export const updateStaleShotsFn = createServerFn({ method: 'POST' })
         shotId: data.shotId,
         depth,
       },
-      { label: buildWorkflowLabel(sequence.id) }
+      {
+        label: buildWorkflowLabel(sequence.id),
+        // Embed the sequence id in the instance id (the timestamp+uuid tail
+        // keeps it unique per click) so `getUpdateStaleShotsRunFn` can verify
+        // a polled run id actually belongs to the sequence being authorized —
+        // without this, any authenticated user could read any run's output.
+        deduplicationId: `${sequence.id}-${Date.now()}-${crypto.randomUUID()}`,
+      }
     );
     return { workflowRunId };
   });
@@ -792,7 +802,17 @@ export const getUpdateStaleShotsRunFn = createServerFn({ method: 'GET' })
       z.object({ sequenceId: ulidSchema, workflowRunId: z.string().min(1) })
     )
   )
-  .handler(async ({ data }) => {
+  .handler(async ({ data, context }) => {
+    // The middleware authorizes the SEQUENCE; the run id is caller-supplied
+    // and would otherwise let any authenticated user read any run's output.
+    // `updateStaleShotsFn` embeds the sequence id in the instance id — require
+    // both the right workflow and the right sequence before reading anything.
+    if (
+      workflowNameFromRunId(data.workflowRunId) !== 'update-stale-shots' ||
+      !data.workflowRunId.includes(context.sequence.id)
+    ) {
+      return { state: 'unknown' as const };
+    }
     const outcome = await getWorkflowRunOutcome(data.workflowRunId);
     if (outcome.state !== 'complete') return outcome;
     const parsed = updateStaleShotsResultSchema.safeParse(outcome.output);

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -4,7 +4,8 @@ import {
   isValidTextToImageModel,
   safeTextToImageModel,
 } from '@/lib/ai/models';
-import { estimateImageCost } from '@/lib/billing/cost-estimation';
+import { getEffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
+import { estimateImageCost, gateEstimate } from '@/lib/billing/cost-estimation';
 import { requireCredits } from '@/lib/billing/preflight';
 import { getWorkflowRunOutcome } from '@/lib/workflow/run-outcome';
 import { workflowNameFromRunId } from '@/lib/workflow/trigger-bindings';
@@ -647,16 +648,25 @@ export const getShotStalenessBatchFn = createServerFn({ method: 'GET' })
     await scopedDb.shots.ensureAnchorFrames(targetShots);
     // Loaded once here and threaded into every shot's comparison as `refs`;
     // without that each shot would re-read all four for both prompt branches.
-    const [anchorRows, scriptBySceneId, characters, locations, elements] =
-      await Promise.all([
-        scopedDb.frames.listAnchorsBySequence(sequence.id),
-        loadSelectedScriptsBySequence(scopedDb, sequence.id),
-        scopedDb.characters.listWithSheets(sequence.id),
-        scopedDb.sequenceLocations.listWithReferences(sequence.id),
-        scopedDb.sequenceElements.list(sequence.id),
-      ]);
+    const [
+      anchorRows,
+      scriptBySceneId,
+      characters,
+      locations,
+      elements,
+      style,
+    ] = await Promise.all([
+      scopedDb.frames.listAnchorsBySequence(sequence.id),
+      loadSelectedScriptsBySequence(scopedDb, sequence.id),
+      scopedDb.characters.listWithSheets(sequence.id),
+      scopedDb.sequenceLocations.listWithReferences(sequence.id),
+      scopedDb.sequenceElements.list(sequence.id),
+      sequence.styleId
+        ? scopedDb.styles.getById(sequence.styleId)
+        : Promise.resolve(null),
+    ]);
     const anchorsByShot = new Map(anchorRows.map((f) => [f.shotId, f]));
-    const refs: ShotStalenessRefs = { characters, locations, elements };
+    const refs: ShotStalenessRefs = { characters, locations, elements, style };
 
     const entries = await Promise.all(
       targetShots.map(
@@ -736,12 +746,17 @@ export const updateStaleShotsFn = createServerFn({ method: 'POST' })
     // level should never start. 'prompts' has no render cost; LLM spend is
     // deducted inside the workflow as always.
     if (depth !== 'prompts') {
+      const model = safeTextToImageModel(
+        sequence.imageModel,
+        DEFAULT_IMAGE_MODEL
+      );
       await requireCredits(
         scopedDb,
-        estimateImageCost(
-          safeTextToImageModel(sequence.imageModel, DEFAULT_IMAGE_MODEL),
-          sequence.aspectRatio,
-          1
+        gateEstimate(
+          estimateImageCost(model, sequence.aspectRatio, 1, {
+            pricing: await getEffectiveFalPricing(),
+          }),
+          { model, operation: 'update-stale-shots' }
         ),
         { errorMessage: 'Insufficient credits to update out-of-date shots' }
       );

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -1,4 +1,12 @@
-import { IMAGE_MODELS, isValidTextToImageModel } from '@/lib/ai/models';
+import {
+  DEFAULT_IMAGE_MODEL,
+  IMAGE_MODELS,
+  isValidTextToImageModel,
+  safeTextToImageModel,
+} from '@/lib/ai/models';
+import { estimateImageCost } from '@/lib/billing/cost-estimation';
+import { requireCredits } from '@/lib/billing/preflight';
+import { getWorkflowRunOutcome } from '@/lib/workflow/run-outcome';
 import type { ShotVariant, NewShot } from '@/lib/db/schema';
 import {
   computeShotStaleness,
@@ -29,6 +37,9 @@ import {
   resolveSceneForShot,
 } from '@/lib/scenes/scene-script';
 import { rescanContinuityFromPrompt } from '@/lib/scenes/rescan-continuity-from-prompt';
+import { triggerWorkflow } from '@/lib/workflow/client';
+import { buildWorkflowLabel } from '@/lib/workflow/labels';
+import type { UpdateStaleShotsWorkflowInput } from '@/lib/workflow/types';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -677,6 +688,105 @@ export const getShotStalenessBatchFn = createServerFn({ method: 'GET' })
       })
     );
     return typedFromEntries(entries);
+  });
+
+/**
+ * "Update all" (#1077): enqueue the durable `UpdateStaleShotsWorkflow` for a
+ * shot / scene / the whole sequence. The workflow recomputes staleness
+ * server-side and regenerates only the artifacts that read stale right now —
+ * no cascade into artifacts a regeneration outdates, and video never
+ * auto-renders — so the payload is just the scope. Returns the run id;
+ * progress surfaces through the staleness indicators as artifacts land.
+ *
+ * Preflights credits before enqueuing. Inside the workflow an out-of-credits
+ * failure can only land in the run result, where it reads as "nothing
+ * happened" — throwing here is the one point where the client still gets an
+ * `InsufficientCreditsError` and can open the billing dialog.
+ */
+export const updateStaleShotsFn = createServerFn({ method: 'POST' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        sceneId: ulidSchema.optional(),
+        shotId: ulidSchema.optional(),
+      })
+    )
+  )
+  .handler(async ({ data, context }) => {
+    const { sequence, teamId, user, scopedDb } = context;
+    // The plan isn't known yet, so this can't be the exact cost — it's a
+    // floor: a run that can't afford even one image should never start.
+    await requireCredits(
+      scopedDb,
+      estimateImageCost(
+        safeTextToImageModel(sequence.imageModel, DEFAULT_IMAGE_MODEL),
+        sequence.aspectRatio,
+        1
+      ),
+      { errorMessage: 'Insufficient credits to update out-of-date shots' }
+    );
+    const workflowRunId = await triggerWorkflow<UpdateStaleShotsWorkflowInput>(
+      '/update-stale-shots',
+      {
+        userId: user.id,
+        teamId,
+        sequenceId: sequence.id,
+        sceneId: data.sceneId,
+        shotId: data.shotId,
+      },
+      { label: buildWorkflowLabel(sequence.id) }
+    );
+    return { workflowRunId };
+  });
+
+/**
+ * Shape of `UpdateStaleShotsWorkflow`'s return value. Parsed rather than cast:
+ * it crosses the Cloudflare Workflows boundary as `unknown`, and a run from a
+ * previously-deployed version of the workflow can legitimately not match.
+ */
+const updateStaleShotsResultSchema = z.object({
+  totalShots: z.number(),
+  visualPrompts: z.number(),
+  motionPrompts: z.number(),
+  images: z.number(),
+  failures: z.array(
+    z.object({ shotId: z.string(), stage: z.string(), error: z.string() })
+  ),
+  skipped: z.array(z.object({ shotId: z.string(), reason: z.string() })),
+});
+
+/**
+ * Terminal outcome of an "Update all" run (#1077).
+ *
+ * The workflow isolates failures per shot so one bad shot never blocks its
+ * peers — which means a run can finish `complete` having regenerated nothing.
+ * Without this endpoint that result is written to a log nobody reads and the
+ * user just watches a spinner stop. The client polls this and reports what
+ * actually happened.
+ */
+export const getUpdateStaleShotsRunFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .inputValidator(
+    zodValidator(
+      z.object({ sequenceId: ulidSchema, workflowRunId: z.string().min(1) })
+    )
+  )
+  .handler(async ({ data }) => {
+    const outcome = await getWorkflowRunOutcome(data.workflowRunId);
+    if (outcome.state !== 'complete') return outcome;
+    const parsed = updateStaleShotsResultSchema.safeParse(outcome.output);
+    // A complete run whose output we can't read is not a failure to report as
+    // one — fall back to 'unknown' so the UI defers to the staleness map.
+    if (!parsed.success) {
+      logger.error(
+        `getUpdateStaleShotsRunFn: unrecognised output for ${data.workflowRunId}`,
+        { issues: parsed.error.issues }
+      );
+      return { state: 'unknown' as const };
+    }
+    return { state: 'complete' as const, result: parsed.data };
   });
 
 /**

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -14,6 +14,7 @@ import {
   type ShotStalenessRefs,
   type ShotStalenessResult,
 } from '@/lib/shots/shot-staleness';
+import { UPDATE_STALE_DEPTHS } from '@/lib/shots/update-stale-depth';
 import {
   projectShotWithImage,
   projectShotMissingFrame,
@@ -717,22 +718,28 @@ export const updateStaleShotsFn = createServerFn({ method: 'POST' })
         sequenceId: ulidSchema,
         sceneId: ulidSchema.optional(),
         shotId: ulidSchema.optional(),
+        depth: z.enum(UPDATE_STALE_DEPTHS).optional(),
       })
     )
   )
   .handler(async ({ data, context }) => {
     const { sequence, teamId, user, scopedDb } = context;
+    const depth = data.depth ?? 'images';
     // The plan isn't known yet, so this can't be the exact cost — it's a
-    // floor: a run that can't afford even one image should never start.
-    await requireCredits(
-      scopedDb,
-      estimateImageCost(
-        safeTextToImageModel(sequence.imageModel, DEFAULT_IMAGE_MODEL),
-        sequence.aspectRatio,
-        1
-      ),
-      { errorMessage: 'Insufficient credits to update out-of-date shots' }
-    );
+    // floor: a run that can't afford even one artifact of its most expensive
+    // level should never start. 'prompts' has no render cost; LLM spend is
+    // deducted inside the workflow as always.
+    if (depth !== 'prompts') {
+      await requireCredits(
+        scopedDb,
+        estimateImageCost(
+          safeTextToImageModel(sequence.imageModel, DEFAULT_IMAGE_MODEL),
+          sequence.aspectRatio,
+          1
+        ),
+        { errorMessage: 'Insufficient credits to update out-of-date shots' }
+      );
+    }
     const workflowRunId = await triggerWorkflow<UpdateStaleShotsWorkflowInput>(
       '/update-stale-shots',
       {
@@ -741,6 +748,7 @@ export const updateStaleShotsFn = createServerFn({ method: 'POST' })
         sequenceId: sequence.id,
         sceneId: data.sceneId,
         shotId: data.shotId,
+        depth,
       },
       { label: buildWorkflowLabel(sequence.id) }
     );
@@ -757,6 +765,11 @@ const updateStaleShotsResultSchema = z.object({
   visualPrompts: z.number(),
   motionPrompts: z.number(),
   images: z.number(),
+  // Depth-picker levels (#1085). Defaulted so a run from a pre-picker
+  // deployment still parses during version skew.
+  videos: z.number().default(0),
+  musicPrompts: z.number().default(0),
+  musicTracks: z.number().default(0),
   failures: z.array(
     z.object({ shotId: z.string(), stage: z.string(), error: z.string() })
   ),

--- a/src/hooks/use-prompt-variants.ts
+++ b/src/hooks/use-prompt-variants.ts
@@ -1,4 +1,5 @@
 import {
+  cancelPendingArtifactFn,
   listSequenceMusicPromptVariantsFn,
   listShotPromptVariantsFn,
   restoreSequenceMusicPromptVariantFn,
@@ -142,6 +143,45 @@ export function useSaveShotPrompt(args: {
         queryClient.invalidateQueries({
           queryKey: shotStalenessNamespace,
         }),
+      ]);
+    },
+  });
+}
+
+/**
+ * Cancel an in-flight pending artifact claim (#1085). Invalidates the history
+ * lists, the shot projection, and the staleness namespace — a cancelled claim
+ * flips the artifact from 'updating' back to 'stale'.
+ */
+export function useCancelPendingArtifact(args: {
+  sequenceId: string;
+  shotId: string;
+}) {
+  const queryClient = useQueryClient();
+  return useMutation<
+    { cancelled: boolean },
+    Error,
+    { versionId: string; artifact: 'visual-prompt' | 'motion-prompt' | 'image' }
+  >({
+    mutationFn: ({ versionId, artifact }) =>
+      cancelPendingArtifactFn({
+        data: {
+          sequenceId: args.sequenceId,
+          shotId: args.shotId,
+          versionId,
+          artifact,
+        },
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: promptVariantKeys.all }),
+        queryClient.invalidateQueries({
+          queryKey: shotKeys.detail(args.shotId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: shotKeys.list(args.sequenceId),
+        }),
+        queryClient.invalidateQueries({ queryKey: shotStalenessNamespace }),
       ]);
     },
   });

--- a/src/hooks/use-shot-staleness.ts
+++ b/src/hooks/use-shot-staleness.ts
@@ -22,9 +22,15 @@ export type ShotStaleness = ShotStalenessResult;
 const staleArtifacts = (staleness: ShotStaleness | undefined): ShotArtifact[] =>
   SHOT_ARTIFACTS.filter((artifact) => staleness?.[artifact] === 'stale');
 
-/** Any artifact on the shot out of date? */
+/** Any artifact on the shot out of date? ('updating' is NOT stale — a job is
+ * already fixing it, so it must not re-arm Update all.) */
 export const shotIsStale = (staleness: ShotStaleness | undefined): boolean =>
   staleArtifacts(staleness).length > 0;
+
+/** Any artifact with a live pending claim — a regeneration is in flight
+ * server-side (#1085). Drives the spinner form of the indicators. */
+export const shotIsUpdating = (staleness: ShotStaleness | undefined): boolean =>
+  SHOT_ARTIFACTS.some((artifact) => staleness?.[artifact] === 'updating');
 
 /**
  * Any artifact whose comparison failed. Surfaced separately from `shotIsStale`

--- a/src/hooks/use-shot-staleness.ts
+++ b/src/hooks/use-shot-staleness.ts
@@ -1,22 +1,30 @@
 import { getShotStalenessBatchFn, getShotStalenessFn } from '@/functions/shots';
-import {
-  SHOT_ARTIFACTS,
-  type ShotArtifact,
-  type ShotStalenessResult,
-} from '@/lib/shots/shot-staleness';
+import type { ArtifactStaleness } from '@/lib/shots/shot-staleness';
 import {
   type QueryClient,
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query';
 
-export type { ShotArtifact };
+/**
+ * Per-artifact staleness state — see `computeShotStaleness` for the state
+ * semantics. `ArtifactStaleness` is imported rather than redeclared so the
+ * client and server can't drift on the vocabulary. Only `'stale'` drives UI
+ * regenerate actions: `'untracked'` (no hash) and `'unknown'` (check failed)
+ * both mean "no opinion to surface as stale", and `'updating'` means a job is
+ * already fixing it (#1085).
+ */
+
+/** The tracked artifacts, and the source of truth for `ShotStaleness`'s keys. */
+const SHOT_ARTIFACTS = ['thumbnail', 'visualPrompt', 'motionPrompt'] as const;
+
+export type ShotArtifact = (typeof SHOT_ARTIFACTS)[number];
 
 /**
- * The server's result shape, re-exported rather than redeclared so the two
- * can't drift on either the state vocabulary or the artifact keys.
+ * Client-facing staleness (wire shape). Server `ShotStalenessResult` also
+ * carries `liveHashes` for enqueue paths; those never cross the wire.
  */
-export type ShotStaleness = ShotStalenessResult;
+export type ShotStaleness = Record<ShotArtifact, ArtifactStaleness>;
 
 /** Which of the shot's artifacts are out of date, if any. */
 const staleArtifacts = (staleness: ShotStaleness | undefined): ShotArtifact[] =>

--- a/src/hooks/use-update-stale-shots.ts
+++ b/src/hooks/use-update-stale-shots.ts
@@ -1,0 +1,162 @@
+import {
+  getUpdateStaleShotsRunFn,
+  updateStaleShotsFn,
+} from '@/functions/shots';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { shotStalenessNamespace } from './use-shot-staleness';
+
+/** How often the run's status is polled while it's in flight. */
+const RUN_POLL_MS = 5_000;
+/**
+ * Backstop for a run we can never get a verdict on (an id that doesn't resolve
+ * to a binding, or a status lookup that keeps failing). The workflow itself is
+ * unaffected — this only stops the client polling forever.
+ */
+const RUN_DEADLINE_MS = 15 * 60_000;
+
+/**
+ * "Update all" (#1077) — enqueues the durable `UpdateStaleShotsWorkflow`
+ * (shot / scene / sequence scope) and reports what it actually did.
+ *
+ * All orchestration is server-side. This hook:
+ *
+ *   1. fires the trigger mutation (a credits preflight there means an
+ *      out-of-credits user gets the billing dialog rather than a run that
+ *      silently regenerates nothing), then
+ *   2. polls the run's terminal outcome, refreshing the staleness namespace
+ *      each tick so indicators clear progressively, and
+ *   3. on completion reports the result — including partial failures.
+ *
+ * Point 3 is the reason this polls the run rather than watching the staleness
+ * map: the workflow isolates failures per shot, so it can finish `complete`
+ * having regenerated nothing. Inferring "done" from indicators clearing can't
+ * distinguish that from success — it just waits for artifacts that will never
+ * change and then gives up quietly.
+ */
+export function useUpdateStaleShots(args: { sequenceId: string }) {
+  const { sequenceId } = args;
+  const queryClient = useQueryClient();
+  const [runId, setRunId] = useState<string | null>(null);
+  const deadlineRef = useRef(0);
+
+  const trigger = useMutation({
+    mutationFn: (vars: { sceneId?: string; shotId?: string }) =>
+      updateStaleShotsFn({ data: { sequenceId, ...vars } }),
+  });
+  const { mutate: triggerMutate, isPending: triggerPending } = trigger;
+
+  const run = useCallback(
+    (vars: { sceneId?: string; shotId?: string }) => {
+      if (triggerPending || runId) return;
+      triggerMutate(
+        { sceneId: vars.sceneId, shotId: vars.shotId },
+        {
+          onSuccess: ({ workflowRunId }) => {
+            deadlineRef.current = Date.now() + RUN_DEADLINE_MS;
+            setRunId(workflowRunId);
+          },
+          onError: (error) => {
+            toast.error('Update failed to start', {
+              description:
+                error instanceof Error ? error.message : 'Unknown error',
+            });
+          },
+        }
+      );
+    },
+    [triggerPending, runId, triggerMutate]
+  );
+
+  const { data: outcome } = useQuery({
+    queryKey: ['update-stale-shots-run', runId],
+    queryFn: () => {
+      if (!runId) throw new Error('runId required');
+      return getUpdateStaleShotsRunFn({
+        data: { sequenceId, workflowRunId: runId },
+      });
+    },
+    enabled: !!runId,
+    refetchInterval: RUN_POLL_MS,
+    staleTime: 0,
+  });
+
+  // Refresh indicators on each tick so artifacts clear as they land, rather
+  // than all at once when the run finishes.
+  useEffect(() => {
+    if (!runId) return;
+    void queryClient.invalidateQueries({ queryKey: shotStalenessNamespace });
+  }, [outcome, runId, queryClient]);
+
+  useEffect(() => {
+    if (!runId || !outcome) return;
+
+    if (outcome.state === 'running') {
+      // Only give up on a run we can't get a verdict on; a genuinely
+      // long-running one keeps its spinner.
+      if (Date.now() > deadlineRef.current) {
+        setRunId(null);
+        toast.warning('Update is taking longer than expected', {
+          description:
+            'It may still be running. Check the indicators, or try again.',
+        });
+      }
+      return;
+    }
+
+    if (outcome.state === 'failed') {
+      setRunId(null);
+      toast.error('Update failed', { description: outcome.error });
+      return;
+    }
+
+    if (outcome.state === 'unknown') {
+      // No verdict available (unresolvable run id, or the status lookup kept
+      // failing). Say so rather than implying success.
+      if (Date.now() > deadlineRef.current) {
+        setRunId(null);
+        toast.warning("Couldn't confirm the update finished", {
+          description: 'Check the indicators to see what is still out of date.',
+        });
+      }
+      return;
+    }
+
+    setRunId(null);
+    const {
+      totalShots,
+      visualPrompts,
+      motionPrompts,
+      images,
+      failures,
+      skipped,
+    } = outcome.result;
+    const regenerated = visualPrompts + motionPrompts + images;
+
+    if (failures.length > 0 || skipped.length > 0) {
+      const problems = failures.length + skipped.length;
+      toast.error(
+        regenerated > 0
+          ? `Updated ${regenerated} item${regenerated === 1 ? '' : 's'}, ${problems} could not be updated`
+          : `Could not update ${problems} item${problems === 1 ? '' : 's'}`,
+        {
+          description:
+            failures[0]?.error ??
+            'Some shots were skipped because their state could not be determined.',
+        }
+      );
+      return;
+    }
+
+    if (totalShots === 0) {
+      toast.success('Everything is already up to date');
+      return;
+    }
+    toast.success(
+      `Updated ${regenerated} item${regenerated === 1 ? '' : 's'} across ${totalShots} shot${totalShots === 1 ? '' : 's'}`
+    );
+  }, [outcome, runId]);
+
+  return { run, isRunning: triggerPending || runId !== null };
+}

--- a/src/hooks/use-update-stale-shots.ts
+++ b/src/hooks/use-update-stale-shots.ts
@@ -2,6 +2,7 @@ import {
   getUpdateStaleShotsRunFn,
   updateStaleShotsFn,
 } from '@/functions/shots';
+import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -42,16 +43,19 @@ export function useUpdateStaleShots(args: { sequenceId: string }) {
   const deadlineRef = useRef(0);
 
   const trigger = useMutation({
-    mutationFn: (vars: { sceneId?: string; shotId?: string }) =>
-      updateStaleShotsFn({ data: { sequenceId, ...vars } }),
+    mutationFn: (vars: {
+      sceneId?: string;
+      shotId?: string;
+      depth?: UpdateStaleDepth;
+    }) => updateStaleShotsFn({ data: { sequenceId, ...vars } }),
   });
   const { mutate: triggerMutate, isPending: triggerPending } = trigger;
 
   const run = useCallback(
-    (vars: { sceneId?: string; shotId?: string }) => {
+    (vars: { sceneId?: string; shotId?: string; depth?: UpdateStaleDepth }) => {
       if (triggerPending || runId) return;
       triggerMutate(
-        { sceneId: vars.sceneId, shotId: vars.shotId },
+        { sceneId: vars.sceneId, shotId: vars.shotId, depth: vars.depth },
         {
           onSuccess: ({ workflowRunId }) => {
             deadlineRef.current = Date.now() + RUN_DEADLINE_MS;
@@ -129,10 +133,20 @@ export function useUpdateStaleShots(args: { sequenceId: string }) {
       visualPrompts,
       motionPrompts,
       images,
+      videos,
+      musicPrompts,
+      musicTracks,
       failures,
       skipped,
     } = outcome.result;
-    const regenerated = visualPrompts + motionPrompts + images;
+    const regenerated =
+      visualPrompts +
+      motionPrompts +
+      images +
+      videos +
+      musicPrompts +
+      musicTracks;
+    const touchedMusic = musicPrompts + musicTracks > 0;
 
     if (failures.length > 0 || skipped.length > 0) {
       const problems = failures.length + skipped.length;
@@ -149,12 +163,14 @@ export function useUpdateStaleShots(args: { sequenceId: string }) {
       return;
     }
 
-    if (totalShots === 0) {
+    if (regenerated === 0) {
       toast.success('Everything is already up to date');
       return;
     }
     toast.success(
-      `Updated ${regenerated} item${regenerated === 1 ? '' : 's'} across ${totalShots} shot${totalShots === 1 ? '' : 's'}`
+      totalShots > 0
+        ? `Updated ${regenerated} item${regenerated === 1 ? '' : 's'} across ${totalShots} shot${totalShots === 1 ? '' : 's'}${touchedMusic ? ' + music' : ''}`
+        : 'Updated the sequence music'
     );
   }, [outcome, runId]);
 

--- a/src/hooks/use-update-stale-shots.ts
+++ b/src/hooks/use-update-stale-shots.ts
@@ -13,7 +13,10 @@ const RUN_POLL_MS = 5_000;
 /**
  * Backstop for a run we can never get a verdict on (an id that doesn't resolve
  * to a binding, or a status lookup that keeps failing). The workflow itself is
- * unaffected — this only stops the client polling forever.
+ * unaffected — this only stops the client polling forever. A verifiably
+ * `running` run RESETS this deadline on every tick, so a genuinely
+ * long-running one (sequence-scope at depth video/music) keeps its spinner
+ * and still gets its terminal report.
  */
 const RUN_DEADLINE_MS = 15 * 60_000;
 
@@ -24,8 +27,8 @@ const RUN_DEADLINE_MS = 15 * 60_000;
  * All orchestration is server-side. This hook:
  *
  *   1. fires the trigger mutation (a credits preflight there means an
- *      out-of-credits user gets the billing dialog rather than a run that
- *      silently regenerates nothing), then
+ *      out-of-credits user gets an immediate failure toast at click time
+ *      rather than a run that silently regenerates nothing), then
  *   2. polls the run's terminal outcome, refreshing the staleness namespace
  *      each tick so indicators clear progressively, and
  *   3. on completion reports the result — including partial failures.
@@ -73,7 +76,7 @@ export function useUpdateStaleShots(args: { sequenceId: string }) {
     [triggerPending, runId, triggerMutate]
   );
 
-  const { data: outcome } = useQuery({
+  const { data: outcome, dataUpdatedAt } = useQuery({
     queryKey: ['update-stale-shots-run', runId],
     queryFn: () => {
       if (!runId) throw new Error('runId required');
@@ -87,25 +90,24 @@ export function useUpdateStaleShots(args: { sequenceId: string }) {
   });
 
   // Refresh indicators on each tick so artifacts clear as they land, rather
-  // than all at once when the run finishes.
+  // than all at once when the run finishes. Keyed on `dataUpdatedAt`, not
+  // `outcome`: structural sharing keeps `outcome` referentially identical
+  // while the run reports `running`, so an outcome-keyed effect fires once
+  // and never again (#1095 review).
   useEffect(() => {
-    if (!runId) return;
+    if (!runId || !dataUpdatedAt) return;
     void queryClient.invalidateQueries({ queryKey: shotStalenessNamespace });
-  }, [outcome, runId, queryClient]);
+  }, [dataUpdatedAt, runId, queryClient]);
 
   useEffect(() => {
     if (!runId || !outcome) return;
 
     if (outcome.state === 'running') {
-      // Only give up on a run we can't get a verdict on; a genuinely
-      // long-running one keeps its spinner.
-      if (Date.now() > deadlineRef.current) {
-        setRunId(null);
-        toast.warning('Update is taking longer than expected', {
-          description:
-            'It may still be running. Check the indicators, or try again.',
-        });
-      }
+      // A verified 'running' verdict means the workflow engine can see the
+      // instance making progress — keep the spinner and push the deadline
+      // out. The deadline only ever fires after RUN_DEADLINE_MS of
+      // consecutive no-verdict ('unknown') ticks.
+      deadlineRef.current = Date.now() + RUN_DEADLINE_MS;
       return;
     }
 
@@ -147,6 +149,26 @@ export function useUpdateStaleShots(args: { sequenceId: string }) {
       musicPrompts +
       musicTracks;
     const touchedMusic = musicPrompts + musicTracks > 0;
+
+    // Dedup working as intended is not an error (#1095 review): when the only
+    // "problems" are shots another run already claims, say that plainly
+    // instead of alarming with "Could not update".
+    if (
+      failures.length === 0 &&
+      skipped.length > 0 &&
+      skipped.every((s) => s.reason === 'already-in-flight')
+    ) {
+      toast.info(
+        regenerated > 0
+          ? `Updated ${regenerated} item${regenerated === 1 ? '' : 's'} — the rest are already being updated`
+          : 'These shots are already being updated',
+        {
+          description:
+            'Another update run is regenerating the remaining artifacts.',
+        }
+      );
+      return;
+    }
 
     if (failures.length > 0 || skipped.length > 0) {
       const problems = failures.length + skipped.length;

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -56,6 +56,8 @@ type GateOperation =
   | 'storyboard:motion'
   | 'storyboard:music'
   | 'storyboard:shot-images'
+  | 'update-stale-shots'
+  | 'update-stale-shots:video'
   | 'variant-upscale';
 
 /** Any model a fal estimate can be gated for. */

--- a/src/lib/cron/reconcile-all.test.ts
+++ b/src/lib/cron/reconcile-all.test.ts
@@ -157,10 +157,11 @@ describe('reconcileAllStuckJobs — run-id-verified passes', () => {
   test('caps stuck-row selection at MAX_ROWS_PER_PASS (100) per verified pass', async () => {
     const { reconcileAllStuckJobs } = await import('./reconcile-all');
     await reconcileAllStuckJobs();
-    // 9 verified (run-id) passes: frames.image + shots.video/audio +
+    // 12 verified (run-id) passes: frames.image + shots.video/audio +
     // frame_variants.status + video_variants.status (#1076) + 2 shot_variants +
-    // sequences.status (#989) + generated_assets.status (#458).
-    expect(limitArgs.filter((n) => n === 100)).toHaveLength(9);
+    // sequences.status (#989) + generated_assets.status (#458) + the three
+    // pending-claim passes (#1085: frame/shot prompt claims + image claims).
+    expect(limitArgs.filter((n) => n === 100)).toHaveLength(12);
   });
 
   test('in-flight instance (resolveRunState null) → no per-row update on verified tables', async () => {

--- a/src/lib/cron/reconcile-all.test.ts
+++ b/src/lib/cron/reconcile-all.test.ts
@@ -12,19 +12,26 @@
 
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
+  framePromptVersions,
+  frameVariants,
   generatedAssets,
+  shotPromptVersions,
   shotVariants,
   shots,
   sequenceElements,
   sequences,
 } from '@/lib/db/schema';
 
+// Claim tables included so #1085 pass assertions can match on table identity.
 type SchemaTable =
   | typeof shots
   | typeof shotVariants
   | typeof sequences
   | typeof sequenceElements
-  | typeof generatedAssets;
+  | typeof generatedAssets
+  | typeof framePromptVersions
+  | typeof shotPromptVersions
+  | typeof frameVariants;
 type SetPayload = Record<string, Date | string>;
 type UpdateCall = {
   table: SchemaTable;
@@ -36,12 +43,20 @@ const updateCalls: UpdateCall[] = [];
 let limitArgs: number[] = [];
 
 let stuckRows: Array<{ id: string; runId: string | null }> = [];
+/** When set, only this table's verified select returns stuckRows (others []). */
+let stuckSelectTable: SchemaTable | null = null;
+/**
+ * Claim verified paths call `.returning()` once per table, then the orphan
+ * path calls it again. Only the first call on stuckSelectTable should echo
+ * stuck ids — otherwise orphan would cascade/fail the same rows again.
+ */
+const verifiedReturningServed = new Set<SchemaTable>();
 let blindFailReturning: Array<{ id: string }> = [];
 let nextSelectThrows: Error | null = null;
 
 const dbMock = {
   select: () => ({
-    from: () => ({
+    from: (table: SchemaTable) => ({
       where: () => ({
         limit: async (n: number) => {
           limitArgs.push(n);
@@ -50,6 +65,7 @@ const dbMock = {
             nextSelectThrows = null;
             throw err;
           }
+          if (stuckSelectTable && table !== stuckSelectTable) return [];
           return stuckRows;
         },
       }),
@@ -58,9 +74,8 @@ const dbMock = {
   update: (table: SchemaTable) => ({
     set: (payload: SetPayload) => ({
       // The real `.where(condition)` returns a thenable that also exposes
-      // `.returning(...)`. Per-row updates `await` it; blind-fail passes call
-      // `.returning(...)` instead. Our mock supports both shapes — the
-      // thenable is intentional here.
+      // `.returning(...)`. Per-row updates `await` it; status-guarded claim
+      // fails and blind-fail passes call `.returning(...)` instead.
       where: () => ({
         // oxlint-disable-next-line no-thenable -- mocking drizzle's chain
         then(resolve: (value: undefined) => void) {
@@ -69,7 +84,19 @@ const dbMock = {
         },
         returning: async () => {
           updateCalls.push({ table, payload, returning: true });
-          return blindFailReturning;
+          if (blindFailReturning.length > 0) return blindFailReturning;
+          // Status-guarded verified claim update (first returning on the
+          // stuck table after a terminal run-state lookup).
+          if (
+            stuckSelectTable &&
+            table === stuckSelectTable &&
+            (runStateResult === 'failed' || runStateResult === 'completed') &&
+            !verifiedReturningServed.has(table)
+          ) {
+            verifiedReturningServed.add(table);
+            return stuckRows.map((r) => ({ id: r.id }));
+          }
+          return [];
         },
       }),
     }),
@@ -90,6 +117,8 @@ beforeEach(() => {
   updateCalls.length = 0;
   limitArgs = [];
   stuckRows = [];
+  stuckSelectTable = null;
+  verifiedReturningServed.clear();
   blindFailReturning = [];
   nextSelectThrows = null;
   runStateResult = null;
@@ -266,5 +295,114 @@ describe('reconcileAllStuckJobs — generated_assets passes (#458)', () => {
     expect(update).toBeDefined();
     expect(update?.payload.error).toMatch(/could not be started/);
     expect(counts['generated_assets.orphaned']).toBe(1);
+  });
+});
+
+describe('reconcileAllStuckJobs — pending artifact claim passes (#1085)', () => {
+  test('terminal instance → prompt claim failed via returning (status-guarded)', async () => {
+    stuckRows = [{ id: 'fpv_1', runId: 'openstory-so_frame-prompt_dead' }];
+    stuckSelectTable = framePromptVersions;
+    runStateResult = 'failed';
+    const { reconcileAllStuckJobs } = await import('./reconcile-all');
+
+    const counts = await reconcileAllStuckJobs();
+
+    const claimFail = updateCalls.find(
+      (c) =>
+        c.table === framePromptVersions &&
+        c.returning &&
+        c.payload.status === 'failed'
+    );
+    expect(claimFail).toBeDefined();
+    // Always 'failed' — never completes a claim from the reconciler.
+    expect(claimFail?.payload.status).toBe('failed');
+    expect(counts['frame_prompt_versions.claims']).toBeGreaterThan(0);
+    // Frame-side cascade cancels live dependents (non-returning update).
+    const cascade = updateCalls.find(
+      (c) =>
+        c.table === frameVariants &&
+        !c.returning &&
+        c.payload.status === 'cancelled'
+    );
+    expect(cascade).toBeDefined();
+    expect(cascade?.payload.error).toMatch(/Upstream visual prompt/);
+  });
+
+  test('unknown / in-flight instance → no claim fail write', async () => {
+    stuckRows = [{ id: 'fpv_1', runId: 'openstory-so_frame-prompt_running' }];
+    stuckSelectTable = framePromptVersions;
+    runStateResult = null;
+    const { reconcileAllStuckJobs } = await import('./reconcile-all');
+
+    const counts = await reconcileAllStuckJobs();
+
+    // Verified path continues without UPDATE; orphan returns no rows for this
+    // mock when runState is non-terminal. Count stays 0 (the orphan UPDATE
+    // statement may still be issued — where would match nothing in real D1).
+    expect(counts['frame_prompt_versions.claims']).toBe(0);
+    const cascade = updateCalls.find(
+      (c) =>
+        c.table === frameVariants &&
+        !c.returning &&
+        c.payload.status === 'cancelled'
+    );
+    expect(cascade).toBeUndefined();
+  });
+
+  test('shot prompt claim fail does not cascade frame variants', async () => {
+    stuckRows = [{ id: 'spv_1', runId: 'openstory-so_motion-prompt_dead' }];
+    stuckSelectTable = shotPromptVersions;
+    runStateResult = 'failed';
+    const { reconcileAllStuckJobs } = await import('./reconcile-all');
+
+    await reconcileAllStuckJobs();
+
+    const shotClaimFail = updateCalls.find(
+      (c) =>
+        c.table === shotPromptVersions &&
+        c.returning &&
+        c.payload.status === 'failed'
+    );
+    expect(shotClaimFail).toBeDefined();
+    const cascade = updateCalls.find(
+      (c) => c.table === frameVariants && c.payload.status === 'cancelled'
+    );
+    expect(cascade).toBeUndefined();
+  });
+
+  test('image claim terminal instance → failed with reason, returning-guarded', async () => {
+    stuckRows = [{ id: 'fv_1', runId: 'openstory-so_image_dead' }];
+    stuckSelectTable = frameVariants;
+    runStateResult = 'completed'; // still failed: claim never completed content
+    const { reconcileAllStuckJobs } = await import('./reconcile-all');
+
+    const counts = await reconcileAllStuckJobs();
+
+    const imageClaimFail = updateCalls.find(
+      (c) =>
+        c.table === frameVariants &&
+        c.returning &&
+        c.payload.status === 'failed' &&
+        typeof c.payload.error === 'string' &&
+        /died before starting/.test(c.payload.error)
+    );
+    expect(imageClaimFail).toBeDefined();
+    expect(counts['frame_variants.claims']).toBeGreaterThan(0);
+  });
+
+  test('orphan prompt claim (no run id) blind-fails after longer threshold', async () => {
+    blindFailReturning = [{ id: 'fpv_orphan' }];
+    const { reconcileAllStuckJobs } = await import('./reconcile-all');
+
+    const counts = await reconcileAllStuckJobs();
+
+    const orphanFail = updateCalls.find(
+      (c) =>
+        c.table === framePromptVersions &&
+        c.returning &&
+        c.payload.status === 'failed'
+    );
+    expect(orphanFail).toBeDefined();
+    expect(counts['frame_prompt_versions.claims']).toBeGreaterThan(0);
   });
 });

--- a/src/lib/cron/reconcile-all.ts
+++ b/src/lib/cron/reconcile-all.ts
@@ -19,10 +19,12 @@
 
 import { getDb } from '#db-client';
 import {
+  framePromptVersions,
   frameVariants,
   frames,
   generatedAssets,
   renderSegments,
+  shotPromptVersions,
   shots,
   shotVariants,
   sequenceElements,
@@ -65,6 +67,17 @@ export async function reconcileAllStuckJobs(): Promise<ReconcileCounts> {
     ['frames.image', () => reconcileFramesImagePass(db)],
     ['shots.video', () => reconcileShotsPass(db, 'video')],
     ['frame_variants.status', () => reconcileFrameVariantsPass(db)],
+    // Pending artifact claims (#1085): a dead run must not leave rows that
+    // read as "a job is fixing this" forever.
+    [
+      'frame_prompt_versions.claims',
+      () => reconcilePromptClaimsPass(db, 'frame'),
+    ],
+    [
+      'shot_prompt_versions.claims',
+      () => reconcilePromptClaimsPass(db, 'shot'),
+    ],
+    ['frame_variants.claims', () => reconcileImageClaimsPass(db)],
     // Video versions live on video_variants now (#990) — without this pass a
     // dead motion run leaves a permanent "generating" chip on the Video tab
     // (#1076).
@@ -242,6 +255,132 @@ async function reconcileVideoVariantsPass(db: Database): Promise<number> {
     updated++;
   }
   return updated;
+}
+
+/**
+ * Sweep zombie pending prompt claims (#1085) — `frame_prompt_versions` /
+ * `shot_prompt_versions` rows still 'pending'/'generating' whose producing
+ * instance is dead. The honest terminal state is always 'failed' (never
+ * 'completed': a live claim on a terminal instance means the completion write
+ * never landed, so there is no content). Failed frame-side claims cascade to
+ * their dependent image claims. Rows with no run id (trigger died between
+ * insert and the run-id stamp) blind-fail after the longer threshold.
+ *
+ * Cutoffs use `createdAt` — these tables have no `updatedAt`, and a claim's
+ * whole lifecycle is minutes, so enqueue age is the right staleness signal.
+ */
+async function reconcilePromptClaimsPass(
+  db: Database,
+  side: 'frame' | 'shot'
+): Promise<number> {
+  const table = side === 'frame' ? framePromptVersions : shotPromptVersions;
+  const staleCutoff = new Date(Date.now() - STALE_THRESHOLD_MS);
+  const blindCutoff = new Date(Date.now() - BLIND_FAIL_THRESHOLD_MS);
+  let updated = 0;
+
+  const cascade = async (versionId: string) => {
+    if (side !== 'frame') return;
+    // No updatedAt bump — see the file-wide rule above `SHOTS_PIPELINE_COLUMNS`.
+    await db
+      .update(frameVariants)
+      .set({
+        status: 'cancelled',
+        error: 'Upstream visual prompt generation died',
+      })
+      .where(
+        and(
+          eq(frameVariants.dependsOnVersionId, versionId),
+          inArray(frameVariants.status, ['pending', 'generating'])
+        )
+      );
+  };
+
+  const stuck = await db
+    .select({ id: table.id, runId: table.workflowRunId })
+    .from(table)
+    .where(
+      and(
+        inArray(table.status, ['pending', 'generating']),
+        isNotNull(table.workflowRunId),
+        lt(table.createdAt, staleCutoff)
+      )
+    )
+    .limit(MAX_ROWS_PER_PASS);
+  for (const row of stuck) {
+    const next = await resolveRunState(row.runId ?? '');
+    if (next === null || next === 'unknown') continue;
+    await db
+      .update(table)
+      .set({ status: 'failed' })
+      .where(eq(table.id, row.id));
+    await cascade(row.id);
+    updated++;
+  }
+
+  const orphaned = await db
+    .update(table)
+    .set({ status: 'failed' })
+    .where(
+      and(
+        inArray(table.status, ['pending', 'generating']),
+        isNull(table.workflowRunId),
+        lt(table.createdAt, blindCutoff)
+      )
+    )
+    .returning({ id: table.id });
+  for (const row of orphaned) await cascade(row.id);
+
+  return updated + orphaned.length;
+}
+
+/**
+ * Sweep zombie 'pending' image claims (#1085). The existing
+ * `frame_variants.status` pass covers 'generating' rows; claim rows that
+ * never reached `set-generating-status` stay 'pending' with the enqueue-time
+ * run id (or none, if the trigger died first). Terminal instance → 'failed';
+ * no run id → blind-fail after the longer threshold.
+ */
+async function reconcileImageClaimsPass(db: Database): Promise<number> {
+  const staleCutoff = new Date(Date.now() - STALE_THRESHOLD_MS);
+  const blindCutoff = new Date(Date.now() - BLIND_FAIL_THRESHOLD_MS);
+  let updated = 0;
+
+  const stuck = await db
+    .select({ id: frameVariants.id, runId: frameVariants.workflowRunId })
+    .from(frameVariants)
+    .where(
+      and(
+        eq(frameVariants.status, 'pending'),
+        isNotNull(frameVariants.workflowRunId),
+        lt(frameVariants.updatedAt, staleCutoff)
+      )
+    )
+    .limit(MAX_ROWS_PER_PASS);
+  for (const row of stuck) {
+    const next = await resolveRunState(row.runId ?? '');
+    if (next === null || next === 'unknown') continue;
+    // 'failed' regardless of the instance verdict: a still-pending claim on a
+    // terminal instance means no render ever landed on this row.
+    await db
+      .update(frameVariants)
+      .set({ status: 'failed', error: 'Generation died before starting' })
+      .where(eq(frameVariants.id, row.id));
+    updated++;
+  }
+
+  const orphaned = await db
+    .update(frameVariants)
+    .set({ status: 'failed', error: 'Generation could not be started' })
+    .where(
+      and(
+        eq(frameVariants.status, 'pending'),
+        isNull(frameVariants.workflowRunId),
+        lt(frameVariants.updatedAt, blindCutoff)
+      )
+    )
+    .returning({ id: frameVariants.id });
+
+  return updated + orphaned.length;
 }
 
 async function reconcileShotsPass(

--- a/src/lib/cron/reconcile-all.ts
+++ b/src/lib/cron/reconcile-all.ts
@@ -309,10 +309,21 @@ async function reconcilePromptClaimsPass(
   for (const row of stuck) {
     const next = await resolveRunState(row.runId ?? '');
     if (next === null || next === 'unknown') continue;
-    await db
+    // Re-guard live status at write time: a long generation can complete the
+    // claim between the SELECT above and this UPDATE (resolveRunState is a
+    // network RPC). Without the predicate we'd overwrite completed content
+    // with 'failed' and cascade-cancel dependent image claims.
+    const transitioned = await db
       .update(table)
       .set({ status: 'failed' })
-      .where(eq(table.id, row.id));
+      .where(
+        and(
+          eq(table.id, row.id),
+          inArray(table.status, ['pending', 'generating'])
+        )
+      )
+      .returning({ id: table.id });
+    if (transitioned.length === 0) continue;
     await cascade(row.id);
     updated++;
   }
@@ -360,11 +371,17 @@ async function reconcileImageClaimsPass(db: Database): Promise<number> {
     const next = await resolveRunState(row.runId ?? '');
     if (next === null || next === 'unknown') continue;
     // 'failed' regardless of the instance verdict: a still-pending claim on a
-    // terminal instance means no render ever landed on this row.
-    await db
+    // terminal instance means no render ever landed on this row. Re-guard
+    // status so a completion that raced the network lookup is never
+    // overwritten (same TOCTOU as the prompt-claim pass).
+    const transitioned = await db
       .update(frameVariants)
       .set({ status: 'failed', error: 'Generation died before starting' })
-      .where(eq(frameVariants.id, row.id));
+      .where(
+        and(eq(frameVariants.id, row.id), eq(frameVariants.status, 'pending'))
+      )
+      .returning({ id: frameVariants.id });
+    if (transitioned.length === 0) continue;
     updated++;
   }
 

--- a/src/lib/db/schema/frame-prompt-versions.ts
+++ b/src/lib/db/schema/frame-prompt-versions.ts
@@ -31,6 +31,22 @@ const PROMPT_VERSION_SOURCES = [
 ] as const;
 export type PromptVersionSource = (typeof PROMPT_VERSION_SOURCES)[number];
 
+/**
+ * Lifecycle of a prompt-version row (#1085). Historically rows were appended
+ * only on completion; pending records are now created at enqueue time so
+ * in-flight work is representable ("updating" staleness, dedup, cancellation).
+ * Default 'completed' keeps every legacy row valid without a backfill.
+ * Shared by `shot_prompt_versions` — same lifecycle, same vocabulary.
+ */
+const PROMPT_VERSION_STATUSES = [
+  'pending',
+  'generating',
+  'completed',
+  'failed',
+  'cancelled',
+] as const;
+export type PromptVersionStatus = (typeof PROMPT_VERSION_STATUSES)[number];
+
 export const framePromptVersions = snakeCase.table(
   'frame_prompt_versions',
   {
@@ -57,6 +73,20 @@ export const framePromptVersions = snakeCase.table(
     // Analysis model that produced the prompt (null for user-edits).
     analysisModel: text({ length: 100 }),
 
+    // Lifecycle (#1085). Non-'completed' rows are in-flight placeholders (or
+    // their terminal failures) and are invisible to every "latest"/"selected"
+    // reader — those filter status = 'completed'.
+    status: text().$type<PromptVersionStatus>().notNull().default('completed'),
+    // The live input hash this generation was enqueued to satisfy — "this row
+    // is the result of inputs H". Set on pending rows; on completion the
+    // existing `inputHash` records what was actually used. Staleness reads
+    // 'updating' only while this matches the current live hash, so an edit
+    // self-invalidates the claim with no cancellation bookkeeping.
+    pendingInputHash: text(),
+    // Workflow instance producing this row — enables cancel + reconciliation
+    // of zombie pending rows whose instance died.
+    workflowRunId: text(),
+
     createdAt: integer({ mode: 'timestamp' })
       .$defaultFn(() => new Date())
       .notNull(),
@@ -77,6 +107,14 @@ export const framePromptVersions = snakeCase.table(
       .on(table.frameId, table.inputHash)
       .where(
         sql`${table.inputHash} IS NOT NULL AND ${table.source} != 'restored'`
+      ),
+    // At most ONE live claim per (frame, live-hash) (#1085): two concurrent
+    // enqueues race their check-then-insert; the loser errors here and
+    // reports already-in-flight instead of double-spending.
+    uniqueIndex('uq_frame_prompt_versions_live_claim')
+      .on(table.frameId, table.pendingInputHash)
+      .where(
+        sql`${table.pendingInputHash} IS NOT NULL AND ${table.status} IN ('pending', 'generating')`
       ),
   ]
 );

--- a/src/lib/db/schema/frame-variants.ts
+++ b/src/lib/db/schema/frame-variants.ts
@@ -19,14 +19,27 @@
  * docs/architecture/scene-shot-frame-redesign.md.
  */
 
-import { type InferInsertModel, type InferSelectModel } from 'drizzle-orm';
-import { index, integer, snakeCase, text } from 'drizzle-orm/sqlite-core';
+import { type InferInsertModel, type InferSelectModel, sql } from 'drizzle-orm';
+import {
+  index,
+  integer,
+  snakeCase,
+  text,
+  uniqueIndex,
+} from 'drizzle-orm/sqlite-core';
 import { generateId } from '../id';
 import { frames } from './frames';
 import { sequences } from './sequences';
 import { SHOT_GENERATION_STATUSES } from './shots';
 
-type FrameGenerationStatus = (typeof SHOT_GENERATION_STATUSES)[number];
+// Frame-variant rows extend the shared generation statuses with 'cancelled'
+// (#1085): a chained image whose upstream pending prompt version failed or was
+// cancelled is cancelled itself — never attempted, distinct from 'failed'.
+const FRAME_VARIANT_STATUSES = [
+  ...SHOT_GENERATION_STATUSES,
+  'cancelled',
+] as const;
+type FrameGenerationStatus = (typeof FRAME_VARIANT_STATUSES)[number];
 
 /** @public consumed from #988+ */
 export const FRAME_VARIANT_KINDS = ['model', 'framing'] as const;
@@ -69,6 +82,15 @@ export const frameVariants = snakeCase.table(
     // Staleness of THIS version.
     promptHash: text(),
     inputHash: text(),
+    // In-flight claim for direct image regens (#1085): the live input hash
+    // this render was enqueued to satisfy. Chained renders (image waiting on
+    // a pending prompt version) leave it null — their validity derives from
+    // the dependency below.
+    pendingInputHash: text(),
+    // App-managed soft pointer (NO FK — D1 cascade trap) to the pending
+    // `frame_prompt_versions` row this chained render will consume. Failure/
+    // cancellation of that row cancels this one; chain depth is 2 today.
+    dependsOnVersionId: text(),
     // Soft pointer to the `frame_prompt_versions` row that was selected when
     // this still was generated (#1070). No FK (same cycle-avoidance pattern as
     // `sourceVariantId` / frames' selection pointers). Selecting this image
@@ -96,6 +118,15 @@ export const frameVariants = snakeCase.table(
       table.model
     ),
     index('idx_frame_variants_sequence').on(table.sequenceId),
+    // At most ONE live direct-regen claim per (frame, live-hash) (#1085).
+    // Chained claims carry a null pendingInputHash and are excluded — their
+    // uniqueness derives from the (already unique) prompt claim they depend
+    // on.
+    uniqueIndex('uq_frame_variants_live_claim')
+      .on(table.frameId, table.pendingInputHash)
+      .where(
+        sql`${table.pendingInputHash} IS NOT NULL AND ${table.status} IN ('pending', 'generating')`
+      ),
   ]
 );
 

--- a/src/lib/db/schema/frame-variants.ts
+++ b/src/lib/db/schema/frame-variants.ts
@@ -119,9 +119,9 @@ export const frameVariants = snakeCase.table(
     ),
     index('idx_frame_variants_sequence').on(table.sequenceId),
     // At most ONE live direct-regen claim per (frame, live-hash) (#1085).
-    // Chained claims carry a null pendingInputHash and are excluded — their
-    // uniqueness derives from the (already unique) prompt claim they depend
-    // on.
+    // Chained claims start with pendingInputHash null and are excluded from
+    // this index. App code reuses a live row with dependsOnVersionId === our
+    // visual claim; there is no DB uniqueness on the dependency edge.
     uniqueIndex('uq_frame_variants_live_claim')
       .on(table.frameId, table.pendingInputHash)
       .where(

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -176,6 +176,7 @@ export type {
 export type {
   FramePromptVersion,
   PromptVersionSource,
+  PromptVersionStatus,
 } from './frame-prompt-versions';
 
 /** @public used by #988+ (append-only cross-sequence activity log) */

--- a/src/lib/db/schema/shot-prompt-versions.ts
+++ b/src/lib/db/schema/shot-prompt-versions.ts
@@ -33,6 +33,7 @@ import {
 } from 'drizzle-orm/sqlite-core';
 import { generateId } from '../id';
 import { user } from './auth';
+import type { PromptVersionStatus } from './frame-prompt-versions';
 import { shots } from './shots';
 
 /**
@@ -103,6 +104,12 @@ export const shotPromptVersions = snakeCase.table(
     // Analysis model that produced the prompt (null for user-edits).
     analysisModel: text({ length: 100 }),
 
+    // Lifecycle + in-flight claim + producing instance (#1085) — see
+    // `frame_prompt_versions` for the full contract; identical semantics.
+    status: text().$type<PromptVersionStatus>().notNull().default('completed'),
+    pendingInputHash: text(),
+    workflowRunId: text(),
+
     createdAt: integer({ mode: 'timestamp' })
       .$defaultFn(() => new Date())
       .notNull(),
@@ -130,6 +137,13 @@ export const shotPromptVersions = snakeCase.table(
       .on(table.shotId, table.promptType, table.inputHash)
       .where(
         sql`${table.inputHash} IS NOT NULL AND ${table.source} != 'restored'`
+      ),
+    // At most ONE live claim per (shot, type, live-hash) (#1085) — see the
+    // frame-side twin for the race this closes.
+    uniqueIndex('uq_shot_prompt_versions_live_claim')
+      .on(table.shotId, table.promptType, table.pendingInputHash)
+      .where(
+        sql`${table.pendingInputHash} IS NOT NULL AND ${table.status} IN ('pending', 'generating')`
       ),
   ]
 );

--- a/src/lib/db/scoped/frame-prompt-versions.test.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.test.ts
@@ -556,6 +556,74 @@ describe('framePromptVersions.completePendingAiVersion', () => {
       })
     ).rejects.toThrow(/not found for frame/);
   });
+
+  it('restore demotes live claims so completion never remirrors', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const original = await m.write({
+      frameId,
+      text: 'Original prompt',
+      source: 'ai-generated',
+      inputHash: 'hash-0',
+      analysisModel: HAIKU,
+    });
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    // User restores the original while the claim is still generating.
+    await m.select(frameId, original.id, { actorId: null });
+
+    const [demoted] = await db
+      .select()
+      .from(framePromptVersions)
+      .where(eq(framePromptVersions.id, claim.id));
+    expect(demoted?.pendingInputHash).toBeNull();
+    expect(await m.getLivePending(frameId, 'live-hash')).toBeNull();
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      frameId,
+      text: 'Would clobber restore',
+      inputHash: 'live-hash',
+      analysisModel: HAIKU,
+    });
+    expect(completed?.status).toBe('completed');
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Original prompt');
+    expect(frame.selectedImagePromptVersionId).toBe(original.id);
+  });
+
+  it('write demotes live claims (edit frees the unique slot + blocks remirror)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    await m.write({
+      frameId,
+      text: 'User edit while regenerating',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+
+    const [demoted] = await db
+      .select()
+      .from(framePromptVersions)
+      .where(eq(framePromptVersions.id, claim.id));
+    expect(demoted?.pendingInputHash).toBeNull();
+    // Live unique slot freed — a fresh enqueue for a new hash can proceed.
+    expect(await m.getLivePending(frameId, 'live-hash')).toBeNull();
+  });
 });
 
 describe('framePromptVersions.getLatestWithInputHash', () => {

--- a/src/lib/db/scoped/frame-prompt-versions.test.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.test.ts
@@ -350,6 +350,214 @@ describe('framePromptVersions.getByIdForFrame', () => {
   });
 });
 
+describe('framePromptVersions.completePendingAiVersion', () => {
+  it('completes the claim in place and mirrors onto the frame', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      frameId,
+      text: 'Regenerated prompt',
+      inputHash: 'live-hash',
+      analysisModel: HAIKU,
+    });
+
+    expect(completed?.id).toBe(claim.id);
+    expect(completed?.status).toBe('completed');
+    expect(completed?.text).toBe('Regenerated prompt');
+    expect(completed?.inputHash).toBe('live-hash');
+
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Regenerated prompt');
+    expect(frame.visualPromptInputHash).toBe('live-hash');
+    expect(frame.selectedImagePromptVersionId).toBe(claim.id);
+  });
+
+  it('a post-click user edit keeps the mirror — the run completes to history only', async () => {
+    // The invariant the PR is named for: the system cannot lose an edit.
+    const m = createFramePromptVersionsMethods(db);
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    // User edits AFTER the claim was enqueued: a newer completed row lands.
+    const edit = await m.write({
+      frameId,
+      text: 'Post-click hand edit',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      frameId,
+      text: 'Older run output',
+      inputHash: 'other-hash',
+      analysisModel: HAIKU,
+    });
+
+    // The claim itself completed into history…
+    expect(completed?.id).toBe(claim.id);
+    expect(completed?.status).toBe('completed');
+
+    // …but the frame still shows the user's edit.
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Post-click hand edit');
+    expect(frame.selectedImagePromptVersionId).toBe(edit.id);
+  });
+
+  it('returns null for a claim cancelled mid-flight and never mirrors', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    await m.write({
+      frameId,
+      text: 'Original',
+      source: 'ai-generated',
+      inputHash: 'hash-0',
+      analysisModel: HAIKU,
+    });
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+    await m.markTerminal(claim.id, 'cancelled');
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      frameId,
+      text: 'Should be discarded',
+      inputHash: 'live-hash',
+      analysisModel: HAIKU,
+    });
+
+    expect(completed).toBeNull();
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Original');
+    const [row] = await db
+      .select()
+      .from(framePromptVersions)
+      .where(eq(framePromptVersions.id, claim.id));
+    expect(row?.status).toBe('cancelled');
+  });
+
+  it('identical text at a colliding hash retires the claim in favour of the existing row', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const existing = await m.write({
+      frameId,
+      text: 'Same output',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'hash-1',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      frameId,
+      text: 'Same output',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+
+    // The existing row wins; the placeholder retires as 'cancelled'.
+    expect(completed?.id).toBe(existing.id);
+    const [placeholder] = await db
+      .select()
+      .from(framePromptVersions)
+      .where(eq(framePromptVersions.id, claim.id));
+    expect(placeholder?.status).toBe('cancelled');
+    // No unique-index violation, and the mirror points at the surviving row.
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.selectedImagePromptVersionId).toBe(existing.id);
+  });
+
+  it('new text at a colliding hash completes with a null row-hash (index bypass)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    await m.write({
+      frameId,
+      text: 'Old output',
+      source: 'ai-generated',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+    const claim = await m.createPending({
+      frameId,
+      pendingInputHash: 'hash-1',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      frameId,
+      text: 'Fresh different output',
+      inputHash: 'hash-1',
+      analysisModel: HAIKU,
+    });
+
+    expect(completed?.id).toBe(claim.id);
+    expect(completed?.inputHash).toBeNull();
+    // The frame's cached hash still tracks the real context.
+    const [frame] = await db
+      .select()
+      .from(frames)
+      .where(eq(frames.id, frameId));
+    if (!frame) throw new Error('test setup: refresh failed');
+    expect(frame.imagePrompt).toBe('Fresh different output');
+    expect(frame.visualPromptInputHash).toBe('hash-1');
+  });
+
+  it('throws for a claim that belongs to another frame (ownership guard)', async () => {
+    const m = createFramePromptVersionsMethods(db);
+    const [sibling] = await db
+      .insert(frames)
+      .values({ shotId, sequenceId, orderIndex: 1, role: 'last' })
+      .returning();
+    if (!sibling) throw new Error('test setup: sibling frame missing');
+    const claim = await m.createPending({
+      frameId: sibling.id,
+      pendingInputHash: 'live-hash',
+    });
+
+    await expect(
+      m.completePendingAiVersion({
+        versionId: claim.id,
+        frameId,
+        text: 'Wrong frame',
+        inputHash: 'live-hash',
+        analysisModel: HAIKU,
+      })
+    ).rejects.toThrow(/not found for frame/);
+  });
+});
+
 describe('framePromptVersions.getLatestWithInputHash', () => {
   it('skips null-hash user-edits and returns the most recent hashed row', async () => {
     const m = createFramePromptVersionsMethods(db);

--- a/src/lib/db/scoped/frame-prompt-versions.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.ts
@@ -77,11 +77,13 @@ export function createFramePromptVersionsMethods(db: Database) {
 
   /**
    * Revoke the mirror right of every live claim on this frame (#1085): after
-   * an explicit user repoint (restore / image-selection prompt restore), an
-   * in-flight regeneration may still land in history but must NOT overwrite
+   * an explicit user repoint (restore / image-selection prompt restore / edit),
+   * an in-flight regeneration may still land in history but must NOT overwrite
    * the user's choice on the frame. Nulling `pendingInputHash` is the
    * revocation — completion mirrors only claims that still hold their hash,
    * and the artifact honestly reads 'stale' again instead of 'updating'.
+   * Also frees the live-claim unique index slot so a fresh enqueue for a new
+   * hash is not blocked by a demoted-but-still-running claim.
    */
   const demoteLiveClaims = (frameId: string) =>
     db
@@ -93,6 +95,38 @@ export function createFramePromptVersionsMethods(db: Database) {
           inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
         )
       );
+
+  /**
+   * Post-transition mirror check for completePendingAiVersion (#1095 TOCTOU).
+   * Must run AFTER the claim has been moved terminal so a concurrent demote
+   * (nulls pendingInputHash while live) or a concurrent write (inserts a
+   * newer completed ULID) is visible before we touch the frame mirror.
+   */
+  const stillHoldsMirrorRight = async (
+    frameId: string,
+    claimId: string
+  ): Promise<boolean> => {
+    const [row] = await db
+      .select({ pendingInputHash: framePromptVersions.pendingInputHash })
+      .from(framePromptVersions)
+      .where(eq(framePromptVersions.id, claimId))
+      .limit(1);
+    if (!row || row.pendingInputHash === null) return false;
+    // ULID ids order by creation time: any completed row newer than the claim
+    // is a post-click edit (or a later run) that must keep the mirror.
+    const [newer] = await db
+      .select({ id: framePromptVersions.id })
+      .from(framePromptVersions)
+      .where(
+        and(
+          eq(framePromptVersions.frameId, frameId),
+          eq(framePromptVersions.status, 'completed'),
+          gt(framePromptVersions.id, claimId)
+        )
+      )
+      .limit(1);
+    return !newer;
+  };
 
   const methods = {
     /**
@@ -163,15 +197,22 @@ export function createFramePromptVersionsMethods(db: Database) {
         throw new Error('Failed to insert frame prompt version');
       }
 
-      await db
-        .update(frames)
-        .set({
-          imagePrompt: input.text,
-          visualPromptInputHash: nextHash,
-          selectedImagePromptVersionId: version.id,
-          updatedAt: new Date(),
-        })
-        .where(eq(frames.id, input.frameId));
+      // Mirror the edit onto the frame, then revoke in-flight claims' mirror
+      // rights so a concurrent completePendingAiVersion cannot clobber this
+      // write (#1085 / #1095 TOCTOU). demote nulls pendingInputHash (and
+      // frees the live-claim unique slot) while claims stay pending/generating.
+      await db.batch([
+        db
+          .update(frames)
+          .set({
+            imagePrompt: input.text,
+            visualPromptInputHash: nextHash,
+            selectedImagePromptVersionId: version.id,
+            updatedAt: new Date(),
+          })
+          .where(eq(frames.id, input.frameId)),
+        demoteLiveClaims(input.frameId),
+      ]);
 
       return version;
     },
@@ -350,31 +391,13 @@ export function createFramePromptVersionsMethods(db: Database) {
         )
         .limit(1);
 
-      // ULID ids order by creation time: any completed row newer than the
-      // claim is a post-click edit (or a later run) that must keep the mirror.
-      const [newer] = await db
-        .select({ id: framePromptVersions.id })
-        .from(framePromptVersions)
-        .where(
-          and(
-            eq(framePromptVersions.frameId, input.frameId),
-            eq(framePromptVersions.status, 'completed'),
-            gt(framePromptVersions.id, claim.id)
-          )
-        )
-        .limit(1);
-
-      // Mirror right (#1085): revoked when a newer completed row landed
-      // (post-click edit), or when an explicit repoint demoted the claim
-      // (pendingInputHash nulled) — either way the user's choice wins and
-      // this run's output goes to history only.
-      const mayMirror = !newer && claim.pendingInputHash !== null;
-
       if (conflicting && conflicting.text === input.text) {
         // Identical output already in history — retire the placeholder. The
         // guarded UPDATE must have transitioned the claim ourselves: a no-op
         // means a cancel already won the race, and cancelled work must not
         // mirror (same contract as the main branch below).
+        // status 'cancelled' here = retired duplicate placeholder (no new
+        // content), not a user cancel.
         const retired = await db
           .update(framePromptVersions)
           .set({ status: 'cancelled' })
@@ -386,7 +409,12 @@ export function createFramePromptVersionsMethods(db: Database) {
           )
           .returning({ id: framePromptVersions.id });
         if (retired.length === 0) return null;
-        if (mayMirror) await mirrorOntoFrame(input.frameId, conflicting);
+        // Re-evaluate mirror right AFTER the terminal transition so a
+        // concurrent write/select that demoted us or landed a newer
+        // completed row wins (#1095 TOCTOU).
+        if (await stillHoldsMirrorRight(input.frameId, claim.id)) {
+          await mirrorOntoFrame(input.frameId, conflicting);
+        }
         return conflicting;
       }
 
@@ -408,7 +436,11 @@ export function createFramePromptVersionsMethods(db: Database) {
         .returning();
       if (!updated) return null; // cancelled mid-flight — discard the output
 
-      if (mayMirror) {
+      // Mirror right (#1085): re-checked after we own the terminal write.
+      // Revoked when a newer completed row landed (post-click edit) or when
+      // write/select demoted the claim (pendingInputHash nulled) — either
+      // way the user's choice wins and this run's output goes to history only.
+      if (await stillHoldsMirrorRight(input.frameId, claim.id)) {
         await db
           .update(frames)
           .set({

--- a/src/lib/db/scoped/frame-prompt-versions.ts
+++ b/src/lib/db/scoped/frame-prompt-versions.ts
@@ -21,8 +21,11 @@ import type { VisualPromptComponents } from '@/lib/ai/scene-analysis.schema';
 import type { Database } from '@/lib/db/client';
 import { framePromptVersions, frames, user } from '@/lib/db/schema';
 import type { FramePromptVersion } from '@/lib/db/schema';
-import { and, desc, eq, isNotNull } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNotNull, ne } from 'drizzle-orm';
 import { buildEventInsert } from './sequence-events';
+
+/** Statuses of an in-flight pending claim — not yet terminal. */
+export const LIVE_PENDING_STATUSES = ['pending', 'generating'] as const;
 
 type WriteFramePromptVersionBase = {
   frameId: string;
@@ -71,6 +74,25 @@ export function createFramePromptVersionsMethods(db: Database) {
         updatedAt: new Date(),
       })
       .where(eq(frames.id, frameId));
+
+  /**
+   * Revoke the mirror right of every live claim on this frame (#1085): after
+   * an explicit user repoint (restore / image-selection prompt restore), an
+   * in-flight regeneration may still land in history but must NOT overwrite
+   * the user's choice on the frame. Nulling `pendingInputHash` is the
+   * revocation — completion mirrors only claims that still hold their hash,
+   * and the artifact honestly reads 'stale' again instead of 'updating'.
+   */
+  const demoteLiveClaims = (frameId: string) =>
+    db
+      .update(framePromptVersions)
+      .set({ pendingInputHash: null })
+      .where(
+        and(
+          eq(framePromptVersions.frameId, frameId),
+          inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+        )
+      );
 
   const methods = {
     /**
@@ -177,6 +199,230 @@ export function createFramePromptVersionsMethods(db: Database) {
     },
 
     /**
+     * Create an in-flight placeholder row for a regeneration that was just
+     * enqueued (#1085). Deliberately does NOT mirror onto the frame or move
+     * the selection pointer — only completion does that — so the pointer
+     * invariant ("selected always points at a completed row") holds by
+     * construction. `inputHash` stays null until completion, keeping the row
+     * out of the partial unique index and out of every hash-matching reader.
+     */
+    createPending: async (input: {
+      frameId: string;
+      pendingInputHash: string;
+      workflowRunId?: string | null;
+      createdBy?: string | null;
+    }): Promise<FramePromptVersion> => {
+      const [row] = await db
+        .insert(framePromptVersions)
+        .values({
+          frameId: input.frameId,
+          text: '',
+          source: 'regenerated',
+          inputHash: null,
+          analysisModel: null,
+          status: 'pending',
+          pendingInputHash: input.pendingInputHash,
+          workflowRunId: input.workflowRunId ?? null,
+          createdBy: input.createdBy ?? null,
+        })
+        .returning();
+      if (!row) throw new Error('Failed to insert pending frame prompt row');
+      return row;
+    },
+
+    /**
+     * The newest live (pending/generating) claim for this frame satisfying
+     * `pendingInputHash` — the dedup + "updating" staleness probe. A claim
+     * whose hash no longer matches the live inputs is dead weight (the edit
+     * self-invalidated it) and is deliberately not returned.
+     */
+    getLivePending: async (
+      frameId: string,
+      pendingInputHash: string
+    ): Promise<FramePromptVersion | null> => {
+      const [row] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.frameId, frameId),
+            eq(framePromptVersions.pendingInputHash, pendingInputHash),
+            inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .orderBy(desc(framePromptVersions.createdAt))
+        .limit(1);
+      return row ?? null;
+    },
+
+    /**
+     * Transition a claim to 'generating' and stamp the instance doing the
+     * work. No-ops (returns false) when the row was cancelled meanwhile —
+     * the caller must then abandon the generation.
+     */
+    markGenerating: async (
+      versionId: string,
+      workflowRunId: string
+    ): Promise<boolean> => {
+      const updated = await db
+        .update(framePromptVersions)
+        .set({ status: 'generating', workflowRunId })
+        .where(
+          and(
+            eq(framePromptVersions.id, versionId),
+            inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning({ id: framePromptVersions.id });
+      return updated.length > 0;
+    },
+
+    /**
+     * Terminal-fail a live claim (workflow failure / zombie sweep / cancel).
+     * Returns the row when the transition happened, null when the row was
+     * already terminal (e.g. completed just before a cancel raced in).
+     */
+    markTerminal: async (
+      versionId: string,
+      status: 'failed' | 'cancelled'
+    ): Promise<FramePromptVersion | null> => {
+      const [row] = await db
+        .update(framePromptVersions)
+        .set({ status })
+        .where(
+          and(
+            eq(framePromptVersions.id, versionId),
+            inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      return row ?? null;
+    },
+
+    /**
+     * Complete a pending claim in place: fill in the generated content, stamp
+     * the hash of the inputs actually used, and flip to 'completed'. Mirrors
+     * onto the frame ONLY when no newer completed version landed meanwhile —
+     * a post-click user edit must never be clobbered by an older run's output
+     * (#1085: "the system cannot lose an edit"). Returns null when the claim
+     * was cancelled mid-flight (the output is discarded).
+     *
+     * Handles the partial-unique-index edge exactly like `write`: if a
+     * completed row already carries this (frameId, inputHash), the claim
+     * either retires in favour of that row (identical text) or completes with
+     * a null row-hash (new text, index bypass) while the frame's cached hash
+     * still tracks the real context.
+     */
+    completePendingAiVersion: async (input: {
+      versionId: string;
+      frameId: string;
+      text: string;
+      components?: VisualPromptComponents | null;
+      inputHash: string;
+      analysisModel: string;
+    }): Promise<FramePromptVersion | null> => {
+      const [claim] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.id, input.versionId),
+            eq(framePromptVersions.frameId, input.frameId)
+          )
+        )
+        .limit(1);
+      if (!claim) {
+        throw new Error(
+          `FramePromptVersion ${input.versionId} not found for frame ${input.frameId}`
+        );
+      }
+
+      const [conflicting] = await db
+        .select()
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.frameId, input.frameId),
+            eq(framePromptVersions.inputHash, input.inputHash),
+            ne(framePromptVersions.id, input.versionId),
+            ne(framePromptVersions.source, 'restored')
+          )
+        )
+        .limit(1);
+
+      // ULID ids order by creation time: any completed row newer than the
+      // claim is a post-click edit (or a later run) that must keep the mirror.
+      const [newer] = await db
+        .select({ id: framePromptVersions.id })
+        .from(framePromptVersions)
+        .where(
+          and(
+            eq(framePromptVersions.frameId, input.frameId),
+            eq(framePromptVersions.status, 'completed'),
+            gt(framePromptVersions.id, claim.id)
+          )
+        )
+        .limit(1);
+
+      // Mirror right (#1085): revoked when a newer completed row landed
+      // (post-click edit), or when an explicit repoint demoted the claim
+      // (pendingInputHash nulled) — either way the user's choice wins and
+      // this run's output goes to history only.
+      const mayMirror = !newer && claim.pendingInputHash !== null;
+
+      if (conflicting && conflicting.text === input.text) {
+        // Identical output already in history — retire the placeholder. The
+        // guarded UPDATE must have transitioned the claim ourselves: a no-op
+        // means a cancel already won the race, and cancelled work must not
+        // mirror (same contract as the main branch below).
+        const retired = await db
+          .update(framePromptVersions)
+          .set({ status: 'cancelled' })
+          .where(
+            and(
+              eq(framePromptVersions.id, input.versionId),
+              inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+            )
+          )
+          .returning({ id: framePromptVersions.id });
+        if (retired.length === 0) return null;
+        if (mayMirror) await mirrorOntoFrame(input.frameId, conflicting);
+        return conflicting;
+      }
+
+      const [updated] = await db
+        .update(framePromptVersions)
+        .set({
+          text: input.text,
+          components: input.components ?? null,
+          inputHash: conflicting ? null : input.inputHash,
+          analysisModel: input.analysisModel,
+          status: 'completed',
+        })
+        .where(
+          and(
+            eq(framePromptVersions.id, input.versionId),
+            inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      if (!updated) return null; // cancelled mid-flight — discard the output
+
+      if (mayMirror) {
+        await db
+          .update(frames)
+          .set({
+            imagePrompt: input.text,
+            visualPromptInputHash: input.inputHash,
+            selectedImagePromptVersionId: updated.id,
+            updatedAt: new Date(),
+          })
+          .where(eq(frames.id, input.frameId));
+      }
+      return updated;
+    },
+
+    /**
      * Repoint the frame at an existing prompt version (a restore) and mirror
      * it onto the frame, committing the change and a `prompt.selected` event
      * in one batch. Returns the selected version.
@@ -200,6 +446,13 @@ export function createFramePromptVersionsMethods(db: Database) {
           `FramePromptVersion ${versionId} not found for frame ${frameId}`
         );
       }
+      if (version.status !== 'completed') {
+        // Same invariant as frameVariants.select: the selection pointer (and
+        // the frame mirror behind it) may only ever reference completed rows.
+        throw new Error(
+          `FramePromptVersion ${versionId} is ${version.status}, not completed`
+        );
+      }
       const [frame] = await db
         .select({
           sequenceId: frames.sequenceId,
@@ -213,6 +466,9 @@ export function createFramePromptVersionsMethods(db: Database) {
 
       await db.batch([
         mirrorOntoFrame(frameId, version),
+        // An explicit repoint revokes in-flight claims' mirror rights (#1085)
+        // — their output still lands in history, but must not clobber this.
+        demoteLiveClaims(frameId),
         buildEventInsert(db, {
           sequenceId: frame.sequenceId,
           actorId: opts.actorId,
@@ -271,12 +527,18 @@ export function createFramePromptVersionsMethods(db: Database) {
       return row ?? null;
     },
 
-    /** Most recent version, or null. */
+    /** Most recent completed version, or null. In-flight/failed rows are
+     * placeholders, not content — every "latest" reader wants completed. */
     getLatest: async (frameId: string): Promise<FramePromptVersion | null> => {
       const [row] = await db
         .select()
         .from(framePromptVersions)
-        .where(eq(framePromptVersions.frameId, frameId))
+        .where(
+          and(
+            eq(framePromptVersions.frameId, frameId),
+            eq(framePromptVersions.status, 'completed')
+          )
+        )
         .orderBy(desc(framePromptVersions.createdAt))
         .limit(1);
       return row ?? null;
@@ -296,7 +558,8 @@ export function createFramePromptVersionsMethods(db: Database) {
         .where(
           and(
             eq(framePromptVersions.frameId, frameId),
-            isNotNull(framePromptVersions.inputHash)
+            isNotNull(framePromptVersions.inputHash),
+            eq(framePromptVersions.status, 'completed')
           )
         )
         .orderBy(desc(framePromptVersions.createdAt))

--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -679,3 +679,192 @@ describe('frameVariants.isStale', () => {
     expect(await m.isStale(hashed.id, 'h-new')).toBe(true);
   });
 });
+
+describe('frameVariants pending claims (#1085)', () => {
+  it('createPendingClaim + listLiveClaims only surface claim rows', async () => {
+    const m = createFrameVariantsMethods(db);
+    // Ordinary append without claim fields is not a "claim".
+    await m.appendVersion(
+      variantInput({
+        status: 'generating',
+        url: null,
+        workflowRunId: 'run-plain',
+      })
+    );
+    const direct = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+      workflowRunId: 'run-claim',
+    });
+    const chained = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      dependsOnVersionId: 'fpv-dep',
+      workflowRunId: 'run-chain',
+    });
+
+    const live = await m.listLiveClaims(frameId);
+    expect(live.map((r) => r.id).sort()).toEqual(
+      [direct.id, chained.id].sort()
+    );
+  });
+
+  it('claimForGeneration returns null after markTerminal (cancel wins)', async () => {
+    const m = createFrameVariantsMethods(db);
+    const claim = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+    });
+    await m.markTerminal(claim.id, 'cancelled', 'Cancelled by user');
+
+    const claimed = await m.claimForGeneration(claim.id, {
+      workflowRunId: 'run-1',
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+    });
+    expect(claimed).toBeNull();
+    const [row] = await db
+      .select()
+      .from(frameVariants)
+      .where(eq(frameVariants.id, claim.id));
+    expect(row?.status).toBe('cancelled');
+  });
+
+  it('completeIfLive returns null when cancelled mid-flight (no resurrection)', async () => {
+    const m = createFrameVariantsMethods(db);
+    const claim = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+    });
+    await m.claimForGeneration(claim.id, {
+      workflowRunId: 'run-1',
+      model: 'nano_banana_2',
+    });
+    await m.markTerminal(claim.id, 'cancelled', 'Cancelled by user');
+
+    const completed = await m.completeIfLive(claim.id, {
+      url: 'https://cdn/should-not-land.png',
+      storagePath: 'r2/nope.png',
+    });
+    expect(completed).toBeNull();
+    const [row] = await db
+      .select()
+      .from(frameVariants)
+      .where(eq(frameVariants.id, claim.id));
+    expect(row?.status).toBe('cancelled');
+    expect(row?.url).toBeNull();
+  });
+
+  it('completeIfLive completes a live claim in place', async () => {
+    const m = createFrameVariantsMethods(db);
+    const claim = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+    });
+    await m.claimForGeneration(claim.id, {
+      workflowRunId: 'run-1',
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+    });
+
+    const completed = await m.completeIfLive(claim.id, {
+      url: 'https://cdn/img.png',
+      storagePath: 'r2/img.png',
+      inputHash: 'img-hash',
+    });
+    expect(completed?.id).toBe(claim.id);
+    expect(completed?.status).toBe('completed');
+    expect(completed?.url).toBe('https://cdn/img.png');
+  });
+
+  it('cancelByDependency cancels only live dependents of that prompt version', async () => {
+    const m = createFrameVariantsMethods(db);
+    const dep = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      dependsOnVersionId: 'fpv-1',
+    });
+    const other = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      dependsOnVersionId: 'fpv-other',
+    });
+    const direct = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      pendingInputHash: 'img-hash',
+    });
+
+    const cascaded = await m.cancelByDependency(
+      'fpv-1',
+      'Upstream visual prompt was cancelled'
+    );
+    expect(cascaded.map((r) => r.id)).toEqual([dep.id]);
+    expect(cascaded[0]?.status).toBe('cancelled');
+
+    const [otherRow] = await db
+      .select()
+      .from(frameVariants)
+      .where(eq(frameVariants.id, other.id));
+    const [directRow] = await db
+      .select()
+      .from(frameVariants)
+      .where(eq(frameVariants.id, direct.id));
+    expect(otherRow?.status).toBe('pending');
+    expect(directRow?.status).toBe('pending');
+  });
+
+  it('claimForGeneration unique-hash collision stands down (null) instead of throwing', async () => {
+    const m = createFrameVariantsMethods(db);
+    // Direct claim already holds the live hash slot.
+    const holder = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      pendingInputHash: 'shared-hash',
+      workflowRunId: 'run-holder',
+    });
+    // Chained claim starts with null hash (excluded from unique index).
+    const chained = await m.createPendingClaim({
+      frameId,
+      sequenceId,
+      model: 'nano_banana_2',
+      dependsOnVersionId: 'fpv-1',
+      workflowRunId: 'run-chain',
+    });
+
+    // Stamping the shared hash onto the chained row hits the partial unique index.
+    const claimed = await m.claimForGeneration(chained.id, {
+      workflowRunId: 'run-chain',
+      model: 'nano_banana_2',
+      pendingInputHash: 'shared-hash',
+    });
+    expect(claimed).toBeNull();
+
+    // Holder still owns the slot; chained stayed pending (update rolled back).
+    const [holderRow] = await db
+      .select()
+      .from(frameVariants)
+      .where(eq(frameVariants.id, holder.id));
+    const [chainedRow] = await db
+      .select()
+      .from(frameVariants)
+      .where(eq(frameVariants.id, chained.id));
+    expect(holderRow?.status).toBe('pending');
+    expect(holderRow?.pendingInputHash).toBe('shared-hash');
+    expect(chainedRow?.status).toBe('pending');
+    expect(chainedRow?.pendingInputHash).toBeNull();
+  });
+});

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -45,20 +45,39 @@ import { buildEventInsert } from './sequence-events';
 function isUniqueConstraintError(error: unknown): boolean {
   let current: unknown = error;
   for (let i = 0; i < 6 && current != null; i++) {
+    if (current instanceof Error) {
+      if (/unique|constraint|SQLITE_CONSTRAINT/i.test(current.message)) {
+        return true;
+      }
+      const code = (current as { code?: unknown }).code;
+      if (typeof code === 'string' && /UNIQUE|CONSTRAINT/i.test(code)) {
+        return true;
+      }
+      current = current.cause;
+      continue;
+    }
     if (typeof current === 'object') {
       const code = (current as { code?: unknown }).code;
       if (typeof code === 'string' && /UNIQUE|CONSTRAINT/i.test(code)) {
         return true;
       }
-      const msg = current instanceof Error ? current.message : String(current);
-      if (/unique|constraint|SQLITE_CONSTRAINT/i.test(msg)) return true;
-      current = (current as { cause?: unknown }).cause;
-    } else {
-      if (/unique|constraint|SQLITE_CONSTRAINT/i.test(String(current))) {
+      const message = (current as { message?: unknown }).message;
+      if (
+        typeof message === 'string' &&
+        /unique|constraint|SQLITE_CONSTRAINT/i.test(message)
+      ) {
         return true;
       }
-      break;
+      current = (current as { cause?: unknown }).cause;
+      continue;
     }
+    if (
+      typeof current === 'string' &&
+      /unique|constraint|SQLITE_CONSTRAINT/i.test(current)
+    ) {
+      return true;
+    }
+    break;
   }
   return false;
 }

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -24,7 +24,17 @@ import type { Database } from '@/lib/db/client';
 import { framePromptVersions, frameVariants, frames } from '@/lib/db/schema';
 import type { FrameVariant, NewFrameVariant } from '@/lib/db/schema';
 import type { FrameVariantKind } from '@/lib/db/schema/frame-variants';
-import { and, asc, desc, eq, isNull } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+} from 'drizzle-orm';
+import { LIVE_PENDING_STATUSES } from './frame-prompt-versions';
 import { buildFrameImageMirror, type CompletedFrameVariant } from './frames';
 import { buildEventInsert } from './sequence-events';
 
@@ -100,15 +110,159 @@ export function createFrameVariantsMethods(db: Database) {
       workflowRunId: string,
       error: string
     ): Promise<void> => {
+      // 'pending' included since #1085: a pre-created claim row whose run died
+      // before reaching `set-generating-status` must not stay live forever.
       await db
         .update(frameVariants)
         .set({ status: 'failed', error, updatedAt: new Date() })
         .where(
           and(
             eq(frameVariants.workflowRunId, workflowRunId),
-            eq(frameVariants.status, 'generating')
+            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
           )
         );
+    },
+
+    /**
+     * Pre-create a claim row for an enqueued image regeneration (#1085).
+     * Direct regens carry `pendingInputHash` (the live hash the render will
+     * satisfy); chained regens (image waiting on a pending visual-prompt row)
+     * carry `dependsOnVersionId` instead — their validity derives from the
+     * dependency. The producing workflow completes this row in place.
+     */
+    createPendingClaim: async (input: {
+      frameId: string;
+      sequenceId: string;
+      model: string;
+      pendingInputHash?: string | null;
+      dependsOnVersionId?: string | null;
+      workflowRunId?: string | null;
+      promptVersionId?: string | null;
+    }): Promise<FrameVariant> => {
+      const [row] = await db
+        .insert(frameVariants)
+        .values({
+          frameId: input.frameId,
+          sequenceId: input.sequenceId,
+          kind: 'model',
+          model: input.model,
+          status: 'pending',
+          pendingInputHash: input.pendingInputHash ?? null,
+          dependsOnVersionId: input.dependsOnVersionId ?? null,
+          workflowRunId: input.workflowRunId ?? null,
+          promptVersionId: input.promptVersionId ?? null,
+        })
+        .returning();
+      if (!row) {
+        throw new Error(
+          `Failed to insert pending image claim for frame ${input.frameId}`
+        );
+      }
+      return row;
+    },
+
+    /**
+     * Live (pending/generating) CLAIM rows for a frame — rows enqueued with a
+     * pending hash or a dependency edge. Ordinary in-flight renders without a
+     * claim (e.g. variant-only adds) are excluded: they don't participate in
+     * staleness. Newest first.
+     */
+    listLiveClaims: async (frameId: string): Promise<FrameVariant[]> => {
+      return await db
+        .select()
+        .from(frameVariants)
+        .where(
+          and(
+            eq(frameVariants.frameId, frameId),
+            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES]),
+            isNull(frameVariants.discardedAt),
+            or(
+              isNotNull(frameVariants.pendingInputHash),
+              isNotNull(frameVariants.dependsOnVersionId)
+            )
+          )
+        )
+        .orderBy(desc(frameVariants.id));
+    },
+
+    /**
+     * Guarded claim → 'generating' transition for a pre-created row (#1085):
+     * stamps the working instance, the resolved model, the prompt-version
+     * pairing, and (when known) the snapshot hash the render satisfies.
+     * Returns null when the claim went terminal meanwhile (user cancel won
+     * the race) — the caller must abandon the render.
+     */
+    claimForGeneration: async (
+      versionId: string,
+      data: {
+        workflowRunId: string;
+        model: string;
+        promptVersionId?: string | null;
+        pendingInputHash?: string | null;
+      }
+    ): Promise<FrameVariant | null> => {
+      const [row] = await db
+        .update(frameVariants)
+        .set({
+          status: 'generating',
+          workflowRunId: data.workflowRunId,
+          model: data.model,
+          promptVersionId: data.promptVersionId ?? null,
+          ...(data.pendingInputHash !== undefined
+            ? { pendingInputHash: data.pendingInputHash }
+            : {}),
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(frameVariants.id, versionId),
+            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      return row ?? null;
+    },
+
+    /** Terminal a live version row (cancel / zombie sweep); null when the row
+     * was already terminal. */
+    markTerminal: async (
+      versionId: string,
+      status: 'failed' | 'cancelled',
+      error?: string
+    ): Promise<FrameVariant | null> => {
+      const [row] = await db
+        .update(frameVariants)
+        .set({ status, error: error ?? null, updatedAt: new Date() })
+        .where(
+          and(
+            eq(frameVariants.id, versionId),
+            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      return row ?? null;
+    },
+
+    /**
+     * Cascade a failed/cancelled prompt-version row onto its dependent image
+     * claims: a chained render whose upstream prompt died is 'cancelled' (it
+     * was never attempted — distinct from 'failed'). Chain depth is 2 today,
+     * so a single sweep is the whole walk.
+     */
+    cancelByDependency: async (
+      promptVersionId: string,
+      reason: string
+    ): Promise<FrameVariant[]> => {
+      return await db
+        .update(frameVariants)
+        .set({ status: 'cancelled', error: reason, updatedAt: new Date() })
+        .where(
+          and(
+            eq(frameVariants.dependsOnVersionId, promptVersionId),
+            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
     },
 
     /** Update generation tracking on an in-flight version (status/url/error/…). */
@@ -463,10 +617,17 @@ export function createFrameVariantsMethods(db: Database) {
             text: framePromptVersions.text,
             inputHash: framePromptVersions.inputHash,
             frameId: framePromptVersions.frameId,
+            status: framePromptVersions.status,
           })
           .from(framePromptVersions)
           .where(eq(framePromptVersions.id, version.promptVersionId));
-        if (promptRow && promptRow.frameId === frameId) {
+        // A non-completed row is a placeholder — mirroring it would blank the
+        // frame's prompt with empty text (#1085).
+        if (
+          promptRow &&
+          promptRow.frameId === frameId &&
+          promptRow.status === 'completed'
+        ) {
           linkedPrompt = promptRow;
         }
       }
@@ -487,10 +648,25 @@ export function createFrameVariantsMethods(db: Database) {
         },
       });
 
+      // Repointing the prompt is an explicit user choice (#1085): revoke the
+      // mirror rights of any in-flight prompt claims on this frame so a
+      // completing regeneration lands in history without clobbering it.
+      const demotePromptClaims = () =>
+        db
+          .update(framePromptVersions)
+          .set({ pendingInputHash: null })
+          .where(
+            and(
+              eq(framePromptVersions.frameId, frameId),
+              inArray(framePromptVersions.status, [...LIVE_PENDING_STATUSES])
+            )
+          );
+
       if (linkedPrompt && shouldClearPending) {
         await db.batch([
           mirrorUpdate,
           imageSelectedEvent,
+          demotePromptClaims(),
           db
             .update(frames)
             .set({
@@ -519,6 +695,7 @@ export function createFrameVariantsMethods(db: Database) {
         await db.batch([
           mirrorUpdate,
           imageSelectedEvent,
+          demotePromptClaims(),
           db
             .update(frames)
             .set({

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -223,6 +223,30 @@ export function createFrameVariantsMethods(db: Database) {
       return row ?? null;
     },
 
+    /**
+     * Status-guarded completion of an in-flight version (#1085 review): the
+     * unguarded `update` let a completion racing a user cancel silently
+     * resurrect the cancelled row to 'completed'. Returns null when the row
+     * went terminal meanwhile — the caller must discard the render result
+     * (the user was already told `cancelled: true`).
+     */
+    completeIfLive: async (
+      versionId: string,
+      data: Partial<NewFrameVariant>
+    ): Promise<FrameVariant | null> => {
+      const [row] = await db
+        .update(frameVariants)
+        .set({ ...data, status: 'completed', updatedAt: new Date() })
+        .where(
+          and(
+            eq(frameVariants.id, versionId),
+            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      return row ?? null;
+    },
+
     /** Terminal a live version row (cancel / zombie sweep); null when the row
      * was already terminal. */
     markTerminal: async (

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -38,6 +38,13 @@ import { LIVE_PENDING_STATUSES } from './frame-prompt-versions';
 import { buildFrameImageMirror, type CompletedFrameVariant } from './frames';
 import { buildEventInsert } from './sequence-events';
 
+function readStringProp(value: object, key: string): string | null {
+  if (!(key in value)) return null;
+  // Reflect.get avoids a typed assertion on an open object bag.
+  const prop = Reflect.get(value, key);
+  return typeof prop === 'string' ? prop : null;
+}
+
 /**
  * D1 / SQLite unique-index violation. Drizzle wraps the driver error in
  * `DrizzleQueryError` ("Failed query: …"), so walk `cause` and check `code`.
@@ -49,26 +56,19 @@ function isUniqueConstraintError(error: unknown): boolean {
       if (/unique|constraint|SQLITE_CONSTRAINT/i.test(current.message)) {
         return true;
       }
-      const code = (current as { code?: unknown }).code;
-      if (typeof code === 'string' && /UNIQUE|CONSTRAINT/i.test(code)) {
-        return true;
-      }
+      const code = readStringProp(current, 'code');
+      if (code && /UNIQUE|CONSTRAINT/i.test(code)) return true;
       current = current.cause;
       continue;
     }
     if (typeof current === 'object') {
-      const code = (current as { code?: unknown }).code;
-      if (typeof code === 'string' && /UNIQUE|CONSTRAINT/i.test(code)) {
+      const code = readStringProp(current, 'code');
+      if (code && /UNIQUE|CONSTRAINT/i.test(code)) return true;
+      const message = readStringProp(current, 'message');
+      if (message && /unique|constraint|SQLITE_CONSTRAINT/i.test(message)) {
         return true;
       }
-      const message = (current as { message?: unknown }).message;
-      if (
-        typeof message === 'string' &&
-        /unique|constraint|SQLITE_CONSTRAINT/i.test(message)
-      ) {
-        return true;
-      }
-      current = (current as { cause?: unknown }).cause;
+      current = Reflect.get(current, 'cause');
       continue;
     }
     if (

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -39,6 +39,31 @@ import { buildFrameImageMirror, type CompletedFrameVariant } from './frames';
 import { buildEventInsert } from './sequence-events';
 
 /**
+ * D1 / SQLite unique-index violation. Drizzle wraps the driver error in
+ * `DrizzleQueryError` ("Failed query: …"), so walk `cause` and check `code`.
+ */
+function isUniqueConstraintError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let i = 0; i < 6 && current != null; i++) {
+    if (typeof current === 'object') {
+      const code = (current as { code?: unknown }).code;
+      if (typeof code === 'string' && /UNIQUE|CONSTRAINT/i.test(code)) {
+        return true;
+      }
+      const msg = current instanceof Error ? current.message : String(current);
+      if (/unique|constraint|SQLITE_CONSTRAINT/i.test(msg)) return true;
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      if (/unique|constraint|SQLITE_CONSTRAINT/i.test(String(current))) {
+        return true;
+      }
+      break;
+    }
+  }
+  return false;
+}
+
+/**
  * An image `FrameVariant` plus the id of the shot whose anchor frame owns it.
  * Frame ids are NOT shot ids (#989), so sequence-wide listings that the client
  * keys by shot (coverage markers, per-shot variant filtering) carry the owning
@@ -201,26 +226,37 @@ export function createFrameVariantsMethods(db: Database) {
         pendingInputHash?: string | null;
       }
     ): Promise<FrameVariant | null> => {
-      const [row] = await db
-        .update(frameVariants)
-        .set({
-          status: 'generating',
-          workflowRunId: data.workflowRunId,
-          model: data.model,
-          promptVersionId: data.promptVersionId ?? null,
-          ...(data.pendingInputHash !== undefined
-            ? { pendingInputHash: data.pendingInputHash }
-            : {}),
-          updatedAt: new Date(),
-        })
-        .where(
-          and(
-            eq(frameVariants.id, versionId),
-            inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
+      try {
+        const [row] = await db
+          .update(frameVariants)
+          .set({
+            status: 'generating',
+            workflowRunId: data.workflowRunId,
+            model: data.model,
+            promptVersionId: data.promptVersionId ?? null,
+            ...(data.pendingInputHash !== undefined
+              ? { pendingInputHash: data.pendingInputHash }
+              : {}),
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(frameVariants.id, versionId),
+              inArray(frameVariants.status, [...LIVE_PENDING_STATUSES])
+            )
           )
-        )
-        .returning();
-      return row ?? null;
+          .returning();
+        return row ?? null;
+      } catch (error) {
+        // Chained claims stamp snapshotInputHash at generation start. If another
+        // live claim on this frame already holds that hash, the partial unique
+        // index rejects the UPDATE. Stand down (null) like a cancel — do not
+        // throw and burn workflow step retries.
+        if (data.pendingInputHash != null && isUniqueConstraintError(error)) {
+          return null;
+        }
+        throw error;
+      }
     },
 
     /**

--- a/src/lib/db/scoped/shot-prompt-versions.test.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.test.ts
@@ -796,6 +796,47 @@ describe('shotPromptVersions.completePendingAiVersion', () => {
     if (!refreshed) throw new Error('test setup: refresh failed');
     expect(refreshed.motionPrompt).toBe('Original');
   });
+
+  it('restore demotes live claims so completion never remirrors', async () => {
+    const m = createShotPromptVersionsMethods(db);
+    const original = await m.write({
+      shotId,
+      promptType: 'motion',
+      text: 'Original motion',
+      source: 'ai-generated',
+      inputHash: 'hash-0',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+    const claim = await m.createPending({
+      shotId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    await m.select(shotId, original.id, { actorId: null });
+
+    const [demoted] = await db
+      .select()
+      .from(shotPromptVersions)
+      .where(eq(shotPromptVersions.id, claim.id));
+    expect(demoted?.pendingInputHash).toBeNull();
+
+    await m.completePendingAiVersion({
+      versionId: claim.id,
+      shotId,
+      text: 'Would clobber restore',
+      inputHash: 'live-hash',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    const [refreshed] = await db
+      .select()
+      .from(shots)
+      .where(eq(shots.id, shotId));
+    if (!refreshed) throw new Error('test setup: refresh failed');
+    expect(refreshed.motionPrompt).toBe('Original motion');
+    expect(refreshed.selectedMotionPromptVersionId).toBe(original.id);
+  });
 });
 
 describe('sequence_music_prompt_variants helper', () => {

--- a/src/lib/db/scoped/shot-prompt-versions.test.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.test.ts
@@ -700,6 +700,104 @@ describe('shot_prompt_variants helper', () => {
   });
 });
 
+describe('shotPromptVersions.completePendingAiVersion', () => {
+  it('completes the claim in place and mirrors onto the shot', async () => {
+    const m = createShotPromptVersionsMethods(db);
+    const claim = await m.createPending({
+      shotId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      shotId,
+      text: 'Regenerated motion prompt',
+      inputHash: 'live-hash',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    expect(completed?.id).toBe(claim.id);
+    expect(completed?.status).toBe('completed');
+
+    const [refreshed] = await db
+      .select()
+      .from(shots)
+      .where(eq(shots.id, shotId));
+    if (!refreshed) throw new Error('test setup: refresh failed');
+    expect(refreshed.motionPrompt).toBe('Regenerated motion prompt');
+    expect(refreshed.motionPromptInputHash).toBe('live-hash');
+    expect(refreshed.selectedMotionPromptVersionId).toBe(claim.id);
+  });
+
+  it('a post-click user edit keeps the mirror — the run completes to history only', async () => {
+    const m = createShotPromptVersionsMethods(db);
+    const claim = await m.createPending({
+      shotId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+
+    const edit = await m.write({
+      shotId,
+      promptType: 'motion',
+      text: 'Post-click hand edit',
+      source: 'user-edit',
+      inputHash: null,
+      analysisModel: null,
+    });
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      shotId,
+      text: 'Older run output',
+      inputHash: 'other-hash',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    expect(completed?.id).toBe(claim.id);
+    expect(completed?.status).toBe('completed');
+
+    const [refreshed] = await db
+      .select()
+      .from(shots)
+      .where(eq(shots.id, shotId));
+    if (!refreshed) throw new Error('test setup: refresh failed');
+    expect(refreshed.motionPrompt).toBe('Post-click hand edit');
+    expect(refreshed.selectedMotionPromptVersionId).toBe(edit.id);
+  });
+
+  it('returns null for a claim cancelled mid-flight and never mirrors', async () => {
+    const m = createShotPromptVersionsMethods(db);
+    await db
+      .update(shots)
+      .set({ motionPrompt: 'Original', motionPromptInputHash: 'hash-0' })
+      .where(eq(shots.id, shotId));
+    const claim = await m.createPending({
+      shotId,
+      pendingInputHash: 'live-hash',
+    });
+    await m.markGenerating(claim.id, 'run-1');
+    await m.markTerminal(claim.id, 'cancelled');
+
+    const completed = await m.completePendingAiVersion({
+      versionId: claim.id,
+      shotId,
+      text: 'Should be discarded',
+      inputHash: 'live-hash',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    expect(completed).toBeNull();
+    const [refreshed] = await db
+      .select()
+      .from(shots)
+      .where(eq(shots.id, shotId));
+    if (!refreshed) throw new Error('test setup: refresh failed');
+    expect(refreshed.motionPrompt).toBe('Original');
+  });
+});
+
 describe('sequence_music_prompt_variants helper', () => {
   it('user-edit clears musicPromptInputHash and overwrites the cached prompt/tags', async () => {
     const methods = createSequenceMusicPromptVersionsMethods(db);

--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -28,7 +28,8 @@ import type {
   ShotPromptVersionComponents,
 } from '@/lib/db/schema';
 import { getLogger } from '@/lib/observability/logger';
-import { and, desc, eq, inArray, isNotNull, lte } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNotNull, lte, ne } from 'drizzle-orm';
+import { LIVE_PENDING_STATUSES } from './frame-prompt-versions';
 import { buildEventInsert } from './sequence-events';
 
 const logger = getLogger(['openstory', 'db', 'shot-prompt-versions']);
@@ -134,6 +135,24 @@ export function createShotPromptVersionsMethods(db: Database) {
       inputHash: version.inputHash,
       versionId: version.id,
     });
+
+  /**
+   * Revoke the mirror right of every live motion claim on this shot (#1085)
+   * — see `framePromptVersions`' demote helper for the contract: an explicit
+   * user repoint wins over any in-flight regeneration, whose output then
+   * lands in history only.
+   */
+  const demoteLiveClaims = (shotId: string) =>
+    db
+      .update(shotPromptVersions)
+      .set({ pendingInputHash: null })
+      .where(
+        and(
+          eq(shotPromptVersions.shotId, shotId),
+          eq(shotPromptVersions.promptType, 'motion'),
+          inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
+        )
+      );
 
   const methods = {
     /**
@@ -277,6 +296,214 @@ export function createShotPromptVersionsMethods(db: Database) {
     },
 
     /**
+     * Create an in-flight placeholder motion row for an enqueued regeneration
+     * (#1085). Does NOT mirror or repoint — only completion does — so the
+     * selection pointer keeps its "completed rows only" invariant. Mirrors
+     * `framePromptVersions.createPending`.
+     */
+    createPending: async (input: {
+      shotId: string;
+      pendingInputHash: string;
+      workflowRunId?: string | null;
+      createdBy?: string | null;
+    }): Promise<ShotPromptVersion> => {
+      const [row] = await db
+        .insert(shotPromptVersions)
+        .values({
+          shotId: input.shotId,
+          promptType: 'motion',
+          text: '',
+          source: 'regenerated',
+          inputHash: null,
+          analysisModel: null,
+          status: 'pending',
+          pendingInputHash: input.pendingInputHash,
+          workflowRunId: input.workflowRunId ?? null,
+          createdBy: input.createdBy ?? null,
+        })
+        .returning();
+      if (!row) throw new Error('Failed to insert pending motion prompt row');
+      return row;
+    },
+
+    /**
+     * Newest live (pending/generating) motion claim satisfying
+     * `pendingInputHash` — the dedup + "updating" staleness probe.
+     */
+    getLivePending: async (
+      shotId: string,
+      pendingInputHash: string
+    ): Promise<ShotPromptVersion | null> => {
+      const [row] = await db
+        .select()
+        .from(shotPromptVersions)
+        .where(
+          and(
+            eq(shotPromptVersions.shotId, shotId),
+            eq(shotPromptVersions.promptType, 'motion'),
+            eq(shotPromptVersions.pendingInputHash, pendingInputHash),
+            inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .orderBy(desc(shotPromptVersions.createdAt))
+        .limit(1);
+      return row ?? null;
+    },
+
+    /** Claim → 'generating' + stamp the working instance; false if the claim
+     * went terminal meanwhile (caller must abandon the generation). */
+    markGenerating: async (
+      versionId: string,
+      workflowRunId: string
+    ): Promise<boolean> => {
+      const updated = await db
+        .update(shotPromptVersions)
+        .set({ status: 'generating', workflowRunId })
+        .where(
+          and(
+            eq(shotPromptVersions.id, versionId),
+            inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning({ id: shotPromptVersions.id });
+      return updated.length > 0;
+    },
+
+    /** Terminal-fail a live claim; null when it was already terminal. */
+    markTerminal: async (
+      versionId: string,
+      status: 'failed' | 'cancelled'
+    ): Promise<ShotPromptVersion | null> => {
+      const [row] = await db
+        .update(shotPromptVersions)
+        .set({ status })
+        .where(
+          and(
+            eq(shotPromptVersions.id, versionId),
+            inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      return row ?? null;
+    },
+
+    /**
+     * Complete a pending motion claim in place. Same contract as
+     * `framePromptVersions.completePendingAiVersion`: mirrors onto the shot
+     * only when no newer completed row landed meanwhile (post-click edits are
+     * never clobbered); returns null when the claim was cancelled mid-flight;
+     * handles the partial-unique-index collision like `write`.
+     */
+    completePendingAiVersion: async (input: {
+      versionId: string;
+      shotId: string;
+      text: string;
+      components?: ShotPromptVersionComponents | null;
+      parameters?: MotionPromptParameters | null;
+      dialogue?: MotionDialogue | null;
+      audio?: MotionAudio | null;
+      inputHash: string;
+      analysisModel: string;
+    }): Promise<ShotPromptVersion | null> => {
+      const [claim] = await db
+        .select()
+        .from(shotPromptVersions)
+        .where(
+          and(
+            eq(shotPromptVersions.id, input.versionId),
+            eq(shotPromptVersions.shotId, input.shotId)
+          )
+        )
+        .limit(1);
+      if (!claim) {
+        throw new Error(
+          `ShotPromptVersion ${input.versionId} not found for shot ${input.shotId}`
+        );
+      }
+
+      const [conflicting] = await db
+        .select()
+        .from(shotPromptVersions)
+        .where(
+          and(
+            eq(shotPromptVersions.shotId, input.shotId),
+            eq(shotPromptVersions.promptType, 'motion'),
+            eq(shotPromptVersions.inputHash, input.inputHash),
+            ne(shotPromptVersions.id, input.versionId),
+            ne(shotPromptVersions.source, 'restored')
+          )
+        )
+        .limit(1);
+
+      // ULID ids order by creation time — a newer completed row is a
+      // post-click edit (or later run) whose mirror must be preserved.
+      const [newer] = await db
+        .select({ id: shotPromptVersions.id })
+        .from(shotPromptVersions)
+        .where(
+          and(
+            eq(shotPromptVersions.shotId, input.shotId),
+            eq(shotPromptVersions.promptType, 'motion'),
+            eq(shotPromptVersions.status, 'completed'),
+            gt(shotPromptVersions.id, claim.id)
+          )
+        )
+        .limit(1);
+
+      // Mirror right (#1085): revoked by a newer completed row (post-click
+      // edit) or by an explicit repoint that demoted the claim.
+      const mayMirror = !newer && claim.pendingInputHash !== null;
+
+      if (conflicting && conflicting.text === input.text) {
+        // Guarded retire — a no-op means a cancel already won the race, and
+        // cancelled work must not mirror (same contract as the main branch).
+        const retired = await db
+          .update(shotPromptVersions)
+          .set({ status: 'cancelled' })
+          .where(
+            and(
+              eq(shotPromptVersions.id, input.versionId),
+              inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
+            )
+          )
+          .returning({ id: shotPromptVersions.id });
+        if (retired.length === 0) return null;
+        if (mayMirror) await mirrorOntoShot(input.shotId, conflicting);
+        return conflicting;
+      }
+
+      const [updated] = await db
+        .update(shotPromptVersions)
+        .set({
+          text: input.text,
+          components: input.components ?? null,
+          parameters: input.parameters ?? null,
+          dialogue: input.dialogue ?? null,
+          audio: input.audio ?? null,
+          inputHash: conflicting ? null : input.inputHash,
+          analysisModel: input.analysisModel,
+          status: 'completed',
+        })
+        .where(
+          and(
+            eq(shotPromptVersions.id, input.versionId),
+            inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
+          )
+        )
+        .returning();
+      if (!updated) return null; // cancelled mid-flight — discard the output
+
+      if (mayMirror) {
+        await mirrorSelection(input.shotId, {
+          text: input.text,
+          inputHash: input.inputHash,
+          versionId: updated.id,
+        });
+      }
+      return updated;
+    },
+
+    /**
      * The motion prompt version the shot currently points at via
      * `shots.selectedMotionPromptVersionId`, or null. This is the resolution
      * source of truth (#713): the render path reconstructs the `MotionPrompt`
@@ -364,6 +591,13 @@ export function createShotPromptVersionsMethods(db: Database) {
           `Motion ShotPromptVersion ${versionId} not found for shot ${shotId}`
         );
       }
+      if (version.status !== 'completed') {
+        // The selection pointer may only reference completed rows — same
+        // invariant as frameVariants.select / framePromptVersions.select.
+        throw new Error(
+          `Motion ShotPromptVersion ${versionId} is ${version.status}, not completed`
+        );
+      }
       const [shot] = await db
         .select({
           sequenceId: shots.sequenceId,
@@ -377,6 +611,8 @@ export function createShotPromptVersionsMethods(db: Database) {
 
       await db.batch([
         mirrorOntoShot(shotId, version),
+        // An explicit repoint revokes in-flight claims' mirror rights (#1085).
+        demoteLiveClaims(shotId),
         buildEventInsert(db, {
           sequenceId: shot.sequenceId,
           actorId: opts.actorId,
@@ -467,14 +703,18 @@ export function createShotPromptVersionsMethods(db: Database) {
           and(
             eq(shotPromptVersions.shotId, shotId),
             eq(shotPromptVersions.promptType, promptType),
-            lte(shotPromptVersions.createdAt, cutoff)
+            lte(shotPromptVersions.createdAt, cutoff),
+            // In-flight/failed placeholders can't match a render's promptHash
+            // and would waste candidate slots in the limited window.
+            eq(shotPromptVersions.status, 'completed')
           )
         )
         .orderBy(desc(shotPromptVersions.createdAt))
         .limit(limit);
     },
 
-    /** Most recent version of a given type, or null if none exists. */
+    /** Most recent completed version of a given type, or null. In-flight and
+     * failed rows are placeholders, not content. */
     getLatest: async (
       shotId: string,
       promptType: ShotPromptType
@@ -485,7 +725,8 @@ export function createShotPromptVersionsMethods(db: Database) {
         .where(
           and(
             eq(shotPromptVersions.shotId, shotId),
-            eq(shotPromptVersions.promptType, promptType)
+            eq(shotPromptVersions.promptType, promptType),
+            eq(shotPromptVersions.status, 'completed')
           )
         )
         .orderBy(desc(shotPromptVersions.createdAt))
@@ -511,7 +752,8 @@ export function createShotPromptVersionsMethods(db: Database) {
           and(
             eq(shotPromptVersions.shotId, shotId),
             eq(shotPromptVersions.promptType, promptType),
-            isNotNull(shotPromptVersions.inputHash)
+            isNotNull(shotPromptVersions.inputHash),
+            eq(shotPromptVersions.status, 'completed')
           )
         )
         .orderBy(desc(shotPromptVersions.createdAt))

--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -139,8 +139,8 @@ export function createShotPromptVersionsMethods(db: Database) {
   /**
    * Revoke the mirror right of every live motion claim on this shot (#1085)
    * — see `framePromptVersions`' demote helper for the contract: an explicit
-   * user repoint wins over any in-flight regeneration, whose output then
-   * lands in history only.
+   * user repoint/edit wins over any in-flight regeneration, whose output then
+   * lands in history only. Also frees the live-claim unique index slot.
    */
   const demoteLiveClaims = (shotId: string) =>
     db
@@ -153,6 +153,35 @@ export function createShotPromptVersionsMethods(db: Database) {
           inArray(shotPromptVersions.status, [...LIVE_PENDING_STATUSES])
         )
       );
+
+  /**
+   * Post-transition mirror check for completePendingAiVersion (#1095 TOCTOU).
+   * See framePromptVersions.stillHoldsMirrorRight for the race rationale.
+   */
+  const stillHoldsMirrorRight = async (
+    shotId: string,
+    claimId: string
+  ): Promise<boolean> => {
+    const [row] = await db
+      .select({ pendingInputHash: shotPromptVersions.pendingInputHash })
+      .from(shotPromptVersions)
+      .where(eq(shotPromptVersions.id, claimId))
+      .limit(1);
+    if (!row || row.pendingInputHash === null) return false;
+    const [newer] = await db
+      .select({ id: shotPromptVersions.id })
+      .from(shotPromptVersions)
+      .where(
+        and(
+          eq(shotPromptVersions.shotId, shotId),
+          eq(shotPromptVersions.promptType, 'motion'),
+          eq(shotPromptVersions.status, 'completed'),
+          gt(shotPromptVersions.id, claimId)
+        )
+      )
+      .limit(1);
+    return !newer;
+  };
 
   const methods = {
     /**
@@ -260,11 +289,16 @@ export function createShotPromptVersionsMethods(db: Database) {
       // setting it here is load-bearing. The cached hash tracks `nextHash` (the
       // real upstream context) even on the force-regen path where the version row
       // itself carries a null hash — see the branch above.
-      await mirrorSelection(input.shotId, {
-        text: input.text,
-        inputHash: nextHash,
-        versionId: version.id,
-      });
+      // Demote live claims in the same batch so a concurrent
+      // completePendingAiVersion cannot clobber this write (#1095 TOCTOU).
+      await db.batch([
+        mirrorSelection(input.shotId, {
+          text: input.text,
+          inputHash: nextHash,
+          versionId: version.id,
+        }),
+        demoteLiveClaims(input.shotId),
+      ]);
 
       return version;
     },
@@ -435,28 +469,10 @@ export function createShotPromptVersionsMethods(db: Database) {
         )
         .limit(1);
 
-      // ULID ids order by creation time — a newer completed row is a
-      // post-click edit (or later run) whose mirror must be preserved.
-      const [newer] = await db
-        .select({ id: shotPromptVersions.id })
-        .from(shotPromptVersions)
-        .where(
-          and(
-            eq(shotPromptVersions.shotId, input.shotId),
-            eq(shotPromptVersions.promptType, 'motion'),
-            eq(shotPromptVersions.status, 'completed'),
-            gt(shotPromptVersions.id, claim.id)
-          )
-        )
-        .limit(1);
-
-      // Mirror right (#1085): revoked by a newer completed row (post-click
-      // edit) or by an explicit repoint that demoted the claim.
-      const mayMirror = !newer && claim.pendingInputHash !== null;
-
       if (conflicting && conflicting.text === input.text) {
         // Guarded retire — a no-op means a cancel already won the race, and
         // cancelled work must not mirror (same contract as the main branch).
+        // status 'cancelled' = retired duplicate placeholder, not user cancel.
         const retired = await db
           .update(shotPromptVersions)
           .set({ status: 'cancelled' })
@@ -468,7 +484,10 @@ export function createShotPromptVersionsMethods(db: Database) {
           )
           .returning({ id: shotPromptVersions.id });
         if (retired.length === 0) return null;
-        if (mayMirror) await mirrorOntoShot(input.shotId, conflicting);
+        // Re-evaluate AFTER the terminal transition (#1095 TOCTOU).
+        if (await stillHoldsMirrorRight(input.shotId, claim.id)) {
+          await mirrorOntoShot(input.shotId, conflicting);
+        }
         return conflicting;
       }
 
@@ -493,7 +512,8 @@ export function createShotPromptVersionsMethods(db: Database) {
         .returning();
       if (!updated) return null; // cancelled mid-flight — discard the output
 
-      if (mayMirror) {
+      // Mirror right re-checked after we own the terminal write (#1085/#1095).
+      if (await stillHoldsMirrorRight(input.shotId, claim.id)) {
         await mirrorSelection(input.shotId, {
           text: input.text,
           inputHash: input.inputHash,

--- a/src/lib/model/sequence-model-coverage.ts
+++ b/src/lib/model/sequence-model-coverage.ts
@@ -1,5 +1,5 @@
 import type { ModelGenerationStatus } from '@/components/model/base-model-selector';
-import type { ShotVariant } from '@/lib/db/schema';
+import type { FrameVariant } from '@/lib/db/schema';
 import type { VariantType } from '@/lib/db/schema/shot-variants';
 
 /**
@@ -36,7 +36,9 @@ export type ModelCoverage = {
  */
 export type CoverageVariant = {
   model: string;
-  status: ShotVariant['status'];
+  // FrameVariant's status is the wider union (adds 'cancelled', #1085);
+  // shot-variant rows assign into it unchanged.
+  status: FrameVariant['status'];
   url: string | null;
   shotId: string;
   discardedAt: Date | null;

--- a/src/lib/shots/shot-image-input.ts
+++ b/src/lib/shots/shot-image-input.ts
@@ -1,0 +1,201 @@
+/**
+ * Image-regeneration trigger input builder (#1077) — the exact payload
+ * assembly `generateShotImageFn` performs (reference matching, model
+ * resolution, credits preflight, scene snapshot + input hash), extracted so
+ * `UpdateStaleShotsWorkflow` builds byte-identical `ImageWorkflowInput`s
+ * server-side without duplicating the logic.
+ */
+
+import { resolveImageModel } from '@/lib/ai/resolve-asset-models';
+import { estimateImageCost } from '@/lib/billing/cost-estimation';
+import { requireCredits } from '@/lib/billing/preflight';
+import {
+  aspectRatioToImageSize,
+  type AspectRatio,
+} from '@/lib/constants/aspect-ratios';
+import type { Frame, SequenceLocation, Shot } from '@/lib/db/schema';
+import { locationMatchesTag } from '@/lib/db/scoped/sequence-locations';
+import type { ScopedDb } from '@/lib/db/scoped';
+import { buildCharacterReferenceImages } from '@/lib/prompts/character-prompt';
+import { buildElementReferenceImages } from '@/lib/prompts/element-prompt';
+import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
+import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
+import type {
+  ImageWorkflowInput,
+  ShotImageSceneSnapshot,
+} from '@/lib/workflow/types';
+import {
+  matchCharactersToScene,
+  matchElementsToScene,
+  matchLocationsToScene,
+} from '@/lib/workflows/scene-matching';
+import { computeShotImageSceneHash } from '@/lib/workflows/sheet-snapshots';
+
+/** Match locations by environmentTag or scene location and return reference images. */
+export function getSceneLocationReferenceImages(
+  allLocations: SequenceLocation[],
+  environmentTag: string,
+  sceneLocation?: string
+): ReferenceImageDescription[] {
+  if (!environmentTag && !sceneLocation) return [];
+
+  const matchedLocations = allLocations.filter(
+    (loc) =>
+      (environmentTag && locationMatchesTag(loc, environmentTag)) ||
+      (sceneLocation && locationMatchesTag(loc, sceneLocation))
+  );
+
+  return buildLocationReferenceImages(matchedLocations);
+}
+
+/**
+ * Build the `/image` workflow payload for a shot from CURRENT scoped state.
+ * Steps: resolve prompt (override > stored anchor-frame mirror > description)
+ * → match character/location/element references → resolve the model
+ * (explicit > last failed attempt > selected version > sequence default) →
+ * credits preflight → scene snapshot + input hash (what makes the rendered
+ * image participate in staleness tracking).
+ *
+ * Throws when the shot has no prompt/description, and rethrows the credits
+ * preflight's `InsufficientCreditsError`.
+ */
+export async function prepareShotImageWorkflowInput(args: {
+  scopedDb: ScopedDb;
+  sequence: {
+    id: string;
+    teamId: string;
+    aspectRatio: AspectRatio;
+    imageModel: string | null;
+  };
+  shot: Shot;
+  frame: Frame;
+  /** Selected scene-script extract, for element matching. */
+  scriptExtract: string;
+  userId: string;
+  promptOverride?: string;
+  modelOverride?: ImageWorkflowInput['model'];
+  /** True only when `promptOverride` came from a user edit (drives rescan upstream). */
+  userEditedPrompt?: boolean;
+}): Promise<ImageWorkflowInput> {
+  const {
+    scopedDb,
+    sequence,
+    shot,
+    frame,
+    scriptExtract,
+    userId,
+    promptOverride,
+    modelOverride,
+    userEditedPrompt = false,
+  } = args;
+
+  // Priority: provided > stored anchor-frame mirror (#989/#713) > description.
+  // The visual prompt lives solely on `frame.imagePrompt` now (the old
+  // `metadata.prompts.visual` fallback is gone).
+  const prompt = promptOverride || frame.imagePrompt || shot.description;
+  if (!prompt) {
+    throw new Error('Shot has no prompt or description to regenerate from');
+  }
+
+  const continuity = shot.metadata?.continuity;
+
+  const allCharacters = await scopedDb.characters.listWithSheets(sequence.id);
+  const matchedCharacters = matchCharactersToScene(
+    allCharacters,
+    continuity?.characterTags ?? []
+  );
+  const characterReferences = buildCharacterReferenceImages(matchedCharacters);
+
+  const allLocations = await scopedDb.sequenceLocations.listWithReferences(
+    sequence.id
+  );
+  const matchedLocations = matchLocationsToScene(
+    allLocations,
+    continuity?.environmentTag ?? '',
+    shot.metadata?.metadata?.location ?? ''
+  );
+  const locationReferences = getSceneLocationReferenceImages(
+    allLocations,
+    continuity?.environmentTag ?? '',
+    shot.metadata?.metadata?.location ?? ''
+  );
+
+  const allElements = await scopedDb.sequenceElements.list(sequence.id);
+  const matchedElements = matchElementsToScene(
+    allElements,
+    continuity?.elementTags ?? [],
+    scriptExtract
+  );
+  const elementReferences = buildElementReferenceImages(matchedElements);
+
+  // Model identity lives on the version that produced the still (#1066): an
+  // explicit per-request model wins (one-off variant generation), else the
+  // model of a failed attempt still awaiting retry, else the frame's
+  // currently selected version, then the sequence default.
+  const [selectedVersion, lastFailed] = await Promise.all([
+    scopedDb.frameVariants.getSelected(frame.id),
+    scopedDb.frameVariants.getLastFailed(frame.id),
+  ]);
+  const model = resolveImageModel({
+    explicit: modelOverride,
+    lastFailedAttemptModel: lastFailed?.model,
+    selectedVersionModel: selectedVersion?.model,
+    sequenceModel: sequence.imageModel,
+  });
+
+  await requireCredits(
+    scopedDb,
+    estimateImageCost(model, sequence.aspectRatio, 1),
+    { errorMessage: 'Insufficient credits for image generation' }
+  );
+
+  // Build a per-scene snapshot so the image workflow records a non-null
+  // `thumbnailInputHash`. Without this the convergent write path stores
+  // `null`, and the staleness check loses the ability to flip back to
+  // 'stale' on a future prompt regenerate. The sceneId fallback covers
+  // legacy shots generated before scene metadata was attached.
+  const sortedHashes = (
+    values: ReadonlyArray<string | null | undefined>
+  ): string[] =>
+    values
+      .filter((v): v is string => typeof v === 'string' && v.length > 0)
+      .sort();
+  const sceneSnapshot: ShotImageSceneSnapshot = {
+    sceneId: shot.metadata?.sceneId ?? shot.id,
+    visualPrompt: prompt,
+    characterSheetHashes: sortedHashes(
+      matchedCharacters.map((c) => c.sheetInputHash)
+    ),
+    locationSheetHashes: sortedHashes(
+      matchedLocations.map((l) => l.referenceInputHash)
+    ),
+    elementReferenceHashes: sortedHashes(
+      matchedElements.map((e) => e.imageUrl)
+    ),
+  };
+  const snapshotInputHash = await computeShotImageSceneHash(
+    sceneSnapshot,
+    model,
+    sequence.aspectRatio
+  );
+
+  return {
+    userId,
+    teamId: sequence.teamId,
+    prompt,
+    model,
+    imageSize: aspectRatioToImageSize(sequence.aspectRatio),
+    numImages: 1,
+    shotId: shot.id,
+    sequenceId: sequence.id,
+    aspectRatio: sequence.aspectRatio,
+    sceneSnapshot,
+    snapshotInputHash,
+    referenceImages: [
+      ...characterReferences,
+      ...locationReferences,
+      ...elementReferences,
+    ],
+    userEditedPrompt,
+  };
+}

--- a/src/lib/shots/shot-image-input.ts
+++ b/src/lib/shots/shot-image-input.ts
@@ -6,8 +6,9 @@
  * server-side without duplicating the logic.
  */
 
+import { getEffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
 import { resolveImageModel } from '@/lib/ai/resolve-asset-models';
-import { estimateImageCost } from '@/lib/billing/cost-estimation';
+import { estimateImageCost, gateEstimate } from '@/lib/billing/cost-estimation';
 import { requireCredits } from '@/lib/billing/preflight';
 import {
   aspectRatioToImageSize,
@@ -145,7 +146,12 @@ export async function prepareShotImageWorkflowInput(args: {
 
   await requireCredits(
     scopedDb,
-    estimateImageCost(model, sequence.aspectRatio, 1),
+    gateEstimate(
+      estimateImageCost(model, sequence.aspectRatio, 1, {
+        pricing: await getEffectiveFalPricing(),
+      }),
+      { model, operation: 'shot-image' }
+    ),
     { errorMessage: 'Insufficient credits for image generation' }
   );
 

--- a/src/lib/shots/shot-staleness.test.ts
+++ b/src/lib/shots/shot-staleness.test.ts
@@ -39,6 +39,15 @@ const sequence = {
 function makeScopedDb(overrides: {
   visualFallbackHash?: string | null;
   motionFallbackHash?: string | null;
+  /** Live visual claim for the 'updating' overlay (#1085). */
+  visualLiveClaim?: { id: string } | null;
+  /** Live motion claim for the 'updating' overlay (#1085). */
+  motionLiveClaim?: { id: string } | null;
+  /** Live image claims (direct or chained). */
+  imageLiveClaims?: Array<{
+    pendingInputHash: string | null;
+    dependsOnVersionId: string | null;
+  }>;
 }) {
   return asStub<ScopedDb>({
     characters: { listWithSheets: vi.fn().mockResolvedValue([]) },
@@ -54,6 +63,12 @@ function makeScopedDb(overrides: {
             ? { inputHash: overrides.visualFallbackHash }
             : null
         ),
+      // Default: no live claim → stale stays stale. Tests that cover the
+      // 'updating' overlay pass visualLiveClaim explicitly.
+      getLivePending: vi
+        .fn()
+        .mockResolvedValue(overrides.visualLiveClaim ?? null),
+      getByIdForFrame: vi.fn().mockResolvedValue(null),
     },
     shotPromptVersions: {
       getLatest: vi.fn().mockResolvedValue(null),
@@ -64,6 +79,14 @@ function makeScopedDb(overrides: {
             ? { inputHash: overrides.motionFallbackHash }
             : null
         ),
+      getLivePending: vi
+        .fn()
+        .mockResolvedValue(overrides.motionLiveClaim ?? null),
+    },
+    frameVariants: {
+      listLiveClaims: vi
+        .fn()
+        .mockResolvedValue(overrides.imageLiveClaims ?? []),
     },
   });
 }
@@ -97,10 +120,16 @@ describe('computeShotStaleness', () => {
       scene,
     });
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       thumbnail: 'unknown',
       visualPrompt: 'fresh',
       motionPrompt: 'stale',
+    });
+    // Thumbnail branch never produced a hash (it threw); prompts did.
+    expect(result.liveHashes).toEqual({
+      thumbnail: null,
+      visualPrompt: 'visual-stored',
+      motionPrompt: 'motion-moved',
     });
   });
 
@@ -124,10 +153,51 @@ describe('computeShotStaleness', () => {
     });
 
     // Without the fallback both would be stuck at 'untracked' forever.
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       thumbnail: 'fresh',
       visualPrompt: 'stale',
       motionPrompt: 'stale',
+    });
+  });
+
+  it("overlays 'updating' when a live claim matches the live hash (#1085)", async () => {
+    buildRegenerateShotSnapshot.mockResolvedValue({
+      snapshotInputHash: 'image-stored',
+    });
+    loadNarrowShotPromptContext.mockResolvedValue({});
+    // Stored hashes diverge → would be stale without a claim.
+    computeVisualPromptInputHash.mockResolvedValue('visual-live');
+    computeMotionPromptInputHash.mockResolvedValue('motion-live');
+
+    const result = await computeShotStaleness({
+      scopedDb: makeScopedDb({
+        visualLiveClaim: { id: 'fpv-claim' },
+        motionLiveClaim: { id: 'spv-claim' },
+        imageLiveClaims: [
+          { pendingInputHash: 'image-stored', dependsOnVersionId: null },
+        ],
+      }),
+      sequence,
+      // Frame image hash matches snapshot → thumbnail would be fresh except we
+      // still cover the image-claim path via a direct hash match on a claim.
+      // Force thumbnail stale by storing a different hash.
+      shot: { ...shot, motionPromptInputHash: 'motion-old' },
+      frame: {
+        ...frame,
+        visualPromptInputHash: 'visual-old',
+        imageInputHash: 'image-old',
+      },
+      scene,
+    });
+
+    expect(result).toMatchObject({
+      visualPrompt: 'updating',
+      motionPrompt: 'updating',
+      // Direct image claim hash matches liveHashes.thumbnail only when the
+      // snapshot hash equals the claim's pendingInputHash — snapshot is
+      // 'image-stored', so set claim accordingly above. With imageInputHash
+      // 'image-old' the thumbnail is stale and the claim promotes it.
+      thumbnail: 'updating',
     });
   });
 });

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -24,28 +24,56 @@ import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'shots', 'staleness']);
 
-/** Per-artifact staleness; see `computeShotStaleness` for the state semantics. */
-type ArtifactStaleness = 'stale' | 'fresh' | 'untracked' | 'unknown';
+/**
+ * Per-artifact staleness. Shared vocabulary — the client re-exports this type
+ * rather than redeclaring it, so the two can't drift.
+ *
+ * `'updating'` (#1085): the stored hash diverges from live, but a live pending
+ * claim (a pre-created `pending`/`generating` version row) exists whose
+ * `pendingInputHash` equals the live hash — a job is already fixing exactly
+ * this. Claims self-invalidate on edit: the live hash moves, the claim no
+ * longer matches, and the artifact honestly reads 'stale' again.
+ */
+export type ArtifactStaleness =
+  | 'stale'
+  | 'fresh'
+  | 'updating'
+  | 'untracked'
+  | 'unknown';
 
-/** The tracked artifacts, and the source of truth for the result's keys. */
-export const SHOT_ARTIFACTS = [
-  'thumbnail',
-  'visualPrompt',
-  'motionPrompt',
-] as const;
-
-export type ShotArtifact = (typeof SHOT_ARTIFACTS)[number];
-
-export type ShotStalenessResult = Record<ShotArtifact, ArtifactStaleness>;
-
-/** Nothing could be compared — the batch handler's per-shot failure cases. */
-export const UNKNOWN_STALENESS: ShotStalenessResult = {
-  thumbnail: 'unknown',
-  visualPrompt: 'unknown',
-  motionPrompt: 'unknown',
+/**
+ * The live input hashes computed during the comparison. Enqueue points reuse
+ * them to stamp pending claims without recomputing; null when the branch
+ * didn't run (untracked/unknown artifacts).
+ */
+type ShotLiveHashes = {
+  thumbnail: string | null;
+  visualPrompt: string | null;
+  motionPrompt: string | null;
 };
 
-export type ShotStalenessRefs = ShotPromptContextRefs;
+export type ShotStalenessResult = {
+  thumbnail: ArtifactStaleness;
+  visualPrompt: ArtifactStaleness;
+  motionPrompt: ArtifactStaleness;
+  liveHashes: ShotLiveHashes;
+};
+
+/** Every artifact unopinionated — the missing-anchor and no-scene cases. */
+export const UNTRACKED_STALENESS: ShotStalenessResult = {
+  thumbnail: 'untracked',
+  visualPrompt: 'untracked',
+  motionPrompt: 'untracked',
+  liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
+};
+
+export type ShotStalenessRefs = {
+  characters: Awaited<ReturnType<ScopedDb['characters']['listWithSheets']>>;
+  locations: Awaited<
+    ReturnType<ScopedDb['sequenceLocations']['listWithReferences']>
+  >;
+  elements: Awaited<ReturnType<ScopedDb['sequenceElements']['list']>>;
+};
 
 /**
  * Four states per artifact:
@@ -75,6 +103,11 @@ export async function computeShotStaleness(args: {
   const { scopedDb, sequence, shot, frame, scene, refs } = args;
   const shotForHash = scene ? { ...shot, metadata: scene } : shot;
 
+  const liveHashes: ShotLiveHashes = {
+    thumbnail: null,
+    visualPrompt: null,
+    motionPrompt: null,
+  };
   let thumbnail: ArtifactStaleness = 'untracked';
   // The visual prompt lives solely on the anchor frame's `imagePrompt` mirror
   // now (#989/#713): the visual-prompt workflow writes a `frame_prompt_versions`
@@ -114,6 +147,7 @@ export async function computeShotStaleness(args: {
           aspectRatio: sequence.aspectRatio,
         });
 
+        liveHashes.thumbnail = snapshot.snapshotInputHash;
         thumbnail =
           snapshot.snapshotInputHash !== frame.imageInputHash
             ? 'stale'
@@ -162,6 +196,7 @@ export async function computeShotStaleness(args: {
           refs,
         });
         const liveHash = await computeVisualPromptInputHash(ctx);
+        liveHashes.visualPrompt = liveHash;
         visualPrompt = liveHash !== referenceHash ? 'stale' : 'fresh';
       }
     } catch (error) {
@@ -199,6 +234,7 @@ export async function computeShotStaleness(args: {
           refs,
         });
         const liveHash = await computeMotionPromptInputHash(ctx);
+        liveHashes.motionPrompt = liveHash;
         motionPrompt = liveHash !== referenceHash ? 'stale' : 'fresh';
       }
     } catch (error) {
@@ -209,5 +245,58 @@ export async function computeShotStaleness(args: {
     }
   }
 
-  return { thumbnail, visualPrompt, motionPrompt };
+  // ============================================================
+  // 'updating' overlay (#1085): a stale artifact with a live pending claim
+  // whose pendingInputHash equals the live hash is already being fixed.
+  // Runs last so the thumbnail's chained-claim check can use the visual
+  // prompt's live hash computed above.
+  // ============================================================
+  if (visualPrompt === 'stale' && liveHashes.visualPrompt) {
+    const claim = await scopedDb.framePromptVersions.getLivePending(
+      frame.id,
+      liveHashes.visualPrompt
+    );
+    if (claim) visualPrompt = 'updating';
+  }
+  if (motionPrompt === 'stale' && liveHashes.motionPrompt) {
+    const claim = await scopedDb.shotPromptVersions.getLivePending(
+      shot.id,
+      liveHashes.motionPrompt
+    );
+    if (claim) motionPrompt = 'updating';
+  }
+  if (thumbnail === 'stale' && liveHashes.thumbnail) {
+    const claims = await scopedDb.frameVariants.listLiveClaims(frame.id);
+    for (const claim of claims) {
+      // Direct regen: the claim satisfies the image's live hash itself.
+      if (claim.pendingInputHash === liveHashes.thumbnail) {
+        thumbnail = 'updating';
+        break;
+      }
+      // Chained regen: validity derives from the dependency prompt row. While
+      // the prompt is in flight its claim must match the live VISUAL hash;
+      // once it completes (render still pending/running) its stamped
+      // inputHash must — either way an edit moves the live hash and honestly
+      // re-stales the image.
+      if (claim.dependsOnVersionId && liveHashes.visualPrompt) {
+        const dep = await scopedDb.framePromptVersions.getByIdForFrame(
+          claim.dependsOnVersionId,
+          frame.id
+        );
+        if (!dep) continue;
+        const depInFlight =
+          (dep.status === 'pending' || dep.status === 'generating') &&
+          dep.pendingInputHash === liveHashes.visualPrompt;
+        const depLanded =
+          dep.status === 'completed' &&
+          dep.inputHash === liveHashes.visualPrompt;
+        if (depInFlight || depLanded) {
+          thumbnail = 'updating';
+          break;
+        }
+      }
+    }
+  }
+
+  return { thumbnail, visualPrompt, motionPrompt, liveHashes };
 }

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -76,9 +76,12 @@ export type ShotStalenessRefs = {
 };
 
 /**
- * Four states per artifact:
+ * Five states per artifact:
  *   - `'stale'`     — stored hash diverges from the freshly computed one.
  *   - `'fresh'`     — stored hash matches.
+ *   - `'updating'`  — stored hash diverges, but a live pending claim matches
+ *                     the live hash — a job is already fixing exactly this
+ *                     (see the overlay at the end of this function, #1085).
  *   - `'untracked'` — no stored hash (legacy artifact, or never generated).
  *                     Distinct from `'fresh'` so the UI can suppress the
  *                     regenerate prompt without lying about the artifact's

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -1,7 +1,8 @@
 /**
- * Per-shot staleness computation (#1077) — backs the `getShotStaleness*`
- * server fns. Each value is computed by re-deriving the current input hash
- * from live scoped state and comparing it to the stored `*_input_hash`.
+ * Per-shot staleness computation (#1077) — shared by the `getShotStaleness*`
+ * server fns and `UpdateStaleShotsWorkflow` (#1085). Each value is computed by
+ * re-deriving the current input hash from live scoped state and comparing it
+ * to the stored `*_input_hash`.
  */
 
 import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -90,7 +90,10 @@ export type ShotStalenessRefs = {
  *                     transient D1 read, malformed row). Distinct from
  *                     `'untracked'`: the UI renders it as "couldn't check"
  *                     rather than as silence, so a broken comparison never
- *                     reads as "up to date".
+ *                     reads as "up to date". WRITE paths must not treat "we
+ *                     couldn't tell" as "nothing to do" — `computePlan`
+ *                     (update-stale-plan) reports these as skipped rather than
+ *                     silently dropping a possibly-stale artifact.
  *
  * `refs` lets batched callers load the sequence-scoped rows once for the whole
  * scene/sequence instead of once per shot; when absent they are loaded lazily.

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -67,13 +67,8 @@ export const UNTRACKED_STALENESS: ShotStalenessResult = {
   liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
 };
 
-export type ShotStalenessRefs = {
-  characters: Awaited<ReturnType<ScopedDb['characters']['listWithSheets']>>;
-  locations: Awaited<
-    ReturnType<ScopedDb['sequenceLocations']['listWithReferences']>
-  >;
-  elements: Awaited<ReturnType<ScopedDb['sequenceElements']['list']>>;
-};
+/** Sequence-scoped rows loaded once for a batch of shot comparisons. */
+export type ShotStalenessRefs = ShotPromptContextRefs;
 
 /**
  * Five states per artifact:

--- a/src/lib/shots/shot-with-image.ts
+++ b/src/lib/shots/shot-with-image.ts
@@ -14,11 +14,13 @@
  */
 
 import type { AssemblableMotionPrompt } from '@/lib/ai/scene-analysis.schema';
-import type { Frame, Shot } from '@/lib/db/schema';
+import type { Frame, FrameVariant, Shot } from '@/lib/db/schema';
 
 export type ShotGridSheet = {
   url: string | null;
-  status: Frame['imageStatus'];
+  // Sourced from a `frame_variants` row, whose status union is wider than the
+  // frame's (adds 'cancelled', #1085).
+  status: Frame['imageStatus'] | FrameVariant['status'];
 };
 
 export type ShotWithImage = Shot & {
@@ -34,7 +36,7 @@ export type ShotWithImage = Shot & {
   thumbnailInputHash: Frame['imageInputHash'];
   visualPromptInputHash: Frame['visualPromptInputHash'];
   variantImageUrl: string | null;
-  variantImageStatus: Frame['imageStatus'];
+  variantImageStatus: ShotGridSheet['status'] | null;
   /** The anchor frame, verbatim — for version/variant-aware callers. */
   frame: Frame;
   /**

--- a/src/lib/shots/update-stale-depth.ts
+++ b/src/lib/shots/update-stale-depth.ts
@@ -1,0 +1,59 @@
+/**
+ * "Update all" cascade depth (#1085). Cumulative levels — each includes the
+ * ones before it:
+ *
+ *   - 'prompts' — stale visual/motion prompts only. Nothing renders.
+ *   - 'images'  — + images: stale stills re-render, and a still whose visual
+ *                 prompt regenerates in this run is re-rendered too (it would
+ *                 read stale the moment the prompt lands). Never creates a
+ *                 FIRST still.
+ *   - 'video'   — + videos: a shot whose motion prompt or still changed in
+ *                 this run gets its video re-rendered. Never renders a FIRST
+ *                 video.
+ *   - 'music'   — + sequence music: regenerates a stale music prompt, then
+ *                 the track itself when one already exists.
+ *
+ * Kept in its own dependency-light module because both the client menu and
+ * the server fn / workflow need the vocabulary.
+ */
+
+export const UPDATE_STALE_DEPTHS = [
+  'prompts',
+  'images',
+  'video',
+  'music',
+] as const;
+
+export type UpdateStaleDepth = (typeof UPDATE_STALE_DEPTHS)[number];
+
+const RANK: Record<UpdateStaleDepth, number> = {
+  prompts: 0,
+  images: 1,
+  video: 2,
+  music: 3,
+};
+
+/** Does `depth` include level `level`? (Levels are cumulative.) */
+export function depthIncludes(
+  depth: UpdateStaleDepth,
+  level: UpdateStaleDepth
+): boolean {
+  return RANK[depth] >= RANK[level];
+}
+
+/** Option copy shared by every "Update all" trigger. */
+export const UPDATE_STALE_DEPTH_LABELS: Record<UpdateStaleDepth, string> = {
+  prompts: 'Prompts only',
+  images: 'Prompts + images',
+  video: 'Prompts, images + videos',
+  music: 'Everything, incl. music',
+};
+
+/** One-line consequence of each level, shown in the confirm dialog. */
+export const UPDATE_STALE_DEPTH_DESCRIPTIONS: Record<UpdateStaleDepth, string> =
+  {
+    prompts: 'Rewrites out-of-date prompts. Nothing is rendered.',
+    images: 'Also re-renders stills affected by prompt changes.',
+    video: 'Also re-renders existing videos whose inputs changed.',
+    music: 'Also refreshes the sequence music prompt and track.',
+  };

--- a/src/lib/shots/update-stale-depth.ts
+++ b/src/lib/shots/update-stale-depth.ts
@@ -26,6 +26,13 @@ export const UPDATE_STALE_DEPTHS = [
 
 export type UpdateStaleDepth = (typeof UPDATE_STALE_DEPTHS)[number];
 
+/**
+ * Default cascade depth when a run (or client) omits `depth`. Matches the
+ * pre–depth-picker gating most closely: prompts + affected stills, no video
+ * or music.
+ */
+export const DEFAULT_UPDATE_STALE_DEPTH: UpdateStaleDepth = 'images';
+
 const RANK: Record<UpdateStaleDepth, number> = {
   prompts: 0,
   images: 1,

--- a/src/lib/shots/update-stale-plan.test.ts
+++ b/src/lib/shots/update-stale-plan.test.ts
@@ -593,6 +593,108 @@ describe('claimTargets (#1085)', () => {
       { shotId: 'shot-1', reason: 'already-in-flight' },
     ]);
   });
+
+  it('lost insert race (create throws, live claim exists) → foreign / already-in-flight', async () => {
+    let getLiveCalls = 0;
+    const db = asScopedDb({
+      framePromptVersions: {
+        getLivePending: () => {
+          getLiveCalls += 1;
+          // First call: empty; second (post-throw): foreign winner.
+          if (getLiveCalls === 1) return Promise.resolve(null);
+          return Promise.resolve({
+            id: 'fpv-winner',
+            workflowRunId: 'other-run',
+          });
+        },
+        createPending: () =>
+          Promise.reject(new Error('UNIQUE constraint failed')),
+      },
+      shotPromptVersions: {
+        getLivePending: () => Promise.resolve(null),
+        createPending: () => Promise.resolve({ id: 'unused' }),
+      },
+      frameVariants: {
+        listLiveClaims: () => Promise.resolve([]),
+        createPendingClaim: () => Promise.resolve({ id: 'unused' }),
+      },
+    });
+
+    const result = await claimTargets({
+      scopedDb: db,
+      targets: [makeTarget({ regenVisual: true })],
+      sequenceId: 'seq-1',
+      parentInstanceId: 'run-1',
+    });
+
+    expect(result.claimsByShot['shot-1']?.visualVersionId).toBeNull();
+    expect(result.skipped).toEqual([
+      { shotId: 'shot-1', reason: 'already-in-flight' },
+    ]);
+  });
+
+  it('create throws without a live claim → rethrows (not silent foreign)', async () => {
+    const db = asScopedDb({
+      framePromptVersions: {
+        getLivePending: () => Promise.resolve(null),
+        createPending: () => Promise.reject(new Error('D1 blip')),
+      },
+      shotPromptVersions: {
+        getLivePending: () => Promise.resolve(null),
+        createPending: () => Promise.resolve({ id: 'unused' }),
+      },
+      frameVariants: {
+        listLiveClaims: () => Promise.resolve([]),
+        createPendingClaim: () => Promise.resolve({ id: 'unused' }),
+      },
+    });
+
+    await expect(
+      claimTargets({
+        scopedDb: db,
+        targets: [makeTarget({ regenVisual: true })],
+        sequenceId: 'seq-1',
+        parentInstanceId: 'run-1',
+      })
+    ).rejects.toThrow(/D1 blip/);
+  });
+
+  it('partial foreign (visual foreign, motion ours) does NOT list the shot as skipped', async () => {
+    const created = { motion: [] as unknown[] };
+    const db = asScopedDb({
+      framePromptVersions: {
+        getLivePending: () =>
+          Promise.resolve({ id: 'fpv-foreign', workflowRunId: 'other-run' }),
+        createPending: () => Promise.resolve({ id: 'unused' }),
+      },
+      shotPromptVersions: {
+        getLivePending: () => Promise.resolve(null),
+        createPending: (input: unknown) => {
+          created.motion.push(input);
+          return Promise.resolve({ id: 'spv-ours' });
+        },
+      },
+      frameVariants: {
+        listLiveClaims: () => Promise.resolve([]),
+        createPendingClaim: () => Promise.resolve({ id: 'unused' }),
+      },
+    });
+
+    const result = await claimTargets({
+      scopedDb: db,
+      targets: [makeTarget({ regenVisual: true, regenMotion: true })],
+      sequenceId: 'seq-1',
+      parentInstanceId: 'run-1',
+    });
+
+    expect(result.claimsByShot['shot-1']).toMatchObject({
+      visualVersionId: null,
+      motionVersionId: 'spv-ours',
+    });
+    expect(created.motion).toHaveLength(1);
+    // Owns motion → not reported as already-in-flight (partial work is honest).
+    expect(result.skipped).toEqual([]);
+  });
 });
 
 describe('computePlan — scope', () => {

--- a/src/lib/shots/update-stale-plan.test.ts
+++ b/src/lib/shots/update-stale-plan.test.ts
@@ -88,8 +88,7 @@ vi.doMock('@/lib/ai/input-hash', () => ({
   computeMusicPromptInputHash: vi.fn(() => Promise.resolve('live-music-hash')),
 }));
 
-const { computePlan, claimTargets } =
-  await import('./update-stale-shots-workflow');
+const { computePlan, claimTargets } = await import('./update-stale-plan');
 
 type VideoFixture = {
   segments?: Array<{

--- a/src/lib/shots/update-stale-plan.test.ts
+++ b/src/lib/shots/update-stale-plan.test.ts
@@ -150,6 +150,7 @@ function buildScopedDb(
     characters: { listWithSheets: () => Promise.resolve([]) },
     sequenceLocations: { listWithReferences: () => Promise.resolve([]) },
     sequenceElements: { list: () => Promise.resolve([]) },
+    styles: { getById: () => Promise.resolve(null) },
     renderSegments: {
       listBySequence: () => Promise.resolve(opts.video?.segments ?? []),
     },

--- a/src/lib/shots/update-stale-plan.ts
+++ b/src/lib/shots/update-stale-plan.ts
@@ -202,16 +202,19 @@ export async function computePlan(args: {
     : new Map<string, ShotVideoState>();
 
   await scopedDb.shots.ensureAnchorFrames(inScope);
-  const [anchorRows, scriptBySceneId, characters, locations, elements] =
+  const [anchorRows, scriptBySceneId, characters, locations, elements, style] =
     await Promise.all([
       scopedDb.frames.listAnchorsBySequence(sequenceId),
       loadSelectedScriptsBySequence(scopedDb, sequenceId),
       scopedDb.characters.listWithSheets(sequenceId),
       scopedDb.sequenceLocations.listWithReferences(sequenceId),
       scopedDb.sequenceElements.list(sequenceId),
+      sequence.styleId
+        ? scopedDb.styles.getById(sequence.styleId)
+        : Promise.resolve(null),
     ]);
   const anchorsByShot = new Map(anchorRows.map((f) => [f.shotId, f]));
-  const refs: ShotStalenessRefs = { characters, locations, elements };
+  const refs: ShotStalenessRefs = { characters, locations, elements, style };
 
   const targets: PlanTarget[] = [];
   const skipped: SkippedShot[] = [];

--- a/src/lib/shots/update-stale-plan.ts
+++ b/src/lib/shots/update-stale-plan.ts
@@ -1,0 +1,744 @@
+/**
+ * "Update all" planning (#1077/#1085) — pure domain logic that decides *what*
+ * regenerates (and therefore what gets billed). The workflow only freezes the
+ * returned plan as a durable `step.do` result and orchestrates children.
+ *
+ * Depth vocabulary: `update-stale-depth.ts`. Staleness comparisons:
+ * `shot-staleness.ts` (prompts/images) and segment assembly (video).
+ *
+ * Plan shape is deliberately ids + flags only — no `Scene` bodies — so a
+ * sequence-scope run fits Cloudflare's 1 MiB step-result cap. Scenes are
+ * materialised per shot at spawn time.
+ */
+
+import { computeMusicPromptInputHash } from '@/lib/ai/input-hash';
+import {
+  DEFAULT_ANALYSIS_MODEL,
+  getAnalysisModelById,
+  type AnalysisModelId,
+} from '@/lib/ai/models.config';
+import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
+import { loadShotPromptContext } from '@/lib/ai/prompt-context';
+import type {
+  CharacterBibleEntry,
+  ElementBibleEntry,
+  LocationBibleEntry,
+  Scene,
+} from '@/lib/ai/scene-analysis.schema';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type { Frame, Sequence, Shot, StyleConfig } from '@/lib/db/schema';
+import type { ScopedDb } from '@/lib/db/scoped';
+import { getLogger } from '@/lib/observability/logger';
+import { assembleSequenceSegments } from '@/lib/scenes/scene-segments';
+import {
+  loadSelectedScriptsBySequence,
+  resolveSceneForShot,
+} from '@/lib/scenes/scene-script';
+import {
+  computeShotStaleness,
+  type ShotStalenessRefs,
+  type ShotStalenessResult,
+} from '@/lib/shots/shot-staleness';
+import {
+  DEFAULT_UPDATE_STALE_DEPTH,
+  depthIncludes,
+  type UpdateStaleDepth,
+} from '@/lib/shots/update-stale-depth';
+import { buildMusicSceneSummaries } from '@/lib/workflows/music-scene-summaries';
+import { WorkflowValidationError } from '@/lib/workflow/errors';
+
+const logger = getLogger(['openstory', 'shots', 'update-stale-plan']);
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/**
+ * One shot's frozen slice of the plan. Holds only ids and flags — no `Scene`
+ * objects (1 MiB step-result cap).
+ */
+export type PlanTarget = {
+  shotId: string;
+  frameId: string;
+  /**
+   * Neighbour shot ids for motion continuity, resolved to raw metadata at
+   * spawn time (parity with regenerateShotPromptFn). Null when not a motion
+   * target, or at the ends of the sequence.
+   */
+  beforeShotId: string | null;
+  afterShotId: string | null;
+  /** Frame image URL at plan time; image stage may produce a newer one later. */
+  startingFrameImageUrl: string | null;
+  regenVisual: boolean;
+  regenMotion: boolean;
+  /**
+   * Re-render the still. Never true without an existing imageUrl — Update all
+   * must not spend credits creating a first still.
+   */
+  regenImage: boolean;
+  /**
+   * Live input hashes at plan time — stamped onto pending claim rows so
+   * in-flight work reads as 'updating' and duplicate enqueues no-op.
+   */
+  visualLiveHash: string | null;
+  motionLiveHash: string | null;
+  imageLiveHash: string | null;
+  /** Model stamped on the image claim row; prepare-image may overwrite it. */
+  imageModel: string;
+  /**
+   * Re-render this shot's video. True only when a video is already selected
+   * (never a FIRST render), none is currently generating, and either an
+   * upstream artifact regenerates in this run or the segment already reads
+   * stale. Video/music use status columns rather than pending-claim rows.
+   */
+  regenVideo: boolean;
+};
+
+/**
+ * Pending rows claimed for one shot. A null slot for a set regen flag means
+ * another run already holds a live claim — this run skips that artifact.
+ */
+export type ShotClaims = {
+  visualVersionId: string | null;
+  motionVersionId: string | null;
+  imageVariantId: string | null;
+};
+
+/**
+ * A shot the plan could not act on. Distinct from a run failure: nothing was
+ * attempted. Reported so a partial run cannot read as a clean success.
+ */
+export type SkippedShot = {
+  shotId: string;
+  reason:
+    | 'no-anchor-frame'
+    | 'no-scene'
+    | 'staleness-unknown'
+    | 'already-in-flight';
+};
+
+/**
+ * Sequence-level music slice (depth 'music').
+ * - `regenPrompt` — stored music-prompt hash diverges from live.
+ * - `regenTrack` — track already exists AND the prompt regenerates (cascade
+ *   only; no track-level staleness signal today). Never a FIRST generation.
+ *
+ * Music is always sequence-scoped, even when shot/scene narrows shot targets.
+ */
+export type MusicPlan = { regenPrompt: boolean; regenTrack: boolean };
+
+type PlanPromptContext = {
+  characterBible: CharacterBibleEntry[];
+  locationBible: LocationBibleEntry[];
+  elementBible: ElementBibleEntry[];
+  styleConfig: StyleConfig;
+  analysisModelId: AnalysisModelId;
+};
+
+export type UpdateStalePlan = {
+  aspectRatio: AspectRatio;
+  /** Non-null only at depth 'music'. */
+  music: MusicPlan | null;
+  promptContext: PlanPromptContext | null;
+  targets: PlanTarget[];
+  skipped: SkippedShot[];
+};
+
+// ---------------------------------------------------------------------------
+// computePlan
+// ---------------------------------------------------------------------------
+
+/**
+ * Recompute staleness for the in-scope shots from live state and freeze the
+ * regeneration plan. The workflow persists this as the `compute-plan` step
+ * result — the run's durable snapshot of what will be billed.
+ */
+export async function computePlan(args: {
+  scopedDb: ScopedDb;
+  sequenceId: string;
+  sceneId?: string;
+  shotId?: string;
+  depth?: UpdateStaleDepth;
+}): Promise<UpdateStalePlan> {
+  const {
+    scopedDb,
+    sequenceId,
+    sceneId,
+    shotId,
+    depth = DEFAULT_UPDATE_STALE_DEPTH,
+  } = args;
+
+  const sequence = await scopedDb.sequences.getById(sequenceId);
+  if (!sequence) {
+    throw new WorkflowValidationError(`Sequence ${sequenceId} not found`);
+  }
+
+  const allShots = await scopedDb.shots.listBySequence(sequenceId);
+  const inScope = filterInScopeShots(allShots, { sceneId, shotId });
+  const shotIndexById = buildShotIndex(allShots);
+
+  // Music is always sequence-scoped (not narrowed by scene/shot).
+  const music = depthIncludes(depth, 'music')
+    ? await computeMusicPlan(scopedDb, sequence, allShots)
+    : null;
+
+  const empty: UpdateStalePlan = {
+    aspectRatio: sequence.aspectRatio,
+    music,
+    promptContext: null,
+    targets: [],
+    skipped: [],
+  };
+  if (inScope.length === 0) return empty;
+
+  const videoStateByShot = depthIncludes(depth, 'video')
+    ? await loadVideoStateByShot(scopedDb, sequenceId, allShots)
+    : new Map<string, ShotVideoState>();
+
+  await scopedDb.shots.ensureAnchorFrames(inScope);
+  const [anchorRows, scriptBySceneId, characters, locations, elements] =
+    await Promise.all([
+      scopedDb.frames.listAnchorsBySequence(sequenceId),
+      loadSelectedScriptsBySequence(scopedDb, sequenceId),
+      scopedDb.characters.listWithSheets(sequenceId),
+      scopedDb.sequenceLocations.listWithReferences(sequenceId),
+      scopedDb.sequenceElements.list(sequenceId),
+    ]);
+  const anchorsByShot = new Map(anchorRows.map((f) => [f.shotId, f]));
+  const refs: ShotStalenessRefs = { characters, locations, elements };
+
+  const targets: PlanTarget[] = [];
+  const skipped: SkippedShot[] = [];
+  // Bibles are sequence-wide; any target scene is enough to load context.
+  let sceneForBibles: Scene | null = null;
+
+  for (const shot of inScope) {
+    const frame = anchorsByShot.get(shot.id);
+    const { scene } = resolveSceneForShot(shot, scriptBySceneId);
+
+    const decision = await decideShotTarget({
+      scopedDb,
+      sequence,
+      shot,
+      frame,
+      scene,
+      refs,
+      depth,
+      videoState: videoStateByShot.get(shot.id),
+      shotIndexById,
+      allShots,
+    });
+
+    if (decision.kind === 'skip') {
+      skipped.push(decision.skip);
+      continue;
+    }
+    if (decision.kind === 'noop') continue;
+
+    targets.push(decision.target);
+    sceneForBibles ??= scene;
+  }
+
+  if (targets.length === 0 || !sceneForBibles) {
+    return { ...empty, skipped };
+  }
+
+  // Sequence-wide bibles + style — same loader as single-shot regen.
+  const ctx = await loadShotPromptContext({
+    scopedDb,
+    sequence,
+    scene: sceneForBibles,
+  });
+
+  return {
+    aspectRatio: sequence.aspectRatio,
+    music,
+    promptContext: {
+      characterBible: ctx.characterBible,
+      locationBible: ctx.locationBible,
+      elementBible: ctx.elementBible,
+      styleConfig: ctx.styleConfig,
+      analysisModelId:
+        getAnalysisModelById(ctx.analysisModel)?.id ?? DEFAULT_ANALYSIS_MODEL,
+    },
+    targets,
+    skipped,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Scope + video state
+// ---------------------------------------------------------------------------
+
+/** shotId wins over sceneId — a one-shot update never widens. */
+function filterInScopeShots(
+  allShots: Shot[],
+  scope: { sceneId?: string; shotId?: string }
+): Shot[] {
+  const { sceneId, shotId } = scope;
+  return allShots.filter((shot) => {
+    if (shotId) return shot.id === shotId;
+    if (sceneId) return shot.sceneId === sceneId;
+    return true;
+  });
+}
+
+function buildShotIndex(allShots: Shot[]): Map<string, number> {
+  const index = new Map<string, number>();
+  for (let i = 0; i < allShots.length; i++) {
+    const shot = allShots[i];
+    if (shot) index.set(shot.id, i);
+  }
+  return index;
+}
+
+type ShotVideoState = {
+  hasVideo: boolean;
+  alreadyStale: boolean;
+  generating: boolean;
+};
+
+/**
+ * Per-shot video state from segment assembly — the same batched reads + pure
+ * assemble the UI's sequence-segments path uses, so "has a video" / "already
+ * stale" / "currently generating" match the indicators.
+ *
+ * Video does not use prompt/image pending-claim rows; in-flight state lives
+ * on `video_variants.status`.
+ */
+async function loadVideoStateByShot(
+  scopedDb: ScopedDb,
+  sequenceId: string,
+  allShots: Shot[]
+): Promise<Map<string, ShotVideoState>> {
+  const [segments, versions, allFrames] = await Promise.all([
+    scopedDb.renderSegments.listBySequence(sequenceId),
+    scopedDb.videoVariants.listBySequence(sequenceId),
+    scopedDb.frames.listBySequence(sequenceId),
+  ]);
+  const assembled = assembleSequenceSegments({
+    segments,
+    versions,
+    shots: allShots,
+    frames: allFrames,
+  });
+
+  const byShot = new Map<string, ShotVideoState>();
+  for (const segment of assembled) {
+    const generating = versions.some(
+      (v) => v.renderSegmentId === segment.id && v.status === 'generating'
+    );
+    for (const segShotId of segment.shotIds) {
+      byShot.set(segShotId, {
+        hasVideo: segment.selectedVersion !== null,
+        alreadyStale: segment.stale,
+        generating,
+      });
+    }
+  }
+  return byShot;
+}
+
+// ---------------------------------------------------------------------------
+// Per-shot decision
+// ---------------------------------------------------------------------------
+
+type ShotDecision =
+  | { kind: 'target'; target: PlanTarget }
+  | { kind: 'skip'; skip: SkippedShot }
+  | { kind: 'noop' };
+
+async function decideShotTarget(args: {
+  scopedDb: ScopedDb;
+  sequence: Sequence;
+  shot: Shot;
+  frame: Frame | undefined;
+  scene: Scene | null;
+  refs: ShotStalenessRefs;
+  depth: UpdateStaleDepth;
+  videoState: ShotVideoState | undefined;
+  shotIndexById: Map<string, number>;
+  allShots: Shot[];
+}): Promise<ShotDecision> {
+  const {
+    scopedDb,
+    sequence,
+    shot,
+    frame,
+    scene,
+    refs,
+    depth,
+    videoState,
+    shotIndexById,
+    allShots,
+  } = args;
+
+  if (!frame) {
+    return {
+      kind: 'skip',
+      skip: { shotId: shot.id, reason: 'no-anchor-frame' },
+    };
+  }
+  if (!scene) {
+    // Client staleness can still mark these stale (thumbnail without scene);
+    // record the skip so the UI does not wait forever on unplanned work.
+    return { kind: 'skip', skip: { shotId: shot.id, reason: 'no-scene' } };
+  }
+
+  const staleness = await computeShotStaleness({
+    scopedDb,
+    sequence,
+    shot,
+    frame,
+    scene,
+    refs,
+  });
+
+  // Fail closed: unknown ≠ fresh. Regenerating on a guess burns credits;
+  // silent skip looks like a clean run.
+  if (hasUnknownStaleness(staleness)) {
+    return {
+      kind: 'skip',
+      skip: { shotId: shot.id, reason: 'staleness-unknown' },
+    };
+  }
+
+  const flags = cascadeFlags({ staleness, frame, depth, videoState });
+  if (
+    !flags.regenVisual &&
+    !flags.regenMotion &&
+    !flags.regenImage &&
+    !flags.regenVideo
+  ) {
+    return { kind: 'noop' };
+  }
+
+  const idx = shotIndexById.get(shot.id) ?? -1;
+  return {
+    kind: 'target',
+    target: {
+      shotId: shot.id,
+      frameId: frame.id,
+      beforeShotId:
+        flags.regenMotion && idx > 0 ? (allShots[idx - 1]?.id ?? null) : null,
+      afterShotId:
+        flags.regenMotion && idx >= 0 ? (allShots[idx + 1]?.id ?? null) : null,
+      startingFrameImageUrl: frame.imageUrl,
+      regenVisual: flags.regenVisual,
+      regenMotion: flags.regenMotion,
+      regenImage: flags.regenImage,
+      visualLiveHash: staleness.liveHashes.visualPrompt,
+      motionLiveHash: staleness.liveHashes.motionPrompt,
+      imageLiveHash: staleness.liveHashes.thumbnail,
+      imageModel: safeTextToImageModel(frame.imageModel, DEFAULT_IMAGE_MODEL),
+      regenVideo: flags.regenVideo,
+    },
+  };
+}
+
+function hasUnknownStaleness(staleness: ShotStalenessResult): boolean {
+  return (
+    staleness.thumbnail === 'unknown' ||
+    staleness.visualPrompt === 'unknown' ||
+    staleness.motionPrompt === 'unknown'
+  );
+}
+
+/**
+ * Cascade boolean algebra for one shot. Depth is cumulative
+ * (`depthIncludes`). Never first-creates a still or video.
+ *
+ * - prompts/images: hash + pending-claim vocabulary from `computeShotStaleness`
+ *   (`'stale'` only; `'updating'` is already covered).
+ * - video: segment assembly status columns (no pending-claim rows yet).
+ */
+function cascadeFlags(args: {
+  staleness: ShotStalenessResult;
+  frame: Pick<Frame, 'imageUrl'>;
+  depth: UpdateStaleDepth;
+  videoState: ShotVideoState | undefined;
+}): {
+  regenVisual: boolean;
+  regenMotion: boolean;
+  regenImage: boolean;
+  regenVideo: boolean;
+} {
+  const { staleness, frame, depth, videoState } = args;
+
+  // 'stale' only — 'updating' is a live claim already fixing this artifact.
+  const regenVisual = staleness.visualPrompt === 'stale';
+  const regenMotion = staleness.motionPrompt === 'stale';
+
+  // Depth ≥ images: re-render stills that are stale, or whose visual prompt
+  // regenerates in this run (would read stale the moment the prompt lands).
+  // Depth 'prompts' renders nothing. Never a FIRST still.
+  const regenImage =
+    depthIncludes(depth, 'images') &&
+    !!frame.imageUrl &&
+    (staleness.thumbnail === 'stale' || regenVisual);
+
+  // Depth ≥ video: existing videos whose upstream changes in this run, or
+  // whose manifest already diverged. Leave in-flight renders alone.
+  const regenVideo =
+    !!videoState &&
+    videoState.hasVideo &&
+    !videoState.generating &&
+    (regenMotion || regenImage || videoState.alreadyStale);
+
+  return { regenVisual, regenMotion, regenImage, regenVideo };
+}
+
+// ---------------------------------------------------------------------------
+// Music plan
+// ---------------------------------------------------------------------------
+
+/**
+ * Sequence-level music slice. Mirrors `getMusicPromptStalenessFn`'s comparison
+ * (latest version's analysis model, fallback to the sequence's). Untracked
+ * (no stored hash / no scenes) means nothing — never a first music prompt or
+ * track. In-flight generation is left to finish.
+ */
+async function computeMusicPlan(
+  scopedDb: ScopedDb,
+  sequence: Sequence,
+  allShots: Shot[]
+): Promise<MusicPlan> {
+  const none: MusicPlan = { regenPrompt: false, regenTrack: false };
+  if (!sequence.musicPromptInputHash) return none;
+
+  const scenes = allShots
+    .map((s) => s.metadata)
+    .filter((m): m is NonNullable<typeof m> => m !== null);
+  if (scenes.length === 0) return none;
+
+  try {
+    const sceneSummaries = buildMusicSceneSummaries(scenes);
+    const latest = await scopedDb.sequenceMusicPromptVersions.getLatest(
+      sequence.id
+    );
+    const analysisModel =
+      latest?.analysisModel ??
+      getAnalysisModelById(sequence.analysisModel)?.id ??
+      DEFAULT_ANALYSIS_MODEL;
+    const liveHash = await computeMusicPromptInputHash({
+      sceneSummaries,
+      analysisModel,
+    });
+    const regenPrompt = liveHash !== sequence.musicPromptInputHash;
+    return {
+      regenPrompt,
+      // Cascade-only: track follows its prompt. No track-level staleness today.
+      regenTrack:
+        regenPrompt &&
+        !!sequence.musicUrl &&
+        sequence.musicStatus !== 'generating',
+    };
+  } catch (error) {
+    // Fail closed — same posture as per-shot 'unknown'.
+    logger.warn(`music staleness uncomputable for sequence ${sequence.id}:`, {
+      err: error,
+    });
+    return none;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// claimTargets
+// ---------------------------------------------------------------------------
+
+/**
+ * Pre-create a pending version row per prompt/image artifact this run will
+ * produce, so in-flight work reads as 'updating', duplicate enqueues no-op,
+ * and children complete these rows in place.
+ *
+ * Idempotent across step retries: a live claim stamped with THIS run's
+ * instance id is reused; one stamped by anyone else → `already-in-flight`.
+ * Video/music have no claim rows (status columns instead).
+ */
+export async function claimTargets(args: {
+  scopedDb: ScopedDb;
+  targets: PlanTarget[];
+  sequenceId: string;
+  parentInstanceId: string;
+}): Promise<{
+  claimsByShot: Record<string, ShotClaims>;
+  skipped: SkippedShot[];
+}> {
+  const { scopedDb, targets, sequenceId, parentInstanceId } = args;
+  const claimsByShot: Record<string, ShotClaims> = {};
+  const skipped: SkippedShot[] = [];
+
+  for (const target of targets) {
+    const { claims, foreignClaim } = await claimShotArtifacts({
+      scopedDb,
+      target,
+      sequenceId,
+      parentInstanceId,
+    });
+    if (foreignClaim) {
+      skipped.push({ shotId: target.shotId, reason: 'already-in-flight' });
+    }
+    claimsByShot[target.shotId] = claims;
+  }
+
+  return { claimsByShot, skipped };
+}
+
+async function claimShotArtifacts(args: {
+  scopedDb: ScopedDb;
+  target: PlanTarget;
+  sequenceId: string;
+  parentInstanceId: string;
+}): Promise<{ claims: ShotClaims; foreignClaim: boolean }> {
+  const { scopedDb, target, sequenceId, parentInstanceId } = args;
+  const claims: ShotClaims = {
+    visualVersionId: null,
+    motionVersionId: null,
+    imageVariantId: null,
+  };
+  let foreignClaim = false;
+
+  if (target.regenVisual && target.visualLiveHash) {
+    const visualLiveHash = target.visualLiveHash;
+    const result = await claimOrReuse({
+      parentInstanceId,
+      getExisting: () =>
+        scopedDb.framePromptVersions.getLivePending(
+          target.frameId,
+          visualLiveHash
+        ),
+      create: () =>
+        scopedDb.framePromptVersions.createPending({
+          frameId: target.frameId,
+          pendingInputHash: visualLiveHash,
+          workflowRunId: parentInstanceId,
+        }),
+    });
+    if (result.kind === 'ours') claims.visualVersionId = result.id;
+    else foreignClaim = true;
+  }
+
+  if (target.regenMotion && target.motionLiveHash) {
+    const motionLiveHash = target.motionLiveHash;
+    const result = await claimOrReuse({
+      parentInstanceId,
+      getExisting: () =>
+        scopedDb.shotPromptVersions.getLivePending(
+          target.shotId,
+          motionLiveHash
+        ),
+      create: () =>
+        scopedDb.shotPromptVersions.createPending({
+          shotId: target.shotId,
+          pendingInputHash: motionLiveHash,
+          workflowRunId: parentInstanceId,
+        }),
+    });
+    if (result.kind === 'ours') claims.motionVersionId = result.id;
+    else foreignClaim = true;
+  }
+
+  if (target.regenImage) {
+    const imageResult = await claimImageArtifact({
+      scopedDb,
+      target,
+      sequenceId,
+      parentInstanceId,
+      visualVersionId: claims.visualVersionId,
+    });
+    if (imageResult.kind === 'ours') {
+      claims.imageVariantId = imageResult.id;
+    } else if (imageResult.kind === 'foreign') {
+      foreignClaim = true;
+    }
+  }
+
+  return { claims, foreignClaim };
+}
+
+type ClaimResult = { kind: 'ours'; id: string } | { kind: 'foreign' };
+
+/**
+ * Reuse our own live claim (step retry), treat anyone else's as foreign, or
+ * create a new pending row. Lost insert races (partial unique index) → foreign.
+ */
+async function claimOrReuse(args: {
+  parentInstanceId: string;
+  getExisting: () => Promise<{
+    id: string;
+    workflowRunId: string | null;
+  } | null>;
+  create: () => Promise<{ id: string }>;
+}): Promise<ClaimResult> {
+  const existing = await args.getExisting();
+  if (existing) {
+    return existing.workflowRunId === args.parentInstanceId
+      ? { kind: 'ours', id: existing.id }
+      : { kind: 'foreign' };
+  }
+  try {
+    const row = await args.create();
+    return { kind: 'ours', id: row.id };
+  } catch {
+    // Lost the insert race to a concurrent enqueue.
+    return { kind: 'foreign' };
+  }
+}
+
+async function claimImageArtifact(args: {
+  scopedDb: ScopedDb;
+  target: PlanTarget;
+  sequenceId: string;
+  parentInstanceId: string;
+  visualVersionId: string | null;
+}): Promise<ClaimResult | { kind: 'none' }> {
+  const { scopedDb, target, sequenceId, parentInstanceId, visualVersionId } =
+    args;
+  const liveClaims = await scopedDb.frameVariants.listLiveClaims(
+    target.frameId
+  );
+
+  if (target.regenVisual) {
+    // Chained render: only valid behind OUR visual claim. A foreign visual
+    // claim means someone else owns the prompt regen — do not chain onto it.
+    if (!visualVersionId) return { kind: 'foreign' };
+
+    const ours = liveClaims.find(
+      (c) => c.dependsOnVersionId === visualVersionId
+    );
+    if (ours) return { kind: 'ours', id: ours.id };
+
+    const row = await scopedDb.frameVariants.createPendingClaim({
+      frameId: target.frameId,
+      sequenceId,
+      model: target.imageModel,
+      dependsOnVersionId: visualVersionId,
+      workflowRunId: parentInstanceId,
+    });
+    return { kind: 'ours', id: row.id };
+  }
+
+  if (!target.imageLiveHash) return { kind: 'none' };
+
+  const existing = liveClaims.find(
+    (c) => c.pendingInputHash === target.imageLiveHash
+  );
+  if (existing) {
+    return existing.workflowRunId === parentInstanceId
+      ? { kind: 'ours', id: existing.id }
+      : { kind: 'foreign' };
+  }
+
+  try {
+    const row = await scopedDb.frameVariants.createPendingClaim({
+      frameId: target.frameId,
+      sequenceId,
+      model: target.imageModel,
+      pendingInputHash: target.imageLiveHash,
+      workflowRunId: parentInstanceId,
+    });
+    return { kind: 'ours', id: row.id };
+  } catch {
+    return { kind: 'foreign' };
+  }
+}

--- a/src/lib/shots/update-stale-plan.ts
+++ b/src/lib/shots/update-stale-plan.ts
@@ -96,7 +96,9 @@ export type PlanTarget = {
 
 /**
  * Pending rows claimed for one shot. A null slot for a set regen flag means
- * another run already holds a live claim — this run skips that artifact.
+ * either that artifact was not requested, or another run already holds a live
+ * claim for it (this run skips only that artifact; other non-null slots still
+ * regenerate).
  */
 export type ShotClaims = {
   visualVersionId: string | null;
@@ -105,8 +107,12 @@ export type ShotClaims = {
 };
 
 /**
- * A shot the plan could not act on. Distinct from a run failure: nothing was
- * attempted. Reported so a partial run cannot read as a clean success.
+ * Shots reported as incomplete work. Distinct from run failures:
+ * - no-anchor / no-scene / staleness-unknown: nothing planned for the shot.
+ * - already-in-flight: another run holds every live claim this run needed;
+ *   this run owns no claims for the shot. (If some artifacts were claimed
+ *   successfully and others were foreign, the shot is NOT listed here — the
+ *   run regenerates the ones it owns.)
  */
 export type SkippedShot = {
   shotId: string;
@@ -575,7 +581,14 @@ export async function claimTargets(args: {
       sequenceId,
       parentInstanceId,
     });
-    if (foreignClaim) {
+    // Only report already-in-flight when this run owns nothing for the shot.
+    // Partial ownership (e.g. visual ours, motion foreign) still regenerates
+    // the owned artifacts and must not read as "nothing attempted".
+    const ownsAny =
+      claims.visualVersionId !== null ||
+      claims.motionVersionId !== null ||
+      claims.imageVariantId !== null;
+    if (foreignClaim && !ownsAny) {
       skipped.push({ shotId: target.shotId, reason: 'already-in-flight' });
     }
     claimsByShot[target.shotId] = claims;
@@ -660,7 +673,8 @@ type ClaimResult = { kind: 'ours'; id: string } | { kind: 'foreign' };
 
 /**
  * Reuse our own live claim (step retry), treat anyone else's as foreign, or
- * create a new pending row. Lost insert races (partial unique index) → foreign.
+ * create a new pending row. Lost insert races (partial unique index) → foreign
+ * only when a live claim actually exists; other insert failures rethrow.
  */
 async function claimOrReuse(args: {
   parentInstanceId: string;
@@ -679,9 +693,16 @@ async function claimOrReuse(args: {
   try {
     const row = await args.create();
     return { kind: 'ours', id: row.id };
-  } catch {
-    // Lost the insert race to a concurrent enqueue.
-    return { kind: 'foreign' };
+  } catch (error) {
+    // Lost the insert race to a concurrent enqueue — only if a live claim
+    // is actually there. D1 blips / other constraint errors must surface.
+    const raced = await args.getExisting();
+    if (raced) {
+      return raced.workflowRunId === args.parentInstanceId
+        ? { kind: 'ours', id: raced.id }
+        : { kind: 'foreign' };
+    }
+    throw error;
   }
 }
 
@@ -738,7 +759,17 @@ async function claimImageArtifact(args: {
       workflowRunId: parentInstanceId,
     });
     return { kind: 'ours', id: row.id };
-  } catch {
-    return { kind: 'foreign' };
+  } catch (error) {
+    // Re-list live claims: unique-index race → foreign/ours; other errors rethrow.
+    const after = await scopedDb.frameVariants.listLiveClaims(target.frameId);
+    const raced = after.find(
+      (c) => c.pendingInputHash === target.imageLiveHash
+    );
+    if (raced) {
+      return raced.workflowRunId === parentInstanceId
+        ? { kind: 'ours', id: raced.id }
+        : { kind: 'foreign' };
+    }
+    throw error;
   }
 }

--- a/src/lib/workflow/run-outcome.ts
+++ b/src/lib/workflow/run-outcome.ts
@@ -35,6 +35,53 @@ export type WorkflowRunOutcome =
    */
   | { state: 'unknown' };
 
+/**
+ * Workflows that produce exactly ONE artifact — safe to terminate when that
+ * artifact's pending claim is cancelled (#1085). Parent orchestrators
+ * (update-stale-shots) are deliberately excluded: their run id is stamped on
+ * every claim they own, and terminating the parent would kill sibling shots'
+ * work. For parent-owned claims, cancellation is data-only — the running
+ * child discards its output against the cancelled row's status guard.
+ */
+const SINGLE_ARTIFACT_WORKFLOWS = new Set([
+  'frame-prompt',
+  'motion-prompt',
+  'image',
+]);
+
+/**
+ * Best-effort terminate of a single-artifact workflow run. Returns false —
+ * never throws — when the id is empty, unknown, not a single-artifact
+ * workflow, or the RPC fails; cancellation stays valid as a data-only state
+ * in all of those cases.
+ */
+export async function terminateSingleArtifactRun(
+  runId: string | null
+): Promise<boolean> {
+  if (!runId) return false;
+  const workflowName = runId.split('_')[1] ?? '';
+  if (!SINGLE_ARTIFACT_WORKFLOWS.has(workflowName)) return false;
+
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- getEnv()'s type is platform-dependent; CF runtime guarantees Cloudflare.Env shape with workflow bindings present
+  const env = getEnv() as unknown as CloudflareEnv;
+  const binding = getCfBindingForRunId(runId, env);
+  if (!binding) return false;
+  try {
+    const instance = await binding.get(runId);
+    try {
+      await instance.terminate();
+      return true;
+    } finally {
+      disposeRpcStub(instance);
+    }
+  } catch (error) {
+    logger.warn(`Failed to terminate workflow run ${runId}:`, {
+      data: error instanceof Error ? error.message : error,
+    });
+    return false;
+  }
+}
+
 export async function getWorkflowRunOutcome(
   runId: string
 ): Promise<WorkflowRunOutcome> {

--- a/src/lib/workflow/run-outcome.ts
+++ b/src/lib/workflow/run-outcome.ts
@@ -13,7 +13,10 @@
 
 import { getEnv } from '#env';
 import { disposeRpcStub } from '@/lib/workflow/rpc-dispose';
-import { getCfBindingForRunId } from '@/lib/workflow/trigger-bindings';
+import {
+  getCfBindingForRunId,
+  workflowNameFromRunId,
+} from '@/lib/workflow/trigger-bindings';
 import type { CloudflareEnv } from '@/lib/workflow/types';
 
 import { getLogger } from '@/lib/observability/logger';
@@ -59,8 +62,12 @@ export async function terminateSingleArtifactRun(
   runId: string | null
 ): Promise<boolean> {
   if (!runId) return false;
-  const workflowName = runId.split('_')[1] ?? '';
-  if (!SINGLE_ARTIFACT_WORKFLOWS.has(workflowName)) return false;
+  // Handles both top-level and parent-spawned child id shapes — an Update-all
+  // chained image child IS a single-artifact run and must be terminable.
+  const workflowName = workflowNameFromRunId(runId);
+  if (!workflowName || !SINGLE_ARTIFACT_WORKFLOWS.has(workflowName)) {
+    return false;
+  }
 
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- getEnv()'s type is platform-dependent; CF runtime guarantees Cloudflare.Env shape with workflow bindings present
   const env = getEnv() as unknown as CloudflareEnv;

--- a/src/lib/workflow/run-outcome.ts
+++ b/src/lib/workflow/run-outcome.ts
@@ -1,0 +1,73 @@
+/**
+ * Read a workflow run's terminal outcome, including its returned output.
+ *
+ * `resolveRunState` (reconcile.ts) answers "is this row still in flight?" for
+ * the cron sweep and deliberately discards the output. This is the other half:
+ * user-facing callers that need to know *what the run reported* — how much
+ * succeeded, what failed — and not merely that it stopped.
+ *
+ * The output is returned as `unknown` on purpose. Callers own its shape and
+ * should validate it (zod) rather than have this helper assert a type it
+ * cannot check.
+ */
+
+import { getEnv } from '#env';
+import { disposeRpcStub } from '@/lib/workflow/rpc-dispose';
+import { getCfBindingForRunId } from '@/lib/workflow/trigger-bindings';
+import type { CloudflareEnv } from '@/lib/workflow/types';
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'workflow', 'run-outcome']);
+
+export type WorkflowRunOutcome =
+  /** Queued, running, paused or waiting — no verdict yet. */
+  | { state: 'running' }
+  /** Reached the end of `runImpl`; `output` is whatever it returned. */
+  | { state: 'complete'; output: unknown }
+  /** `errored` or `terminated`. */
+  | { state: 'failed'; error: string }
+  /**
+   * The lookup itself failed, or the id doesn't map to a known binding (a
+   * legacy run id, or the mock id `triggerWorkflow` hands back under
+   * `E2E_TEST`). Distinct from `failed`: we have no verdict, so callers must
+   * not report an error the user can't act on.
+   */
+  | { state: 'unknown' };
+
+export async function getWorkflowRunOutcome(
+  runId: string
+): Promise<WorkflowRunOutcome> {
+  if (runId === '') return { state: 'unknown' };
+
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- getEnv()'s type is platform-dependent; CF runtime guarantees Cloudflare.Env shape with workflow bindings present
+  const env = getEnv() as unknown as CloudflareEnv;
+  const binding = getCfBindingForRunId(runId, env);
+  if (!binding) return { state: 'unknown' };
+
+  try {
+    // `binding.get()` hands back a WorkflowInstance RPC result; dispose it
+    // once the read is done so the runtime doesn't warn about a leaked result.
+    const instance = await binding.get(runId);
+    try {
+      const { status, output, error } = await instance.status();
+      if (status === 'complete') return { state: 'complete', output };
+      if (status === 'errored' || status === 'terminated') {
+        // Engine error shape is { name, message } — flatten it, same as
+        // await-child.ts does at its step boundary.
+        return {
+          state: 'failed',
+          error: error ? `${error.name}: ${error.message}` : `Run ${status}`,
+        };
+      }
+      return { state: 'running' };
+    } finally {
+      disposeRpcStub(instance);
+    }
+  } catch (error) {
+    logger.error(`Failed to read workflow outcome for ${runId}:`, {
+      data: error instanceof Error ? error.message : error,
+    });
+    return { state: 'unknown' };
+  }
+}

--- a/src/lib/workflow/trigger-bindings.test.ts
+++ b/src/lib/workflow/trigger-bindings.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, expect, test, vi } from 'vitest';
-import { triggerCfWorkflow } from './trigger-bindings';
+import { triggerCfWorkflow, workflowNameFromRunId } from './trigger-bindings';
 import type { CloudflareEnv } from '@/lib/workflow/types';
 
 // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal env stub: triggerCfWorkflow only reads VITE_APP_URL (via buildInstanceId)
@@ -55,6 +55,43 @@ const alreadyExists = () =>
   Promise.reject(
     new Error('(instance.already_exists) Instance already exists')
   );
+
+describe('workflowNameFromRunId', () => {
+  test('resolves top-level ids (envSlug_workflowName_suffix)', () => {
+    expect(
+      workflowNameFromRunId('localhost-3000_image_1785655915935-abc')
+    ).toBe('image');
+    expect(
+      workflowNameFromRunId('openstory_update-stale-shots_1785-uuid')
+    ).toBe('update-stale-shots');
+  });
+
+  test('resolves child ids from spawnAndAwaitChild (workflowName first segment)', () => {
+    // Child ids are the sanitized `<trigger-key>:<...>` semantic id + run tag
+    // — the reconciler false-failed these before segment[0] was tried (#1095
+    // review H1).
+    expect(workflowNameFromRunId('image_01KVEQFF_01KVEQG7_rw1yxay')).toBe(
+      'image'
+    );
+    expect(
+      workflowNameFromRunId('motion_01KYH2HK_01KYH2K9_seedance_v2_ro0648u')
+    ).toBe('motion');
+    expect(
+      workflowNameFromRunId('frame-prompt_01KVEQFF_01KVEQG7_rw1yxay')
+    ).toBe('frame-prompt');
+  });
+
+  test('prefers segment[1] so top-level ids are never misread as child ids', () => {
+    // Pathological envSlug that is itself a trigger key: segment[1] wins.
+    expect(workflowNameFromRunId('image_motion_suffix')).toBe('motion');
+  });
+
+  test('returns null for legacy / mock ids', () => {
+    expect(workflowNameFromRunId('qstash-run-abc123')).toBeNull();
+    expect(workflowNameFromRunId('mock_e2e_run')).toBeNull();
+    expect(workflowNameFromRunId('')).toBeNull();
+  });
+});
 
 describe('triggerCfWorkflow', () => {
   test('returns the created instance id on success', async () => {

--- a/src/lib/workflow/trigger-bindings.ts
+++ b/src/lib/workflow/trigger-bindings.ts
@@ -45,6 +45,7 @@ const TRIGGER_TO_BINDING: Record<string, keyof CloudflareEnv> = {
   'motion-prompts-batch': 'MOTION_PROMPT_BATCH_WORKFLOW',
   'motion-music-prompts': 'MOTION_MUSIC_PROMPTS_WORKFLOW',
   'regenerate-shots': 'REGENERATE_SHOTS_WORKFLOW',
+  'update-stale-shots': 'UPDATE_STALE_SHOTS_WORKFLOW',
   'recast-location': 'RECAST_LOCATION_WORKFLOW',
   'replace-element': 'REPLACE_ELEMENT_WORKFLOW',
   'scene-split': 'SCENE_SPLIT_WORKFLOW',

--- a/src/lib/workflow/trigger-bindings.ts
+++ b/src/lib/workflow/trigger-bindings.ts
@@ -93,19 +93,40 @@ export function getCfBindingForTriggerPath(
 }
 
 /**
+ * Extract the workflow (trigger) name from a stored run id. Two id shapes
+ * exist:
+ *
+ *   - Top-level runs (`buildInstanceId`): `${envSlug}_${workflowName}_${suffix}`
+ *     — the name is the second underscore-delimited segment.
+ *   - Child runs (`buildChildInstanceId`): the sanitized semantic child id,
+ *     `${workflowName}_${...}_r${hash}` (child ids are built as
+ *     `<trigger-key>:<...>` and `:` sanitizes to `_`) — the name is the FIRST
+ *     segment. Without this branch the reconciler treated every parent-spawned
+ *     child render as unresolvable and false-failed it mid-flight.
+ *
+ * Segment[1] is tried first so top-level ids can never be misread as child
+ * ids. Returns null when neither segment maps (legacy QStash ids, E2E mock
+ * ids).
+ */
+export function workflowNameFromRunId(runId: string): string | null {
+  const segments = runId.split('_');
+  for (const segment of [segments[1], segments[0]]) {
+    if (segment && segment in TRIGGER_TO_BINDING) return segment;
+  }
+  return null;
+}
+
+/**
  * Resolve the CF binding for a stored workflow run id, used by the
- * reconciler to query instance status. Run ids built by `buildInstanceId`
- * have the shape `${envSlug}_${workflowName}_${suffix}` — the workflow name
- * is the second underscore-delimited segment. Returns null for ids that don't
- * map to a known workflow (e.g. legacy QStash run ids), so callers can treat
- * them as unresolvable.
+ * reconciler to query instance status. Returns null for ids that don't map
+ * to a known workflow (see {@link workflowNameFromRunId}), so callers can
+ * treat them as unresolvable.
  */
 export function getCfBindingForRunId(
   runId: string,
   env: CloudflareEnv
 ): Workflow<unknown> | null {
-  const segments = runId.split('_');
-  const workflowName = segments[1];
+  const workflowName = workflowNameFromRunId(runId);
   if (!workflowName) return null;
   const bindingName = TRIGGER_TO_BINDING[workflowName];
   if (!bindingName) return null;

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -353,6 +353,21 @@ export type RegenerateShotSnapshot = {
  * workflow does not read live mutable state inside `context.run`. See
  * docs/architecture/workflow-snapshots-and-content-hash-staleness.md.
  */
+/**
+ * "Update all" (#1077): regenerate every stale artifact in scope, in
+ * dependency order (prompt → image per shot). The payload is deliberately
+ * tiny — the workflow's `compute-plan` step recomputes staleness from live
+ * scoped state at run start and persists the plan as its durable step result,
+ * so the target set is authoritative and immune to a stale client cache.
+ */
+export interface UpdateStaleShotsWorkflowInput extends SequenceWorkflowContext {
+  sequenceId: string;
+  /** Limit to one scene's shots (scene-scope Update all). */
+  sceneId?: string;
+  /** Limit to a single shot (shot-scope Update all). */
+  shotId?: string;
+}
+
 export interface RegenerateShotsWorkflowInput extends SequenceWorkflowContext {
   /** Shot IDs to regenerate */
   shotIds: string[];

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -111,6 +111,14 @@ export interface ImageWorkflowInput extends SequenceWorkflowContext {
    * (there is no primary to protect).
    */
   variantOnly?: boolean;
+  /**
+   * Pre-created pending `frame_variants` claim row to complete in place
+   * (#1085). When set, `set-generating-status` transitions THIS row to
+   * 'generating' instead of appending a fresh one, and `persist-result`
+   * completes it. Absent on legacy paths (variant adds, storyboard, preview),
+   * which keep the append-in-workflow behaviour.
+   */
+  targetVariantId?: string;
 }
 
 /**
@@ -538,6 +546,13 @@ export interface FramePromptWorkflowInput extends SequenceWorkflowContext {
    * publishes on workflows nobody is watching.
    */
   emitStreaming?: boolean;
+  /**
+   * Pre-created pending `frame_prompt_versions` row to complete in place
+   * (#1085). Set by enqueue points that claim their targets up front
+   * (regenerateShotPromptFn, UpdateStaleShotsWorkflow); absent on the
+   * analysis-pipeline path, which still appends on completion.
+   */
+  targetVersionId?: string;
 }
 
 export interface MotionPromptBatchWorkflowInput extends SequenceWorkflowContext {
@@ -579,6 +594,11 @@ export interface MotionPromptWorkflowInput extends SequenceWorkflowContext {
   startingFrameImageUrl?: string | null;
   /** See {@link FramePromptWorkflowInput.emitStreaming}. */
   emitStreaming?: boolean;
+  /**
+   * Pre-created pending `shot_prompt_versions` row (motion) to complete in
+   * place (#1085). See {@link FramePromptWorkflowInput.targetVersionId}.
+   */
+  targetVersionId?: string;
 }
 /**
  * Workflow result types

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -44,6 +44,7 @@ import type {
   StyleConfig,
 } from '@/lib/db/schema';
 import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
+import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
 import type { Json } from '@/types/database';
 import { z } from 'zod';
 import type { musicDesignResultSchema } from '../ai/response-schemas';
@@ -374,6 +375,13 @@ export interface UpdateStaleShotsWorkflowInput extends SequenceWorkflowContext {
   sceneId?: string;
   /** Limit to a single shot (shot-scope Update all). */
   shotId?: string;
+  /**
+   * Cascade depth (#1085): 'prompts' | 'images' | 'video' | 'music',
+   * cumulative — see src/lib/shots/update-stale-depth.ts. Absent on runs
+   * enqueued before the picker existed; treated as 'images' (the closest
+   * match to the original stale-only behaviour).
+   */
+  depth?: UpdateStaleDepth;
 }
 
 export interface RegenerateShotsWorkflowInput extends SequenceWorkflowContext {

--- a/src/lib/workflows/frame-prompt-workflow.ts
+++ b/src/lib/workflows/frame-prompt-workflow.ts
@@ -366,17 +366,38 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
           );
         }
         // The prompt is NOT written into `scene.metadata` any more (#713):
-        // `frame_prompt_versions.writeAiVersion` mirrors its text onto
-        // `frame.imagePrompt` and repoints `selectedImagePromptVersionId`,
-        // superseding any prior user-override automatically (the override stays in
-        // history and can be restored).
-        await scopedDb.framePromptVersions.writeAiVersion({
-          frameId,
-          text: result.visual.fullPrompt,
-          components: result.visual.components,
-          inputHash,
-          analysisModel: analysisModelId,
-        });
+        // the version write mirrors its text onto `frame.imagePrompt` and
+        // repoints `selectedImagePromptVersionId`, superseding any prior
+        // user-override automatically (the override stays in history and can
+        // be restored).
+        if (input.targetVersionId) {
+          // #1085: a pre-created pending claim row exists — complete it in
+          // place. Null result = the claim was cancelled mid-flight; the
+          // output is deliberately discarded (nothing mirrored, no event).
+          const completed =
+            await scopedDb.framePromptVersions.completePendingAiVersion({
+              versionId: input.targetVersionId,
+              frameId,
+              text: result.visual.fullPrompt,
+              components: result.visual.components,
+              inputHash,
+              analysisModel: analysisModelId,
+            });
+          if (!completed) {
+            logger.info(
+              `[FramePromptWorkflow:cf] claim ${input.targetVersionId} was cancelled mid-run; output discarded`
+            );
+            return;
+          }
+        } else {
+          await scopedDb.framePromptVersions.writeAiVersion({
+            frameId,
+            text: result.visual.fullPrompt,
+            components: result.visual.components,
+            inputHash,
+            analysisModel: analysisModelId,
+          });
+        }
 
         // The generated prompt now lives on `frame.imagePrompt` (mirror), not
         // in `metadata`; carry the base scene so the client refreshes the shot
@@ -403,6 +424,7 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
   protected override async onFailure({
     event,
     error,
+    scopedDb,
   }: {
     event: Readonly<WorkflowEvent<FramePromptWorkflowInput>>;
     error: string;
@@ -413,6 +435,26 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
       workflowRunId: event.instanceId,
       error,
     });
+    // #1085: fail the pending claim and cancel any chained image claim that
+    // was waiting on it — a run that died must not leave rows that read as
+    // "a job is fixing this" forever. Best-effort (the reconciler sweeps
+    // anything this misses).
+    if (payload.targetVersionId) {
+      try {
+        await scopedDb.framePromptVersions.markTerminal(
+          payload.targetVersionId,
+          'failed'
+        );
+        await scopedDb.frameVariants.cancelByDependency(
+          payload.targetVersionId,
+          'Upstream visual prompt generation failed'
+        );
+      } catch (dbErr) {
+        logger.warn('[FramePromptWorkflow:cf] failed to mark claim failed', {
+          err: dbErr,
+        });
+      }
+    }
     // Surface the failure on the per-shot channel so an actively-viewing
     // client can clear its streaming state and toast. Best-effort.
     try {

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -202,18 +202,45 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
         // is actually selected for this gen (#1070). Selecting this still later
         // restores that prompt so still + text stay paired.
         const frameForStamp = await scopedDb.frames.getById(frame.id);
-        const version = await scopedDb.frameVariants.appendVersion({
-          frameId: frame.id,
-          sequenceId: input.sequenceId,
-          kind: 'model',
-          model,
-          status: 'generating',
-          workflowRunId,
-          promptVersionId:
-            frameForStamp?.selectedImagePromptVersionId ??
-            frame.selectedImagePromptVersionId ??
-            null,
-        });
+        const promptVersionId =
+          frameForStamp?.selectedImagePromptVersionId ??
+          frame.selectedImagePromptVersionId ??
+          null;
+        let version;
+        if (input.targetVariantId) {
+          // #1085: a pre-created claim row exists — transition IT rather than
+          // appending. Null = the claim was cancelled before the render
+          // started; abandon the run without spending credits.
+          version = await scopedDb.frameVariants.claimForGeneration(
+            input.targetVariantId,
+            {
+              workflowRunId,
+              model,
+              promptVersionId,
+              // Direct-regen claims already carry the hash from enqueue;
+              // chained claims get it stamped here (the render's snapshot
+              // hash), so "updating" detection survives the upstream prompt
+              // completing.
+              pendingInputHash: input.snapshotInputHash ?? null,
+            }
+          );
+          if (!version) {
+            logger.info(
+              `[ImageWorkflow] claim ${input.targetVariantId} was cancelled before generation; skipping`
+            );
+            return null;
+          }
+        } else {
+          version = await scopedDb.frameVariants.appendVersion({
+            frameId: frame.id,
+            sequenceId: input.sequenceId,
+            kind: 'model',
+            model,
+            status: 'generating',
+            workflowRunId,
+            promptVersionId,
+          });
+        }
 
         // Primary regen claims auto-promote; last kickoff wins (#1070).
         // variantOnly add-model never claims the primary.
@@ -325,6 +352,18 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
             `[ImageWorkflow] Shot ${shotId} lost its anchor frame before select; skipping`
           );
           return { imageUrl: upload.url };
+        }
+
+        // A user cancel that raced the render wins: the completed image must
+        // not resurrect a cancelled claim row or repoint the selection (#1085).
+        if (input.targetVariantId) {
+          const claimNow = await scopedDb.frameVariants.getById(versionId);
+          if (claimNow && claimNow.status === 'cancelled') {
+            logger.info(
+              `[ImageWorkflow] claim ${versionId} was cancelled mid-render; discarding result`
+            );
+            return { imageUrl: upload.url };
+          }
         }
 
         // Complete the in-flight version. Its inputHash IS the snapshot hash —

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -2,18 +2,18 @@
  * Image generation workflow (#989: writes to `frames` / `frame_variants`).
  *
  * The still image is the FRAME's surface now. Each run:
- *   1. set-generating-status — flips the anchor frame to 'generating', records a
- *      user-edited prompt as a `frame_prompt_versions` row, and APPENDS an
- *      in-flight `frame_variants` version (kind='model').
+ *   1. set-generating-status — claim-or-append a `frame_variants` version, then
+ *      (unless variantOnly) flip the primary frame to 'generating'. With
+ *      `targetVariantId` (#1085) a pre-created pending claim is transitioned
+ *      in place via `claimForGeneration` (no append). Without it, a new
+ *      in-flight version is appended. Prep can exit null when the claim was
+ *      cancelled mid-flight or the anchor frame vanished.
  *   2. generate-image / deduct-credits / upload-image — unchanged.
- *   3. persist-result — completes the version, emits `image.generated`, then
- *      SELECT-OR-NOT: a new selection is a pointer repoint
- *      (`frameVariants.select`, which mirrors + emits `image.selected`), never an
- *      overwrite. `variantOnly` (adding a model) appends without selecting; a
- *      mid-flight input drift (snapshot ≠ current) appends a retained,
- *      stale-flagged version without repointing the primary. The old
- *      divergent-alternate machinery (`persistImageResult` / `divergedAt`) is
- *      retired — divergence is just "a version you didn't select".
+ *   3. persist-result — status-guarded complete (`completeIfLive`), emits
+ *      `image.generated`, then SELECT-OR-NOT: a new selection is a pointer
+ *      repoint (`frameVariants.select`), never an overwrite. `variantOnly`
+ *      (adding a model) appends without selecting; mid-flight input drift
+ *      retains a stale-flagged version without repointing the primary.
  */
 
 import { computeVisualPromptInputHash } from '@/lib/ai/input-hash';
@@ -62,8 +62,8 @@ type ImageWorkflowResult = {
 };
 
 /** Output of `set-generating-status`: the generation params plus the id of the
- * in-flight `frame_variants` version it appended (empty when there's no frame
- * context, e.g. preview mode or a shotless ad-hoc generation). */
+ * in-flight `frame_variants` version claimed or appended (empty when there's
+ * no frame context, e.g. preview mode or a shotless ad-hoc generation). */
 type PrepResult = {
   params: ImageGenerationParams;
   versionId: string;
@@ -273,7 +273,10 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
     );
 
     if (!prep) {
-      // The only null path above is a claim cancelled before the render.
+      // null prep = claim cancelled / unique-hash stand-down, OR anchor frame
+      // gone mid-run. Both are stand-downs for parents today (no imageUrl,
+      // cancelled: true) so Update all does not treat a missing frame as a
+      // hard stage failure.
       return {
         imageUrl: '',
         shotId: input.shotId,

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -52,6 +52,13 @@ type ImageWorkflowResult = {
   imageUrl: string;
   shotId?: string;
   sequenceId?: string;
+  /**
+   * The render's claim was cancelled by the user (before or during the
+   * render) and its result was discarded (#1085). Parents must treat this as
+   * a stand-down, not a success (nothing landed) and not a failure (the user
+   * asked for it).
+   */
+  cancelled?: boolean;
 };
 
 /** Output of `set-generating-status`: the generation params plus the id of the
@@ -183,21 +190,6 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
           });
         }
 
-        // Variant-only (adding a model) must not flip the primary frame to
-        // 'generating' — only this model's new version carries the in-flight
-        // state, so the picker can't trip staleness on the live selection.
-        if (!input.variantOnly) {
-          await scopedDb.frames.setImageGenerationStatus(
-            frame.id,
-            {
-              imageStatus: 'generating',
-              imageWorkflowRunId: workflowRunId,
-              imageModel: model,
-            },
-            { throwOnMissing: false }
-          );
-        }
-
         // Re-read after any prompt write so we stamp the prompt version that
         // is actually selected for this gen (#1070). Selecting this still later
         // restores that prompt so still + text stay paired.
@@ -242,9 +234,24 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
           });
         }
 
-        // Primary regen claims auto-promote; last kickoff wins (#1070).
-        // variantOnly add-model never claims the primary.
+        // Flip the primary frame to 'generating' only AFTER the claim held
+        // (#1095 review): flipping first meant a pre-render cancel abandoned
+        // the run with the frame stuck 'generating' forever. Variant-only
+        // (adding a model) never flips the primary — only this model's new
+        // version carries the in-flight state, so the picker can't trip
+        // staleness on the live selection.
         if (!input.variantOnly) {
+          await scopedDb.frames.setImageGenerationStatus(
+            frame.id,
+            {
+              imageStatus: 'generating',
+              imageWorkflowRunId: workflowRunId,
+              imageModel: model,
+            },
+            { throwOnMissing: false }
+          );
+          // Primary regen claims auto-promote; last kickoff wins (#1070).
+          // variantOnly add-model never claims the primary.
           await scopedDb.frames.setPendingPromoteVersionId(
             frame.id,
             version.id
@@ -266,10 +273,12 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
     );
 
     if (!prep) {
+      // The only null path above is a claim cancelled before the render.
       return {
         imageUrl: '',
         shotId: input.shotId,
         sequenceId: input.sequenceId,
+        cancelled: true,
       };
     }
 
@@ -339,136 +348,161 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
         return uploadImageToStorage({ imageUrl, teamId, sequenceId, shotId });
       });
 
-      const writeResult = await step.do('persist-result', async () => {
-        const promptHash = input.prompt ? simpleHash(input.prompt) : null;
-        const { model } = prep.params;
-        const versionId = prep.versionId;
+      const writeResult = await step.do(
+        'persist-result',
+        async (): Promise<{ imageUrl: string; cancelled?: boolean }> => {
+          const promptHash = input.prompt ? simpleHash(input.prompt) : null;
+          const { model } = prep.params;
+          const versionId = prep.versionId;
 
-        // Resolve the anchor frame (frame id ≠ shot id, #989) for the event
-        // target + selection repoint below.
-        const frame = await scopedDb.frames.getAnchorByShot(shotId);
-        if (!frame) {
-          logger.info(
-            `[ImageWorkflow] Shot ${shotId} lost its anchor frame before select; skipping`
-          );
-          return { imageUrl: upload.url };
-        }
-
-        // A user cancel that raced the render wins: the completed image must
-        // not resurrect a cancelled claim row or repoint the selection (#1085).
-        if (input.targetVariantId) {
-          const claimNow = await scopedDb.frameVariants.getById(versionId);
-          if (claimNow && claimNow.status === 'cancelled') {
+          // Resolve the anchor frame (frame id ≠ shot id, #989) for the event
+          // target + selection repoint below.
+          const frame = await scopedDb.frames.getAnchorByShot(shotId);
+          if (!frame) {
             logger.info(
-              `[ImageWorkflow] claim ${versionId} was cancelled mid-render; discarding result`
+              `[ImageWorkflow] Shot ${shotId} lost its anchor frame before select; skipping`
             );
             return { imageUrl: upload.url };
           }
-        }
 
-        // Complete the in-flight version. Its inputHash IS the snapshot hash —
-        // staleness of this version is its own concern (immutable once done).
-        await scopedDb.frameVariants.update(versionId, {
-          status: 'completed',
-          url: upload.url,
-          storagePath: upload.path,
-          previewUrl: null,
-          generatedAt: new Date(),
-          error: null,
-          promptHash,
-          inputHash: snapshotHash,
-        });
-
-        await scopedDb.sequenceEvents.record({
-          sequenceId,
-          actorId: input.userId,
-          kind: 'image.generated',
-          targetType: 'frame',
-          targetId: frame.id,
-          summary: `Generated ${model} image`,
-          data: { versionId, model, variantOnly: input.variantOnly ?? false },
-        });
-
-        const channel = getGenerationChannel(sequenceId);
-
-        // Adding a model — leave the primary selection untouched.
-        if (input.variantOnly) {
-          await channel.emit('generation.image:progress', {
-            shotId,
-            status: 'completed',
-            thumbnailUrl: upload.url,
-            model,
-            variantOnly: true,
-          });
-          return { imageUrl: upload.url };
-        }
-
-        // Re-read pending claim: last kickoff / explicit history select may have
-        // moved it since this run started (#1070).
-        const frameNow = await scopedDb.frames.getById(frame.id);
-        const shouldPromote = frameNow?.pendingPromoteVersionId === versionId;
-
-        if (shouldPromote) {
-          // Promote even if the prompt/refs drifted mid-flight — the still is
-          // stamped with its own inputHash and will surface as stale if the
-          // live prompt moved. Explicit selection is what cancels promote.
-          await scopedDb.frameVariants.select(frame.id, versionId, {
-            actorId: input.userId,
-          });
-          // A new still invalidates the shot's downstream video.
-          await scopedDb.shots.update(
-            shotId,
+          // Complete the in-flight version — status-guarded, so a user cancel
+          // that raced the render wins: the completed image must not resurrect
+          // a cancelled claim row or repoint the selection (#1085). Its
+          // inputHash IS the snapshot hash — staleness of this version is its
+          // own concern (immutable once done).
+          const completed = await scopedDb.frameVariants.completeIfLive(
+            versionId,
             {
-              videoUrl: null,
-              videoPath: null,
-              videoStatus: 'pending',
-              videoWorkflowRunId: null,
-              videoGeneratedAt: null,
-              videoError: null,
+              url: upload.url,
+              storagePath: upload.path,
+              previewUrl: null,
+              generatedAt: new Date(),
+              error: null,
+              promptHash,
+              inputHash: snapshotHash,
+            }
+          );
+          if (!completed) {
+            logger.info(
+              `[ImageWorkflow] version ${versionId} went terminal mid-render (user cancel); discarding result`
+            );
+            // Settle the primary frame the prep step flipped to 'generating' —
+            // without this the shot keeps a perpetual spinner (#1095 review).
+            if (!input.variantOnly) {
+              const frameNow = await scopedDb.frames.getById(frame.id);
+              await scopedDb.frames.setImageGenerationStatus(
+                frame.id,
+                {
+                  imageStatus: frameNow?.selectedImageVersionId
+                    ? 'completed'
+                    : 'pending',
+                  imageWorkflowRunId: null,
+                  imageError: null,
+                },
+                { throwOnMissing: false }
+              );
+              await scopedDb.frames.clearPendingPromoteVersionIdIf(
+                frame.id,
+                versionId
+              );
+            }
+            return { imageUrl: upload.url, cancelled: true };
+          }
+
+          await scopedDb.sequenceEvents.record({
+            sequenceId,
+            actorId: input.userId,
+            kind: 'image.generated',
+            targetType: 'frame',
+            targetId: frame.id,
+            summary: `Generated ${model} image`,
+            data: { versionId, model, variantOnly: input.variantOnly ?? false },
+          });
+
+          const channel = getGenerationChannel(sequenceId);
+
+          // Adding a model — leave the primary selection untouched.
+          if (input.variantOnly) {
+            await channel.emit('generation.image:progress', {
+              shotId,
+              status: 'completed',
+              thumbnailUrl: upload.url,
+              model,
+              variantOnly: true,
+            });
+            return { imageUrl: upload.url };
+          }
+
+          // Re-read pending claim: last kickoff / explicit history select may have
+          // moved it since this run started (#1070).
+          const frameNow = await scopedDb.frames.getById(frame.id);
+          const shouldPromote = frameNow?.pendingPromoteVersionId === versionId;
+
+          if (shouldPromote) {
+            // Promote even if the prompt/refs drifted mid-flight — the still is
+            // stamped with its own inputHash and will surface as stale if the
+            // live prompt moved. Explicit selection is what cancels promote.
+            await scopedDb.frameVariants.select(frame.id, versionId, {
+              actorId: input.userId,
+            });
+            // A new still invalidates the shot's downstream video.
+            await scopedDb.shots.update(
+              shotId,
+              {
+                videoUrl: null,
+                videoPath: null,
+                videoStatus: 'pending',
+                videoWorkflowRunId: null,
+                videoGeneratedAt: null,
+                videoError: null,
+              },
+              { throwOnMissing: false }
+            );
+            await channel.emit('generation.image:progress', {
+              shotId,
+              status: 'completed',
+              thumbnailUrl: upload.url,
+              model,
+            });
+            logger.info(`[ImageWorkflow] Uploaded + selected: ${upload.path}`);
+            return { imageUrl: upload.url };
+          }
+
+          // Not the promote target — finalize into history only. Reset in-flight
+          // frame status so we don't leave a perpetual generating spinner.
+          const settleStatus = frameNow?.selectedImageVersionId
+            ? 'completed'
+            : 'pending';
+          await scopedDb.frames.setImageGenerationStatus(
+            frame.id,
+            {
+              imageStatus: settleStatus,
+              imageWorkflowRunId: null,
+              imageError: null,
             },
             { throwOnMissing: false }
           );
+          // Clear pending only if it still points at us (shouldn't if user
+          // cancelled; belt-and-suspenders if claim was stale).
+          await scopedDb.frames.clearPendingPromoteVersionIdIf(
+            frame.id,
+            versionId
+          );
           await channel.emit('generation.image:progress', {
             shotId,
-            status: 'completed',
-            thumbnailUrl: upload.url,
+            status: settleStatus,
             model,
           });
-          logger.info(`[ImageWorkflow] Uploaded + selected: ${upload.path}`);
+          logger.info(
+            `[ImageWorkflow] Uploaded unselected (pending promote moved): ${upload.path}`
+          );
           return { imageUrl: upload.url };
         }
-
-        // Not the promote target — finalize into history only. Reset in-flight
-        // frame status so we don't leave a perpetual generating spinner.
-        const settleStatus = frameNow?.selectedImageVersionId
-          ? 'completed'
-          : 'pending';
-        await scopedDb.frames.setImageGenerationStatus(
-          frame.id,
-          {
-            imageStatus: settleStatus,
-            imageWorkflowRunId: null,
-            imageError: null,
-          },
-          { throwOnMissing: false }
-        );
-        // Clear pending only if it still points at us (shouldn't if user
-        // cancelled; belt-and-suspenders if claim was stale).
-        await scopedDb.frames.clearPendingPromoteVersionIdIf(
-          frame.id,
-          versionId
-        );
-        await channel.emit('generation.image:progress', {
-          shotId,
-          status: settleStatus,
-          model,
-        });
-        logger.info(
-          `[ImageWorkflow] Uploaded unselected (pending promote moved): ${upload.path}`
-        );
-        return { imageUrl: upload.url };
-      });
+      );
       imageUrl = writeResult.imageUrl;
+      if (writeResult.cancelled) {
+        return { imageUrl, shotId, sequenceId, cancelled: true };
+      }
     } else if (imageUrl && shotId && input.skipStorage) {
       await step.do('store-preview-url', async () => {
         const anchor = await scopedDb.frames.getAnchorByShot(shotId);

--- a/src/lib/workflows/motion-prompt-workflow.ts
+++ b/src/lib/workflows/motion-prompt-workflow.ts
@@ -157,21 +157,43 @@ export class MotionPromptWorkflow extends OpenStoryWorkflowEntrypoint<MotionProm
 
       await step.do('save-motion-prompt-to-db', async () => {
         // The motion prompt is NOT written into `scene.metadata` any more
-        // (#713). `writeAiVersion` decides ai-generated vs regenerated from
-        // history, appends the version, mirrors its text onto
-        // `shot.motionPrompt`, and repoints `selectedMotionPromptVersionId` —
-        // superseding any prior user override automatically (the override stays
-        // in history and can be restored).
-        await scopedDb.shotPromptVersions.writeAiVersion({
-          shotId,
-          text: motionPrompt.fullPrompt,
-          components: motionPrompt.components,
-          parameters: motionPrompt.parameters,
-          dialogue: motionPrompt.dialogue ?? null,
-          audio: motionPrompt.audio ?? null,
-          inputHash,
-          analysisModel: analysisModelId,
-        });
+        // (#713). The version write mirrors its text onto `shot.motionPrompt`
+        // and repoints `selectedMotionPromptVersionId` — superseding any prior
+        // user override automatically (the override stays in history and can
+        // be restored).
+        if (input.targetVersionId) {
+          // #1085: complete the pre-created pending claim in place. Null =
+          // cancelled mid-flight; the output is deliberately discarded.
+          const completed =
+            await scopedDb.shotPromptVersions.completePendingAiVersion({
+              versionId: input.targetVersionId,
+              shotId,
+              text: motionPrompt.fullPrompt,
+              components: motionPrompt.components,
+              parameters: motionPrompt.parameters,
+              dialogue: motionPrompt.dialogue ?? null,
+              audio: motionPrompt.audio ?? null,
+              inputHash,
+              analysisModel: analysisModelId,
+            });
+          if (!completed) {
+            logger.info(
+              `[MotionPromptWorkflow:cf] claim ${input.targetVersionId} was cancelled mid-run; output discarded`
+            );
+            return;
+          }
+        } else {
+          await scopedDb.shotPromptVersions.writeAiVersion({
+            shotId,
+            text: motionPrompt.fullPrompt,
+            components: motionPrompt.components,
+            parameters: motionPrompt.parameters,
+            dialogue: motionPrompt.dialogue ?? null,
+            audio: motionPrompt.audio ?? null,
+            inputHash,
+            analysisModel: analysisModelId,
+          });
+        }
 
         // The prompt lives on `shot.motionPrompt` (mirror) now, not metadata;
         // carry the base scene so the client refreshes the shot on this event.
@@ -194,12 +216,27 @@ export class MotionPromptWorkflow extends OpenStoryWorkflowEntrypoint<MotionProm
   protected override async onFailure({
     event,
     error,
+    scopedDb,
   }: {
     event: Readonly<WorkflowEvent<MotionPromptWorkflowInput>>;
     error: string;
     scopedDb: ScopedDb;
   }): Promise<void> {
     logger.error('[MotionPromptWorkflow:cf] Failed', { error });
+    // #1085: fail the pending claim so it stops reading as "updating".
+    // Best-effort — the reconciler sweeps anything this misses.
+    if (event.payload.targetVersionId) {
+      try {
+        await scopedDb.shotPromptVersions.markTerminal(
+          event.payload.targetVersionId,
+          'failed'
+        );
+      } catch (dbErr) {
+        logger.warn('[MotionPromptWorkflow:cf] failed to mark claim failed', {
+          err: dbErr,
+        });
+      }
+    }
     try {
       const payload = event.payload;
       if (payload.emitStreaming && payload.shotId) {

--- a/src/lib/workflows/update-stale-shots-workflow.test.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.test.ts
@@ -73,24 +73,93 @@ vi.doMock('@/lib/ai/prompt-context', () => ({
     })
   ),
 }));
+// Music-plan inputs (#1085 depth 'music'): deterministic summaries + live
+// hash so the stored-vs-live comparison is driven purely by the fixture's
+// stored `musicPromptInputHash`.
+const realMusicSummaries =
+  await import('@/lib/workflows/music-scene-summaries');
+vi.doMock('@/lib/workflows/music-scene-summaries', () => ({
+  ...realMusicSummaries,
+  buildMusicSceneSummaries: vi.fn(() => []),
+}));
+const realInputHash = await import('@/lib/ai/input-hash');
+vi.doMock('@/lib/ai/input-hash', () => ({
+  ...realInputHash,
+  computeMusicPromptInputHash: vi.fn(() => Promise.resolve('live-music-hash')),
+}));
 
 const { computePlan, claimTargets } =
   await import('./update-stale-shots-workflow');
 
-function buildScopedDb(shots: Shot[], frames: Frame[]): ScopedDb {
+type VideoFixture = {
+  segments?: Array<{
+    id: string;
+    sceneId: string;
+    selectedVideoVersionId: string | null;
+  }>;
+  versions?: Array<{
+    id: string;
+    renderSegmentId: string;
+    model: string;
+    status: string;
+    url: string | null;
+    previewUrl: string | null;
+    createdAt: Date;
+    manifest: Array<{
+      shotId: string;
+      motionPromptVersionId: string | null;
+      frameVersionId: string | null;
+    }>;
+  }>;
+  segFrames?: Array<{
+    shotId: string;
+    role: string;
+    selectedImageVersionId: string | null;
+  }>;
+};
+
+function buildScopedDb(
+  shots: Shot[],
+  frames: Frame[],
+  opts: {
+    video?: VideoFixture;
+    sequence?: Record<string, unknown>;
+  } = {}
+): ScopedDb {
   return asScopedDb({
     sequences: {
       getById: () =>
-        Promise.resolve({ id: 'seq-1', aspectRatio: '16:9', styleId: 'st-1' }),
+        Promise.resolve({
+          id: 'seq-1',
+          aspectRatio: '16:9',
+          styleId: 'st-1',
+          analysisModel: null,
+          musicPromptInputHash: null,
+          musicUrl: null,
+          musicStatus: 'pending',
+          ...opts.sequence,
+        }),
     },
     shots: {
       listBySequence: () => Promise.resolve(shots),
       ensureAnchorFrames: () => Promise.resolve(undefined),
     },
-    frames: { listAnchorsBySequence: () => Promise.resolve(frames) },
+    frames: {
+      listAnchorsBySequence: () => Promise.resolve(frames),
+      listBySequence: () => Promise.resolve(opts.video?.segFrames ?? []),
+    },
     characters: { listWithSheets: () => Promise.resolve([]) },
     sequenceLocations: { listWithReferences: () => Promise.resolve([]) },
     sequenceElements: { list: () => Promise.resolve([]) },
+    renderSegments: {
+      listBySequence: () => Promise.resolve(opts.video?.segments ?? []),
+    },
+    videoVariants: {
+      listBySequence: () => Promise.resolve(opts.video?.versions ?? []),
+    },
+    sequenceMusicPromptVersions: {
+      getLatest: () => Promise.resolve(null),
+    },
   });
 }
 
@@ -103,10 +172,15 @@ function asScopedDb<T>(stub: T): ScopedDb {
 const plan = (
   shots: Shot[],
   frames: Frame[],
-  scope: { sceneId?: string; shotId?: string } = {}
+  scope: {
+    sceneId?: string;
+    shotId?: string;
+    depth?: 'prompts' | 'images' | 'video' | 'music';
+    db?: ScopedDb;
+  } = {}
 ) =>
   computePlan({
-    scopedDb: buildScopedDb(shots, frames),
+    scopedDb: scope.db ?? buildScopedDb(shots, frames),
     sequenceId: 'seq-1',
     ...scope,
   });
@@ -120,14 +194,31 @@ describe('computePlan — what gets regenerated', () => {
     expect(result.skipped).toEqual([]);
   });
 
-  it('does not cascade: a stale visual prompt leaves a fresh image alone', async () => {
-    stalenessByShot.set('shot-1', { ...FRESH, visualPrompt: 'stale' });
-    const result = await plan([makeShot()], [makeFrame()]);
+  it("depth 'prompts' never renders: a stale visual prompt leaves even a stale image alone", async () => {
+    stalenessByShot.set('shot-1', {
+      ...FRESH,
+      visualPrompt: 'stale',
+      thumbnail: 'stale',
+    });
+    const result = await plan([makeShot()], [makeFrame()], {
+      depth: 'prompts',
+    });
     expect(result.targets).toHaveLength(1);
     expect(result.targets[0]).toMatchObject({
       regenVisual: true,
       regenMotion: false,
       regenImage: false,
+      regenVideo: false,
+    });
+  });
+
+  it("depth 'images' (default) cascades: a regenerating visual prompt re-renders its currently-fresh image", async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, visualPrompt: 'stale' });
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0]).toMatchObject({
+      regenVisual: true,
+      regenImage: true,
     });
   });
 
@@ -167,6 +258,170 @@ describe('computePlan — what gets regenerated', () => {
   it('reports a shot still awaiting script analysis', async () => {
     const result = await plan([makeShot({ metadata: null })], [makeFrame()]);
     expect(result.skipped).toEqual([{ shotId: 'shot-1', reason: 'no-scene' }]);
+  });
+});
+
+describe("computePlan — depth 'video' (#1085)", () => {
+  /** One shot, one segment, one selected completed video whose manifest may
+   * or may not match the shot's current pointers. */
+  const videoShot = () =>
+    makeShot({
+      orderIndex: 0,
+      renderSegmentId: 'seg-1',
+      selectedMotionPromptVersionId: 'mpv-1',
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- stub
+    } as Partial<Shot>);
+  const videoFixture = (opts?: {
+    manifestMotionId?: string;
+    selected?: boolean;
+    generating?: boolean;
+  }): VideoFixture => ({
+    segments: [
+      {
+        id: 'seg-1',
+        sceneId: 'scene-1',
+        selectedVideoVersionId: (opts?.selected ?? true) ? 'vv-1' : null,
+      },
+    ],
+    versions: [
+      {
+        id: 'vv-1',
+        renderSegmentId: 'seg-1',
+        model: 'kling',
+        status: 'completed',
+        url: 'https://example.com/v.mp4',
+        previewUrl: null,
+        createdAt: new Date(0),
+        manifest: [
+          {
+            shotId: 'shot-1',
+            motionPromptVersionId: opts?.manifestMotionId ?? 'mpv-1',
+            frameVersionId: 'fv-1',
+          },
+        ],
+      },
+      ...(opts?.generating
+        ? [
+            {
+              id: 'vv-2',
+              renderSegmentId: 'seg-1',
+              model: 'kling',
+              status: 'generating',
+              url: null,
+              previewUrl: null,
+              createdAt: new Date(0),
+              manifest: [],
+            },
+          ]
+        : []),
+    ],
+    segFrames: [
+      { shotId: 'shot-1', role: 'first', selectedImageVersionId: 'fv-1' },
+    ],
+  });
+  const videoDb = (opts?: Parameters<typeof videoFixture>[0]) =>
+    buildScopedDb([videoShot()], [makeFrame()], { video: videoFixture(opts) });
+
+  it('re-renders an existing video when its motion prompt regenerates in this run', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, motionPrompt: 'stale' });
+    const result = await plan([videoShot()], [makeFrame()], {
+      depth: 'video',
+      db: videoDb(),
+    });
+    expect(result.targets[0]).toMatchObject({
+      regenMotion: true,
+      regenVideo: true,
+    });
+  });
+
+  it("depth 'images' never touches video even with a stale upstream", async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, motionPrompt: 'stale' });
+    const result = await plan([videoShot()], [makeFrame()], {
+      depth: 'images',
+      db: videoDb(),
+    });
+    expect(result.targets[0]).toMatchObject({ regenVideo: false });
+  });
+
+  it('re-renders a video whose manifest already diverged, with no other stale artifact', async () => {
+    const result = await plan([videoShot()], [makeFrame()], {
+      depth: 'video',
+      db: videoDb({ manifestMotionId: 'mpv-0' }),
+    });
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0]).toMatchObject({
+      regenVisual: false,
+      regenMotion: false,
+      regenImage: false,
+      regenVideo: true,
+    });
+  });
+
+  it('never renders a FIRST video, and leaves an in-flight render alone', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, motionPrompt: 'stale' });
+    const noVideo = await plan([videoShot()], [makeFrame()], {
+      depth: 'video',
+      db: videoDb({ selected: false }),
+    });
+    expect(noVideo.targets[0]).toMatchObject({ regenVideo: false });
+
+    const inFlight = await plan([videoShot()], [makeFrame()], {
+      depth: 'video',
+      db: videoDb({ generating: true }),
+    });
+    expect(inFlight.targets[0]).toMatchObject({ regenVideo: false });
+  });
+});
+
+describe("computePlan — depth 'music' (#1085)", () => {
+  it("is null below depth 'music'", async () => {
+    const result = await plan([makeShot()], [makeFrame()], { depth: 'video' });
+    expect(result.music).toBeNull();
+  });
+
+  it('regenerates a stale music prompt and cascades onto an existing track', async () => {
+    const db = buildScopedDb([makeShot()], [makeFrame()], {
+      sequence: {
+        musicPromptInputHash: 'old-music-hash',
+        musicUrl: 'https://example.com/m.mp3',
+        musicStatus: 'completed',
+      },
+    });
+    const result = await plan([makeShot()], [makeFrame()], {
+      depth: 'music',
+      db,
+    });
+    expect(result.music).toEqual({ regenPrompt: true, regenTrack: true });
+  });
+
+  it('never creates a first prompt or track (untracked / no music)', async () => {
+    const untracked = await plan([makeShot()], [makeFrame()], {
+      depth: 'music',
+    });
+    expect(untracked.music).toEqual({ regenPrompt: false, regenTrack: false });
+
+    const promptOnly = await plan([makeShot()], [makeFrame()], {
+      depth: 'music',
+      db: buildScopedDb([makeShot()], [makeFrame()], {
+        sequence: { musicPromptInputHash: 'old-music-hash', musicUrl: null },
+      }),
+    });
+    expect(promptOnly.music).toEqual({ regenPrompt: true, regenTrack: false });
+  });
+
+  it('leaves a fresh music prompt and its track alone', async () => {
+    const db = buildScopedDb([makeShot()], [makeFrame()], {
+      sequence: {
+        musicPromptInputHash: 'live-music-hash',
+        musicUrl: 'https://example.com/m.mp3',
+        musicStatus: 'completed',
+      },
+    });
+    const result = await plan([makeShot()], [makeFrame()], {
+      depth: 'music',
+      db,
+    });
+    expect(result.music).toEqual({ regenPrompt: false, regenTrack: false });
   });
 });
 
@@ -215,6 +470,7 @@ describe('claimTargets (#1085)', () => {
       motionLiveHash: 'mh',
       imageLiveHash: 'ih',
       imageModel: 'nano_banana_2',
+      regenVideo: false,
       ...overrides,
     };
   }

--- a/src/lib/workflows/update-stale-shots-workflow.test.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.test.ts
@@ -17,6 +17,11 @@ const FRESH: ShotStalenessResult = {
   thumbnail: 'fresh',
   visualPrompt: 'fresh',
   motionPrompt: 'fresh',
+  liveHashes: {
+    thumbnail: 'live-thumb',
+    visualPrompt: 'live-visual',
+    motionPrompt: 'live-motion',
+  },
 };
 
 // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub; computePlan only reads sceneId off the scene
@@ -69,7 +74,8 @@ vi.doMock('@/lib/ai/prompt-context', () => ({
   ),
 }));
 
-const { computePlan } = await import('./update-stale-shots-workflow');
+const { computePlan, claimTargets } =
+  await import('./update-stale-shots-workflow');
 
 function buildScopedDb(shots: Shot[], frames: Frame[]): ScopedDb {
   return asScopedDb({
@@ -161,6 +167,176 @@ describe('computePlan — what gets regenerated', () => {
   it('reports a shot still awaiting script analysis', async () => {
     const result = await plan([makeShot({ metadata: null })], [makeFrame()]);
     expect(result.skipped).toEqual([{ shotId: 'shot-1', reason: 'no-scene' }]);
+  });
+});
+
+describe("computePlan — 'updating' dedup (#1085)", () => {
+  it('does not target an artifact already covered by a live claim', async () => {
+    stalenessByShot.set('shot-1', {
+      ...FRESH,
+      visualPrompt: 'updating',
+      motionPrompt: 'stale',
+    });
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0]).toMatchObject({
+      regenVisual: false,
+      regenMotion: true,
+    });
+  });
+
+  it('carries the live hashes the claim rows will be stamped with', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, visualPrompt: 'stale' });
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets[0]).toMatchObject({
+      visualLiveHash: 'live-visual',
+      motionLiveHash: 'live-motion',
+      imageLiveHash: 'live-thumb',
+    });
+  });
+});
+
+describe('claimTargets (#1085)', () => {
+  type PendingRow = { id: string; workflowRunId: string | null };
+
+  function makeTarget(
+    overrides: Partial<Parameters<typeof claimTargets>[0]['targets'][number]>
+  ) {
+    return {
+      shotId: 'shot-1',
+      frameId: 'frame-1',
+      beforeShotId: null,
+      afterShotId: null,
+      startingFrameImageUrl: null,
+      regenVisual: false,
+      regenMotion: false,
+      regenImage: false,
+      visualLiveHash: 'vh',
+      motionLiveHash: 'mh',
+      imageLiveHash: 'ih',
+      imageModel: 'nano_banana_2',
+      ...overrides,
+    };
+  }
+
+  function buildClaimDb(opts: {
+    existingVisual?: PendingRow | null;
+    existingMotion?: PendingRow | null;
+    liveImageClaims?: Array<{
+      id: string;
+      workflowRunId: string | null;
+      pendingInputHash: string | null;
+      dependsOnVersionId: string | null;
+    }>;
+  }) {
+    const created = {
+      visual: [] as unknown[],
+      motion: [] as unknown[],
+      image: [] as unknown[],
+    };
+    let seq = 0;
+    const db = asScopedDb({
+      framePromptVersions: {
+        getLivePending: () => Promise.resolve(opts.existingVisual ?? null),
+        createPending: (input: unknown) => {
+          created.visual.push(input);
+          return Promise.resolve({ id: `fpv-${++seq}` });
+        },
+      },
+      shotPromptVersions: {
+        getLivePending: () => Promise.resolve(opts.existingMotion ?? null),
+        createPending: (input: unknown) => {
+          created.motion.push(input);
+          return Promise.resolve({ id: `spv-${++seq}` });
+        },
+      },
+      frameVariants: {
+        listLiveClaims: () => Promise.resolve(opts.liveImageClaims ?? []),
+        createPendingClaim: (input: unknown) => {
+          created.image.push(input);
+          return Promise.resolve({ id: `fv-${++seq}` });
+        },
+      },
+    });
+    return { db, created };
+  }
+
+  it('creates one pending row per artifact and chains the image onto the visual claim', async () => {
+    const { db, created } = buildClaimDb({});
+    const result = await claimTargets({
+      scopedDb: db,
+      targets: [
+        makeTarget({ regenVisual: true, regenMotion: true, regenImage: true }),
+      ],
+      sequenceId: 'seq-1',
+      parentInstanceId: 'run-1',
+    });
+
+    expect(created.visual).toHaveLength(1);
+    expect(created.motion).toHaveLength(1);
+    expect(created.image).toHaveLength(1);
+    expect(created.visual[0]).toMatchObject({
+      frameId: 'frame-1',
+      pendingInputHash: 'vh',
+      workflowRunId: 'run-1',
+    });
+    // Chained image: dependency edge, no direct hash claim.
+    expect(created.image[0]).toMatchObject({
+      dependsOnVersionId: result.claimsByShot['shot-1']?.visualVersionId,
+    });
+    expect(created.image[0]).not.toHaveProperty('pendingInputHash', 'ih');
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('direct image regen (prompt fresh) claims with the image live hash', async () => {
+    const { db, created } = buildClaimDb({});
+    await claimTargets({
+      scopedDb: db,
+      targets: [makeTarget({ regenImage: true })],
+      sequenceId: 'seq-1',
+      parentInstanceId: 'run-1',
+    });
+    expect(created.image[0]).toMatchObject({
+      pendingInputHash: 'ih',
+      workflowRunId: 'run-1',
+    });
+  });
+
+  it('reuses its OWN existing claim on a step retry instead of duplicating', async () => {
+    const { db, created } = buildClaimDb({
+      existingVisual: { id: 'fpv-prior', workflowRunId: 'run-1' },
+    });
+    const result = await claimTargets({
+      scopedDb: db,
+      targets: [makeTarget({ regenVisual: true })],
+      sequenceId: 'seq-1',
+      parentInstanceId: 'run-1',
+    });
+    expect(created.visual).toHaveLength(0);
+    expect(result.claimsByShot['shot-1']?.visualVersionId).toBe('fpv-prior');
+    expect(result.skipped).toEqual([]);
+  });
+
+  it("skips an artifact claimed by ANOTHER run and reports 'already-in-flight'", async () => {
+    const { db, created } = buildClaimDb({
+      existingVisual: { id: 'fpv-foreign', workflowRunId: 'other-run' },
+    });
+    const result = await claimTargets({
+      scopedDb: db,
+      targets: [makeTarget({ regenVisual: true, regenImage: true })],
+      sequenceId: 'seq-1',
+      parentInstanceId: 'run-1',
+    });
+    expect(created.visual).toHaveLength(0);
+    // Chained image must not chain onto a foreign claim.
+    expect(created.image).toHaveLength(0);
+    expect(result.claimsByShot['shot-1']).toMatchObject({
+      visualVersionId: null,
+      imageVariantId: null,
+    });
+    expect(result.skipped).toEqual([
+      { shotId: 'shot-1', reason: 'already-in-flight' },
+    ]);
   });
 });
 

--- a/src/lib/workflows/update-stale-shots-workflow.test.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.test.ts
@@ -1,0 +1,225 @@
+/**
+ * `computePlan` decides what "Update all" (#1077) regenerates — and therefore
+ * what the user is billed for. These cover the gating rules that are cheap to
+ * regress and expensive to get wrong: only-currently-stale targeting, the
+ * never-create-a-first-still guard, the deliberate no-cascade, scope
+ * precedence, and the skip reporting that stops a partial run reading as a
+ * clean one.
+ */
+
+import type { Frame, Shot } from '@/lib/db/schema';
+import type { ScopedDb } from '@/lib/db/scoped';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import type { ShotStalenessResult } from '@/lib/shots/shot-staleness';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FRESH: ShotStalenessResult = {
+  thumbnail: 'fresh',
+  visualPrompt: 'fresh',
+  motionPrompt: 'fresh',
+};
+
+// oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub; computePlan only reads sceneId off the scene
+const scene = { sceneId: 'scene-1' } as unknown as Scene;
+
+function makeShot(overrides: Partial<Shot> = {}): Shot {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Shot stub exposing only what computePlan reads
+  return {
+    id: 'shot-1',
+    sceneId: 'scene-1',
+    metadata: scene,
+    ...overrides,
+  } as unknown as Shot;
+}
+
+function makeFrame(overrides: Partial<Frame> = {}): Frame {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Frame stub exposing only what computePlan reads
+  return {
+    id: 'frame-1',
+    shotId: 'shot-1',
+    imageUrl: 'https://example.com/a.jpg',
+    ...overrides,
+  } as unknown as Frame;
+}
+
+/** Staleness keyed by shot id; anything unlisted reads fresh. */
+const stalenessByShot = new Map<string, ShotStalenessResult>();
+
+vi.doMock('@/lib/shots/shot-staleness', () => ({
+  computeShotStaleness: vi.fn(
+    ({ shot }: { shot: Shot }) => stalenessByShot.get(shot.id) ?? FRESH
+  ),
+}));
+vi.doMock('@/lib/scenes/scene-script', () => ({
+  loadSelectedScriptsBySequence: vi.fn(() => Promise.resolve(new Map())),
+  resolveSceneForShot: vi.fn((shot: Shot) => ({
+    scene: shot.metadata ?? null,
+    script: null,
+  })),
+}));
+vi.doMock('@/lib/ai/prompt-context', () => ({
+  loadShotPromptContext: vi.fn(() =>
+    Promise.resolve({
+      characterBible: [],
+      locationBible: [],
+      elementBible: [],
+      styleConfig: {},
+      analysisModel: 'x',
+    })
+  ),
+}));
+
+const { computePlan } = await import('./update-stale-shots-workflow');
+
+function buildScopedDb(shots: Shot[], frames: Frame[]): ScopedDb {
+  return asScopedDb({
+    sequences: {
+      getById: () =>
+        Promise.resolve({ id: 'seq-1', aspectRatio: '16:9', styleId: 'st-1' }),
+    },
+    shots: {
+      listBySequence: () => Promise.resolve(shots),
+      ensureAnchorFrames: () => Promise.resolve(undefined),
+    },
+    frames: { listAnchorsBySequence: () => Promise.resolve(frames) },
+    characters: { listWithSheets: () => Promise.resolve([]) },
+    sequenceLocations: { listWithReferences: () => Promise.resolve([]) },
+    sequenceElements: { list: () => Promise.resolve([]) },
+  });
+}
+
+/** Minimal ScopedDb stub exposing only the namespaces computePlan touches. */
+function asScopedDb<T>(stub: T): ScopedDb {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
+  return stub as unknown as ScopedDb;
+}
+
+const plan = (
+  shots: Shot[],
+  frames: Frame[],
+  scope: { sceneId?: string; shotId?: string } = {}
+) =>
+  computePlan({
+    scopedDb: buildScopedDb(shots, frames),
+    sequenceId: 'seq-1',
+    ...scope,
+  });
+
+beforeEach(() => stalenessByShot.clear());
+
+describe('computePlan — what gets regenerated', () => {
+  it('targets nothing when every artifact reads fresh', async () => {
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets).toEqual([]);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('does not cascade: a stale visual prompt leaves a fresh image alone', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, visualPrompt: 'stale' });
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0]).toMatchObject({
+      regenVisual: true,
+      regenMotion: false,
+      regenImage: false,
+    });
+  });
+
+  it('never renders a first still: a stale thumbnail on a shot with no image is not a target', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, thumbnail: 'stale' });
+    const result = await plan([makeShot()], [makeFrame({ imageUrl: null })]);
+    expect(result.targets).toEqual([]);
+  });
+
+  it('re-renders a stale thumbnail when an image already exists', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, thumbnail: 'stale' });
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets[0]).toMatchObject({
+      regenImage: true,
+      regenVisual: false,
+    });
+  });
+
+  it('reports a shot whose staleness could not be computed instead of dropping it', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, visualPrompt: 'unknown' });
+    const result = await plan([makeShot()], [makeFrame()]);
+    expect(result.targets).toEqual([]);
+    expect(result.skipped).toEqual([
+      { shotId: 'shot-1', reason: 'staleness-unknown' },
+    ]);
+  });
+
+  it('reports a shot with no anchor frame rather than silently skipping it', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, visualPrompt: 'stale' });
+    const result = await plan([makeShot()], []);
+    expect(result.targets).toEqual([]);
+    expect(result.skipped).toEqual([
+      { shotId: 'shot-1', reason: 'no-anchor-frame' },
+    ]);
+  });
+
+  it('reports a shot still awaiting script analysis', async () => {
+    const result = await plan([makeShot({ metadata: null })], [makeFrame()]);
+    expect(result.skipped).toEqual([{ shotId: 'shot-1', reason: 'no-scene' }]);
+  });
+});
+
+describe('computePlan — scope', () => {
+  const shots = [
+    makeShot({ id: 'shot-1', sceneId: 'scene-1' }),
+    makeShot({ id: 'shot-2', sceneId: 'scene-1' }),
+    makeShot({ id: 'shot-3', sceneId: 'scene-2' }),
+  ];
+  const frames = [
+    makeFrame({ id: 'f1', shotId: 'shot-1' }),
+    makeFrame({ id: 'f2', shotId: 'shot-2' }),
+    makeFrame({ id: 'f3', shotId: 'shot-3' }),
+  ];
+  const allStale = () => {
+    for (const id of ['shot-1', 'shot-2', 'shot-3'])
+      stalenessByShot.set(id, { ...FRESH, visualPrompt: 'stale' });
+  };
+
+  it('covers every shot when neither sceneId nor shotId is given', async () => {
+    allStale();
+    const result = await plan(shots, frames);
+    expect(result.targets.map((t) => t.shotId)).toEqual([
+      'shot-1',
+      'shot-2',
+      'shot-3',
+    ]);
+  });
+
+  it('limits to one scene', async () => {
+    allStale();
+    const result = await plan(shots, frames, { sceneId: 'scene-1' });
+    expect(result.targets.map((t) => t.shotId)).toEqual(['shot-1', 'shot-2']);
+  });
+
+  it('lets shotId win over sceneId — a one-shot update never widens', async () => {
+    allStale();
+    const result = await plan(shots, frames, {
+      sceneId: 'scene-1',
+      shotId: 'shot-3',
+    });
+    expect(result.targets.map((t) => t.shotId)).toEqual(['shot-3']);
+  });
+});
+
+describe('computePlan — durable step-result size', () => {
+  it('keeps scene bodies out of the plan (1 MiB step-result cap)', async () => {
+    stalenessByShot.set('shot-1', { ...FRESH, motionPrompt: 'stale' });
+    const result = await plan(
+      [makeShot({ id: 'shot-0' }), makeShot(), makeShot({ id: 'shot-2' })],
+      [makeFrame()]
+    );
+    const target = result.targets[0];
+    expect(target).toBeDefined();
+    // Neighbours are carried as ids, resolved to scenes per shot at spawn time.
+    expect(target).toMatchObject({
+      beforeShotId: 'shot-0',
+      afterShotId: 'shot-2',
+    });
+    expect(JSON.stringify(target)).not.toContain('sceneId');
+  });
+});

--- a/src/lib/workflows/update-stale-shots-workflow.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.ts
@@ -1,0 +1,599 @@
+/**
+ * "Update all" (#1077) — durable server-side regeneration of every artifact
+ * in scope (a shot, a scene, or the whole sequence) that reads stale *right
+ * now*. One artifact per stale flag, no cascade: regenerating a visual prompt
+ * outdates the shot's image, but that image is only re-rendered if it was
+ * already stale itself. The user sees the new staleness afterwards and can
+ * run Update all again. (Cascading is deliberately deferred to a later issue.)
+ *
+ * Per shot:
+ *
+ *   visual prompt stale → FramePromptWorkflow child
+ *   motion prompt stale → MotionPromptWorkflow child   (no auto video render)
+ *   image stale         → ImageWorkflow child
+ *
+ * When both the visual prompt and the image are independently stale, the
+ * image waits on the prompt — that is dependency ordering, not a cascade;
+ * rendering in parallel would burn credits on the prompt we're replacing.
+ *
+ * Concurrency model — no locks, self-correcting via input hashes:
+ *
+ *   - The PLAN (which shots, which artifacts) is computed from live scoped
+ *     state in the `compute-plan` step and persisted as its durable result:
+ *     frozen at run start, identical across replays. Edits made mid-run
+ *     can't add or remove targets — they simply produce new staleness that
+ *     the indicators surface after the run. The plan holds ids and flags
+ *     only; scene bodies are materialised per shot in `prepare-prompt-*` to
+ *     keep the step result under CF's 1 MiB cap.
+ *   - Each prompt child gets its inputs snapshotted in its own
+ *     `prepare-prompt-*` step (#991 — leaves never read the DB mid-run) and
+ *     stamps the hash of the inputs it actually used, so a mid-run script
+ *     edit leaves the new prompt honestly stale again rather than silently
+ *     wrong.
+ *   - The image step deliberately re-reads CURRENT state after its prompt
+ *     child completes (`prepare-image-*`): if the user hand-edited the
+ *     prompt in the gap, the render uses their newer text (last-write-wins
+ *     on intent) and stamps its hash accordingly.
+ *
+ * Failures are per-shot: one child failing (including an insufficient-credits
+ * preflight on an image) leaves that artifact stale and visible; siblings
+ * proceed.
+ */
+
+import {
+  DEFAULT_ANALYSIS_MODEL,
+  getAnalysisModelById,
+} from '@/lib/ai/models.config';
+import { loadShotPromptContext } from '@/lib/ai/prompt-context';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import type { ScopedDb } from '@/lib/db/scoped';
+import {
+  loadSelectedScriptsBySequence,
+  resolveSceneForShot,
+} from '@/lib/scenes/scene-script';
+import { prepareShotImageWorkflowInput } from '@/lib/shots/shot-image-input';
+import {
+  computeShotStaleness,
+  type ShotStalenessRefs,
+} from '@/lib/shots/shot-staleness';
+import { isInsufficientCreditsError } from '@/lib/errors';
+import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
+import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { WorkflowValidationError } from '@/lib/workflow/errors';
+import type {
+  FramePromptWorkflowInput,
+  ImageWorkflowInput,
+  MotionPromptWorkflowInput,
+  UpdateStaleShotsWorkflowInput,
+} from '@/lib/workflow/types';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import { NonRetryableError } from 'cloudflare:workflows';
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'workflow', 'update-stale-shots']);
+
+const PARENT_BINDING_NAME = 'UPDATE_STALE_SHOTS_WORKFLOW';
+
+type UpdateStage = 'visual-prompt' | 'motion-prompt' | 'image';
+
+type UpdateFailure = { shotId: string; stage: UpdateStage; error: string };
+
+type UpdateStaleShotsResult = {
+  totalShots: number;
+  visualPrompts: number;
+  motionPrompts: number;
+  images: number;
+  failures: UpdateFailure[];
+  /** Shots the plan could not act on — see `SkippedShot`. */
+  skipped: SkippedShot[];
+};
+
+/**
+ * One shot's frozen slice of the plan.
+ *
+ * Deliberately holds only ids and flags — no `Scene` objects. The whole plan
+ * is persisted as one `step.do` result, which Cloudflare caps at 1 MiB
+ * (docs/investigations/cloudflare-workflows.md). A sequence-scope run right
+ * after a style edit is the worst case: every shot stale, and inlining each
+ * target's scene plus two neighbour scenes blew the cap and killed the run at
+ * its first step. Scenes are materialised per shot in `prepare-prompt-*`
+ * instead. The invariant the plan exists to protect — the frozen *target
+ * set*, immune to mid-run edits adding or removing work — is unchanged.
+ */
+type PlanTarget = {
+  shotId: string;
+  frameId: string;
+  /**
+   * Neighbour shot ids for motion continuity, resolved to raw metadata at
+   * spawn time (parity with regenerateShotPromptFn). Null when not a motion
+   * target, or at the ends of the sequence.
+   */
+  beforeShotId: string | null;
+  afterShotId: string | null;
+  startingFrameImageUrl: string | null;
+  regenVisual: boolean;
+  regenMotion: boolean;
+  /**
+   * The image itself read stale. Rendered directly, or chained after the
+   * visual prompt when that is stale too. Never true for shots without a
+   * rendered image — Update all must not spend credits creating a first
+   * still.
+   */
+  regenImage: boolean;
+};
+
+/**
+ * A shot the plan could not act on. Distinct from a `UpdateFailure`: nothing
+ * was attempted. Reported so a run that quietly covered less than the user
+ * asked for can't read as a clean success.
+ */
+type SkippedShot = {
+  shotId: string;
+  reason: 'no-anchor-frame' | 'no-scene' | 'staleness-unknown';
+};
+
+type Plan = {
+  aspectRatio: FramePromptWorkflowInput['aspectRatio'];
+  promptContext: {
+    characterBible: FramePromptWorkflowInput['characterBible'];
+    locationBible: FramePromptWorkflowInput['locationBible'];
+    elementBible: FramePromptWorkflowInput['elementBible'];
+    styleConfig: FramePromptWorkflowInput['styleConfig'];
+    analysisModelId: FramePromptWorkflowInput['analysisModelId'];
+  } | null;
+  targets: PlanTarget[];
+  skipped: SkippedShot[];
+};
+
+type ImageChildOutput = { imageUrl?: string };
+
+/** A prompt target's scenes, materialised per shot in `prepare-prompt-*`. */
+type PromptScenes = {
+  /** Script-overlaid scene metadata, the prompt children's primary input. */
+  scene: Scene;
+  /** Raw neighbour metadata for motion continuity. */
+  sceneBefore?: Scene;
+  sceneAfter?: Scene;
+};
+
+export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<UpdateStaleShotsWorkflowInput> {
+  protected override async runImpl(
+    event: Readonly<WorkflowEvent<UpdateStaleShotsWorkflowInput>>,
+    step: WorkflowStep,
+    scopedDb: ScopedDb
+  ): Promise<UpdateStaleShotsResult> {
+    const input = event.payload;
+    const parentInstanceId = event.instanceId;
+    const { userId, teamId, sequenceId, sceneId, shotId } = input;
+    if (!sequenceId) {
+      throw new WorkflowValidationError('Sequence ID is required');
+    }
+
+    // ============================================================
+    // PHASE 1: compute the plan from live state. The step result is
+    // durably persisted — this is the run's frozen snapshot.
+    // ============================================================
+    const plan = await step.do('compute-plan', () =>
+      computePlan({ scopedDb, sequenceId, sceneId, shotId })
+    );
+
+    if (plan.targets.length === 0) {
+      return {
+        totalShots: 0,
+        visualPrompts: 0,
+        motionPrompts: 0,
+        images: 0,
+        failures: [],
+        skipped: plan.skipped,
+      };
+    }
+
+    const counters = { visualPrompts: 0, motionPrompts: 0, images: 0 };
+    const failures: UpdateFailure[] = [];
+    const promptCommon = plan.promptContext;
+    if (!promptCommon) {
+      // Targets exist but the prompt context failed to load (e.g. style
+      // deleted) — nothing downstream can run.
+      throw new NonRetryableError(
+        'Prompt context unavailable for stale-shot update',
+        'WorkflowValidationError'
+      );
+    }
+
+    const spawnImage = async (target: PlanTarget): Promise<void> => {
+      // Deliberately reads CURRENT state (not the plan snapshot): the prompt
+      // this render uses is whatever is stored right now — the prompt child's
+      // freshly persisted text, or a user's even-newer mid-run edit.
+      // JSON round-trip at the step boundary: `ImageWorkflowInput.style` is
+      // typed `Json`, which the step's Serializable constraint rejects even
+      // though the value is plain JSON (same pattern as await-child.ts).
+      const imageInputJson = await step.do(
+        `prepare-image-${target.shotId}`,
+        async () => {
+          const [shot, frame, sequence] = await Promise.all([
+            scopedDb.shots.getById(target.shotId),
+            scopedDb.frames.getAnchorByShot(target.shotId),
+            scopedDb.sequences.getById(sequenceId),
+          ]);
+          if (!shot || !frame || !sequence) {
+            throw new NonRetryableError(
+              `Shot ${target.shotId} disappeared mid-update`,
+              'WorkflowValidationError'
+            );
+          }
+          const scriptBySceneId = await loadSelectedScriptsBySequence(
+            scopedDb,
+            sequenceId
+          );
+          const { scene, script } = resolveSceneForShot(shot, scriptBySceneId);
+          try {
+            return JSON.stringify(
+              await prepareShotImageWorkflowInput({
+                scopedDb,
+                sequence,
+                shot,
+                frame,
+                scriptExtract:
+                  script?.extract ?? scene?.originalScript.extract ?? '',
+                userId,
+              })
+            );
+          } catch (error) {
+            // Running out of credits is terminal, not transient: retrying
+            // burns the step's whole budget on a call that cannot succeed and
+            // keeps the run "in flight" long past the point the user could be
+            // told why nothing is happening.
+            if (isInsufficientCreditsError(error)) {
+              throw new NonRetryableError(
+                error instanceof Error ? error.message : String(error),
+                'InsufficientCreditsError'
+              );
+            }
+            throw error;
+          }
+        }
+      );
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the step above serialized exactly this type
+      const imageInput = JSON.parse(imageInputJson) as ImageWorkflowInput;
+      const output = await spawnAndAwaitChild<
+        ImageWorkflowInput,
+        ImageChildOutput
+      >(step, {
+        binding: this.env.IMAGE_WORKFLOW,
+        parentBindingName: PARENT_BINDING_NAME,
+        parentInstanceId,
+        childId: `image:${sequenceId}:${target.shotId}`,
+        childPayload: imageInput,
+        spawnStepName: `spawn-image-${target.shotId}`,
+        awaitStepName: `await-image-${target.shotId}`,
+      });
+      // ImageWorkflow has a success path that renders nothing — it returns an
+      // empty `imageUrl` when its anchor frame vanished mid-run. Counting that
+      // as a render would report work the user never got.
+      if (!output.imageUrl) {
+        throw new Error('Image workflow completed without producing an image');
+      }
+      counters.images += 1;
+    };
+
+    /**
+     * Materialise a prompt target's scenes. Kept out of the plan (see
+     * `PlanTarget`) so the plan stays under the 1 MiB step-result cap; one
+     * step per shot means each result carries a single shot's scenes.
+     * Neighbours are raw `shot.metadata`, matching regenerateShotPromptFn.
+     */
+    const loadPromptScenes = (target: PlanTarget): Promise<PromptScenes> =>
+      step.do(`prepare-prompt-${target.shotId}`, async () => {
+        const [shot, scriptBySceneId] = await Promise.all([
+          scopedDb.shots.getById(target.shotId),
+          loadSelectedScriptsBySequence(scopedDb, sequenceId),
+        ]);
+        if (!shot) {
+          throw new NonRetryableError(
+            `Shot ${target.shotId} disappeared mid-update`,
+            'WorkflowValidationError'
+          );
+        }
+        const { scene } = resolveSceneForShot(shot, scriptBySceneId);
+        if (!scene) {
+          throw new NonRetryableError(
+            `Shot ${target.shotId} lost its scene metadata mid-update`,
+            'WorkflowValidationError'
+          );
+        }
+        const neighbourIds = [target.beforeShotId, target.afterShotId].filter(
+          (id): id is string => id !== null
+        );
+        const neighbours = await Promise.all(
+          neighbourIds.map((id) => scopedDb.shots.getById(id))
+        );
+        const byId = new Map(
+          neighbours.filter((s) => !!s).map((s) => [s.id, s])
+        );
+        return {
+          scene,
+          sceneBefore: target.beforeShotId
+            ? (byId.get(target.beforeShotId)?.metadata ?? undefined)
+            : undefined,
+          sceneAfter: target.afterShotId
+            ? (byId.get(target.afterShotId)?.metadata ?? undefined)
+            : undefined,
+        };
+      });
+
+    // ============================================================
+    // PHASE 2: fan out — one job per shot, so a shot's scene step runs once
+    // for both its prompt children. Within a shot the visual-prompt → image
+    // chain is sequential while the motion prompt runs alongside. Failures
+    // are recorded per stage so one shot never blocks its peers.
+    // ============================================================
+    const jobs = plan.targets.map((target) =>
+      (async (): Promise<void> => {
+        const needsPrompt = target.regenVisual || target.regenMotion;
+        let scenes: PromptScenes | null = null;
+        if (needsPrompt) {
+          try {
+            scenes = await loadPromptScenes(target);
+          } catch (error) {
+            // Both prompt stages depend on this; neither can proceed.
+            if (target.regenVisual)
+              failures.push(toFailure(target.shotId, 'visual-prompt', error));
+            if (target.regenMotion)
+              failures.push(toFailure(target.shotId, 'motion-prompt', error));
+            return;
+          }
+        }
+
+        const base = scenes && {
+          userId,
+          teamId,
+          sequenceId,
+          shotId: target.shotId,
+          scene: scenes.scene,
+          aspectRatio: plan.aspectRatio,
+          ...promptCommon,
+          // The user just clicked Update all, so a mounted shot panel should
+          // see its prompt stream in — same as the single-shot regen path.
+          emitStreaming: true,
+        };
+
+        const stages: Array<Promise<void>> = [];
+
+        if (target.regenMotion && base && scenes) {
+          stages.push(
+            spawnAndAwaitChild<MotionPromptWorkflowInput, unknown>(step, {
+              binding: this.env.MOTION_PROMPT_WORKFLOW,
+              parentBindingName: PARENT_BINDING_NAME,
+              parentInstanceId,
+              childId: `motion-prompt:${sequenceId}:${target.shotId}`,
+              childPayload: {
+                ...base,
+                sceneBefore: scenes.sceneBefore,
+                sceneAfter: scenes.sceneAfter,
+                startingFrameImageUrl: target.startingFrameImageUrl,
+              },
+              spawnStepName: `spawn-motion-prompt-${target.shotId}`,
+              awaitStepName: `await-motion-prompt-${target.shotId}`,
+            }).then(
+              () => {
+                counters.motionPrompts += 1;
+              },
+              (error: unknown) => {
+                failures.push(toFailure(target.shotId, 'motion-prompt', error));
+              }
+            )
+          );
+        }
+
+        if (target.regenVisual && base) {
+          stages.push(
+            (async () => {
+              try {
+                await spawnAndAwaitChild<FramePromptWorkflowInput, unknown>(
+                  step,
+                  {
+                    binding: this.env.FRAME_PROMPT_WORKFLOW,
+                    parentBindingName: PARENT_BINDING_NAME,
+                    parentInstanceId,
+                    childId: `frame-prompt:${sequenceId}:${target.shotId}`,
+                    childPayload: { ...base, frameId: target.frameId },
+                    spawnStepName: `spawn-frame-prompt-${target.shotId}`,
+                    awaitStepName: `await-frame-prompt-${target.shotId}`,
+                  }
+                );
+                counters.visualPrompts += 1;
+              } catch (error) {
+                // Never render from the prompt the regen failed to replace.
+                failures.push(toFailure(target.shotId, 'visual-prompt', error));
+                return;
+              }
+              if (!target.regenImage) return;
+              try {
+                await spawnImage(target);
+              } catch (error) {
+                failures.push(toFailure(target.shotId, 'image', error));
+              }
+            })()
+          );
+        } else if (target.regenImage) {
+          stages.push(
+            spawnImage(target).catch((error: unknown) => {
+              failures.push(toFailure(target.shotId, 'image', error));
+            })
+          );
+        }
+
+        await Promise.allSettled(stages);
+      })()
+    );
+    await Promise.allSettled(jobs);
+
+    // A user-initiated action that partly failed is a production issue, not a
+    // warning — `error` is the only severity that surfaces in error tracking.
+    if (failures.length > 0) {
+      logger.error(
+        `[UpdateStaleShotsWorkflow] ${failures.length} stage failure(s) across ${plan.targets.length} shots`,
+        { failures }
+      );
+    }
+    if (plan.skipped.length > 0) {
+      logger.error(
+        `[UpdateStaleShotsWorkflow] ${plan.skipped.length} shot(s) skipped by the plan`,
+        { skipped: plan.skipped }
+      );
+    }
+
+    return {
+      totalShots: plan.targets.length,
+      ...counters,
+      failures,
+      skipped: plan.skipped,
+    };
+  }
+}
+
+function toFailure(
+  shotId: string,
+  stage: UpdateStage,
+  error: unknown
+): UpdateFailure {
+  return {
+    shotId,
+    stage,
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+/**
+ * Recompute staleness for the in-scope shots from live state and freeze the
+ * regeneration plan. Runs inside `step.do('compute-plan')`, so the returned
+ * value is the run's durable snapshot. Exported for testing — the gating
+ * rules here decide what gets regenerated and therefore what gets billed.
+ */
+export async function computePlan(args: {
+  scopedDb: ScopedDb;
+  sequenceId: string;
+  sceneId?: string;
+  shotId?: string;
+}): Promise<Plan> {
+  const { scopedDb, sequenceId, sceneId, shotId } = args;
+  const sequence = await scopedDb.sequences.getById(sequenceId);
+  if (!sequence) {
+    throw new NonRetryableError(
+      `Sequence ${sequenceId} not found`,
+      'WorkflowValidationError'
+    );
+  }
+
+  const allShots = await scopedDb.shots.listBySequence(sequenceId);
+  const inScope = allShots.filter((shot) => {
+    if (shotId) return shot.id === shotId;
+    if (sceneId) return shot.sceneId === sceneId;
+    return true;
+  });
+  const skipped: SkippedShot[] = [];
+  const planBase: Plan = {
+    aspectRatio: sequence.aspectRatio,
+    promptContext: null,
+    targets: [],
+    skipped,
+  };
+  if (inScope.length === 0) return planBase;
+
+  await scopedDb.shots.ensureAnchorFrames(inScope);
+  const [anchorRows, scriptBySceneId, characters, locations, elements] =
+    await Promise.all([
+      scopedDb.frames.listAnchorsBySequence(sequenceId),
+      loadSelectedScriptsBySequence(scopedDb, sequenceId),
+      scopedDb.characters.listWithSheets(sequenceId),
+      scopedDb.sequenceLocations.listWithReferences(sequenceId),
+      scopedDb.sequenceElements.list(sequenceId),
+    ]);
+  const anchorsByShot = new Map(anchorRows.map((f) => [f.shotId, f]));
+  const refs: ShotStalenessRefs = { characters, locations, elements };
+
+  const targets: PlanTarget[] = [];
+  // Any target's scene works for the bible load below — the scene only
+  // matters to the hash/narrowing paths, not the bible construction.
+  let anyScene: Scene | null = null;
+  for (const shot of inScope) {
+    const frame = anchorsByShot.get(shot.id);
+    if (!frame) {
+      skipped.push({ shotId: shot.id, reason: 'no-anchor-frame' });
+      continue;
+    }
+    const { scene } = resolveSceneForShot(shot, scriptBySceneId);
+    if (!scene) {
+      // Shots awaiting script analysis have null metadata. The client's
+      // staleness map can still mark such a shot stale (the thumbnail branch
+      // runs without a scene), so record the skip rather than dropping it —
+      // otherwise the UI waits forever on work that was never planned.
+      skipped.push({ shotId: shot.id, reason: 'no-scene' });
+      continue;
+    }
+    const staleness = await computeShotStaleness({
+      scopedDb,
+      sequence,
+      shot,
+      frame,
+      scene,
+      refs,
+    });
+    // 'unknown' means the comparison failed, not that the artifact is fine.
+    // Regenerating on a guess would burn credits; skipping silently would
+    // report a clean run. Record it so the user is told.
+    if (
+      staleness.thumbnail === 'unknown' ||
+      staleness.visualPrompt === 'unknown' ||
+      staleness.motionPrompt === 'unknown'
+    ) {
+      skipped.push({ shotId: shot.id, reason: 'staleness-unknown' });
+      continue;
+    }
+    const regenVisual = staleness.visualPrompt === 'stale';
+    const regenMotion = staleness.motionPrompt === 'stale';
+    // Only what reads stale right now. Regenerating the visual prompt
+    // outdates the image, but that downstream staleness is left for the
+    // indicators to surface rather than cascaded into this run.
+    const regenImage = !!frame.imageUrl && staleness.thumbnail === 'stale';
+    if (!regenVisual && !regenMotion && !regenImage) continue;
+
+    anyScene ??= scene;
+    // Neighbour ids give the motion LLM the same continuity context the
+    // single-shot regen path passes (parity with regenerateShotPromptFn:
+    // raw metadata, ordered by the sequence's shot list). Resolved to scenes
+    // at spawn time — see `PlanTarget`.
+    const idx = allShots.findIndex((s) => s.id === shot.id);
+    targets.push({
+      shotId: shot.id,
+      frameId: frame.id,
+      beforeShotId: regenMotion ? (allShots[idx - 1]?.id ?? null) : null,
+      afterShotId: regenMotion ? (allShots[idx + 1]?.id ?? null) : null,
+      startingFrameImageUrl: frame.imageUrl,
+      regenVisual,
+      regenMotion,
+      regenImage,
+    });
+  }
+  if (targets.length === 0 || !anyScene) return planBase;
+
+  // Bibles + style are sequence-wide; load once via the same context loader
+  // the single-shot regen path uses.
+  const ctx = await loadShotPromptContext({
+    scopedDb,
+    sequence,
+    scene: anyScene,
+  });
+  return {
+    ...planBase,
+    promptContext: {
+      characterBible: ctx.characterBible,
+      locationBible: ctx.locationBible,
+      elementBible: ctx.elementBible,
+      styleConfig: ctx.styleConfig,
+      analysisModelId:
+        getAnalysisModelById(ctx.analysisModel)?.id ?? DEFAULT_ANALYSIS_MODEL,
+    },
+    targets,
+  };
+}

--- a/src/lib/workflows/update-stale-shots-workflow.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.ts
@@ -48,32 +48,33 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
-import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
-import { loadShotPromptContext } from '@/lib/ai/prompt-context';
 import { resolveVideoModel } from '@/lib/ai/resolve-asset-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import { requireCredits } from '@/lib/billing/preflight';
 import { estimateVideoCost } from '@/lib/billing/cost-estimation';
-import type { Shot } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
+import { isInsufficientCreditsError } from '@/lib/errors';
 import { buildMotionReferenceImages } from '@/lib/motion/build-motion-references';
 import { resolveMotionPromptFromVersion } from '@/lib/motion/resolve-motion-prompt';
 import { resolveShotDuration } from '@/lib/motion/resolve-shot-duration';
-import { assembleSequenceSegments } from '@/lib/scenes/scene-segments';
+import { getLogger } from '@/lib/observability/logger';
 import {
   loadSelectedScriptsBySequence,
   resolveSceneForShot,
 } from '@/lib/scenes/scene-script';
 import { prepareShotImageWorkflowInput } from '@/lib/shots/shot-image-input';
 import {
-  computeShotStaleness,
-  type ShotStalenessRefs,
-} from '@/lib/shots/shot-staleness';
-import {
-  depthIncludes,
+  DEFAULT_UPDATE_STALE_DEPTH,
   type UpdateStaleDepth,
 } from '@/lib/shots/update-stale-depth';
-import { isInsufficientCreditsError } from '@/lib/errors';
+import {
+  claimTargets,
+  computePlan,
+  type MusicPlan,
+  type PlanTarget,
+  type ShotClaims,
+  type SkippedShot,
+} from '@/lib/shots/update-stale-plan';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
@@ -90,7 +91,6 @@ import type {
 import { buildMusicSceneSummaries } from '@/lib/workflows/music-scene-summaries';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
-import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'update-stale-shots']);
 
@@ -120,110 +120,6 @@ type UpdateStaleShotsResult = {
   skipped: SkippedShot[];
 };
 
-/**
- * One shot's frozen slice of the plan.
- *
- * Deliberately holds only ids and flags — no `Scene` objects. The whole plan
- * is persisted as one `step.do` result, which Cloudflare caps at 1 MiB
- * (docs/investigations/cloudflare-workflows.md). A sequence-scope run right
- * after a style edit is the worst case: every shot stale, and inlining each
- * target's scene plus two neighbour scenes blew the cap and killed the run at
- * its first step. Scenes are materialised per shot in `prepare-prompt-*`
- * instead. The invariant the plan exists to protect — the frozen *target
- * set*, immune to mid-run edits adding or removing work — is unchanged.
- */
-type PlanTarget = {
-  shotId: string;
-  frameId: string;
-  /**
-   * Neighbour shot ids for motion continuity, resolved to raw metadata at
-   * spawn time (parity with regenerateShotPromptFn). Null when not a motion
-   * target, or at the ends of the sequence.
-   */
-  beforeShotId: string | null;
-  afterShotId: string | null;
-  startingFrameImageUrl: string | null;
-  regenVisual: boolean;
-  regenMotion: boolean;
-  /**
-   * The image itself read stale. Rendered directly, or chained after the
-   * visual prompt when that is stale too. Never true for shots without a
-   * rendered image — Update all must not spend credits creating a first
-   * still.
-   */
-  regenImage: boolean;
-  /**
-   * Live input hashes captured at plan time (#1085) — stamped onto the
-   * pending claim rows in `claim-targets` so in-flight work reads as
-   * 'updating' and duplicate enqueues no-op. Non-null whenever the matching
-   * regen flag is set.
-   */
-  visualLiveHash: string | null;
-  motionLiveHash: string | null;
-  imageLiveHash: string | null;
-  /** Model to stamp on the image claim row; the render's own resolution in
-   * `prepare-image-*` overwrites it via `claimForGeneration`. */
-  imageModel: string;
-  /**
-   * Depth ≥ 'video' (#1085): re-render this shot's video. True only when a
-   * video is already selected (never a FIRST render), none is currently
-   * generating, and either an upstream artifact regenerates in this run or
-   * the segment's selected version already reads stale (manifest pointers
-   * diverged). Waits on this run's motion-prompt and image stages.
-   */
-  regenVideo: boolean;
-};
-
-/**
- * The pending rows claimed for one shot (#1085). A null slot for a set regen
- * flag means another run already holds a live claim for that artifact — this
- * run skips it rather than double-generating.
- */
-type ShotClaims = {
-  visualVersionId: string | null;
-  motionVersionId: string | null;
-  imageVariantId: string | null;
-};
-
-/**
- * A shot the plan could not act on. Distinct from a `UpdateFailure`: nothing
- * was attempted. Reported so a run that quietly covered less than the user
- * asked for can't read as a clean success.
- */
-type SkippedShot = {
-  shotId: string;
-  reason:
-    | 'no-anchor-frame'
-    | 'no-scene'
-    | 'staleness-unknown'
-    | 'already-in-flight';
-};
-
-/**
- * Depth 'music' (#1085): the sequence-level music slice of the plan.
- * `regenPrompt` — the music prompt's stored hash diverges from live.
- * `regenTrack` — a track already exists AND the prompt regenerates in this
- * run (cascade-only: there is no track-level staleness signal today, so a
- * fresh prompt with an old track is deliberately left alone). Never a FIRST
- * generation of either.
- */
-type MusicPlan = { regenPrompt: boolean; regenTrack: boolean };
-
-type Plan = {
-  aspectRatio: FramePromptWorkflowInput['aspectRatio'];
-  /** Non-null only at depth 'music'. */
-  music: MusicPlan | null;
-  promptContext: {
-    characterBible: FramePromptWorkflowInput['characterBible'];
-    locationBible: FramePromptWorkflowInput['locationBible'];
-    elementBible: FramePromptWorkflowInput['elementBible'];
-    styleConfig: FramePromptWorkflowInput['styleConfig'];
-    analysisModelId: FramePromptWorkflowInput['analysisModelId'];
-  } | null;
-  targets: PlanTarget[];
-  skipped: SkippedShot[];
-};
-
 type ImageChildOutput = { imageUrl?: string; cancelled?: boolean };
 
 /** A prompt target's scenes, materialised per shot in `prepare-prompt-*`. */
@@ -247,17 +143,32 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
     if (!sequenceId) {
       throw new WorkflowValidationError('Sequence ID is required');
     }
-    // Runs enqueued before the depth picker existed carry no depth; 'images'
-    // matches the pre-picker gating most closely.
-    const depth: UpdateStaleDepth = input.depth ?? 'images';
+    // Runs enqueued before the depth picker existed carry no depth.
+    const depth: UpdateStaleDepth = input.depth ?? DEFAULT_UPDATE_STALE_DEPTH;
 
     // ============================================================
-    // PHASE 1: compute the plan from live state. The step result is
-    // durably persisted — this is the run's frozen snapshot.
+    // PHASE 1: freeze the plan from live state (domain logic lives in
+    // `@/lib/shots/update-stale-plan`). The step result is the run's
+    // durable snapshot of what will regenerate / be billed.
     // ============================================================
-    const plan = await step.do('compute-plan', () =>
-      computePlan({ scopedDb, sequenceId, sceneId, shotId, depth })
-    );
+    const plan = await step.do('compute-plan', async () => {
+      try {
+        return await computePlan({
+          scopedDb,
+          sequenceId,
+          sceneId,
+          shotId,
+          depth,
+        });
+      } catch (error) {
+        // Plan throws WorkflowValidationError (lib-safe); CF retries plain
+        // Errors inside step.do, so re-wrap as NonRetryableError here.
+        if (error instanceof WorkflowValidationError) {
+          throw new NonRetryableError(error.message, error.name);
+        }
+        throw error;
+      }
+    });
 
     const counters = {
       visualPrompts: 0,
@@ -1088,394 +999,4 @@ function toFailure(
     stage,
     error: error instanceof Error ? error.message : String(error),
   };
-}
-
-/**
- * Recompute staleness for the in-scope shots from live state and freeze the
- * regeneration plan. Runs inside `step.do('compute-plan')`, so the returned
- * value is the run's durable snapshot. Exported for testing — the gating
- * rules here decide what gets regenerated and therefore what gets billed.
- */
-export async function computePlan(args: {
-  scopedDb: ScopedDb;
-  sequenceId: string;
-  sceneId?: string;
-  shotId?: string;
-  depth?: UpdateStaleDepth;
-}): Promise<Plan> {
-  const { scopedDb, sequenceId, sceneId, shotId, depth = 'images' } = args;
-  const sequence = await scopedDb.sequences.getById(sequenceId);
-  if (!sequence) {
-    throw new NonRetryableError(
-      `Sequence ${sequenceId} not found`,
-      'WorkflowValidationError'
-    );
-  }
-
-  const allShots = await scopedDb.shots.listBySequence(sequenceId);
-  const inScope = allShots.filter((shot) => {
-    if (shotId) return shot.id === shotId;
-    if (sceneId) return shot.sceneId === sceneId;
-    return true;
-  });
-  const skipped: SkippedShot[] = [];
-  const planBase: Plan = {
-    aspectRatio: sequence.aspectRatio,
-    music: depthIncludes(depth, 'music')
-      ? await computeMusicPlan(scopedDb, sequence, allShots)
-      : null,
-    promptContext: null,
-    targets: [],
-    skipped,
-  };
-  if (inScope.length === 0) return planBase;
-
-  // Depth ≥ 'video': per-shot video state from the segment assembly — the
-  // same 4 batched reads + pure assemble `getSequenceSegmentsFn` uses, so
-  // "has a video" / "already stale" / "currently generating" match the UI.
-  const videoStateByShot = new Map<
-    string,
-    { hasVideo: boolean; alreadyStale: boolean; generating: boolean }
-  >();
-  if (depthIncludes(depth, 'video')) {
-    const [segments, versions, allFrames] = await Promise.all([
-      scopedDb.renderSegments.listBySequence(sequenceId),
-      scopedDb.videoVariants.listBySequence(sequenceId),
-      scopedDb.frames.listBySequence(sequenceId),
-    ]);
-    const assembled = assembleSequenceSegments({
-      segments,
-      versions,
-      shots: allShots,
-      frames: allFrames,
-    });
-    for (const segment of assembled) {
-      const generating = versions.some(
-        (v) => v.renderSegmentId === segment.id && v.status === 'generating'
-      );
-      for (const segShotId of segment.shotIds) {
-        videoStateByShot.set(segShotId, {
-          hasVideo: segment.selectedVersion !== null,
-          alreadyStale: segment.stale,
-          generating,
-        });
-      }
-    }
-  }
-
-  await scopedDb.shots.ensureAnchorFrames(inScope);
-  const [anchorRows, scriptBySceneId, characters, locations, elements] =
-    await Promise.all([
-      scopedDb.frames.listAnchorsBySequence(sequenceId),
-      loadSelectedScriptsBySequence(scopedDb, sequenceId),
-      scopedDb.characters.listWithSheets(sequenceId),
-      scopedDb.sequenceLocations.listWithReferences(sequenceId),
-      scopedDb.sequenceElements.list(sequenceId),
-    ]);
-  const anchorsByShot = new Map(anchorRows.map((f) => [f.shotId, f]));
-  const refs: ShotStalenessRefs = { characters, locations, elements };
-
-  const targets: PlanTarget[] = [];
-  // Any target's scene works for the bible load below — the scene only
-  // matters to the hash/narrowing paths, not the bible construction.
-  let anyScene: Scene | null = null;
-  for (const shot of inScope) {
-    const frame = anchorsByShot.get(shot.id);
-    if (!frame) {
-      skipped.push({ shotId: shot.id, reason: 'no-anchor-frame' });
-      continue;
-    }
-    const { scene } = resolveSceneForShot(shot, scriptBySceneId);
-    if (!scene) {
-      // Shots awaiting script analysis have null metadata. The client's
-      // staleness map can still mark such a shot stale (the thumbnail branch
-      // runs without a scene), so record the skip rather than dropping it —
-      // otherwise the UI waits forever on work that was never planned.
-      skipped.push({ shotId: shot.id, reason: 'no-scene' });
-      continue;
-    }
-    const staleness = await computeShotStaleness({
-      scopedDb,
-      sequence,
-      shot,
-      frame,
-      scene,
-      refs,
-    });
-    // 'unknown' means the comparison failed, not that the artifact is fine.
-    // Regenerating on a guess would burn credits; skipping silently would
-    // report a clean run. Record it so the user is told.
-    if (
-      staleness.thumbnail === 'unknown' ||
-      staleness.visualPrompt === 'unknown' ||
-      staleness.motionPrompt === 'unknown'
-    ) {
-      skipped.push({ shotId: shot.id, reason: 'staleness-unknown' });
-      continue;
-    }
-    // 'stale' only — 'updating' means a live claim already covers the
-    // artifact (this run's dedup, #1085), 'fresh'/'untracked' need nothing.
-    const regenVisual = staleness.visualPrompt === 'stale';
-    const regenMotion = staleness.motionPrompt === 'stale';
-    // Depth ≥ 'images' cascades: a still whose visual prompt regenerates in
-    // this run is re-rendered too (it would read stale the moment the prompt
-    // lands), alongside stills that are stale in their own right. Depth
-    // 'prompts' renders nothing. Never a FIRST still, at any depth.
-    const regenImage =
-      depthIncludes(depth, 'images') &&
-      !!frame.imageUrl &&
-      (staleness.thumbnail === 'stale' || regenVisual);
-    // Depth ≥ 'video' cascades onto existing videos whose upstream changes in
-    // this run — or whose manifest already diverged. Skipped while a render
-    // is in flight (the in-flight one is already producing the fix).
-    const videoState = videoStateByShot.get(shot.id);
-    const regenVideo =
-      !!videoState &&
-      videoState.hasVideo &&
-      !videoState.generating &&
-      (regenMotion || regenImage || videoState.alreadyStale);
-    if (!regenVisual && !regenMotion && !regenImage && !regenVideo) continue;
-
-    anyScene ??= scene;
-    // Neighbour ids give the motion LLM the same continuity context the
-    // single-shot regen path passes (parity with regenerateShotPromptFn:
-    // raw metadata, ordered by the sequence's shot list). Resolved to scenes
-    // at spawn time — see `PlanTarget`.
-    const idx = allShots.findIndex((s) => s.id === shot.id);
-    targets.push({
-      shotId: shot.id,
-      frameId: frame.id,
-      beforeShotId: regenMotion ? (allShots[idx - 1]?.id ?? null) : null,
-      afterShotId: regenMotion ? (allShots[idx + 1]?.id ?? null) : null,
-      startingFrameImageUrl: frame.imageUrl,
-      regenVisual,
-      regenMotion,
-      regenImage,
-      visualLiveHash: staleness.liveHashes.visualPrompt,
-      motionLiveHash: staleness.liveHashes.motionPrompt,
-      imageLiveHash: staleness.liveHashes.thumbnail,
-      imageModel: safeTextToImageModel(frame.imageModel, DEFAULT_IMAGE_MODEL),
-      regenVideo,
-    });
-  }
-  if (targets.length === 0 || !anyScene) return planBase;
-
-  // Bibles + style are sequence-wide; load once via the same context loader
-  // the single-shot regen path uses.
-  const ctx = await loadShotPromptContext({
-    scopedDb,
-    sequence,
-    scene: anyScene,
-  });
-  return {
-    ...planBase,
-    promptContext: {
-      characterBible: ctx.characterBible,
-      locationBible: ctx.locationBible,
-      elementBible: ctx.elementBible,
-      styleConfig: ctx.styleConfig,
-      analysisModelId:
-        getAnalysisModelById(ctx.analysisModel)?.id ?? DEFAULT_ANALYSIS_MODEL,
-    },
-    targets,
-  };
-}
-
-/**
- * Sequence-level music slice of the plan (depth 'music'). Mirrors
- * `getMusicPromptStalenessFn`'s comparison exactly (latest version's
- * analysis model, fallback to the sequence's). Untracked (no stored hash,
- * no scenes) means NOTHING — Update all never creates a first music prompt
- * or track — and an in-flight generation (musicStatus 'generating') is left
- * to finish rather than duplicated.
- */
-async function computeMusicPlan(
-  scopedDb: ScopedDb,
-  sequence: NonNullable<Awaited<ReturnType<ScopedDb['sequences']['getById']>>>,
-  allShots: Shot[]
-): Promise<MusicPlan> {
-  const none: MusicPlan = { regenPrompt: false, regenTrack: false };
-  if (!sequence.musicPromptInputHash) return none;
-  const scenes = allShots
-    .map((s) => s.metadata)
-    .filter((m): m is NonNullable<typeof m> => m !== null);
-  if (scenes.length === 0) return none;
-  try {
-    const sceneSummaries = buildMusicSceneSummaries(scenes);
-    const latest = await scopedDb.sequenceMusicPromptVersions.getLatest(
-      sequence.id
-    );
-    const analysisModel =
-      latest?.analysisModel ??
-      getAnalysisModelById(sequence.analysisModel)?.id ??
-      DEFAULT_ANALYSIS_MODEL;
-    const liveHash = await computeMusicPromptInputHash({
-      sceneSummaries,
-      analysisModel,
-    });
-    const regenPrompt = liveHash !== sequence.musicPromptInputHash;
-    return {
-      regenPrompt,
-      // Cascade-only: the track follows its prompt. No prompt change → the
-      // track is left alone (no track-level staleness signal exists today).
-      regenTrack:
-        regenPrompt &&
-        !!sequence.musicUrl &&
-        sequence.musicStatus !== 'generating',
-    };
-  } catch (error) {
-    // Hash uncomputable — report nothing rather than guessing (same
-    // fail-closed posture as the per-shot 'unknown' handling).
-    logger.warn(`music staleness uncomputable for sequence ${sequence.id}:`, {
-      err: error,
-    });
-    return none;
-  }
-}
-
-/**
- * Claim the plan's targets (#1085): pre-create a pending version row per
- * artifact this run will produce, so in-flight work reads as 'updating',
- * duplicate enqueues no-op, and the children complete these rows in place.
- *
- * Runs inside `step.do('claim-targets')` and is idempotent across step
- * retries: an existing live claim stamped with THIS run's instance id is
- * reused; one stamped by anyone else means the artifact is already being
- * produced elsewhere, so this run skips it (reported as `already-in-flight`
- * rather than silently narrowing the run). Exported for testing.
- */
-export async function claimTargets(args: {
-  scopedDb: ScopedDb;
-  targets: PlanTarget[];
-  sequenceId: string;
-  parentInstanceId: string;
-}): Promise<{
-  claimsByShot: Record<string, ShotClaims>;
-  skipped: SkippedShot[];
-}> {
-  const { scopedDb, targets, sequenceId, parentInstanceId } = args;
-  const claimsByShot: Record<string, ShotClaims> = {};
-  const skipped: SkippedShot[] = [];
-
-  for (const target of targets) {
-    const claims: ShotClaims = {
-      visualVersionId: null,
-      motionVersionId: null,
-      imageVariantId: null,
-    };
-    let foreignClaim = false;
-
-    if (target.regenVisual && target.visualLiveHash) {
-      const existing = await scopedDb.framePromptVersions.getLivePending(
-        target.frameId,
-        target.visualLiveHash
-      );
-      if (existing) {
-        if (existing.workflowRunId === parentInstanceId) {
-          claims.visualVersionId = existing.id;
-        } else {
-          foreignClaim = true;
-        }
-      } else {
-        try {
-          const row = await scopedDb.framePromptVersions.createPending({
-            frameId: target.frameId,
-            pendingInputHash: target.visualLiveHash,
-            workflowRunId: parentInstanceId,
-          });
-          claims.visualVersionId = row.id;
-        } catch {
-          // Lost the insert race to a concurrent enqueue (partial unique
-          // index on live claims) — the artifact is already being produced.
-          foreignClaim = true;
-        }
-      }
-    }
-
-    if (target.regenMotion && target.motionLiveHash) {
-      const existing = await scopedDb.shotPromptVersions.getLivePending(
-        target.shotId,
-        target.motionLiveHash
-      );
-      if (existing) {
-        if (existing.workflowRunId === parentInstanceId) {
-          claims.motionVersionId = existing.id;
-        } else {
-          foreignClaim = true;
-        }
-      } else {
-        try {
-          const row = await scopedDb.shotPromptVersions.createPending({
-            shotId: target.shotId,
-            pendingInputHash: target.motionLiveHash,
-            workflowRunId: parentInstanceId,
-          });
-          claims.motionVersionId = row.id;
-        } catch {
-          foreignClaim = true; // lost the insert race — see the visual twin
-        }
-      }
-    }
-
-    if (target.regenImage) {
-      const liveClaims = await scopedDb.frameVariants.listLiveClaims(
-        target.frameId
-      );
-      if (target.regenVisual) {
-        // Chained render: valid only behind OUR visual claim. A foreign
-        // visual claim means someone else owns the prompt regen — chaining
-        // onto their run is not this run's call, so skip the image too.
-        if (claims.visualVersionId) {
-          const visualVersionId = claims.visualVersionId;
-          const ours = liveClaims.find(
-            (c) => c.dependsOnVersionId === visualVersionId
-          );
-          claims.imageVariantId =
-            ours?.id ??
-            (
-              await scopedDb.frameVariants.createPendingClaim({
-                frameId: target.frameId,
-                sequenceId,
-                model: target.imageModel,
-                dependsOnVersionId: visualVersionId,
-                workflowRunId: parentInstanceId,
-              })
-            ).id;
-        } else {
-          foreignClaim = true;
-        }
-      } else if (target.imageLiveHash) {
-        const existing = liveClaims.find(
-          (c) => c.pendingInputHash === target.imageLiveHash
-        );
-        if (existing) {
-          if (existing.workflowRunId === parentInstanceId) {
-            claims.imageVariantId = existing.id;
-          } else {
-            foreignClaim = true;
-          }
-        } else {
-          try {
-            const row = await scopedDb.frameVariants.createPendingClaim({
-              frameId: target.frameId,
-              sequenceId,
-              model: target.imageModel,
-              pendingInputHash: target.imageLiveHash,
-              workflowRunId: parentInstanceId,
-            });
-            claims.imageVariantId = row.id;
-          } catch {
-            foreignClaim = true; // lost the insert race — see the visual twin
-          }
-        }
-      }
-    }
-
-    if (foreignClaim) {
-      skipped.push({ shotId: target.shotId, reason: 'already-in-flight' });
-    }
-    claimsByShot[target.shotId] = claims;
-  }
-
-  return { claimsByShot, skipped };
 }

--- a/src/lib/workflows/update-stale-shots-workflow.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.ts
@@ -224,7 +224,7 @@ type Plan = {
   skipped: SkippedShot[];
 };
 
-type ImageChildOutput = { imageUrl?: string };
+type ImageChildOutput = { imageUrl?: string; cancelled?: boolean };
 
 /** A prompt target's scenes, materialised per shot in `prepare-prompt-*`. */
 type PromptScenes = {
@@ -332,7 +332,7 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
       // though the value is plain JSON (same pattern as await-child.ts).
       const imageInputJson = await step.do(
         `prepare-image-${target.shotId}`,
-        async () => {
+        async (): Promise<string | null> => {
           const [shot, frame, sequence] = await Promise.all([
             scopedDb.shots.getById(target.shotId),
             scopedDb.frames.getAnchorByShot(target.shotId),
@@ -358,12 +358,18 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
               // frame's current mirror.
               promptOverride = frame.imagePrompt ?? undefined;
             } else {
-              // Cancelled / failed upstream: never render from the prompt
-              // the run failed to produce.
-              throw new NonRetryableError(
-                `Upstream visual prompt for shot ${target.shotId} was cancelled`,
-                'WorkflowValidationError'
-              );
+              // The upstream prompt didn't land for this run: the user
+              // cancelled it, or a post-click edit superseded the mirror.
+              // Never render from it — but this is a stand-down, not a run
+              // failure (#1095 review). Release the image claim and skip.
+              if (claims.imageVariantId) {
+                await scopedDb.frameVariants.markTerminal(
+                  claims.imageVariantId,
+                  'cancelled',
+                  'Upstream visual prompt was cancelled or superseded by a newer edit'
+                );
+              }
+              return null;
             }
           }
           const scriptBySceneId = await loadSelectedScriptsBySequence(
@@ -401,6 +407,13 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
           }
         }
       );
+      if (imageInputJson === null) {
+        // Upstream prompt cancelled/superseded — stood down in prepare.
+        logger.info(
+          `[UpdateStaleShotsWorkflow] image for shot ${target.shotId} stood down (upstream prompt cancelled or superseded)`
+        );
+        return;
+      }
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the step above serialized exactly this type
       const imageInput = JSON.parse(imageInputJson) as ImageWorkflowInput;
       const output = await spawnAndAwaitChild<
@@ -415,6 +428,14 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
         spawnStepName: `spawn-image-${target.shotId}`,
         awaitStepName: `await-image-${target.shotId}`,
       });
+      // A user cancel (before or during the render) is a stand-down, not a
+      // failure — and definitely not a render to count (#1095 review).
+      if (output.cancelled) {
+        logger.info(
+          `[UpdateStaleShotsWorkflow] image for shot ${target.shotId} was cancelled by the user; not counted`
+        );
+        return;
+      }
       // ImageWorkflow has a success path that renders nothing — it returns an
       // empty `imageUrl` when its anchor frame vanished mid-run. Counting that
       // as a render would report work the user never got.
@@ -737,35 +758,57 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
 
             const stages: Array<Promise<void>> = [];
 
-            if (doMotion && base && scenes) {
-              stages.push(
-                spawnAndAwaitChild<MotionPromptWorkflowInput, unknown>(step, {
-                  binding: this.env.MOTION_PROMPT_WORKFLOW,
-                  parentBindingName: PARENT_BINDING_NAME,
-                  parentInstanceId,
-                  childId: `motion-prompt:${sequenceId}:${target.shotId}`,
-                  childPayload: {
-                    ...base,
-                    sceneBefore: scenes.sceneBefore,
-                    sceneAfter: scenes.sceneAfter,
-                    startingFrameImageUrl: target.startingFrameImageUrl,
-                    targetVersionId: claims.motionVersionId ?? undefined,
-                  },
-                  spawnStepName: `spawn-motion-prompt-${target.shotId}`,
-                  awaitStepName: `await-motion-prompt-${target.shotId}`,
-                }).then(
-                  () => {
-                    counters.motionPrompts += 1;
-                  },
-                  async (error: unknown) => {
-                    upstream.motionOk = false;
-                    failures.push(
-                      toFailure(target.shotId, 'motion-prompt', error)
+            // The motion prompt is conditioned on the rendered still (#929),
+            // so when this run ALSO regenerates the image it must run after
+            // the image chain and read the fresh still — racing them stamps a
+            // hash the new still immediately invalidates, and the artifact
+            // reads stale again the moment the run finishes (#1095 review).
+            const runMotionPrompt = async (): Promise<void> => {
+              if (!(doMotion && base && scenes)) return;
+              let startingFrameImageUrl = target.startingFrameImageUrl;
+              if (doImage) {
+                startingFrameImageUrl = await step.do(
+                  `refresh-still-${target.shotId}`,
+                  async () => {
+                    const frameNow = await scopedDb.frames.getAnchorByShot(
+                      target.shotId
                     );
-                    await failClaims('motion-prompt');
+                    return (
+                      frameNow?.imageUrl ?? target.startingFrameImageUrl ?? null
+                    );
                   }
-                )
-              );
+                );
+              }
+              try {
+                await spawnAndAwaitChild<MotionPromptWorkflowInput, unknown>(
+                  step,
+                  {
+                    binding: this.env.MOTION_PROMPT_WORKFLOW,
+                    parentBindingName: PARENT_BINDING_NAME,
+                    parentInstanceId,
+                    childId: `motion-prompt:${sequenceId}:${target.shotId}`,
+                    childPayload: {
+                      ...base,
+                      sceneBefore: scenes.sceneBefore,
+                      sceneAfter: scenes.sceneAfter,
+                      startingFrameImageUrl: startingFrameImageUrl ?? undefined,
+                      targetVersionId: claims.motionVersionId ?? undefined,
+                    },
+                    spawnStepName: `spawn-motion-prompt-${target.shotId}`,
+                    awaitStepName: `await-motion-prompt-${target.shotId}`,
+                  }
+                );
+                counters.motionPrompts += 1;
+              } catch (error) {
+                upstream.motionOk = false;
+                failures.push(toFailure(target.shotId, 'motion-prompt', error));
+                await failClaims('motion-prompt');
+              }
+            };
+
+            if (!doImage) {
+              // No image regen — the still can't move, run alongside.
+              stages.push(runMotionPrompt());
             }
 
             if (doVisual && base) {
@@ -796,7 +839,10 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
                       toFailure(target.shotId, 'visual-prompt', error)
                     );
                     await failClaims('visual-prompt');
-                    // The chained image claim was cancelled by the cascade above.
+                    // The chained image claim was cancelled by the cascade
+                    // above. The motion prompt still runs — the still didn't
+                    // change, so its claim hash remains valid.
+                    if (doImage) await runMotionPrompt();
                     return;
                   }
                   if (!doImage) return;
@@ -807,15 +853,24 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
                     failures.push(toFailure(target.shotId, 'image', error));
                     await failClaims('image');
                   }
+                  // After the image settles either way: fresh still on
+                  // success, unchanged still on failure — both are safe
+                  // inputs for the motion prompt.
+                  await runMotionPrompt();
                 })()
               );
             } else if (doImage) {
               stages.push(
-                spawnImage(target, claims).catch(async (error: unknown) => {
-                  upstream.imageOk = false;
-                  failures.push(toFailure(target.shotId, 'image', error));
-                  await failClaims('image');
-                })
+                (async () => {
+                  try {
+                    await spawnImage(target, claims);
+                  } catch (error) {
+                    upstream.imageOk = false;
+                    failures.push(toFailure(target.shotId, 'image', error));
+                    await failClaims('image');
+                  }
+                  await runMotionPrompt();
+                })()
               );
             }
 

--- a/src/lib/workflows/update-stale-shots-workflow.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.ts
@@ -1,22 +1,22 @@
 /**
- * "Update all" (#1077) — durable server-side regeneration of every artifact
- * in scope (a shot, a scene, or the whole sequence) that reads stale *right
- * now*. One artifact per stale flag, no cascade: regenerating a visual prompt
- * outdates the shot's image, but that image is only re-rendered if it was
- * already stale itself. The user sees the new staleness afterwards and can
- * run Update all again. (Cascading is deliberately deferred to a later issue.)
+ * "Update all" (#1077/#1085) — durable server-side regeneration of the
+ * out-of-date artifacts in scope (a shot, a scene, or the whole sequence),
+ * at a user-chosen cascade depth (src/lib/shots/update-stale-depth.ts):
  *
- * Per shot:
+ *   'prompts' → stale visual/motion prompts only, nothing renders
+ *   'images'  → + stale stills, and stills whose visual prompt regenerates
+ *               in this run (cascade); never a FIRST still
+ *   'video'   → + existing videos whose upstream changed in this run or
+ *               whose manifest already diverged; never a FIRST video
+ *   'music'   → + the sequence music prompt, and the existing track behind
+ *               a successful prompt regen; never a FIRST generation
  *
- *   visual prompt stale → FramePromptWorkflow child
- *   motion prompt stale → MotionPromptWorkflow child   (no auto video render)
- *   image stale         → ImageWorkflow child
+ * Per shot the dependency order is visual-prompt → image → video, with the
+ * motion prompt alongside (video waits on it too). Chained stages never run
+ * from an upstream the run failed to replace.
  *
- * When both the visual prompt and the image are independently stale, the
- * image waits on the prompt — that is dependency ordering, not a cascade;
- * rendering in parallel would burn credits on the prompt we're replacing.
- *
- * Concurrency model — no locks, self-correcting via input hashes:
+ * Concurrency model — no locks, self-correcting via input hashes + pending
+ * claims (#1085):
  *
  *   - The PLAN (which shots, which artifacts) is computed from live scoped
  *     state in the `compute-plan` step and persisted as its durable result:
@@ -25,29 +25,41 @@
  *     the indicators surface after the run. The plan holds ids and flags
  *     only; scene bodies are materialised per shot in `prepare-prompt-*` to
  *     keep the step result under CF's 1 MiB cap.
+ *   - `claim-targets` pre-creates a pending version row per prompt/image
+ *     artifact, so in-flight work reads 'updating' and duplicate enqueues
+ *     no-op. (Video/music ride their existing status columns instead.)
  *   - Each prompt child gets its inputs snapshotted in its own
  *     `prepare-prompt-*` step (#991 — leaves never read the DB mid-run) and
  *     stamps the hash of the inputs it actually used, so a mid-run script
  *     edit leaves the new prompt honestly stale again rather than silently
  *     wrong.
- *   - The image step deliberately re-reads CURRENT state after its prompt
- *     child completes (`prepare-image-*`): if the user hand-edited the
- *     prompt in the gap, the render uses their newer text (last-write-wins
- *     on intent) and stamps its hash accordingly.
+ *   - A chained image consumes the prompt its OWN dependency claim produced
+ *     (see `spawnImage`), so a post-click edit cannot leak into the run; the
+ *     video stage then reads the freshly-completed selection pointers.
  *
- * Failures are per-shot: one child failing (including an insufficient-credits
- * preflight on an image) leaves that artifact stale and visible; siblings
- * proceed.
+ * Failures are per-shot and per-stage: one child failing (including an
+ * insufficient-credits preflight) leaves that artifact out of date and
+ * visible; siblings proceed, and downstream stages of the failed artifact
+ * are skipped, not rendered from stale inputs.
  */
 
+import { computeMusicPromptInputHash } from '@/lib/ai/input-hash';
 import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
 import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
 import { loadShotPromptContext } from '@/lib/ai/prompt-context';
+import { resolveVideoModel } from '@/lib/ai/resolve-asset-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import { requireCredits } from '@/lib/billing/preflight';
+import { estimateVideoCost } from '@/lib/billing/cost-estimation';
+import type { Shot } from '@/lib/db/schema';
 import type { ScopedDb } from '@/lib/db/scoped';
+import { buildMotionReferenceImages } from '@/lib/motion/build-motion-references';
+import { resolveMotionPromptFromVersion } from '@/lib/motion/resolve-motion-prompt';
+import { resolveShotDuration } from '@/lib/motion/resolve-shot-duration';
+import { assembleSequenceSegments } from '@/lib/scenes/scene-segments';
 import {
   loadSelectedScriptsBySequence,
   resolveSceneForShot,
@@ -57,6 +69,10 @@ import {
   computeShotStaleness,
   type ShotStalenessRefs,
 } from '@/lib/shots/shot-staleness';
+import {
+  depthIncludes,
+  type UpdateStaleDepth,
+} from '@/lib/shots/update-stale-depth';
 import { isInsufficientCreditsError } from '@/lib/errors';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
@@ -65,8 +81,13 @@ import type {
   FramePromptWorkflowInput,
   ImageWorkflowInput,
   MotionPromptWorkflowInput,
+  MotionWorkflowInput,
+  MotionWorkflowResult,
+  MusicPromptWorkflowInput,
+  MusicWorkflowInput,
   UpdateStaleShotsWorkflowInput,
 } from '@/lib/workflow/types';
+import { buildMusicSceneSummaries } from '@/lib/workflows/music-scene-summaries';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
 import { getLogger } from '@/lib/observability/logger';
@@ -75,8 +96,15 @@ const logger = getLogger(['openstory', 'workflow', 'update-stale-shots']);
 
 const PARENT_BINDING_NAME = 'UPDATE_STALE_SHOTS_WORKFLOW';
 
-type UpdateStage = 'visual-prompt' | 'motion-prompt' | 'image';
+type UpdateStage =
+  | 'visual-prompt'
+  | 'motion-prompt'
+  | 'image'
+  | 'video'
+  | 'music-prompt'
+  | 'music';
 
+/** `shotId` is the sequence id for the sequence-scoped music stages. */
 type UpdateFailure = { shotId: string; stage: UpdateStage; error: string };
 
 type UpdateStaleShotsResult = {
@@ -84,6 +112,9 @@ type UpdateStaleShotsResult = {
   visualPrompts: number;
   motionPrompts: number;
   images: number;
+  videos: number;
+  musicPrompts: number;
+  musicTracks: number;
   failures: UpdateFailure[];
   /** Shots the plan could not act on — see `SkippedShot`. */
   skipped: SkippedShot[];
@@ -133,6 +164,14 @@ type PlanTarget = {
   /** Model to stamp on the image claim row; the render's own resolution in
    * `prepare-image-*` overwrites it via `claimForGeneration`. */
   imageModel: string;
+  /**
+   * Depth ≥ 'video' (#1085): re-render this shot's video. True only when a
+   * video is already selected (never a FIRST render), none is currently
+   * generating, and either an upstream artifact regenerates in this run or
+   * the segment's selected version already reads stale (manifest pointers
+   * diverged). Waits on this run's motion-prompt and image stages.
+   */
+  regenVideo: boolean;
 };
 
 /**
@@ -160,8 +199,20 @@ type SkippedShot = {
     | 'already-in-flight';
 };
 
+/**
+ * Depth 'music' (#1085): the sequence-level music slice of the plan.
+ * `regenPrompt` — the music prompt's stored hash diverges from live.
+ * `regenTrack` — a track already exists AND the prompt regenerates in this
+ * run (cascade-only: there is no track-level staleness signal today, so a
+ * fresh prompt with an old track is deliberately left alone). Never a FIRST
+ * generation of either.
+ */
+type MusicPlan = { regenPrompt: boolean; regenTrack: boolean };
+
 type Plan = {
   aspectRatio: FramePromptWorkflowInput['aspectRatio'];
+  /** Non-null only at depth 'music'. */
+  music: MusicPlan | null;
   promptContext: {
     characterBible: FramePromptWorkflowInput['characterBible'];
     locationBible: FramePromptWorkflowInput['locationBible'];
@@ -196,30 +247,47 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
     if (!sequenceId) {
       throw new WorkflowValidationError('Sequence ID is required');
     }
+    // Runs enqueued before the depth picker existed carry no depth; 'images'
+    // matches the pre-picker gating most closely.
+    const depth: UpdateStaleDepth = input.depth ?? 'images';
 
     // ============================================================
     // PHASE 1: compute the plan from live state. The step result is
     // durably persisted — this is the run's frozen snapshot.
     // ============================================================
     const plan = await step.do('compute-plan', () =>
-      computePlan({ scopedDb, sequenceId, sceneId, shotId })
+      computePlan({ scopedDb, sequenceId, sceneId, shotId, depth })
     );
 
-    if (plan.targets.length === 0) {
+    const counters = {
+      visualPrompts: 0,
+      motionPrompts: 0,
+      images: 0,
+      videos: 0,
+      musicPrompts: 0,
+      musicTracks: 0,
+    };
+    const failures: UpdateFailure[] = [];
+    // Version-skew guard: a run whose `compute-plan` step was cached by a
+    // pre-depth-picker deploy replays a Plan with NO `music` key at all —
+    // `?? null` keeps that `undefined` from being dereferenced below.
+    const planMusic = plan.music ?? null;
+    const musicToRun =
+      planMusic && (planMusic.regenPrompt || planMusic.regenTrack)
+        ? planMusic
+        : null;
+
+    if (plan.targets.length === 0 && musicToRun === null) {
       return {
         totalShots: 0,
-        visualPrompts: 0,
-        motionPrompts: 0,
-        images: 0,
+        ...counters,
         failures: [],
         skipped: plan.skipped,
       };
     }
 
-    const counters = { visualPrompts: 0, motionPrompts: 0, images: 0 };
-    const failures: UpdateFailure[] = [];
     const promptCommon = plan.promptContext;
-    if (!promptCommon) {
+    if (plan.targets.length > 0 && !promptCommon) {
       // Targets exist but the prompt context failed to load (e.g. style
       // deleted) — nothing downstream can run.
       throw new NonRetryableError(
@@ -232,16 +300,21 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
     // PHASE 1b: claim the targets (#1085) — one pending version row per
     // artifact this run will produce. From here on the run is visible as
     // 'updating' and duplicate enqueues (second click / tab / teammate)
-    // no-op server-side.
+    // no-op server-side. (Video/music have no claim rows — their in-flight
+    // state lives on video_variants.status / sequences.musicStatus, which
+    // the plan already treats as "leave it alone".)
     // ============================================================
-    const claimed = await step.do('claim-targets', () =>
-      claimTargets({
-        scopedDb,
-        targets: plan.targets,
-        sequenceId,
-        parentInstanceId,
-      })
-    );
+    const claimed =
+      plan.targets.length > 0
+        ? await step.do('claim-targets', () =>
+            claimTargets({
+              scopedDb,
+              targets: plan.targets,
+              sequenceId,
+              parentInstanceId,
+            })
+          )
+        : { claimsByShot: {}, skipped: [] };
     const allSkipped = [...plan.skipped, ...claimed.skipped];
 
     const spawnImage = async (
@@ -352,6 +425,158 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
     };
 
     /**
+     * Re-render a shot's video (depth ≥ 'video', #1085). The prepare step
+     * resolves everything from CURRENT state — by design AFTER this run's
+     * motion-prompt and image stages have landed, so the render consumes the
+     * freshly regenerated prompt (via the selection pointer completion just
+     * repointed) and the fresh still. Mirrors `generateShotMotionFn`'s
+     * resolution: selected motion version → assembled prompt, video model
+     * from selected version → sequence default, #873 reference images,
+     * model-snapped duration, credits preflight.
+     */
+    const spawnVideo = async (target: PlanTarget): Promise<void> => {
+      const motionInputJson = await step.do(
+        `prepare-video-${target.shotId}`,
+        async (): Promise<string | null> => {
+          const [shot, frame, sequence] = await Promise.all([
+            scopedDb.shots.getById(target.shotId),
+            scopedDb.frames.getAnchorByShot(target.shotId),
+            scopedDb.sequences.getById(sequenceId),
+          ]);
+          if (!shot || !frame || !sequence) {
+            throw new NonRetryableError(
+              `Shot ${target.shotId} disappeared mid-update`,
+              'WorkflowValidationError'
+            );
+          }
+          if (!frame.imageUrl) {
+            throw new NonRetryableError(
+              `Shot ${target.shotId} has no rendered still to animate`,
+              'WorkflowValidationError'
+            );
+          }
+
+          const [selectedMotion, selectedVideo, characters, elements] =
+            await Promise.all([
+              scopedDb.shotPromptVersions.getSelectedMotion(shot.id),
+              scopedDb.videoVariants.getSelectedByShot(shot.id),
+              scopedDb.characters.listWithSheets(sequenceId),
+              scopedDb.sequenceElements.list(sequenceId),
+            ]);
+
+          // Spawn-time re-check (billing safety): the plan's video gating ran
+          // at run START, possibly many minutes ago, and video has no claim
+          // rows — a concurrent Update all (second tab, teammate) or a manual
+          // render could have started or finished this exact work meanwhile.
+          // Re-evaluate against CURRENT state and skip quietly (null): if a
+          // render is in flight, it is already producing the fix; if the
+          // selected manifest again matches the live pointers, someone
+          // already rendered from the fresh inputs; if the selection vanished
+          // there is no video to update (never a FIRST render).
+          if (!selectedVideo) return null;
+          if (shot.renderSegmentId) {
+            const segmentVersions = await scopedDb.videoVariants.listBySegment(
+              shot.renderSegmentId
+            );
+            if (segmentVersions.some((v) => v.status === 'generating')) {
+              return null;
+            }
+          }
+          const manifestEntry = selectedVideo.manifest.find(
+            (entry) => entry.shotId === shot.id
+          );
+          const diverged =
+            !manifestEntry ||
+            manifestEntry.motionPromptVersionId !==
+              shot.selectedMotionPromptVersionId ||
+            manifestEntry.frameVersionId !== frame.selectedImageVersionId;
+          if (!diverged) return null;
+          // Selected-version model → sequence default. (The single-shot fn
+          // also consults a last-failed attempt; irrelevant here — a video
+          // must already exist for this target to be planned.)
+          const model = resolveVideoModel({
+            selectedVersionModel: selectedVideo.model,
+            sequenceModel: sequence.videoModel,
+          });
+          const prompt = resolveMotionPromptFromVersion(
+            selectedMotion,
+            {
+              motionPromptMirror: shot.motionPrompt,
+              characterTags: shot.metadata?.continuity?.characterTags,
+              description: shot.description,
+            },
+            model
+          );
+          if (!prompt) {
+            throw new NonRetryableError(
+              `Shot ${target.shotId} has no motion prompt to render from`,
+              'WorkflowValidationError'
+            );
+          }
+          const referenceImages = buildMotionReferenceImages({
+            scene: shot.metadata
+              ? { ...shot.metadata, continuity: shot.metadata.continuity }
+              : null,
+            characters,
+            elements,
+          });
+          const duration = resolveShotDuration({
+            durationMs: shot.durationMs,
+            metadataSeconds: shot.metadata?.metadata?.durationSeconds,
+            model,
+          });
+          try {
+            await requireCredits(scopedDb, estimateVideoCost(model, duration), {
+              errorMessage: 'Insufficient credits for video generation',
+            });
+          } catch (error) {
+            if (isInsufficientCreditsError(error)) {
+              throw new NonRetryableError(
+                error instanceof Error ? error.message : String(error),
+                'InsufficientCreditsError'
+              );
+            }
+            throw error;
+          }
+          const motionInput: MotionWorkflowInput = {
+            userId,
+            teamId,
+            sequenceId,
+            shotId: shot.id,
+            imageUrl: frame.imageUrl,
+            prompt,
+            model,
+            duration,
+            aspectRatio: sequence.aspectRatio,
+            referenceImages,
+          };
+          return JSON.stringify(motionInput);
+        }
+      );
+      if (motionInputJson === null) {
+        logger.info(
+          `[UpdateStaleShotsWorkflow] video for shot ${target.shotId} no longer needs rendering; skipping`
+        );
+        return;
+      }
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the step above serialized exactly this type
+      const motionInput = JSON.parse(motionInputJson) as MotionWorkflowInput;
+      await spawnAndAwaitChild<MotionWorkflowInput, MotionWorkflowResult>(
+        step,
+        {
+          binding: this.env.MOTION_WORKFLOW,
+          parentBindingName: PARENT_BINDING_NAME,
+          parentInstanceId,
+          childId: `motion:${sequenceId}:${target.shotId}`,
+          childPayload: motionInput,
+          spawnStepName: `spawn-video-${target.shotId}`,
+          awaitStepName: `await-video-${target.shotId}`,
+        }
+      );
+      counters.videos += 1;
+    };
+
+    /**
      * Materialise a prompt target's scenes. Kept out of the plan (see
      * `PlanTarget`) so the plan stays under the 1 MiB step-result cap; one
      * step per shot means each result carries a single shot's scenes.
@@ -399,171 +624,380 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
     // ============================================================
     // PHASE 2: fan out — one job per shot, so a shot's scene step runs once
     // for both its prompt children. Within a shot the visual-prompt → image
-    // chain is sequential while the motion prompt runs alongside. Failures
-    // are recorded per stage so one shot never blocks its peers.
+    // chain is sequential while the motion prompt runs alongside, and the
+    // video render (depth ≥ 'video') waits on both. Failures are recorded
+    // per stage so one shot never blocks its peers.
     // ============================================================
-    const jobs = plan.targets.map((target) =>
-      (async (): Promise<void> => {
-        const claims = claimed.claimsByShot[target.shotId] ?? {
-          visualVersionId: null,
-          motionVersionId: null,
-          imageVariantId: null,
-        };
-        // A regen flag without a claim means another run already owns that
-        // artifact ('already-in-flight' in `skipped`) — this run stands down.
-        const doVisual = target.regenVisual && claims.visualVersionId !== null;
-        const doMotion = target.regenMotion && claims.motionVersionId !== null;
-        const doImage = target.regenImage && claims.imageVariantId !== null;
+    // `promptCommon` is provably non-null whenever targets exist (the guard
+    // above throws otherwise); the ternary is for the compiler, and yields
+    // the same empty job list a target-less (music-only) run needs.
+    const jobs = !promptCommon
+      ? []
+      : plan.targets.map((target) =>
+          (async (): Promise<void> => {
+            const claims = claimed.claimsByShot[target.shotId] ?? {
+              visualVersionId: null,
+              motionVersionId: null,
+              imageVariantId: null,
+            };
+            // A regen flag without a claim means another run already owns that
+            // artifact ('already-in-flight' in `skipped`) — this run stands down.
+            const doVisual =
+              target.regenVisual && claims.visualVersionId !== null;
+            const doMotion =
+              target.regenMotion && claims.motionVersionId !== null;
+            const doImage = target.regenImage && claims.imageVariantId !== null;
 
-        // Best-effort claim cleanup on a stage failure — a claim must never
-        // outlive its run's ability to complete it (the reconciler is the
-        // backstop for anything this misses).
-        const failClaims = async (stage: UpdateStage): Promise<void> => {
-          try {
-            if (stage === 'visual-prompt' && claims.visualVersionId) {
-              await scopedDb.framePromptVersions.markTerminal(
-                claims.visualVersionId,
-                'failed'
-              );
-              await scopedDb.frameVariants.cancelByDependency(
-                claims.visualVersionId,
-                'Upstream visual prompt generation failed'
-              );
-            }
-            if (stage === 'motion-prompt' && claims.motionVersionId) {
-              await scopedDb.shotPromptVersions.markTerminal(
-                claims.motionVersionId,
-                'failed'
-              );
-            }
-            if (stage === 'image' && claims.imageVariantId) {
-              await scopedDb.frameVariants.markTerminal(
-                claims.imageVariantId,
-                'failed',
-                'Image stage failed in Update all'
-              );
-            }
-          } catch (err) {
-            logger.warn(
-              `[UpdateStaleShotsWorkflow] failed to clean up claim for shot ${target.shotId}`,
-              { err }
-            );
-          }
-        };
-
-        const needsPrompt = doVisual || doMotion;
-        let scenes: PromptScenes | null = null;
-        if (needsPrompt) {
-          try {
-            scenes = await loadPromptScenes(target);
-          } catch (error) {
-            // Both prompt stages depend on this; neither can proceed.
-            if (doVisual) {
-              failures.push(toFailure(target.shotId, 'visual-prompt', error));
-              await failClaims('visual-prompt');
-            }
-            if (doMotion) {
-              failures.push(toFailure(target.shotId, 'motion-prompt', error));
-              await failClaims('motion-prompt');
-            }
-            if (doImage) await failClaims('image');
-            return;
-          }
-        }
-
-        const base = scenes && {
-          userId,
-          teamId,
-          sequenceId,
-          shotId: target.shotId,
-          scene: scenes.scene,
-          aspectRatio: plan.aspectRatio,
-          ...promptCommon,
-          // The user just clicked Update all, so a mounted shot panel should
-          // see its prompt stream in — same as the single-shot regen path.
-          emitStreaming: true,
-        };
-
-        const stages: Array<Promise<void>> = [];
-
-        if (doMotion && base && scenes) {
-          stages.push(
-            spawnAndAwaitChild<MotionPromptWorkflowInput, unknown>(step, {
-              binding: this.env.MOTION_PROMPT_WORKFLOW,
-              parentBindingName: PARENT_BINDING_NAME,
-              parentInstanceId,
-              childId: `motion-prompt:${sequenceId}:${target.shotId}`,
-              childPayload: {
-                ...base,
-                sceneBefore: scenes.sceneBefore,
-                sceneAfter: scenes.sceneAfter,
-                startingFrameImageUrl: target.startingFrameImageUrl,
-                targetVersionId: claims.motionVersionId ?? undefined,
-              },
-              spawnStepName: `spawn-motion-prompt-${target.shotId}`,
-              awaitStepName: `await-motion-prompt-${target.shotId}`,
-            }).then(
-              () => {
-                counters.motionPrompts += 1;
-              },
-              async (error: unknown) => {
-                failures.push(toFailure(target.shotId, 'motion-prompt', error));
-                await failClaims('motion-prompt');
-              }
-            )
-          );
-        }
-
-        if (doVisual && base) {
-          stages.push(
-            (async () => {
+            // Best-effort claim cleanup on a stage failure — a claim must never
+            // outlive its run's ability to complete it (the reconciler is the
+            // backstop for anything this misses).
+            const failClaims = async (stage: UpdateStage): Promise<void> => {
               try {
-                await spawnAndAwaitChild<FramePromptWorkflowInput, unknown>(
-                  step,
-                  {
-                    binding: this.env.FRAME_PROMPT_WORKFLOW,
-                    parentBindingName: PARENT_BINDING_NAME,
-                    parentInstanceId,
-                    childId: `frame-prompt:${sequenceId}:${target.shotId}`,
-                    childPayload: {
-                      ...base,
-                      frameId: target.frameId,
-                      targetVersionId: claims.visualVersionId ?? undefined,
-                    },
-                    spawnStepName: `spawn-frame-prompt-${target.shotId}`,
-                    awaitStepName: `await-frame-prompt-${target.shotId}`,
-                  }
+                if (stage === 'visual-prompt' && claims.visualVersionId) {
+                  await scopedDb.framePromptVersions.markTerminal(
+                    claims.visualVersionId,
+                    'failed'
+                  );
+                  await scopedDb.frameVariants.cancelByDependency(
+                    claims.visualVersionId,
+                    'Upstream visual prompt generation failed'
+                  );
+                }
+                if (stage === 'motion-prompt' && claims.motionVersionId) {
+                  await scopedDb.shotPromptVersions.markTerminal(
+                    claims.motionVersionId,
+                    'failed'
+                  );
+                }
+                if (stage === 'image' && claims.imageVariantId) {
+                  await scopedDb.frameVariants.markTerminal(
+                    claims.imageVariantId,
+                    'failed',
+                    'Image stage failed in Update all'
+                  );
+                }
+              } catch (err) {
+                logger.warn(
+                  `[UpdateStaleShotsWorkflow] failed to clean up claim for shot ${target.shotId}`,
+                  { err }
                 );
-                counters.visualPrompts += 1;
+              }
+            };
+
+            const needsPrompt = doVisual || doMotion;
+            let scenes: PromptScenes | null = null;
+            if (needsPrompt) {
+              try {
+                scenes = await loadPromptScenes(target);
               } catch (error) {
-                // Never render from the prompt the regen failed to replace.
-                failures.push(toFailure(target.shotId, 'visual-prompt', error));
-                await failClaims('visual-prompt');
-                // The chained image claim was cancelled by the cascade above.
+                // Both prompt stages depend on this; neither can proceed.
+                if (doVisual) {
+                  failures.push(
+                    toFailure(target.shotId, 'visual-prompt', error)
+                  );
+                  await failClaims('visual-prompt');
+                }
+                if (doMotion) {
+                  failures.push(
+                    toFailure(target.shotId, 'motion-prompt', error)
+                  );
+                  await failClaims('motion-prompt');
+                }
+                if (doImage) await failClaims('image');
+                if (target.regenVideo) {
+                  failures.push({
+                    shotId: target.shotId,
+                    stage: 'video',
+                    error:
+                      'Upstream regeneration failed — video not re-rendered',
+                  });
+                }
                 return;
               }
-              if (!doImage) return;
-              try {
-                await spawnImage(target, claims);
-              } catch (error) {
-                failures.push(toFailure(target.shotId, 'image', error));
-                await failClaims('image');
-              }
-            })()
-          );
-        } else if (doImage) {
-          stages.push(
-            spawnImage(target, claims).catch(async (error: unknown) => {
-              failures.push(toFailure(target.shotId, 'image', error));
-              await failClaims('image');
-            })
-          );
-        }
+            }
 
-        await Promise.allSettled(stages);
-      })()
-    );
-    await Promise.allSettled(jobs);
+            // Video ordering (#1085 depth ≥ 'video'): the render consumes the
+            // regenerated motion prompt AND the regenerated still, so it waits on
+            // BOTH stages and only runs when every upstream it depends on landed.
+            // Vacuously true for stages this run isn't regenerating.
+            const upstream = { motionOk: true, imageOk: true };
+
+            const base = scenes && {
+              userId,
+              teamId,
+              sequenceId,
+              shotId: target.shotId,
+              scene: scenes.scene,
+              aspectRatio: plan.aspectRatio,
+              ...promptCommon,
+              // The user just clicked Update all, so a mounted shot panel should
+              // see its prompt stream in — same as the single-shot regen path.
+              emitStreaming: true,
+            };
+
+            const stages: Array<Promise<void>> = [];
+
+            if (doMotion && base && scenes) {
+              stages.push(
+                spawnAndAwaitChild<MotionPromptWorkflowInput, unknown>(step, {
+                  binding: this.env.MOTION_PROMPT_WORKFLOW,
+                  parentBindingName: PARENT_BINDING_NAME,
+                  parentInstanceId,
+                  childId: `motion-prompt:${sequenceId}:${target.shotId}`,
+                  childPayload: {
+                    ...base,
+                    sceneBefore: scenes.sceneBefore,
+                    sceneAfter: scenes.sceneAfter,
+                    startingFrameImageUrl: target.startingFrameImageUrl,
+                    targetVersionId: claims.motionVersionId ?? undefined,
+                  },
+                  spawnStepName: `spawn-motion-prompt-${target.shotId}`,
+                  awaitStepName: `await-motion-prompt-${target.shotId}`,
+                }).then(
+                  () => {
+                    counters.motionPrompts += 1;
+                  },
+                  async (error: unknown) => {
+                    upstream.motionOk = false;
+                    failures.push(
+                      toFailure(target.shotId, 'motion-prompt', error)
+                    );
+                    await failClaims('motion-prompt');
+                  }
+                )
+              );
+            }
+
+            if (doVisual && base) {
+              stages.push(
+                (async () => {
+                  try {
+                    await spawnAndAwaitChild<FramePromptWorkflowInput, unknown>(
+                      step,
+                      {
+                        binding: this.env.FRAME_PROMPT_WORKFLOW,
+                        parentBindingName: PARENT_BINDING_NAME,
+                        parentInstanceId,
+                        childId: `frame-prompt:${sequenceId}:${target.shotId}`,
+                        childPayload: {
+                          ...base,
+                          frameId: target.frameId,
+                          targetVersionId: claims.visualVersionId ?? undefined,
+                        },
+                        spawnStepName: `spawn-frame-prompt-${target.shotId}`,
+                        awaitStepName: `await-frame-prompt-${target.shotId}`,
+                      }
+                    );
+                    counters.visualPrompts += 1;
+                  } catch (error) {
+                    // Never render from the prompt the regen failed to replace.
+                    upstream.imageOk = false;
+                    failures.push(
+                      toFailure(target.shotId, 'visual-prompt', error)
+                    );
+                    await failClaims('visual-prompt');
+                    // The chained image claim was cancelled by the cascade above.
+                    return;
+                  }
+                  if (!doImage) return;
+                  try {
+                    await spawnImage(target, claims);
+                  } catch (error) {
+                    upstream.imageOk = false;
+                    failures.push(toFailure(target.shotId, 'image', error));
+                    await failClaims('image');
+                  }
+                })()
+              );
+            } else if (doImage) {
+              stages.push(
+                spawnImage(target, claims).catch(async (error: unknown) => {
+                  upstream.imageOk = false;
+                  failures.push(toFailure(target.shotId, 'image', error));
+                  await failClaims('image');
+                })
+              );
+            }
+
+            await Promise.allSettled(stages);
+
+            if (target.regenVideo) {
+              if (upstream.motionOk && upstream.imageOk) {
+                try {
+                  await spawnVideo(target);
+                } catch (error) {
+                  failures.push(toFailure(target.shotId, 'video', error));
+                }
+              } else {
+                // Rendering from the prompt/still the run failed to replace would
+                // bill for a video the user didn't ask for.
+                failures.push({
+                  shotId: target.shotId,
+                  stage: 'video',
+                  error: 'Upstream regeneration failed — video not re-rendered',
+                });
+              }
+            }
+          })()
+        );
+
+    // ============================================================
+    // PHASE 3 (depth 'music', #1085): sequence-level music, alongside the
+    // shot jobs. Prompt first; the track cascades only behind a successful
+    // prompt regeneration (see MusicPlan).
+    // ============================================================
+    const musicJob = musicToRun
+      ? (async (music: MusicPlan): Promise<void> => {
+          if (music.regenPrompt) {
+            try {
+              const musicPromptInputJson = await step.do(
+                'prepare-music-prompt',
+                async (): Promise<string | null> => {
+                  const [sequence, shots] = await Promise.all([
+                    scopedDb.sequences.getById(sequenceId),
+                    scopedDb.shots.listBySequence(sequenceId),
+                  ]);
+                  if (!sequence) {
+                    throw new NonRetryableError(
+                      `Sequence ${sequenceId} disappeared mid-update`,
+                      'WorkflowValidationError'
+                    );
+                  }
+                  const sceneSummaries = buildMusicSceneSummaries(
+                    shots
+                      .map((s) => s.metadata)
+                      .filter((m): m is NonNullable<typeof m> => m !== null)
+                  );
+                  const analysisModelId =
+                    getAnalysisModelById(sequence.analysisModel)?.id ??
+                    DEFAULT_ANALYSIS_MODEL;
+                  // Spawn-time re-check (no claim rows for music): if the
+                  // stored hash caught up with live meanwhile, a concurrent
+                  // run or manual regenerate already produced this prompt —
+                  // skip quietly, and let that run own the track cascade.
+                  const liveHash = await computeMusicPromptInputHash({
+                    sceneSummaries,
+                    analysisModel: analysisModelId,
+                  });
+                  if (liveHash === sequence.musicPromptInputHash) return null;
+                  const payload: MusicPromptWorkflowInput = {
+                    userId,
+                    teamId,
+                    sequenceId,
+                    sceneSummaries,
+                    analysisModelId,
+                  };
+                  return JSON.stringify(payload);
+                }
+              );
+              if (musicPromptInputJson === null) {
+                logger.info(
+                  `[UpdateStaleShotsWorkflow] music prompt for ${sequenceId} already regenerated elsewhere; skipping`
+                );
+                return;
+              }
+              await spawnAndAwaitChild<MusicPromptWorkflowInput, unknown>(
+                step,
+                {
+                  binding: this.env.MUSIC_PROMPT_WORKFLOW,
+                  parentBindingName: PARENT_BINDING_NAME,
+                  parentInstanceId,
+                  childId: `music-prompt:${sequenceId}`,
+                  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the step above serialized exactly this type
+                  childPayload: JSON.parse(
+                    musicPromptInputJson
+                  ) as MusicPromptWorkflowInput,
+                  spawnStepName: 'spawn-music-prompt',
+                  awaitStepName: 'await-music-prompt',
+                }
+              );
+              counters.musicPrompts += 1;
+            } catch (error) {
+              failures.push(toFailure(sequenceId, 'music-prompt', error));
+              if (music.regenTrack) {
+                // Never regenerate the track from the prompt the run
+                // failed to replace.
+                failures.push({
+                  shotId: sequenceId,
+                  stage: 'music',
+                  error: 'Upstream music prompt failed — track not regenerated',
+                });
+              }
+              return;
+            }
+          }
+
+          if (!music.regenTrack) return;
+          try {
+            const musicInputJson = await step.do(
+              'prepare-music-track',
+              async (): Promise<string | null> => {
+                // Read AFTER the prompt child landed: its completion
+                // mirrored the fresh prompt/tags onto the sequence.
+                const [sequence, shots] = await Promise.all([
+                  scopedDb.sequences.getById(sequenceId),
+                  scopedDb.shots.listBySequence(sequenceId),
+                ]);
+                if (!sequence?.musicPrompt) {
+                  throw new NonRetryableError(
+                    'Sequence has no music prompt to regenerate from',
+                    'WorkflowValidationError'
+                  );
+                }
+                // Spawn-time re-check: a concurrent run or manual
+                // regenerate already has a track render in flight — it is
+                // producing the fix, don't double-bill.
+                if (sequence.musicStatus === 'generating') return null;
+                // Same duration rule as generateMusicFn: shot durations
+                // with the 30s empty floor. Model stays the workflow
+                // default — parity with the manual regenerate path.
+                const durationSeconds =
+                  Math.round(
+                    shots.reduce(
+                      (sum, s) =>
+                        sum +
+                        (s.durationMs
+                          ? s.durationMs / 1000
+                          : (s.metadata?.metadata?.durationSeconds ?? 10)),
+                      0
+                    )
+                  ) || 30;
+                const payload: MusicWorkflowInput = {
+                  userId,
+                  teamId,
+                  sequenceId,
+                  prompt: sequence.musicPrompt,
+                  tags: sequence.musicTags ?? '',
+                  duration: durationSeconds,
+                  isPrimary: true,
+                };
+                return JSON.stringify(payload);
+              }
+            );
+            if (musicInputJson === null) {
+              logger.info(
+                `[UpdateStaleShotsWorkflow] music track for ${sequenceId} already rendering elsewhere; skipping`
+              );
+              return;
+            }
+            await spawnAndAwaitChild<MusicWorkflowInput, unknown>(step, {
+              binding: this.env.MUSIC_WORKFLOW,
+              parentBindingName: PARENT_BINDING_NAME,
+              parentInstanceId,
+              childId: `music:${sequenceId}`,
+              // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- the step above serialized exactly this type
+              childPayload: JSON.parse(musicInputJson) as MusicWorkflowInput,
+              spawnStepName: 'spawn-music-track',
+              awaitStepName: 'await-music-track',
+            });
+            counters.musicTracks += 1;
+          } catch (error) {
+            failures.push(toFailure(sequenceId, 'music', error));
+          }
+        })(musicToRun)
+      : null;
+
+    await Promise.allSettled(musicJob ? [...jobs, musicJob] : jobs);
 
     // A user-initiated action that partly failed is a production issue, not a
     // warning — `error` is the only severity that surfaces in error tracking.
@@ -612,8 +1046,9 @@ export async function computePlan(args: {
   sequenceId: string;
   sceneId?: string;
   shotId?: string;
+  depth?: UpdateStaleDepth;
 }): Promise<Plan> {
-  const { scopedDb, sequenceId, sceneId, shotId } = args;
+  const { scopedDb, sequenceId, sceneId, shotId, depth = 'images' } = args;
   const sequence = await scopedDb.sequences.getById(sequenceId);
   if (!sequence) {
     throw new NonRetryableError(
@@ -631,11 +1066,47 @@ export async function computePlan(args: {
   const skipped: SkippedShot[] = [];
   const planBase: Plan = {
     aspectRatio: sequence.aspectRatio,
+    music: depthIncludes(depth, 'music')
+      ? await computeMusicPlan(scopedDb, sequence, allShots)
+      : null,
     promptContext: null,
     targets: [],
     skipped,
   };
   if (inScope.length === 0) return planBase;
+
+  // Depth ≥ 'video': per-shot video state from the segment assembly — the
+  // same 4 batched reads + pure assemble `getSequenceSegmentsFn` uses, so
+  // "has a video" / "already stale" / "currently generating" match the UI.
+  const videoStateByShot = new Map<
+    string,
+    { hasVideo: boolean; alreadyStale: boolean; generating: boolean }
+  >();
+  if (depthIncludes(depth, 'video')) {
+    const [segments, versions, allFrames] = await Promise.all([
+      scopedDb.renderSegments.listBySequence(sequenceId),
+      scopedDb.videoVariants.listBySequence(sequenceId),
+      scopedDb.frames.listBySequence(sequenceId),
+    ]);
+    const assembled = assembleSequenceSegments({
+      segments,
+      versions,
+      shots: allShots,
+      frames: allFrames,
+    });
+    for (const segment of assembled) {
+      const generating = versions.some(
+        (v) => v.renderSegmentId === segment.id && v.status === 'generating'
+      );
+      for (const segShotId of segment.shotIds) {
+        videoStateByShot.set(segShotId, {
+          hasVideo: segment.selectedVersion !== null,
+          alreadyStale: segment.stale,
+          generating,
+        });
+      }
+    }
+  }
 
   await scopedDb.shots.ensureAnchorFrames(inScope);
   const [anchorRows, scriptBySceneId, characters, locations, elements] =
@@ -691,11 +1162,24 @@ export async function computePlan(args: {
     // artifact (this run's dedup, #1085), 'fresh'/'untracked' need nothing.
     const regenVisual = staleness.visualPrompt === 'stale';
     const regenMotion = staleness.motionPrompt === 'stale';
-    // Only what reads stale right now. Regenerating the visual prompt
-    // outdates the image, but that downstream staleness is left for the
-    // indicators to surface rather than cascaded into this run.
-    const regenImage = !!frame.imageUrl && staleness.thumbnail === 'stale';
-    if (!regenVisual && !regenMotion && !regenImage) continue;
+    // Depth ≥ 'images' cascades: a still whose visual prompt regenerates in
+    // this run is re-rendered too (it would read stale the moment the prompt
+    // lands), alongside stills that are stale in their own right. Depth
+    // 'prompts' renders nothing. Never a FIRST still, at any depth.
+    const regenImage =
+      depthIncludes(depth, 'images') &&
+      !!frame.imageUrl &&
+      (staleness.thumbnail === 'stale' || regenVisual);
+    // Depth ≥ 'video' cascades onto existing videos whose upstream changes in
+    // this run — or whose manifest already diverged. Skipped while a render
+    // is in flight (the in-flight one is already producing the fix).
+    const videoState = videoStateByShot.get(shot.id);
+    const regenVideo =
+      !!videoState &&
+      videoState.hasVideo &&
+      !videoState.generating &&
+      (regenMotion || regenImage || videoState.alreadyStale);
+    if (!regenVisual && !regenMotion && !regenImage && !regenVideo) continue;
 
     anyScene ??= scene;
     // Neighbour ids give the motion LLM the same continuity context the
@@ -716,6 +1200,7 @@ export async function computePlan(args: {
       motionLiveHash: staleness.liveHashes.motionPrompt,
       imageLiveHash: staleness.liveHashes.thumbnail,
       imageModel: safeTextToImageModel(frame.imageModel, DEFAULT_IMAGE_MODEL),
+      regenVideo,
     });
   }
   if (targets.length === 0 || !anyScene) return planBase;
@@ -739,6 +1224,58 @@ export async function computePlan(args: {
     },
     targets,
   };
+}
+
+/**
+ * Sequence-level music slice of the plan (depth 'music'). Mirrors
+ * `getMusicPromptStalenessFn`'s comparison exactly (latest version's
+ * analysis model, fallback to the sequence's). Untracked (no stored hash,
+ * no scenes) means NOTHING — Update all never creates a first music prompt
+ * or track — and an in-flight generation (musicStatus 'generating') is left
+ * to finish rather than duplicated.
+ */
+async function computeMusicPlan(
+  scopedDb: ScopedDb,
+  sequence: NonNullable<Awaited<ReturnType<ScopedDb['sequences']['getById']>>>,
+  allShots: Shot[]
+): Promise<MusicPlan> {
+  const none: MusicPlan = { regenPrompt: false, regenTrack: false };
+  if (!sequence.musicPromptInputHash) return none;
+  const scenes = allShots
+    .map((s) => s.metadata)
+    .filter((m): m is NonNullable<typeof m> => m !== null);
+  if (scenes.length === 0) return none;
+  try {
+    const sceneSummaries = buildMusicSceneSummaries(scenes);
+    const latest = await scopedDb.sequenceMusicPromptVersions.getLatest(
+      sequence.id
+    );
+    const analysisModel =
+      latest?.analysisModel ??
+      getAnalysisModelById(sequence.analysisModel)?.id ??
+      DEFAULT_ANALYSIS_MODEL;
+    const liveHash = await computeMusicPromptInputHash({
+      sceneSummaries,
+      analysisModel,
+    });
+    const regenPrompt = liveHash !== sequence.musicPromptInputHash;
+    return {
+      regenPrompt,
+      // Cascade-only: the track follows its prompt. No prompt change → the
+      // track is left alone (no track-level staleness signal exists today).
+      regenTrack:
+        regenPrompt &&
+        !!sequence.musicUrl &&
+        sequence.musicStatus !== 'generating',
+    };
+  } catch (error) {
+    // Hash uncomputable — report nothing rather than guessing (same
+    // fail-closed posture as the per-shot 'unknown' handling).
+    logger.warn(`music staleness uncomputable for sequence ${sequence.id}:`, {
+      err: error,
+    });
+    return none;
+  }
 }
 
 /**

--- a/src/lib/workflows/update-stale-shots-workflow.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.ts
@@ -44,6 +44,7 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
+import { DEFAULT_IMAGE_MODEL, safeTextToImageModel } from '@/lib/ai/models';
 import { loadShotPromptContext } from '@/lib/ai/prompt-context';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { ScopedDb } from '@/lib/db/scoped';
@@ -120,6 +121,29 @@ type PlanTarget = {
    * still.
    */
   regenImage: boolean;
+  /**
+   * Live input hashes captured at plan time (#1085) — stamped onto the
+   * pending claim rows in `claim-targets` so in-flight work reads as
+   * 'updating' and duplicate enqueues no-op. Non-null whenever the matching
+   * regen flag is set.
+   */
+  visualLiveHash: string | null;
+  motionLiveHash: string | null;
+  imageLiveHash: string | null;
+  /** Model to stamp on the image claim row; the render's own resolution in
+   * `prepare-image-*` overwrites it via `claimForGeneration`. */
+  imageModel: string;
+};
+
+/**
+ * The pending rows claimed for one shot (#1085). A null slot for a set regen
+ * flag means another run already holds a live claim for that artifact — this
+ * run skips it rather than double-generating.
+ */
+type ShotClaims = {
+  visualVersionId: string | null;
+  motionVersionId: string | null;
+  imageVariantId: string | null;
 };
 
 /**
@@ -129,7 +153,11 @@ type PlanTarget = {
  */
 type SkippedShot = {
   shotId: string;
-  reason: 'no-anchor-frame' | 'no-scene' | 'staleness-unknown';
+  reason:
+    | 'no-anchor-frame'
+    | 'no-scene'
+    | 'staleness-unknown'
+    | 'already-in-flight';
 };
 
 type Plan = {
@@ -200,10 +228,32 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
       );
     }
 
-    const spawnImage = async (target: PlanTarget): Promise<void> => {
-      // Deliberately reads CURRENT state (not the plan snapshot): the prompt
-      // this render uses is whatever is stored right now — the prompt child's
-      // freshly persisted text, or a user's even-newer mid-run edit.
+    // ============================================================
+    // PHASE 1b: claim the targets (#1085) — one pending version row per
+    // artifact this run will produce. From here on the run is visible as
+    // 'updating' and duplicate enqueues (second click / tab / teammate)
+    // no-op server-side.
+    // ============================================================
+    const claimed = await step.do('claim-targets', () =>
+      claimTargets({
+        scopedDb,
+        targets: plan.targets,
+        sequenceId,
+        parentInstanceId,
+      })
+    );
+    const allSkipped = [...plan.skipped, ...claimed.skipped];
+
+    const spawnImage = async (
+      target: PlanTarget,
+      claims: ShotClaims
+    ): Promise<void> => {
+      // The prompt source is deterministic (#1085): a chained render consumes
+      // the prompt its OWN dependency row produced — never a re-read of
+      // whatever is stored at spawn time — so a post-click edit cannot leak
+      // into this run (it re-stales the artifact instead). Direct renders
+      // (image stale, prompt not) still read current state; their claim hash
+      // self-invalidates on edit.
       // JSON round-trip at the step boundary: `ImageWorkflowInput.style` is
       // typed `Json`, which the step's Serializable constraint rejects even
       // though the value is plain JSON (same pattern as await-child.ts).
@@ -221,23 +271,48 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
               'WorkflowValidationError'
             );
           }
+          let promptOverride: string | undefined;
+          if (target.regenVisual && claims.visualVersionId) {
+            const dep = await scopedDb.framePromptVersions.getByIdForFrame(
+              claims.visualVersionId,
+              frame.id
+            );
+            if (dep?.status === 'completed') {
+              promptOverride = dep.text;
+            } else if (frame.visualPromptInputHash === target.visualLiveHash) {
+              // The claim retired in favour of an identical existing row
+              // (unique-index collision path) — the intended prompt is the
+              // frame's current mirror.
+              promptOverride = frame.imagePrompt ?? undefined;
+            } else {
+              // Cancelled / failed upstream: never render from the prompt
+              // the run failed to produce.
+              throw new NonRetryableError(
+                `Upstream visual prompt for shot ${target.shotId} was cancelled`,
+                'WorkflowValidationError'
+              );
+            }
+          }
           const scriptBySceneId = await loadSelectedScriptsBySequence(
             scopedDb,
             sequenceId
           );
           const { scene, script } = resolveSceneForShot(shot, scriptBySceneId);
           try {
-            return JSON.stringify(
-              await prepareShotImageWorkflowInput({
-                scopedDb,
-                sequence,
-                shot,
-                frame,
-                scriptExtract:
-                  script?.extract ?? scene?.originalScript.extract ?? '',
-                userId,
-              })
-            );
+            const prepared = await prepareShotImageWorkflowInput({
+              scopedDb,
+              sequence,
+              shot,
+              frame,
+              scriptExtract:
+                script?.extract ?? scene?.originalScript.extract ?? '',
+              userId,
+              promptOverride,
+            });
+            return JSON.stringify({
+              ...prepared,
+              targetVariantId: claims.imageVariantId ?? undefined,
+            });
           } catch (error) {
             // Running out of credits is terminal, not transient: retrying
             // burns the step's whole budget on a call that cannot succeed and
@@ -329,17 +404,69 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
     // ============================================================
     const jobs = plan.targets.map((target) =>
       (async (): Promise<void> => {
-        const needsPrompt = target.regenVisual || target.regenMotion;
+        const claims = claimed.claimsByShot[target.shotId] ?? {
+          visualVersionId: null,
+          motionVersionId: null,
+          imageVariantId: null,
+        };
+        // A regen flag without a claim means another run already owns that
+        // artifact ('already-in-flight' in `skipped`) — this run stands down.
+        const doVisual = target.regenVisual && claims.visualVersionId !== null;
+        const doMotion = target.regenMotion && claims.motionVersionId !== null;
+        const doImage = target.regenImage && claims.imageVariantId !== null;
+
+        // Best-effort claim cleanup on a stage failure — a claim must never
+        // outlive its run's ability to complete it (the reconciler is the
+        // backstop for anything this misses).
+        const failClaims = async (stage: UpdateStage): Promise<void> => {
+          try {
+            if (stage === 'visual-prompt' && claims.visualVersionId) {
+              await scopedDb.framePromptVersions.markTerminal(
+                claims.visualVersionId,
+                'failed'
+              );
+              await scopedDb.frameVariants.cancelByDependency(
+                claims.visualVersionId,
+                'Upstream visual prompt generation failed'
+              );
+            }
+            if (stage === 'motion-prompt' && claims.motionVersionId) {
+              await scopedDb.shotPromptVersions.markTerminal(
+                claims.motionVersionId,
+                'failed'
+              );
+            }
+            if (stage === 'image' && claims.imageVariantId) {
+              await scopedDb.frameVariants.markTerminal(
+                claims.imageVariantId,
+                'failed',
+                'Image stage failed in Update all'
+              );
+            }
+          } catch (err) {
+            logger.warn(
+              `[UpdateStaleShotsWorkflow] failed to clean up claim for shot ${target.shotId}`,
+              { err }
+            );
+          }
+        };
+
+        const needsPrompt = doVisual || doMotion;
         let scenes: PromptScenes | null = null;
         if (needsPrompt) {
           try {
             scenes = await loadPromptScenes(target);
           } catch (error) {
             // Both prompt stages depend on this; neither can proceed.
-            if (target.regenVisual)
+            if (doVisual) {
               failures.push(toFailure(target.shotId, 'visual-prompt', error));
-            if (target.regenMotion)
+              await failClaims('visual-prompt');
+            }
+            if (doMotion) {
               failures.push(toFailure(target.shotId, 'motion-prompt', error));
+              await failClaims('motion-prompt');
+            }
+            if (doImage) await failClaims('image');
             return;
           }
         }
@@ -359,7 +486,7 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
 
         const stages: Array<Promise<void>> = [];
 
-        if (target.regenMotion && base && scenes) {
+        if (doMotion && base && scenes) {
           stages.push(
             spawnAndAwaitChild<MotionPromptWorkflowInput, unknown>(step, {
               binding: this.env.MOTION_PROMPT_WORKFLOW,
@@ -371,6 +498,7 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
                 sceneBefore: scenes.sceneBefore,
                 sceneAfter: scenes.sceneAfter,
                 startingFrameImageUrl: target.startingFrameImageUrl,
+                targetVersionId: claims.motionVersionId ?? undefined,
               },
               spawnStepName: `spawn-motion-prompt-${target.shotId}`,
               awaitStepName: `await-motion-prompt-${target.shotId}`,
@@ -378,14 +506,15 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
               () => {
                 counters.motionPrompts += 1;
               },
-              (error: unknown) => {
+              async (error: unknown) => {
                 failures.push(toFailure(target.shotId, 'motion-prompt', error));
+                await failClaims('motion-prompt');
               }
             )
           );
         }
 
-        if (target.regenVisual && base) {
+        if (doVisual && base) {
           stages.push(
             (async () => {
               try {
@@ -396,7 +525,11 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
                     parentBindingName: PARENT_BINDING_NAME,
                     parentInstanceId,
                     childId: `frame-prompt:${sequenceId}:${target.shotId}`,
-                    childPayload: { ...base, frameId: target.frameId },
+                    childPayload: {
+                      ...base,
+                      frameId: target.frameId,
+                      targetVersionId: claims.visualVersionId ?? undefined,
+                    },
                     spawnStepName: `spawn-frame-prompt-${target.shotId}`,
                     awaitStepName: `await-frame-prompt-${target.shotId}`,
                   }
@@ -405,20 +538,24 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
               } catch (error) {
                 // Never render from the prompt the regen failed to replace.
                 failures.push(toFailure(target.shotId, 'visual-prompt', error));
+                await failClaims('visual-prompt');
+                // The chained image claim was cancelled by the cascade above.
                 return;
               }
-              if (!target.regenImage) return;
+              if (!doImage) return;
               try {
-                await spawnImage(target);
+                await spawnImage(target, claims);
               } catch (error) {
                 failures.push(toFailure(target.shotId, 'image', error));
+                await failClaims('image');
               }
             })()
           );
-        } else if (target.regenImage) {
+        } else if (doImage) {
           stages.push(
-            spawnImage(target).catch((error: unknown) => {
+            spawnImage(target, claims).catch(async (error: unknown) => {
               failures.push(toFailure(target.shotId, 'image', error));
+              await failClaims('image');
             })
           );
         }
@@ -436,10 +573,10 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
         { failures }
       );
     }
-    if (plan.skipped.length > 0) {
+    if (allSkipped.length > 0) {
       logger.error(
-        `[UpdateStaleShotsWorkflow] ${plan.skipped.length} shot(s) skipped by the plan`,
-        { skipped: plan.skipped }
+        `[UpdateStaleShotsWorkflow] ${allSkipped.length} shot(s) skipped by the plan`,
+        { skipped: allSkipped }
       );
     }
 
@@ -447,7 +584,7 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
       totalShots: plan.targets.length,
       ...counters,
       failures,
-      skipped: plan.skipped,
+      skipped: allSkipped,
     };
   }
 }
@@ -550,6 +687,8 @@ export async function computePlan(args: {
       skipped.push({ shotId: shot.id, reason: 'staleness-unknown' });
       continue;
     }
+    // 'stale' only — 'updating' means a live claim already covers the
+    // artifact (this run's dedup, #1085), 'fresh'/'untracked' need nothing.
     const regenVisual = staleness.visualPrompt === 'stale';
     const regenMotion = staleness.motionPrompt === 'stale';
     // Only what reads stale right now. Regenerating the visual prompt
@@ -573,6 +712,10 @@ export async function computePlan(args: {
       regenVisual,
       regenMotion,
       regenImage,
+      visualLiveHash: staleness.liveHashes.visualPrompt,
+      motionLiveHash: staleness.liveHashes.motionPrompt,
+      imageLiveHash: staleness.liveHashes.thumbnail,
+      imageModel: safeTextToImageModel(frame.imageModel, DEFAULT_IMAGE_MODEL),
     });
   }
   if (targets.length === 0 || !anyScene) return planBase;
@@ -596,4 +739,151 @@ export async function computePlan(args: {
     },
     targets,
   };
+}
+
+/**
+ * Claim the plan's targets (#1085): pre-create a pending version row per
+ * artifact this run will produce, so in-flight work reads as 'updating',
+ * duplicate enqueues no-op, and the children complete these rows in place.
+ *
+ * Runs inside `step.do('claim-targets')` and is idempotent across step
+ * retries: an existing live claim stamped with THIS run's instance id is
+ * reused; one stamped by anyone else means the artifact is already being
+ * produced elsewhere, so this run skips it (reported as `already-in-flight`
+ * rather than silently narrowing the run). Exported for testing.
+ */
+export async function claimTargets(args: {
+  scopedDb: ScopedDb;
+  targets: PlanTarget[];
+  sequenceId: string;
+  parentInstanceId: string;
+}): Promise<{
+  claimsByShot: Record<string, ShotClaims>;
+  skipped: SkippedShot[];
+}> {
+  const { scopedDb, targets, sequenceId, parentInstanceId } = args;
+  const claimsByShot: Record<string, ShotClaims> = {};
+  const skipped: SkippedShot[] = [];
+
+  for (const target of targets) {
+    const claims: ShotClaims = {
+      visualVersionId: null,
+      motionVersionId: null,
+      imageVariantId: null,
+    };
+    let foreignClaim = false;
+
+    if (target.regenVisual && target.visualLiveHash) {
+      const existing = await scopedDb.framePromptVersions.getLivePending(
+        target.frameId,
+        target.visualLiveHash
+      );
+      if (existing) {
+        if (existing.workflowRunId === parentInstanceId) {
+          claims.visualVersionId = existing.id;
+        } else {
+          foreignClaim = true;
+        }
+      } else {
+        try {
+          const row = await scopedDb.framePromptVersions.createPending({
+            frameId: target.frameId,
+            pendingInputHash: target.visualLiveHash,
+            workflowRunId: parentInstanceId,
+          });
+          claims.visualVersionId = row.id;
+        } catch {
+          // Lost the insert race to a concurrent enqueue (partial unique
+          // index on live claims) — the artifact is already being produced.
+          foreignClaim = true;
+        }
+      }
+    }
+
+    if (target.regenMotion && target.motionLiveHash) {
+      const existing = await scopedDb.shotPromptVersions.getLivePending(
+        target.shotId,
+        target.motionLiveHash
+      );
+      if (existing) {
+        if (existing.workflowRunId === parentInstanceId) {
+          claims.motionVersionId = existing.id;
+        } else {
+          foreignClaim = true;
+        }
+      } else {
+        try {
+          const row = await scopedDb.shotPromptVersions.createPending({
+            shotId: target.shotId,
+            pendingInputHash: target.motionLiveHash,
+            workflowRunId: parentInstanceId,
+          });
+          claims.motionVersionId = row.id;
+        } catch {
+          foreignClaim = true; // lost the insert race — see the visual twin
+        }
+      }
+    }
+
+    if (target.regenImage) {
+      const liveClaims = await scopedDb.frameVariants.listLiveClaims(
+        target.frameId
+      );
+      if (target.regenVisual) {
+        // Chained render: valid only behind OUR visual claim. A foreign
+        // visual claim means someone else owns the prompt regen — chaining
+        // onto their run is not this run's call, so skip the image too.
+        if (claims.visualVersionId) {
+          const visualVersionId = claims.visualVersionId;
+          const ours = liveClaims.find(
+            (c) => c.dependsOnVersionId === visualVersionId
+          );
+          claims.imageVariantId =
+            ours?.id ??
+            (
+              await scopedDb.frameVariants.createPendingClaim({
+                frameId: target.frameId,
+                sequenceId,
+                model: target.imageModel,
+                dependsOnVersionId: visualVersionId,
+                workflowRunId: parentInstanceId,
+              })
+            ).id;
+        } else {
+          foreignClaim = true;
+        }
+      } else if (target.imageLiveHash) {
+        const existing = liveClaims.find(
+          (c) => c.pendingInputHash === target.imageLiveHash
+        );
+        if (existing) {
+          if (existing.workflowRunId === parentInstanceId) {
+            claims.imageVariantId = existing.id;
+          } else {
+            foreignClaim = true;
+          }
+        } else {
+          try {
+            const row = await scopedDb.frameVariants.createPendingClaim({
+              frameId: target.frameId,
+              sequenceId,
+              model: target.imageModel,
+              pendingInputHash: target.imageLiveHash,
+              workflowRunId: parentInstanceId,
+            });
+            claims.imageVariantId = row.id;
+          } catch {
+            foreignClaim = true; // lost the insert race — see the visual twin
+          }
+        }
+      }
+    }
+
+    if (foreignClaim) {
+      skipped.push({ shotId: target.shotId, reason: 'already-in-flight' });
+    }
+    claimsByShot[target.shotId] = claims;
+  }
+
+  return { claimsByShot, skipped };
 }

--- a/src/lib/workflows/update-stale-shots-workflow.ts
+++ b/src/lib/workflows/update-stale-shots-workflow.ts
@@ -50,8 +50,9 @@ import {
 } from '@/lib/ai/models.config';
 import { resolveVideoModel } from '@/lib/ai/resolve-asset-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
+import { getEffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
+import { estimateVideoCost, gateEstimate } from '@/lib/billing/cost-estimation';
 import { requireCredits } from '@/lib/billing/preflight';
-import { estimateVideoCost } from '@/lib/billing/cost-estimation';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { isInsufficientCreditsError } from '@/lib/errors';
 import { buildMotionReferenceImages } from '@/lib/motion/build-motion-references';
@@ -458,9 +459,18 @@ export class UpdateStaleShotsWorkflow extends OpenStoryWorkflowEntrypoint<Update
             model,
           });
           try {
-            await requireCredits(scopedDb, estimateVideoCost(model, duration), {
-              errorMessage: 'Insufficient credits for video generation',
-            });
+            await requireCredits(
+              scopedDb,
+              gateEstimate(
+                estimateVideoCost(model, duration, {
+                  pricing: await getEffectiveFalPricing(),
+                }),
+                { model, operation: 'update-stale-shots:video' }
+              ),
+              {
+                errorMessage: 'Insufficient credits for video generation',
+              }
+            );
           } catch (error) {
             if (isInsufficientCreditsError(error)) {
               throw new NonRetryableError(

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,6 +87,7 @@ export { FramePromptBatchWorkflow } from '@/lib/workflows/frame-prompt-batch-wor
 export { MotionPromptBatchWorkflow } from '@/lib/workflows/motion-prompt-batch-workflow';
 export { MotionMusicPromptsWorkflow } from '@/lib/workflows/motion-music-prompts-workflow';
 export { RegenerateShotsWorkflow } from '@/lib/workflows/regenerate-shots-workflow';
+export { UpdateStaleShotsWorkflow } from '@/lib/workflows/update-stale-shots-workflow';
 export { RecastLocationWorkflow } from '@/lib/workflows/recast-location-workflow';
 export { ReplaceElementWorkflow } from '@/lib/workflows/replace-element-workflow';
 export { SceneSplitWorkflow } from '@/lib/workflows/scene-split-workflow';

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -67,6 +67,7 @@ declare namespace Cloudflare {
 		MOTION_PROMPT_BATCH_WORKFLOW: Workflow<Parameters<import("./src/server").MotionPromptBatchWorkflow['run']>[0]['payload']>;
 		MOTION_MUSIC_PROMPTS_WORKFLOW: Workflow<Parameters<import("./src/server").MotionMusicPromptsWorkflow['run']>[0]['payload']>;
 		REGENERATE_SHOTS_WORKFLOW: Workflow<Parameters<import("./src/server").RegenerateShotsWorkflow['run']>[0]['payload']>;
+		UPDATE_STALE_SHOTS_WORKFLOW: Workflow<Parameters<import("./src/server").UpdateStaleShotsWorkflow['run']>[0]['payload']>;
 		RECAST_LOCATION_WORKFLOW: Workflow<Parameters<import("./src/server").RecastLocationWorkflow['run']>[0]['payload']>;
 		REPLACE_ELEMENT_WORKFLOW: Workflow<Parameters<import("./src/server").ReplaceElementWorkflow['run']>[0]['payload']>;
 		SCENE_SPLIT_WORKFLOW: Workflow<Parameters<import("./src/server").SceneSplitWorkflow['run']>[0]['payload']>;
@@ -136,6 +137,7 @@ declare namespace Cloudflare {
 		MOTION_PROMPT_BATCH_WORKFLOW: Workflow<Parameters<import("./src/server").MotionPromptBatchWorkflow['run']>[0]['payload']>;
 		MOTION_MUSIC_PROMPTS_WORKFLOW: Workflow<Parameters<import("./src/server").MotionMusicPromptsWorkflow['run']>[0]['payload']>;
 		REGENERATE_SHOTS_WORKFLOW: Workflow<Parameters<import("./src/server").RegenerateShotsWorkflow['run']>[0]['payload']>;
+		UPDATE_STALE_SHOTS_WORKFLOW: Workflow<Parameters<import("./src/server").UpdateStaleShotsWorkflow['run']>[0]['payload']>;
 		RECAST_LOCATION_WORKFLOW: Workflow<Parameters<import("./src/server").RecastLocationWorkflow['run']>[0]['payload']>;
 		REPLACE_ELEMENT_WORKFLOW: Workflow<Parameters<import("./src/server").ReplaceElementWorkflow['run']>[0]['payload']>;
 		SCENE_SPLIT_WORKFLOW: Workflow<Parameters<import("./src/server").SceneSplitWorkflow['run']>[0]['payload']>;
@@ -205,6 +207,7 @@ declare namespace Cloudflare {
 		MOTION_PROMPT_BATCH_WORKFLOW: Workflow<Parameters<import("./src/server").MotionPromptBatchWorkflow['run']>[0]['payload']>;
 		MOTION_MUSIC_PROMPTS_WORKFLOW: Workflow<Parameters<import("./src/server").MotionMusicPromptsWorkflow['run']>[0]['payload']>;
 		REGENERATE_SHOTS_WORKFLOW: Workflow<Parameters<import("./src/server").RegenerateShotsWorkflow['run']>[0]['payload']>;
+		UPDATE_STALE_SHOTS_WORKFLOW: Workflow<Parameters<import("./src/server").UpdateStaleShotsWorkflow['run']>[0]['payload']>;
 		RECAST_LOCATION_WORKFLOW: Workflow<Parameters<import("./src/server").RecastLocationWorkflow['run']>[0]['payload']>;
 		REPLACE_ELEMENT_WORKFLOW: Workflow<Parameters<import("./src/server").ReplaceElementWorkflow['run']>[0]['payload']>;
 		SCENE_SPLIT_WORKFLOW: Workflow<Parameters<import("./src/server").SceneSplitWorkflow['run']>[0]['payload']>;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -231,6 +231,11 @@
       "class_name": "RegenerateShotsWorkflow",
     },
     {
+      "name": "update-stale-shots-workflow",
+      "binding": "UPDATE_STALE_SHOTS_WORKFLOW",
+      "class_name": "UpdateStaleShotsWorkflow",
+    },
+    {
       "name": "recast-location-workflow",
       "binding": "RECAST_LOCATION_WORKFLOW",
       "class_name": "RecastLocationWorkflow",
@@ -466,6 +471,11 @@
           "name": "regenerate-shots-workflow",
           "binding": "REGENERATE_SHOTS_WORKFLOW",
           "class_name": "RegenerateShotsWorkflow",
+        },
+        {
+          "name": "update-stale-shots-workflow",
+          "binding": "UPDATE_STALE_SHOTS_WORKFLOW",
+          "class_name": "UpdateStaleShotsWorkflow",
         },
         {
           "name": "recast-location-workflow",
@@ -743,6 +753,11 @@
           "name": "regenerate-shots-workflow",
           "binding": "REGENERATE_SHOTS_WORKFLOW",
           "class_name": "RegenerateShotsWorkflow",
+        },
+        {
+          "name": "update-stale-shots-workflow",
+          "binding": "UPDATE_STALE_SHOTS_WORKFLOW",
+          "class_name": "UpdateStaleShotsWorkflow",
         },
         {
           "name": "recast-location-workflow",


### PR DESCRIPTION
Closes #1085

## Phase 1 — pre-created pending artifact records

When a regeneration is enqueued, its version rows are created up front as **pending claims** and completed in place, so in-flight work is representable as data:

- `frame_prompt_versions` + `shot_prompt_versions` gain `status` (default `'completed'` — legacy rows valid without backfill), `pendingInputHash`, `workflowRunId`; `frame_variants` gains `dependsOnVersionId` + `pendingInputHash`. Additive migrations only, plus partial unique indexes allowing at most **one live claim per (owner, live-hash)** — concurrent enqueues lose the insert race and report already-in-flight instead of double-billing.
- Enqueue points (`regenerateShotPromptFn`, `generateShotImageFn`, a new `claim-targets` step in `UpdateStaleShotsWorkflow`) create the claims; the child workflows complete them in place. Claims never mirror or repoint — completion does, and only while the claim still holds its **mirror right**: revoked by a newer completed row (post-click edit) or an explicit repoint (restore / image selection), which demotes live claims to history-only. The system cannot lose an edit.
- Chained image renders consume the prompt **their dependency row produced** — a post-click edit can no longer leak into a running Update all.
- Staleness gains **`'updating'`**: stale + a live claim satisfying the live hash (directly or via the dependency chain). Claims self-invalidate on edit. UI renders it as the existing spinner forms; history sheets show pending/failed/cancelled entries with a **cancel** affordance.
- `cancelPendingArtifactFn` cancels a claim, cascades to dependent image claims, and terminates the producing run — single-artifact workflows only, never an update-stale-shots parent (data-only there; the child discards its output against the status guard). Cancel beats a racing completion.
- The cron reconciler sweeps zombie claims (run-id-verified, terminal state always `'failed'`, frame-side cascade; blind-fail for claims that never got a run id).

## Depth picker — prompts / images / video / music

"Update all" (shot status line + scene/sequence summary) now opens a **confirm dialog** with four cumulative levels, each with its cost consequence spelled out:

| Level | Does |
|---|---|
| Prompts only | Stale visual/motion prompts; nothing renders |
| Prompts + images | + stale stills, **and stills whose prompt regenerates in this run (cascade)**; never a first still |
| Prompts, images + videos | + existing videos whose upstream changed or whose manifest already diverged; never a first video |
| Everything, incl. music | + the music prompt when stale, and the existing track behind a successful prompt regen |

Per shot the video render waits on **both** the motion-prompt and image stages and never runs from an upstream the run failed to replace. Music runs sequence-level alongside the shot fan-out, track strictly behind its prompt.

**Billing safety** — video/music have no claim rows (they ride `video_variants.status` / `sequences.musicStatus`), so each spawn re-verifies current state inside its prepare step: video skips when a render is in flight or the manifest no longer diverges; music skips when the stored hash caught up or a track is generating. A replayed `compute-plan` result from a pre-picker deploy is guarded against (`plan.music ?? null`).

## Review + verification

- Two adversarial review passes; all findings fixed (restore-clobber mirror guard, cancel-race in the identical-text completion path, image-trigger dedup id, version-skew crash, concurrent video/music double-billing window).
- Gates: typecheck, oxlint (0 errors), knip, **1,976 unit tests** incl. new coverage for claim/dedup lifecycle, depth gating, video/music plan rules.
- Migrations verified `ADD COLUMN` / `CREATE INDEX` only (no D1 table rebuild) and applied to local D1.

Phase 2 (analysis pipeline adopting pending records, unifying initial-generation progress with staleness) is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
