### PR TITLE
Defer shot staleness checks while sequence is generating (#1121)

### DIFF
--- a/src/components/scenes/scene-music-facet.tsx
+++ b/src/components/scenes/scene-music-facet.tsx
@@ -8,6 +8,7 @@ import { generateMusicFn } from '@/functions/sequences';
 import { useActiveAudioModel } from '@/hooks/use-active-audio-model';
 import { useShotsBySequence } from '@/hooks/use-shots';
 import {
+  musicPromptStalenessKey,
   sequenceKeys,
   useSequence,
   useSequenceAudioVariants,
@@ -237,12 +238,9 @@ export const SceneMusicFacet: React.FC<SceneMusicFacetProps> = ({
     },
   });
 
-  const musicPromptStalenessKey = [
-    'music-prompt-staleness',
-    sequenceId,
-  ] as const;
+  const stalenessKey = musicPromptStalenessKey(sequenceId);
   const { data: musicPromptStaleness } = useQuery({
-    queryKey: musicPromptStalenessKey,
+    queryKey: stalenessKey,
     queryFn: () => getMusicPromptStalenessFn({ data: { sequenceId } }),
     staleTime: 30_000,
     enabled: editable,
@@ -255,7 +253,7 @@ export const SceneMusicFacet: React.FC<SceneMusicFacetProps> = ({
         toast.info('Music prompt is already up to date');
       }
       await queryClient.invalidateQueries({
-        queryKey: musicPromptStalenessKey,
+        queryKey: stalenessKey,
       });
       await queryClient.invalidateQueries({
         queryKey: sequenceKeys.detail(sequenceId),

--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -29,6 +29,7 @@ import { NotFoundError } from '@/lib/errors';
 import { getLogger, toErrorPayload } from '@/lib/observability/logger';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import type { Frame } from '@/lib/db/schema';
+import type { SequenceStatus } from '@/lib/db/schema/sequences';
 import type { Shot, Sequence } from '@/types/database';
 import { createMiddleware } from '@tanstack/react-start';
 import { getRequest } from '@tanstack/react-start/server';
@@ -71,7 +72,9 @@ type PartialSequence = {
   id: string;
   teamId: string;
   title: string;
-  status: string;
+  /** Narrow, not `string`: staleness defers while the sequence is
+   * 'processing' (#1121), and that check must not be a string compare. */
+  status: SequenceStatus;
   styleId: string | null;
   imageModel: string;
   videoModel: string;

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -786,6 +786,15 @@ export const getMusicPromptStalenessFn = createServerFn({ method: 'GET' })
   .handler(async ({ context }) => {
     const { sequence, scopedDb } = context;
 
+    // Mid-run (#1121): the hash is taken over the scene summaries, and a
+    // storyboard run is still writing scenes — the divergence is the pipeline
+    // working, not the user's edit. Same short-circuit as
+    // `computeShotStaleness`, for the same reason: no verdict while the
+    // sequence is being built.
+    if (sequence.status === 'processing') {
+      return { musicPrompt: 'generating' as const };
+    }
+
     // No stored hash: legacy sequence or never generated. Surface explicitly
     // so the UI can suppress the "regenerate" prompt without claiming
     // freshness.

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -53,6 +53,7 @@ import {
   shotAccessMiddleware,
   sequenceAccessMiddleware,
 } from './middleware';
+import { ValidationError } from '@/lib/errors';
 
 import { getLogger } from '@/lib/observability/logger';
 
@@ -696,6 +697,16 @@ export const updateStaleShotsFn = createServerFn({ method: 'POST' })
   .handler(async ({ data, context }) => {
     const { sequence, teamId, user, scopedDb } = context;
     const depth = data.depth ?? DEFAULT_UPDATE_STALE_DEPTH;
+    // Never race the pipeline (#1121). While a storyboard run owns the
+    // sequence it is rewriting these artifacts anyway, so an Update all run
+    // would bill for work that is about to be overwritten. Staleness reads
+    // 'generating' during this window, so the UI offers no action to get
+    // here — this is the guard for a stale tab or a direct API call.
+    if (sequence.status === 'processing') {
+      throw new ValidationError(
+        'This sequence is still generating — wait for the run to finish before updating out-of-date shots.'
+      );
+    }
     // Deliberately before the plan: this is a floor, not a quote — a run that
     // can't afford even one artifact of its most expensive level should never
     // start, and there's no point planning a whole sequence to tell the user

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -30,6 +30,16 @@ export const sequenceKeys = {
   detail: (id?: string) => [...sequenceKeys.details(), id] as const,
 };
 
+/**
+ * Music-prompt staleness — its own key rather than a member of
+ * `sequenceKeys`, since it is a computed verdict rather than a slice of the
+ * sequence row and must not be swept by a `sequenceKeys.all` invalidation.
+ * Shared with the realtime cache updater, which refreshes it when a
+ * generation run ends and its verdict becomes computable again (#1121).
+ */
+export const musicPromptStalenessKey = (sequenceId: string) =>
+  ['music-prompt-staleness', sequenceId] as const;
+
 // All music variant rows for a sequence (#546). Used by the music tab to
 // resolve playback through the active model's track.
 export function useSequenceAudioVariants(sequenceId?: string) {

--- a/src/hooks/use-shot-staleness.ts
+++ b/src/hooks/use-shot-staleness.ts
@@ -11,8 +11,11 @@ import {
  * semantics. `ArtifactStaleness` is imported rather than redeclared so the
  * client and server can't drift on the vocabulary. Only `'stale'` drives UI
  * regenerate actions: `'untracked'` (no hash) and `'unknown'` (check failed)
- * both mean "no opinion to surface as stale", and `'updating'` means a job is
- * already fixing it (#1085).
+ * both mean "no opinion to surface as stale", `'updating'` means a job is
+ * already fixing it (#1085), and `'generating'` means the sequence is mid-run
+ * so no verdict was computed at all (#1121). The predicates below deliberately
+ * match none of the last three as stale, so a `'generating'` shot renders
+ * exactly nothing — no banner, no chip, no dot.
  */
 
 /** The tracked artifacts, and the source of truth for `ShotStaleness`'s keys. */

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -7,7 +7,7 @@ import { shotKeys } from '@/hooks/use-shots';
 import { locationSheetVariantKeys } from '@/hooks/use-location-sheet-variants';
 import { sequenceCharacterKeys } from '@/hooks/use-sequence-characters';
 import { sequenceLocationKeys } from '@/hooks/use-sequence-locations';
-import { sequenceKeys } from '@/hooks/use-sequences';
+import { musicPromptStalenessKey, sequenceKeys } from '@/hooks/use-sequences';
 import type { Sequence } from '@/types/database';
 import type { ShotView } from '@/lib/shots/shot-view';
 import type { QueryClient } from '@tanstack/react-query';
@@ -554,6 +554,17 @@ export function updateQueryCacheFromEvent(
       // intermediate character event was missed.
       void queryClient.invalidateQueries({
         queryKey: sequenceCharacterKeys.list(sequenceId),
+      });
+      // Staleness was deferred for the whole run (#1121: every artifact reads
+      // 'generating' while the sequence is 'processing'). The run ending is
+      // the moment a real verdict becomes computable, and nothing else
+      // invalidates this namespace at that point — without it the deferred
+      // entries sit in cache until something unrelated refetches them.
+      void queryClient.invalidateQueries({
+        queryKey: shotStalenessNamespace,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: musicPromptStalenessKey(sequenceId),
       });
       break;
 

--- a/src/lib/shots/shot-staleness.test.ts
+++ b/src/lib/shots/shot-staleness.test.ts
@@ -33,6 +33,9 @@ const sequence = {
   styleId: 'style-1',
   aspectRatio: '16:9',
   analysisModel: 'model-1',
+  // Settled sequence — the mid-run short-circuit (#1121) is exercised by its
+  // own test below, and must not silence any of the others.
+  status: 'completed',
 } as const;
 
 /** `null` cached hashes force the `getLatestWithInputHash` fallback path. */
@@ -217,4 +220,78 @@ describe('computeShotStaleness', () => {
       thumbnail: 'updating',
     });
   });
+
+  it("defers to 'generating' while the sequence is mid-run (#1121)", async () => {
+    // Every hash diverges — this shot would read fully stale on a settled
+    // sequence, which is exactly the false "Out of date since your edit"
+    // banner the initial-generation run used to raise.
+    buildRegenerateShotSnapshot.mockResolvedValue({
+      snapshotInputHash: 'image-live',
+    });
+    loadNarrowShotPromptContext.mockResolvedValue({});
+    computeVisualPromptInputHash.mockResolvedValue('visual-live');
+    computeMotionPromptInputHash.mockResolvedValue('motion-live');
+    const scopedDb = makeScopedDb({
+      motionSelectedHash: 'motion-old',
+      visualSelected: { inputHash: 'visual-old' },
+    });
+    // The hash mocks are module-level and shared across tests; only calls made
+    // by THIS one may count towards the assertions below.
+    buildRegenerateShotSnapshot.mockClear();
+    computeVisualPromptInputHash.mockClear();
+
+    const result = await computeShotStaleness({
+      scopedDb,
+      sequence: { ...sequence, status: 'processing' },
+      shot,
+      frame,
+      selectedImage: selectedImage('image-old'),
+      scene,
+    });
+
+    expect(result).toEqual({
+      thumbnail: 'generating',
+      visualPrompt: 'generating',
+      motionPrompt: 'generating',
+      liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
+    });
+    // Short-circuits before any work: the batch fn runs this for every shot in
+    // the sequence, on the poll loop that runs hardest during generation.
+    expect(scopedDb.framePromptVersions.getSelected).not.toHaveBeenCalled();
+    expect(computeVisualPromptInputHash).not.toHaveBeenCalled();
+    expect(buildRegenerateShotSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each(['draft', 'completed', 'failed', 'archived'] as const)(
+    'still reports staleness when the sequence is %s',
+    async (status) => {
+      buildRegenerateShotSnapshot.mockResolvedValue({
+        snapshotInputHash: 'image-live',
+      });
+      loadNarrowShotPromptContext.mockResolvedValue({});
+      computeVisualPromptInputHash.mockResolvedValue('visual-live');
+      computeMotionPromptInputHash.mockResolvedValue('motion-live');
+
+      const result = await computeShotStaleness({
+        scopedDb: makeScopedDb({
+          motionSelectedHash: 'motion-old',
+          visualSelected: { inputHash: 'visual-old' },
+        }),
+        sequence: { ...sequence, status },
+        shot,
+        frame,
+        selectedImage: selectedImage('image-old'),
+        scene,
+      });
+
+      // Only 'processing' defers — a shot regenerate or an Update all run
+      // never moves the sequence status, so a real post-edit verdict is never
+      // suppressed.
+      expect(result).toMatchObject({
+        thumbnail: 'stale',
+        visualPrompt: 'stale',
+        motionPrompt: 'stale',
+      });
+    }
+  );
 });

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -18,6 +18,7 @@ import {
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import type { Frame, FrameVariant, Shot } from '@/lib/db/schema';
+import type { SequenceStatus } from '@/lib/db/schema/sequences';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { buildRegenerateShotSnapshot } from '@/lib/workflows/regenerate-shots-snapshot';
 import { getLogger } from '@/lib/observability/logger';
@@ -33,11 +34,15 @@ const logger = getLogger(['openstory', 'shots', 'staleness']);
  * `pendingInputHash` equals the live hash — a job is already fixing exactly
  * this. Claims self-invalidate on edit: the live hash moves, the claim no
  * longer matches, and the artifact honestly reads 'stale' again.
+ *
+ * `'generating'` (#1121): the sequence itself is mid-run. See
+ * `computeShotStaleness`'s early return.
  */
 export type ArtifactStaleness =
   | 'stale'
   | 'fresh'
   | 'updating'
+  | 'generating'
   | 'untracked'
   | 'unknown';
 
@@ -67,6 +72,24 @@ export const UNTRACKED_STALENESS: ShotStalenessResult = {
   liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
 };
 
+/** Every artifact deferred — the sequence is mid-run (#1121). */
+const GENERATING_STALENESS: ShotStalenessResult = {
+  thumbnail: 'generating',
+  visualPrompt: 'generating',
+  motionPrompt: 'generating',
+  liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
+};
+
+/**
+ * The one status that means "a run owns this sequence's artifacts right now":
+ * `triggerStoryboard` is the only writer (create / retry / regenerate), and it
+ * rebuilds every shot. Nothing else — a shot regenerate, an Update all run —
+ * moves the sequence off 'completed', so this never suppresses a genuine
+ * post-edit staleness verdict.
+ */
+const isSequenceGenerating = (status: SequenceStatus): boolean =>
+  status === 'processing';
+
 /** Sequence-scoped rows loaded once for a batch of shot comparisons. */
 export type ShotStalenessRefs = ShotPromptContextRefs;
 
@@ -81,6 +104,8 @@ export type ShotStalenessRefs = ShotPromptContextRefs;
  *                     Distinct from `'fresh'` so the UI can suppress the
  *                     regenerate prompt without lying about the artifact's
  *                     freshness.
+ *   - `'generating'`— the sequence is mid-generation run (#1121); see the
+ *                     early return below.
  *   - `'unknown'`   — the comparison itself failed (style deleted mid-flight,
  *                     transient D1 read, malformed row). Distinct from
  *                     `'untracked'`: the UI renders it as "couldn't check"
@@ -95,7 +120,10 @@ export type ShotStalenessRefs = ShotPromptContextRefs;
  */
 export async function computeShotStaleness(args: {
   scopedDb: ScopedDb;
-  sequence: ShotPromptContextSequence & { aspectRatio: AspectRatio };
+  sequence: ShotPromptContextSequence & {
+    aspectRatio: AspectRatio;
+    status: SequenceStatus;
+  };
   shot: Shot;
   frame: Frame;
   /**
@@ -108,6 +136,29 @@ export async function computeShotStaleness(args: {
   refs?: ShotStalenessRefs;
 }): Promise<ShotStalenessResult> {
   const { scopedDb, sequence, shot, frame, selectedImage, scene, refs } = args;
+
+  // ============================================================
+  // Mid-run short-circuit (#1121). Every comparison below pits a hash stamped
+  // at some earlier moment against one recomputed from live scoped state. That
+  // is only a statement about the user's edits once the sequence has settled:
+  // during a storyboard run the inputs the hashes are taken over — cast rows,
+  // locations, elements, and therefore the narrowed bibles
+  // `loadNarrowShotPromptContext` derives — are still being written, so a
+  // prompt stamped against the context of five minutes ago legitimately
+  // diverges from the context of now, and the run itself is what closes the
+  // gap (the pipeline writes a final version against the settled context,
+  // which is why the banner used to clear on its own at the end).
+  //
+  // Reporting that as 'stale' told the user "out of date since your edit" when
+  // they had not edited anything, and offered "Update all" — regenerating,
+  // for real money, artifacts the running pipeline was about to overwrite.
+  // 'generating' is the honest answer: no verdict, no action, and the client
+  // predicates (`shotIsStale`/`shotIsUpdating`/`shotStalenessUnknown`) all
+  // ignore it, so nothing renders. Returned BEFORE any read: the batch fn
+  // recomputes hashes for every shot in the sequence on a poll loop that runs
+  // hardest during exactly this window.
+  // ============================================================
+  if (isSequenceGenerating(sequence.status)) return GENERATING_STALENESS;
 
   const liveHashes: ShotLiveHashes = {
     thumbnail: null,


### PR DESCRIPTION
## Related Issue

Closes #1121

## Summary of Changes

Fixes a false "Out of date since your edit" banner that appeared during storyboard generation runs by deferring staleness verdict computation while the sequence is mid-run.

**The problem:** During a storyboard generation run, the sequence status is `'processing'`. The staleness check compares hashes stamped at an earlier moment against hashes recomputed from the current scoped state. However, during generation the underlying data (cast rows, locations, elements, etc.) is still being written by the pipeline, so legitimate hash divergences occur that have nothing to do with user edits. This caused the UI to incorrectly report shots as stale and offer to "Update all" — regenerating artifacts the running pipeline was about to overwrite.

**The solution:** 
- Add a new `'generating'` staleness state that is returned immediately when `sequence.status === 'processing'`, before any hash computation
- This short-circuits the expensive batch operation that runs on every poll during generation
- Update all staleness predicates to treat `'generating'` as "no opinion" (like `'untracked'` and `'unknown'`), so nothing renders
- Guard the `updateStaleShotsFn` handler to prevent Update all runs from executing while a storyboard run owns the sequence
- Invalidate staleness caches when a generation run completes so real verdicts become computable again
- Extract `musicPromptStalenessKey` to a shared location so the realtime cache updater can invalidate it on sequence status changes

**Changes across:**
- `shot-staleness.ts`: Add `'generating'` state, early return when `sequence.status === 'processing'`
- `shot-staleness.test.ts`: Add test for mid-run short-circuit and tests verifying staleness still reports correctly for other statuses
- `updateStaleShotsFn`: Guard against running during `'processing'` status
- `getMusicPromptStalenessFn`: Same short-circuit for music prompt staleness
- `query-cache-updater.ts`: Invalidate staleness caches when generation run ends
- `use-sequences.ts`: Extract `musicPromptStalenessKey` for shared use
- `scene-music-facet.tsx`: Use extracted key
- `use-shot-staleness.ts`: Document that `'generating'` is ignored by predicates
- `middleware.ts`: Narrow `sequence.status` type to `SequenceStatus` for type safety

## Risk Assessment

- [x] Low

The change is defensive: it adds an early return that prevents work during a specific window (sequence generation), and ensures nothing renders differently during that window. The staleness verdict is deferred, not changed. All other statuses (`'draft'`, `'completed'`, `'failed'`, `'archived'`) continue to report staleness normally. The guard on `updateStaleShotsFn` prevents a race condition but only affects an edge case (stale tab or direct API call during generation).

## Test Coverage

- Added unit test verifying the short-circuit returns `'generating'` for all artifacts when `sequence.status === 'processing'`
- Added parameterized test verifying staleness still reports correctly for `'draft'`, `'completed'`, `'failed'`, and `'archived'` statuses
- Existing tests continue to pass with the new `status: 'completed'` field added to the test sequence fixture

https://claude.ai/code/session_01UKqYrSkYrr9zvGVWHavJM5