### PR TITLE
fix(#1087): make CatalogApiError ride the OpenStoryError serialization adapter

### DIFF
--- a/src/components/models/model-detail-view.tsx
+++ b/src/components/models/model-detail-view.tsx
@@ -68,14 +68,18 @@ import { Suspense, useState } from 'react';
 
 /**
  * `getModelDetail` throws CatalogApiError(404, 'unknown_schema') when the
- * endpoint has no input schema. Seroval preserves own props across the
- * server-fn boundary (#1087), so we match on status+code — not message prose.
- * A modelschemas outage is 5xx and will not match.
+ * endpoint has no input schema. CatalogApiError extends OpenStoryError, so
+ * the serialization adapter (#1087/#1099) delivers `code`/`statusCode` here —
+ * match on those, never message prose. A modelschemas outage is 5xx and will
+ * not match.
  */
 function isNoSchemaError(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
-  const { status, code } = error as { status?: unknown; code?: unknown };
-  return status === 404 && code === 'unknown_schema';
+  const { statusCode, code } = error as {
+    statusCode?: unknown;
+    code?: unknown;
+  };
+  return statusCode === 404 && code === 'unknown_schema';
 }
 
 /**

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -179,9 +179,9 @@ describe('errorCode / isInsufficientCreditsError', () => {
   });
 
   it('matches our error across the server-fn boundary but not a provider’s', () => {
-    // Seroval reconstitutes a thrown OpenStoryError as a plain Error with the
-    // same own props (code/statusCode/details) — not the original class.
-    // See #1087 / seroval Error own-property serialization.
+    // The serialization adapter reconstitutes a thrown OpenStoryError with
+    // the same own props (code/statusCode/details) — not the original
+    // subclass. See #1087/#1099.
     const acrossBoundary = Object.assign(
       new Error('Insufficient credits for image'),
       {

--- a/src/lib/models/catalog.test.ts
+++ b/src/lib/models/catalog.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { openStoryErrorSerializationAdapter } from '@/lib/errors';
 
 /**
  * The catalog module holds a TTL response cache at module level, so each
@@ -271,7 +272,7 @@ describe('listCatalogModelFamilies', () => {
     const promise = listCatalogModelFamilies();
     await expect(promise).rejects.toBeInstanceOf(CatalogApiError);
     await expect(promise).rejects.toMatchObject({
-      status: 429,
+      statusCode: 429,
       code: 'rate_limited',
       message: 'Too many requests',
     });
@@ -282,8 +283,29 @@ describe('listCatalogModelFamilies', () => {
     mockFetch.mockResolvedValueOnce(new Response('gateway荒', { status: 502 }));
 
     await expect(listCatalogModelFamilies()).rejects.toMatchObject({
-      status: 502,
+      statusCode: 502,
+      code: 'CATALOG_API_ERROR',
       message: 'modelschemas request failed (502)',
+    });
+  });
+
+  it('carries code/statusCode across the server-fn boundary', async () => {
+    // CatalogApiError must stay an OpenStoryError: any plain Error is
+    // flattened to message-only by TanStack Router's ShallowErrorPlugin, and
+    // isNoSchemaError (model-detail-view.tsx) would silently never match.
+    const { CatalogApiError } = await importCatalog();
+    const restored: unknown =
+      openStoryErrorSerializationAdapter.fromSerializable(
+        openStoryErrorSerializationAdapter.toSerializable(
+          new CatalogApiError('No schema', 404, 'unknown_schema')
+        )
+      );
+
+    expect(restored).toMatchObject({
+      name: 'CatalogApiError',
+      message: 'No schema',
+      statusCode: 404,
+      code: 'unknown_schema',
     });
   });
 });
@@ -372,7 +394,7 @@ describe('getModelDetail', () => {
     const promise = getModelDetail('fal-ai/does-not-exist', 'image');
     await expect(promise).rejects.toBeInstanceOf(CatalogApiError);
     await expect(promise).rejects.toMatchObject({
-      status: 404,
+      statusCode: 404,
       code: 'unknown_schema',
     });
   });

--- a/src/lib/models/catalog.ts
+++ b/src/lib/models/catalog.ts
@@ -25,6 +25,7 @@
  */
 import type { GeneratedAssetActivity, JsonValue } from '@/lib/db/schema';
 import { getEnv } from '#env';
+import { OpenStoryError } from '@/lib/errors';
 import { groupModelsIntoFamilies, type ModelFamily } from './model-families';
 
 const MODELSCHEMAS_BASE_URL = 'https://modelschemas.com';
@@ -121,20 +122,17 @@ export type ModelDetail = {
 };
 
 /**
- * @public Typed upstream failure. Own props (`status`/`code`) survive the
- * server-fn boundary via seroval (#1087), so client code can branch on them
- * (see `isNoSchemaError` in model-detail-view.tsx). Inside this module,
- * `fetchSchema` still maps 404 → null before rethrowing a richer error.
+ * @public Typed upstream failure. Extends OpenStoryError because that is the
+ * only error the serialization adapter in `createStart` carries across the
+ * server-fn boundary — every other Error hits TanStack Router's
+ * ShallowErrorPlugin, which keeps `message` alone (#1087/#1099). Client code
+ * branches on `code`/`statusCode` (see `isNoSchemaError` in
+ * model-detail-view.tsx). Inside this module, `fetchSchema` still maps
+ * 404 → null before rethrowing a richer error.
  */
-export class CatalogApiError extends Error {
-  readonly status: number;
-  readonly code?: string;
-
-  constructor(message: string, status: number, code?: string) {
-    super(message);
-    this.name = 'CatalogApiError';
-    this.status = status;
-    this.code = code;
+export class CatalogApiError extends OpenStoryError {
+  constructor(message: string, statusCode: number, code?: string) {
+    super(message, code ?? 'CATALOG_API_ERROR', statusCode);
   }
 }
 
@@ -412,7 +410,8 @@ async function fetchSchema(
     );
     return parseSchemaResponse(body, endpointId);
   } catch (error) {
-    if (error instanceof CatalogApiError && error.status === 404) return null;
+    if (error instanceof CatalogApiError && error.statusCode === 404)
+      return null;
     throw error;
   }
 }


### PR DESCRIPTION
Closes #1087

## Problem

The #1087 work is almost fully shipped: `errorCode()` predicates landed in #1093, and the real transport fix — `openStoryErrorSerializationAdapter` registered in `createStart` — merged via #1099. One broken remnant was left behind:

`CatalogApiError` still extended plain `Error`. TanStack Router's `ShallowErrorPlugin` flattens every plain `Error` to message-only in transit, so the `status`/`code` props that `isNoSchemaError` (model-detail-view.tsx) checks **never arrived at the client** — its comment still claimed the disproven "seroval preserves own props" premise. Concretely: a deep link to a `/models` endpoint with no input schema hits the error boundary instead of the friendly "not runnable" empty state, and the multi-activity fallback loop aborts on its first candidate.

## Fix

- **`catalog.ts`** — `CatalogApiError` now extends `OpenStoryError`, so the existing serialization adapter carries it across the boundary. `status` renamed to `statusCode` (matching the parent instead of mirroring it); upstream code defaults to `CATALOG_API_ERROR` when the service sends none. Class doc rewritten to state the real constraint: any error branched on client-side after a server-fn throw must extend `OpenStoryError`.
- **`model-detail-view.tsx`** — `isNoSchemaError` matches `statusCode === 404 && code === 'unknown_schema'`; comment corrected.
- **`catalog.test.ts`** — assertions updated to `statusCode`, plus a new test round-tripping a `CatalogApiError` through the adapter, pinning that `code`/`statusCode`/`name` survive the wire.
- **`errors.test.ts`** — fixed one stale comment still crediting seroval for prop survival.

`route-error-fallback.tsx`'s message fallback is left alone — it already prefers `errorCode()` and only sniffs prose for genuinely code-less errors (router `notFound()`), which the merged work kept deliberately.

## Verification

- Full unit suite: 202 files / 2100 tests passing
- `bun typecheck` clean, `bun lint` 0 errors, `bun format:check` clean
