### PR TITLE
fix(#1110): identify PostHog person on signup so alerts show email

### DIFF
--- a/scripts/setup-posthog-slack-alerts.ts
+++ b/scripts/setup-posthog-slack-alerts.ts
@@ -222,10 +222,12 @@ function specs(): DestinationSpec[] {
       type: 'destination',
       event: 'user_signed_up',
       channel: PRODUCT_CHANNEL,
-      text: 'New signup: {person.properties.email ?? event.distinct_id}',
+      // Prefer person email (set via identify/$set on signup, #1110); fall
+      // back to event property email, then distinct_id.
+      text: 'New signup: {person.properties.email ?? event.properties.email ?? event.distinct_id}',
       blocks: productBlocks(
         '🎉 New signup',
-        '*{person.properties.email ?? event.distinct_id}* just created an account'
+        '*{person.properties.email ?? event.properties.email ?? event.distinct_id}* just created an account'
       ),
     },
     {
@@ -233,10 +235,10 @@ function specs(): DestinationSpec[] {
       type: 'destination',
       event: 'user_signed_in',
       channel: PRODUCT_CHANNEL,
-      text: 'Sign-in: {person.properties.email ?? event.distinct_id}',
+      text: 'Sign-in: {person.properties.email ?? event.properties.email ?? event.distinct_id}',
       blocks: productBlocks(
         '👋 User signed in',
-        '*{person.properties.email ?? event.distinct_id}* signed in ({event.properties.path ?? "session"})'
+        '*{person.properties.email ?? event.properties.email ?? event.distinct_id}* signed in ({event.properties.path ?? "session"})'
       ),
     },
     {
@@ -244,10 +246,10 @@ function specs(): DestinationSpec[] {
       type: 'destination',
       event: 'sequence_generated',
       channel: PRODUCT_CHANNEL,
-      text: 'Film started: {person.properties.email ?? event.distinct_id}',
+      text: 'Film started: {person.properties.email ?? event.properties.email ?? event.distinct_id}',
       blocks: productBlocks(
         '🎬 Film / sequence created',
-        '*{person.properties.email ?? event.distinct_id}* created a sequence ({event.properties.source ?? "create"}, {event.properties.sequence_count ?? 1} seq, style `{event.properties.style_id}`)'
+        '*{person.properties.email ?? event.properties.email ?? event.distinct_id}* created a sequence ({event.properties.source ?? "create"}, {event.properties.sequence_count ?? 1} seq, style `{event.properties.style_id}`)'
       ),
     },
     {

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -272,6 +272,9 @@ function createAuth() {
             );
 
             // First-time account only — drives #product-alerts via PostHog (#1088).
+            // personProperties set email/name on the PostHog person so Slack
+            // templates (`person.properties.email ?? distinct_id`) show email,
+            // not only the ULID (#1110).
             captureProductEvent({
               distinctId: user.id,
               event: 'user_signed_up',
@@ -279,6 +282,10 @@ function createAuth() {
                 email: user.email,
                 name: user.name,
                 team_id: team.id,
+              },
+              personProperties: {
+                email: user.email,
+                name: user.name,
               },
             });
           },

--- a/src/lib/observability/product-events.test.ts
+++ b/src/lib/observability/product-events.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 const capture = vi.fn();
+const identify = vi.fn();
 vi.doMock('@/lib/posthog-server', () => ({
-  getPostHogClient: () => ({ capture }),
+  getPostHogClient: () => ({ capture, identify }),
 }));
 
 const { captureProductEvent } = await import('./product-events');
@@ -10,15 +11,66 @@ const { captureProductEvent } = await import('./product-events');
 describe('captureProductEvent', () => {
   it('forwards to posthog-node with distinctId + event', () => {
     capture.mockClear();
+    identify.mockClear();
     captureProductEvent({
       distinctId: 'user_1',
       event: 'user_signed_up',
       properties: { email: 'a@b.com' },
     });
+    expect(identify).not.toHaveBeenCalled();
     expect(capture).toHaveBeenCalledWith({
       distinctId: 'user_1',
       event: 'user_signed_up',
       properties: { email: 'a@b.com' },
+    });
+  });
+
+  it('identifies the person and $sets person properties on the event (#1110)', () => {
+    capture.mockClear();
+    identify.mockClear();
+    captureProductEvent({
+      distinctId: 'user_1',
+      event: 'user_signed_up',
+      properties: {
+        email: 'a@b.com',
+        name: 'Ada',
+        team_id: 'team_1',
+      },
+      personProperties: {
+        email: 'a@b.com',
+        name: 'Ada',
+      },
+    });
+    expect(identify).toHaveBeenCalledWith({
+      distinctId: 'user_1',
+      properties: { email: 'a@b.com', name: 'Ada' },
+    });
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: 'user_1',
+      event: 'user_signed_up',
+      properties: {
+        email: 'a@b.com',
+        name: 'Ada',
+        team_id: 'team_1',
+        $set: { email: 'a@b.com', name: 'Ada' },
+      },
+    });
+  });
+
+  it('skips identify and $set when personProperties is empty', () => {
+    capture.mockClear();
+    identify.mockClear();
+    captureProductEvent({
+      distinctId: 'user_1',
+      event: 'user_signed_in',
+      properties: { path: '/api/auth/sign-in' },
+      personProperties: {},
+    });
+    expect(identify).not.toHaveBeenCalled();
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: 'user_1',
+      event: 'user_signed_in',
+      properties: { path: '/api/auth/sign-in' },
     });
   });
 });

