### PR TITLE
fix(#1119): thread the anchor frameId through every image spawner

### DIFF
--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -92,8 +92,14 @@ export interface ImageWorkflowInput extends SequenceWorkflowContext {
   /**
    * The shot's anchor frame, resolved at trigger time. Frame id ≠ shot id
    * (#989); passing it keeps every step of the run bound to the SAME frame
-   * instead of re-resolving the anchor per step. Optional for un-migrated
-   * triggers, which fall back to `frames.getAnchorByShot`.
+   * instead of re-resolving the anchor per step.
+   *
+   * MANDATORY whenever `shotId` is set. There is no `frames.getAnchorByShot`
+   * fallback any more (#1067) — a payload with a `shotId` and no `frameId`
+   * writes NOTHING back to the frame: the image still generates and bills, and
+   * every frame write (status, variant selection, preview url) is skipped.
+   * Optional in the type only for shotless ad-hoc runs and for stale in-flight
+   * instances spawned by a pre-#1067 build. See #1119.
    */
   frameId?: string;
   /**

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -75,12 +75,27 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
    * in-flight instance from a previous build — stand down rather than
    * resolve the anchor by shot, which could land on a DIFFERENT frame than
    * a sibling step resolved.
+   *
+   * A `shotId` with no `frameId` is logged as the invariant violation it is:
+   * every caller of this reports the null as "the frame is gone", which read
+   * as a routine skip for a whole release while scene-split's preview triggers
+   * silently wrote nothing (#1119).
    */
   private resolveFrame(
     scopedDb: WorkflowScopedDb,
     input: Pick<ImageWorkflowInput, 'frameId' | 'shotId'>
   ): Promise<Frame | null> {
-    if (!input.frameId) return Promise.resolve(null);
+    if (!input.frameId) {
+      if (input.shotId) {
+        logger.warn(
+          `[ImageWorkflow] Shot ${input.shotId} was triggered without a frameId; ` +
+            `this run writes nothing back to the frame. Either a stale in-flight ` +
+            `instance from a pre-#1067 build, or a spawner that failed to thread ` +
+            `the anchor frame id.`
+        );
+      }
+      return Promise.resolve(null);
+    }
     return scopedDb.liveRead.frames.getById(input.frameId);
   }
 

--- a/src/lib/workflows/regenerate-shots-workflow.ts
+++ b/src/lib/workflows/regenerate-shots-workflow.ts
@@ -155,6 +155,9 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
           teamId,
           sequenceId,
           shotId: snapshot.shotId,
+          // Mandatory alongside `shotId` — without it the child renders and
+          // bills, then writes nothing back to the frame (#1119).
+          frameId: snapshot.frameId ?? undefined,
           prompt: snapshot.imagePrompt,
           model: imageModel,
           imageSize: aspectRatioToImageSize(aspectRatio),

--- a/src/lib/workflows/replace-element-workflow.ts
+++ b/src/lib/workflows/replace-element-workflow.ts
@@ -426,6 +426,9 @@ export class ReplaceElementWorkflow extends OpenStoryWorkflowEntrypoint<ReplaceE
           teamId: input.teamId,
           sequenceId,
           shotId,
+          // Mandatory alongside `shotId` — without it the child renders and
+          // bills, then writes nothing back to the frame (#1119).
+          frameId: snapshot.frameId ?? undefined,
           prompt: editPrompt,
           model,
           imageSize: aspectRatioToImageSize(aspectRatio),

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -208,7 +208,13 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         let finalText = '';
         let chunkCount = 0;
         let prevScene: SceneSplittingScene | undefined = undefined;
-        let prevShotId: string | undefined = undefined;
+        /**
+         * The previous scene's shot AND its anchor frame, as one value: the
+         * preview trigger needs both, and `ImageWorkflow` silently stands down
+         * on a payload that carries `shotId` without `frameId` (#1119). Paired
+         * so the two can't drift apart again.
+         */
+        let prevShot: { id: string; frameId: string } | undefined = undefined;
         let parsedResult: SceneSplittingResult | undefined;
         let capturedUsage: TokenUsage | undefined;
 
@@ -346,7 +352,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                     orderIndex: ev.index,
                   }
                 );
