### PR TITLE
Persist generated sequence posters to R2 storage (#1117)

### DIFF
--- a/docs/developer-guide/workflow.md
+++ b/docs/developer-guide/workflow.md
@@ -141,7 +141,11 @@ flowchart TD
 
 - Generates a poster image from the script+title+style for the video player empty state
 - Non-critical — failures are logged and swallowed
-- Emits `generation.poster:ready` with the URL
+
+**Steps: `upload-poster` → `save-poster`**
+
+- `upload-poster` streams the provider image into R2 (`uploadPosterToStorage`) so the stored URL is the origin-relative `/r2/` path and never expires (#1117). Also non-critical: an upload failure falls back to the provider URL
+- `save-poster` writes `posterUrl` on the sequence and emits `generation.poster:ready` with the URL
 
 Then spawns the `AnalyzeScriptWorkflow` child via `spawnAndAwaitChild(ANALYZE_SCRIPT_WORKFLOW, …)` (`src/lib/workflow/await-child.ts`) and awaits its completion. The child runs as its own durable instance with its own per-step retry budget.
 

--- a/src/lib/db/schema/sequences.ts
+++ b/src/lib/db/schema/sequences.ts
@@ -125,8 +125,10 @@ export const sequences = snakeCase.table(
     // dialogue audio are unaffected (#834).
     includeMusic: integer({ mode: 'boolean' }).default(true).notNull(),
 
-    // Poster image (sequence-level preview from script, ephemeral CDN URL)
-    // TB-20260804: DB-Audit: posterUrl should be stored - not ephemeral
+    // Poster image (sequence-level preview generated from the script). Stored
+    // in R2 as an origin-relative `/r2/` URL (#1117, #894) — rows written
+    // before that fix hold a provider CDN URL that may have expired, and fall
+    // back to the player's empty state until the sequence regenerates.
     posterUrl: text(),
 
     // Auto-generation flags (set at sequence creation, read by UI for phase display)

--- a/src/lib/image/image-storage.test.ts
+++ b/src/lib/image/image-storage.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Poster/image upload key layout (#1117).
+ *
+ * The poster used to be persisted as fal's own CDN URL, which expires — the
+ * video-player empty state then 404s. These pin that both uploaders stream
+ * into the thumbnails bucket under a team/sequence-scoped key and hand back
+ * the stored URL, not the provider one.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPublicUrl, type StorageBucket } from '@/lib/storage/buckets';
+
+const uploadFile = vi.fn(
+  (
+    bucket: StorageBucket,
+    path: string,
+    _file: unknown,
+    options?: { contentType?: string }
+  ) =>
+    Promise.resolve({
+      path: `${bucket}/${path}`,
+      publicUrl: getPublicUrl(bucket, path),
+      fullPath: `${bucket}/${path}`,
+      contentType: options?.contentType,
+    })
+);
+vi.doMock('#storage', () => ({ uploadFile }));
+vi.doMock('#env', () => ({ getEnv: () => ({}) }));
+
+// Dynamic import so the mocks apply (vi.doMock is not hoisted).
+const { uploadImageToStorage, uploadPosterToStorage } =
+  await import('./image-storage');
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+function respondWith(contentType: string): void {
+  fetchMock.mockResolvedValue(
+    new Response(new Uint8Array([1, 2, 3]), {
+      headers: { 'content-type': contentType },
+    })
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  uploadFile.mockClear();
+});
+
+describe('uploadPosterToStorage', () => {
+  it('stores the poster under the sequence and returns the /r2 URL', async () => {
+    respondWith('image/png');
+
+    const result = await uploadPosterToStorage({
+      imageUrl: 'https://v3.fal.media/files/b/abc/poster.png',
+      teamId: 'team_1',
+      sequenceId: 'seq_1',
+    });
+
+    expect(result.path).toMatch(
+      /^teams\/team_1\/sequences\/seq_1\/poster\/[0-9A-Z]+\.png$/
+    );
+    expect(result.url).toBe(`/r2/thumbnails/${result.path}`);
+
+    expect(uploadFile).toHaveBeenCalledWith(
+      'thumbnails',
+      result.path,
+      expect.anything(),
+      expect.objectContaining({ contentType: 'image/png' })
+    );
+  });
+
+  it('falls back to the response content-type when the URL has no extension', async () => {
+    respondWith('image/webp');
+
+    const result = await uploadPosterToStorage({
+      imageUrl: 'https://v3.fal.media/files/b/abc/poster',
+      teamId: 'team_1',
+      sequenceId: 'seq_1',
+    });
+
+    expect(result.path).toMatch(/\.webp$/);
+  });
+
+  it('throws when the provider image cannot be downloaded', async () => {
+    fetchMock.mockResolvedValue(
+      new Response(null, { status: 404, statusText: 'Not Found' })
+    );
+
+    await expect(
+      uploadPosterToStorage({
+        imageUrl: 'https://v3.fal.media/files/b/abc/poster.png',
+        teamId: 'team_1',
+        sequenceId: 'seq_1',
+      })
+    ).rejects.toThrow('Failed to download image');
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('uploadImageToStorage', () => {
+  it('keeps the existing shot-scoped key layout', async () => {
+    respondWith('image/png');
+
+    const result = await uploadImageToStorage({
+      imageUrl: 'https://v3.fal.media/files/b/abc/shot.png',
+      teamId: 'team_1',
+      sequenceId: 'seq_1',
+      shotId: 'shot_1',
+    });
+
+    expect(result.path).toMatch(
+      /^teams\/team_1\/sequences\/seq_1\/frames\/shot_1\/[0-9A-Z]+\.png$/
+    );
+  });
+});

--- a/src/lib/image/image-storage.ts
+++ b/src/lib/image/image-storage.ts
@@ -18,20 +18,26 @@ interface UploadImageOptions {
   shotId: string;
 }
 
+interface UploadPosterOptions {
+  imageUrl: string;
+  teamId: string;
+  sequenceId: string;
+}
+
 type StorageResult = {
   url: string;
   path: string;
 };
 
 /**
- * Upload an image from URL to R2 Storage
- * Uses ULID-based filename and preserves original file extension
+ * Download an image from a (provider) URL and stream it into the thumbnails
+ * bucket. `buildPath` receives the resolved file extension so callers own the
+ * key layout without duplicating the extension sniffing below.
  */
-export async function uploadImageToStorage(
-  options: UploadImageOptions
+async function uploadImageFromUrl(
+  imageUrl: string,
+  buildPath: (extension: string) => string
 ): Promise<StorageResult> {
-  const { imageUrl, teamId, sequenceId, shotId } = options;
-
   // Download image from URL first to get content type
   const response = await fetch(imageUrl);
 
@@ -52,9 +58,7 @@ export async function uploadImageToStorage(
     else if (responseContentType.includes('gif')) extension = 'gif';
   }
 
-  // Generate ULID-based filename
-  const ulid = generateId();
-  const storagePath = `teams/${teamId}/sequences/${sequenceId}/frames/${shotId}/${ulid}.${extension}`;
+  const storagePath = buildPath(extension);
 
   // Get proper MIME type for the extension
   const contentType = getMimeTypeFromExtension(extension);
@@ -73,4 +77,40 @@ export async function uploadImageToStorage(
     url: result.publicUrl,
     path: storagePath,
   };
+}
+
+/**
+ * Upload an image from URL to R2 Storage
+ * Uses ULID-based filename and preserves original file extension
+ */
+export async function uploadImageToStorage(
+  options: UploadImageOptions
+): Promise<StorageResult> {
+  const { imageUrl, teamId, sequenceId, shotId } = options;
+
+  return uploadImageFromUrl(
+    imageUrl,
+    (extension) =>
+      `teams/${teamId}/sequences/${sequenceId}/frames/${shotId}/${generateId()}.${extension}`
+  );
+}
+
+/**
+ * Upload a generated sequence poster to R2 Storage (#1117).
+ *
+ * Posters used to be persisted as the provider's own CDN URL, which expires —
+ * the video-player empty state then silently 404s. Like every other generated
+ * asset, the poster now lives in our bucket and the row holds the
+ * origin-relative `/r2/` path (#894).
+ */
+export async function uploadPosterToStorage(
+  options: UploadPosterOptions
+): Promise<StorageResult> {
+  const { imageUrl, teamId, sequenceId } = options;
+
+  return uploadImageFromUrl(
+    imageUrl,
+    (extension) =>
+      `teams/${teamId}/sequences/${sequenceId}/poster/${generateId()}.${extension}`
+  );
 }

--- a/src/lib/workflows/storyboard-workflow.ts
+++ b/src/lib/workflows/storyboard-workflow.ts
@@ -30,6 +30,7 @@ import {
 import { aspectRatioToImageSize } from '@/lib/constants/aspect-ratios';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import { generateImageWithProvider } from '@/lib/image/image-generation';
+import { uploadPosterToStorage } from '@/lib/image/image-storage';
 import { buildPosterPrompt } from '@/lib/prompts/poster-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import { validateSequenceAuth } from '@/lib/workflow/auth';
@@ -116,8 +117,30 @@ export class StoryboardWorkflow extends OpenStoryWorkflowEntrypoint<StoryboardWo
     });
 
     if (posterResult) {
-      const posterUrl = posterResult.imageUrls[0];
-      if (posterUrl) {
+      const generatedPosterUrl = posterResult.imageUrls[0];
+      if (generatedPosterUrl) {
+        // The provider URL is ephemeral — persist the bytes into R2 so the
+        // stored row keeps resolving after the CDN link expires (#1117).
+        // Non-critical like the generation above: an upload outage falls back
+        // to the provider URL (today's behaviour) rather than failing the run.
+        const storedPosterUrl = await step.do('upload-poster', async () => {
+          try {
+            const upload = await uploadPosterToStorage({
+              imageUrl: generatedPosterUrl,
+              teamId,
+              sequenceId,
+            });
+            return upload.url;
+          } catch (error) {
+            logger.warn('[StoryboardWorkflow:cf] Poster upload failed:', {
+              err: error,
+            });
+            return null;
+          }
+        });
+
+        const posterUrl = storedPosterUrl ?? generatedPosterUrl;
+
         await step.do('save-poster', async () => {
           await scopedDb.sequences.update({ id: sequenceId, posterUrl });
           await getGenerationChannel(sequenceId).emit(


### PR DESCRIPTION
## Related Issue

Closes #1117

## Summary of Changes

Sequence posters are now persisted to R2 storage instead of relying on ephemeral provider CDN URLs that expire. This prevents the video player empty state from silently 404ing when the provider URL becomes unavailable.

**Key changes:**

1. **Refactored `uploadImageFromUrl`** — extracted common image download/upload logic into a reusable helper that accepts a `buildPath` callback, allowing callers to define their own key layout without duplicating extension sniffing.

2. **Added `uploadPosterToStorage`** — new export that uploads generated posters under `teams/{teamId}/sequences/{sequenceId}/poster/{ulid}.{ext}` and returns the origin-relative `/r2/` URL for storage in the database.

3. **Updated `StoryboardWorkflow`** — integrated poster upload as a non-critical step (`upload-poster`) that falls back to the provider URL if upload fails, ensuring generation doesn't break on upload outages.

4. **Updated schema documentation** — clarified that `posterUrl` is now stored in R2 as an origin-relative path; rows written before this fix may hold expired provider URLs and fall back to the player's empty state until regenerated.

5. **Added comprehensive tests** — `image-storage.test.ts` covers both poster and image uploads, including extension detection, content-type handling, and error cases.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

The change is low-risk because:
- Poster upload is non-critical and wrapped in error handling that falls back to the provider URL
- Existing image upload logic (`uploadImageToStorage`) is unchanged
- New code is isolated to poster-specific paths and tested
- Backward compatible: old rows with provider URLs continue to work until sequences regenerate

## Additional Notes

The poster upload step is intentionally non-critical (like generation itself) to avoid cascading failures. If R2 upload fails, the workflow logs a warning and uses the provider URL, matching today's behavior. This graceful degradation ensures the workflow completes even if storage is temporarily unavailable.

The fix addresses #894 (origin-relative `/r2/` paths for all generated assets) and #1117 (ephemeral poster URLs).

https://claude.ai/code/session_01Qcicest5z7kKZJgBKxfWjr