--- a/src/lib/observability/product-events.ts
+++ b/src/lib/observability/product-events.ts
@@ -3,6 +3,10 @@
  *
  * Prefer server-side capture so OAuth redirects, passkeys, and the public API
  * all emit the same events. Failures must never break the critical path.
+ *
+ * Person properties (email/name) must be set via `$set` / identify — event
+ * properties alone leave `person.properties.*` empty, so Slack templates that
+ * fall back to `event.distinct_id` only show the user id (#1110).
  */
 
 import { getPostHogClient } from '@/lib/posthog-server';
@@ -23,6 +27,12 @@ export type CaptureProductEventArgs = {
   distinctId: string;
   event: ProductEventName;
   properties?: Record<string, unknown>;
+  /**
+   * Person properties attached to this distinctId. Sent as `$set` on the event
+   * and via `identify` so PostHog People / Slack templates can read
+   * `person.properties.email` (etc.) when the product event lands.
+   */
+  personProperties?: Record<string, unknown>;
 };
 
 /**
@@ -32,10 +42,30 @@ export function captureProductEvent(args: CaptureProductEventArgs): void {
   try {
     const posthog = getPostHogClient();
     if (!posthog) return;
+
+    if (
+      args.personProperties &&
+      Object.keys(args.personProperties).length > 0
+    ) {
+      // Identify so the person profile is updated even if capture is filtered.
+      posthog.identify({
+        distinctId: args.distinctId,
+        properties: args.personProperties,
+      });
+    }
+
     posthog.capture({
       distinctId: args.distinctId,
       event: args.event,
-      properties: args.properties,
+      properties: {
+        ...args.properties,
+        // Atomic with the event: destination templates that resolve
+        // person.properties.* at ingest time see email/name immediately.
+        ...(args.personProperties &&
+        Object.keys(args.personProperties).length > 0
+          ? { $set: args.personProperties }
+          : {}),
+      },
     });
   } catch (err) {
     logger.error('captureProductEvent failed', {


### PR DESCRIPTION
## Summary

- On `user_signed_up`, set PostHog **person** properties (email, name) via `identify` + `$set`, not only event properties
- Slack `#product-alerts` templates read `person.properties.email`; without person props they only showed the user ULID
- Harden setup-script destination templates with `event.properties.email` as a secondary fallback

## Test plan

- [x] `bun run test src/lib/observability/product-events.test.ts`
- [x] `bun typecheck`
- [ ] Deploy / wait for merge, then sign up a test user and confirm `#product-alerts` shows email
- [ ] Confirm the PostHog person profile has email/name after signup

Closes #1110