-                if (prevScene && prevShotId) {
+                if (prevScene && prevShot) {
                   const sceneText =
                     // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
                     prevScene.originalScript?.extract ??
@@ -370,20 +376,23 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                       model: PREVIEW_IMAGE_MODEL,
                       imageSize: aspectRatioToImageSize(aspectRatio),
                       numImages: 1,
-                      shotId: prevShotId,
+                      shotId: prevShot.id,
+                      // Without this the run generates (and bills) the preview,
+                      // then drops it at `store-preview-url` (#1119).
+                      frameId: prevShot.frameId,
                       skipStorage: true,
                     } satisfies ImageWorkflowInput,
                     {
                       label: buildWorkflowLabel(sequenceId),
                       deduplicationId: previewImageDedupId(
                         event.instanceId,
-                        prevShotId
+                        prevShot.id
                       ),
                     }
                   );
                 }
 
-                prevShotId = shot.id;
+                prevShot = { id: shot.id, frameId: shot.anchorFrameId };
               }
               prevScene = ev.scene;
             }
@@ -391,7 +400,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         }
 
         // Trigger preview for the last scene (the loop only triggers N-1).
-        if (prevScene && prevShotId && sequenceId) {
+        if (prevScene && prevShot && sequenceId) {
           const sceneText =
             // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
             prevScene.originalScript?.extract ??
@@ -410,14 +419,15 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
               model: PREVIEW_IMAGE_MODEL,
               imageSize: aspectRatioToImageSize(aspectRatio),
               numImages: 1,
-              shotId: prevShotId,
+              shotId: prevShot.id,
+              frameId: prevShot.frameId,
               skipStorage: true,
             } satisfies ImageWorkflowInput,
             {
               label: buildWorkflowLabel(sequenceId),
               deduplicationId: previewImageDedupId(
                 event.instanceId,
-                prevShotId
+                prevShot.id
               ),
             }
           );


### PR DESCRIPTION
Closes #1119

## The bug

`e76280ae` (#1067, "snapshot workflow inputs at the trigger") replaced
`scopedDb.frames.getAnchorByShot(shotId)` in `ImageWorkflow` with a private
`resolveFrame` that stands down and returns `null` unless the payload carries
`frameId`. Its doc comment asserted the invariant *"every spawner threads
`frameId` alongside `shotId`"*.

Three spawners did not:

| Spawner | Symptom |
| --- | --- |
| `scene-split-workflow.ts` preview triggers (×2) | #1119 — scene-list thumbnails stay on the gradient placeholder for the whole generation |
| `replace-element-workflow.ts` | "Replace element" silently writes nothing back |
| `regenerate-shots-workflow.ts` | recast / regenerate-shots silently writes nothing back |

`resolveFrame` gates *every* frame write — status, variant selection, preview
url — so all three have been no-ops since the merge. The image is still
generated and billed in each case: `set-generating-status` returns early for
`skipStorage` / preview runs *before* `resolveFrame`, so only the write-back is
dropped.

## The fix

Each spawner now threads the anchor id it already had in scope
(`shot.anchorFrameId`, `snapshot.frameId`). In `scene-split-workflow` the shot
id and its anchor are paired into one `prevShot` value so the two can't drift
apart again.

Two changes to stop this recurring silently:

- `ImageWorkflowInput.frameId`'s doc comment still promised the
  `frames.getAnchorByShot` fallback that #1067 removed. That stale comment is
  what made the omission invisible at the call site — it now states that
  `frameId` is mandatory whenever `shotId` is set, and what breaks without it.
- `resolveFrame` now `logger.warn`s on a `shotId` with no `frameId`. Every
  caller reported that null as "the frame is gone", so an invariant violation
  read as a routine skip in the logs for a whole release.

## Why e2e didn't catch it

`full-sequence.spec.ts` has no assertion that fails when previews are dead. The
canvas auto-reveal condition is:

```ts
const canvasReady = !isProcessing ||
  (shots?.some((s) => s.image?.url || s.frame.previewImageUrl) ?? false);
```

By the time the spec asserts the canvas toggle is on, the pipeline has finished
and real shot images have landed — `image.url` satisfies it, and `!isProcessing`
satisfies it again. The only preview-*timed* assertion in the spec asserts that
previews have **not** arrived yet, which passes harder when they never arrive at
all. Catching this needs an assertion that a preview lands *while*
`isProcessing` is true, before any real image — not added here, since it is the
flakiest kind of assertion in that spec and worth its own discussion.

## Verification

- `bun typecheck` — clean
- `bun lint` — 0 errors (21 pre-existing warnings, none in touched files)
- `bun run test` — 2203/2203 passing

## Not in scope

False "Out of date since your edit" banners during initial generation, before
any user edit. Different code path (`computeShotStaleness`); tracked separately.
