### PR TITLE
feat(#1126): wave-bound workflow image fan-out

### DIFF
--- a/src/lib/workflow/map-in-waves.test.ts
+++ b/src/lib/workflow/map-in-waves.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FANOUT_CONCURRENCY, mapInWaves } from './map-in-waves';
+
+describe('FANOUT_CONCURRENCY', () => {
+  it('exposes positive caps', () => {
+    expect(FANOUT_CONCURRENCY.image).toBeGreaterThan(0);
+    expect(FANOUT_CONCURRENCY.variantTrigger).toBeGreaterThan(0);
+    expect(FANOUT_CONCURRENCY.sheet).toBeGreaterThan(0);
+    expect(FANOUT_CONCURRENCY.motion).toBeGreaterThan(0);
+  });
+});
+
+describe('mapInWaves', () => {
+  it('returns empty for empty input', async () => {
+    const fn = vi.fn();
+    await expect(mapInWaves([], 4, fn)).resolves.toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('runs all items and preserves order of settled results', async () => {
+    const results = await mapInWaves([10, 20, 30], 2, async (n) => n * 2);
+    expect(results).toEqual([
+      { status: 'fulfilled', value: 20 },
+      { status: 'fulfilled', value: 40 },
+      { status: 'fulfilled', value: 60 },
+    ]);
+  });
+
+  it('isolates failures within a wave (allSettled)', async () => {
+    const results = await mapInWaves([1, 2, 3], 3, async (n) => {
+      if (n === 2) throw new Error('boom');
+      return n;
+    });
+    expect(results[0]).toEqual({ status: 'fulfilled', value: 1 });
+    expect(results[1]?.status).toBe('rejected');
+    expect(results[2]).toEqual({ status: 'fulfilled', value: 3 });
+  });
+
+  it('never runs more than concurrency jobs at once', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    await mapInWaves(items, 3, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 5));
+      inFlight--;
+    });
+
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(0);
+  });
+
+  it('treats concurrency < 1 as 1', async () => {
+    let peak = 0;
+    let inFlight = 0;
+    await mapInWaves([1, 2, 3], 0, async () => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise((r) => setTimeout(r, 2));
+      inFlight--;
+    });
+    expect(peak).toBe(1);
+  });
+
+  it('passes the global index (not wave-local) to fn', async () => {
+    const indexes: number[] = [];
+    await mapInWaves(['a', 'b', 'c', 'd'], 2, async (_item, index) => {
+      indexes.push(index);
+    });
+    expect(indexes).toEqual([0, 1, 2, 3]);
+  });
+
+  it('starts the next wave only after the previous settles', async () => {
+    const started: number[] = [];
+    const finished: number[] = [];
+
+    await mapInWaves([0, 1, 2, 3], 2, async (n) => {
+      started.push(n);
+      await new Promise((r) => setTimeout(r, 10));
+      finished.push(n);
+    });
+
+    // First wave must fully finish before second wave starts any work.
+    const byNum = (a: number, b: number) => a - b;
+    expect(finished.slice(0, 2).sort(byNum)).toEqual([0, 1]);
+    expect(started.slice(0, 2).sort(byNum)).toEqual([0, 1]);
+    expect(started.indexOf(2)).toBeGreaterThanOrEqual(2);
+    expect(started.indexOf(3)).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/lib/workflow/map-in-waves.ts
+++ b/src/lib/workflow/map-in-waves.ts
@@ -1,0 +1,51 @@
+/**
+ * Bounded fan-out for Cloudflare Workflow parents.
+ *
+ * Parents used to `Promise.allSettled` over every child spawn at once, which
+ * stampsed Workflow isolates + D1 under large batches (hung-cancel storms).
+ * Waves keep at most `concurrency` jobs in flight: each wave is an
+ * allSettled, waves run sequentially.
+ *
+ * Replay-safe when each `fn` still uses stable `step.do` / waitForEvent
+ * names (e.g. `spawn-image-${index}`) — completed steps return cached
+ * results on parent re-entry.
+ */
+
+/** Starting concurrency caps for parent fan-out phases. Tune via call sites. */
+export const FANOUT_CONCURRENCY = {
+  /** Image children (`spawnAndAwaitChild` to IMAGE_WORKFLOW). */
+  image: 4,
+  /** Fire-and-forget `/variant-image` creates. */
+  variantTrigger: 8,
+  /** Character / location sheet children. */
+  sheet: 4,
+  /** Motion children in motion-batch. */
+  motion: 3,
+} as const;
+
+/**
+ * Run `fn` over `items` in waves of `concurrency`.
+ * Within a wave: `Promise.allSettled` (one failure does not reject the wave).
+ * Between waves: sequential.
+ */
+export async function mapInWaves<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  fn: (item: T, index: number) => Promise<R>
+): Promise<PromiseSettledResult<R>[]> {
+  if (items.length === 0) return [];
+
+  const limit = Math.max(1, Math.floor(concurrency));
+  const out: PromiseSettledResult<R>[] = [];
+
+  for (let i = 0; i < items.length; i += limit) {
+    const slice = items.slice(i, i + limit);
+    const base = i;
+    const wave = await Promise.allSettled(
+      slice.map((item, j) => fn(item, base + j))
+    );
+    out.push(...wave);
+  }
+
+  return out;
+}

--- a/src/lib/workflows/regenerate-shots-workflow.ts
+++ b/src/lib/workflows/regenerate-shots-workflow.ts
@@ -14,11 +14,10 @@
  *     and the workflow run id from `event.instanceId` instead of
  *     `context.workflowRunId`.
  *   - The Promise.all over `context.invoke('image', ...)` becomes
- *     `Promise.all` spawn + `Promise.allSettled` await of
- *     `spawnAndAwaitChild` (Pattern 3 fan-out helpers in
- *     `await-child.ts`). Each child gets a deterministic instance ID
- *     (`image:${sequenceId}:${shotId}`) and a unique event-type qualifier so
- *     siblings cannot match each other's completion events.
+ *     wave-bounded (#1126) Pattern 3 `spawnAndAwaitChild` fan-out
+ *     (`mapInWaves` + `await-child.ts`). Each child gets a deterministic
+ *     instance ID (`image:${sequenceId}:${shotId}`) and a unique event-type
+ *     qualifier so siblings cannot match each other's completion events.
  *   - Calls the snapshot DTO computer (`computeRegenerateShotsBatchHash`)
  *     directly inside `step.do('validate-snapshot')` instead of going
  *     through the `context.snapshot.*` extension.
@@ -32,6 +31,7 @@ import { WorkflowValidationError } from '@/lib/workflow/errors';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { FANOUT_CONCURRENCY, mapInWaves } from '@/lib/workflow/map-in-waves';
 import type {
   ImageWorkflowInput,
   RegenerateShotsWorkflowInput,
@@ -128,21 +128,21 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
     });
 
     // ============================================================
-    // PHASE: Per-shot image regeneration — fan out via Pattern 3.
-    // Use Promise.allSettled so a single child timeout / failure does not
-    // kill the parent — each sibling resolves independently, and per-shot
-    // failures become `ShotResult` entries that the reconcile pass below
-    // handles individually.
+    // PHASE: Per-shot image regeneration — Pattern 3 fan-out, wave-bounded
+    // (#1126) so large batches don't stampede Workflow isolates + D1.
+    // Within a wave: allSettled isolation; between waves: sequential.
     // ============================================================
-    const settled = await Promise.allSettled(
-      snapshots.map((snapshot, shotIndex): Promise<ShotResult> => {
+    const settled = await mapInWaves(
+      snapshots,
+      FANOUT_CONCURRENCY.image,
+      async (snapshot, shotIndex): Promise<ShotResult> => {
         if (!snapshot.imagePrompt) {
           // Per-shot failure — peer shots in the batch should still run.
-          return Promise.resolve({
+          return {
             shotId: snapshot.shotId,
             success: false,
             error: 'no image prompt',
-          });
+          };
         }
 
         const referenceImages = [
@@ -165,50 +165,49 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
           referenceImages,
         };
 
-        return spawnAndAwaitChild<ImageWorkflowInput, ImageChildOutput>(step, {
-          binding: childBinding,
-          parentBindingName: 'REGENERATE_SHOTS_WORKFLOW',
-          parentInstanceId,
-          childId: `image:${sequenceId}:${snapshot.shotId}`,
-          childPayload,
-          spawnStepName: `spawn-image-${shotIndex}`,
-          awaitStepName: `await-image-${shotIndex}`,
-        }).then(
-          (body): ShotResult => {
-            if (!body.imageUrl) {
-              logger.error(
-                `[RegenerateShotsWorkflow:cf] Image generation failed shot=${snapshot.shotId} reason=no imageUrl`
-              );
-              return {
-                shotId: snapshot.shotId,
-                success: false,
-                error: 'Image generation no imageUrl',
-              };
-            }
-            return {
-              shotId: snapshot.shotId,
-              success: true,
-              imageUrl: body.imageUrl,
-            };
-          },
-          (err: unknown): ShotResult => {
-            const reason = err instanceof Error ? err.message : String(err);
+        try {
+          const body = await spawnAndAwaitChild<
+            ImageWorkflowInput,
+            ImageChildOutput
+          >(step, {
+            binding: childBinding,
+            parentBindingName: 'REGENERATE_SHOTS_WORKFLOW',
+            parentInstanceId,
+            childId: `image:${sequenceId}:${snapshot.shotId}`,
+            childPayload,
+            spawnStepName: `spawn-image-${shotIndex}`,
+            awaitStepName: `await-image-${shotIndex}`,
+          });
+          if (!body.imageUrl) {
             logger.error(
-              `[RegenerateShotsWorkflow:cf] Image generation failed shot=${snapshot.shotId} reason=${reason}`
+              `[RegenerateShotsWorkflow:cf] Image generation failed shot=${snapshot.shotId} reason=no imageUrl`
             );
             return {
               shotId: snapshot.shotId,
               success: false,
-              error: `Image generation failed: ${reason}`,
+              error: 'Image generation no imageUrl',
             };
           }
-        );
-      })
+          return {
+            shotId: snapshot.shotId,
+            success: true,
+            imageUrl: body.imageUrl,
+          };
+        } catch (err: unknown) {
+          const reason = err instanceof Error ? err.message : String(err);
+          logger.error(
+            `[RegenerateShotsWorkflow:cf] Image generation failed shot=${snapshot.shotId} reason=${reason}`
+          );
+          return {
+            shotId: snapshot.shotId,
+            success: false,
+            error: `Image generation failed: ${reason}`,
+          };
+        }
+      }
     );
 
-    // Promise.allSettled with onfulfilled/onrejected mappers above means every
-    // entry is a resolved ShotResult. Collect them into the same shape the
-    // QStash original produced.
+    // mapInWaves is allSettled per wave; collect into ShotResult[] for reconcile.
     const imageResults: ShotResult[] = settled.map((outcome, i) => {
       if (outcome.status === 'fulfilled') return outcome.value;
       const snapshot = snapshots[i];
@@ -234,10 +233,13 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
 
     // Regenerate the 3×3 grid sheet for each (re)imaged shot — it is derived
     // from the primary still and would otherwise show the pre-recast subject.
-    // Fire-and-forget; each variant runs as its own workflow.
+    // Fire-and-forget; wave-bounded creates so we don't open N variant DOs
+    // in one tick (#1126).
     await step.do('trigger-variant-regen', async () => {
-      await Promise.all(
-        succeeded.map(async (result) => {
+      await mapInWaves(
+        succeeded,
+        FANOUT_CONCURRENCY.variantTrigger,
+        async (result) => {
           const snapshot = snapshots.find((s) => s.shotId === result.shotId);
           if (!snapshot) return;
           await triggerWorkflow<ShotVariantWorkflowInput>(
@@ -267,7 +269,7 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
               deduplicationId: `variant-image-${result.shotId}-${imageModel}-${snapshot.snapshotInputHash.slice(0, 16)}`,
             }
           );
-        })
+        }
       );
     });
 

--- a/src/lib/workflows/regenerate-shots-workflow.ts
+++ b/src/lib/workflows/regenerate-shots-workflow.ts
@@ -233,44 +233,47 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
 
     // Regenerate the 3×3 grid sheet for each (re)imaged shot — it is derived
     // from the primary still and would otherwise show the pre-recast subject.
-    // Fire-and-forget; wave-bounded creates so we don't open N variant DOs
-    // in one tick (#1126).
+    // Fire-and-forget creates, wave-bounded (#1126). Use Promise.all within
+    // each wave (not allSettled) so a failed create fails the durable step
+    // and CF retries — mapInWaves would swallow partial failures.
     await step.do('trigger-variant-regen', async () => {
-      await mapInWaves(
-        succeeded,
-        FANOUT_CONCURRENCY.variantTrigger,
-        async (result) => {
-          const snapshot = snapshots.find((s) => s.shotId === result.shotId);
-          if (!snapshot) return;
-          await triggerWorkflow<ShotVariantWorkflowInput>(
-            '/variant-image',
-            {
-              userId: input.userId,
-              teamId,
-              sequenceId,
-              shotId: result.shotId,
-              frameId: snapshot.frameId ?? undefined,
-              thumbnailUrl: result.imageUrl,
-              scenePrompt: snapshot.imagePrompt,
-              characterReferences:
-                snapshot.characterRefs.length > 0
-                  ? snapshot.characterRefs
-                  : undefined,
-              locationReferences:
-                snapshot.locationRefs.length > 0
-                  ? snapshot.locationRefs
-                  : undefined,
-              aspectRatio,
-              model: imageModel,
-            },
-            {
-              label,
-              // Dedupe: a retry of this step.do mustn't re-fire variants.
-              deduplicationId: `variant-image-${result.shotId}-${imageModel}-${snapshot.snapshotInputHash.slice(0, 16)}`,
-            }
-          );
-        }
-      );
+      const limit = FANOUT_CONCURRENCY.variantTrigger;
+      for (let i = 0; i < succeeded.length; i += limit) {
+        const wave = succeeded.slice(i, i + limit);
+        await Promise.all(
+          wave.map(async (result) => {
+            const snapshot = snapshots.find((s) => s.shotId === result.shotId);
+            if (!snapshot) return;
+            await triggerWorkflow<ShotVariantWorkflowInput>(
+              '/variant-image',
+              {
+                userId: input.userId,
+                teamId,
+                sequenceId,
+                shotId: result.shotId,
+                frameId: snapshot.frameId ?? undefined,
+                thumbnailUrl: result.imageUrl,
+                scenePrompt: snapshot.imagePrompt,
+                characterReferences:
+                  snapshot.characterRefs.length > 0
+                    ? snapshot.characterRefs
+                    : undefined,
+                locationReferences:
+                  snapshot.locationRefs.length > 0
+                    ? snapshot.locationRefs
+                    : undefined,
+                aspectRatio,
+                model: imageModel,
+              },
+              {
+                label,
+                // Dedupe: a retry of this step.do mustn't re-fire variants.
+                deduplicationId: `variant-image-${result.shotId}-${imageModel}-${snapshot.snapshotInputHash.slice(0, 16)}`,
+              }
+            );
+          })
+        );
+      }
     });
 
     const failedShots = imageResults

--- a/src/lib/workflows/shot-images-workflow.ts
+++ b/src/lib/workflows/shot-images-workflow.ts
@@ -15,8 +15,9 @@
  *   - Calls the snapshot DTO computer directly in a `validate-snapshot`
  *     step instead of going through the `context.snapshot.*` extension.
  *   - Per-scene × per-model fan-out uses Pattern 3 — `spawnAndAwaitChild`
- *     against `IMAGE_WORKFLOW`. `Promise.allSettled` so a single failing
- *     image (or timeout) doesn't kill the rest of the batch.
+ *     against `IMAGE_WORKFLOW`. Wave-bounded (#1126) allSettled so a single
+ *     failing image (or timeout) doesn't kill the rest of the batch, without
+ *     stamping every child at once.
  *   - The variant-image (shot-grid) fire-and-forget kick remains routed
  *     through `triggerWorkflow('/variant-image', …)` for parity with the
  *     QStash original — the engine registry decides whether that hits CF
@@ -34,6 +35,7 @@ import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import { buildWorkflowLabel } from '@/lib/workflow/labels';
+import { FANOUT_CONCURRENCY, mapInWaves } from '@/lib/workflow/map-in-waves';
 import { NonRetryableError } from 'cloudflare:workflows';
 import type {
   ShotImagesWorkflowInput,
@@ -185,12 +187,15 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
 
     const imageBinding = this.env.IMAGE_WORKFLOW;
 
-    // Fan out one IMAGE_WORKFLOW child per (scene, model). `Promise.allSettled`
-    // so a single image timeout / failure doesn't poison the rest of the
-    // batch — we surface per-scene failures via WorkflowValidationError below
-    // for parity with the QStash version's `result.isFailed` check.
-    const sceneResults = await Promise.allSettled(
-      scenesWithVisualPrompts.map(async (scene) => {
+    // Fan out one IMAGE_WORKFLOW child per (scene, model). Wave-bounded
+    // (#1126) so large sequences don't stampede isolates + D1; allSettled
+    // isolation is preserved within each wave. Per-scene failures surface
+    // via WorkflowValidationError below for parity with the QStash
+    // `result.isFailed` check.
+    const sceneResults = await mapInWaves(
+      scenesWithVisualPrompts,
+      FANOUT_CONCURRENCY.image,
+      async (scene) => {
         // The visual prompt is no longer carried on `scene.prompts` (#713); it
         // rides on the per-scene snapshot, which analyze-script populates from
         // the shot's `frame.imagePrompt` mirror. Sourcing it here keeps the
@@ -231,109 +236,105 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
         // right.
         const sceneSnapshot = sceneSnapshotsById.get(scene.sceneId);
 
-        // Generate with each selected model in parallel. Each (scene, model)
-        // becomes one Pattern 3 child invocation. `Promise.allSettled` here
-        // too so one model failure doesn't poison the other models for the
-        // same scene.
-        const modelResults = await Promise.allSettled(
-          imageModels.map(async (model) => {
-            const perShotSnapshotInputHash =
-              snapshotHashByKey[snapshotHashKey(scene.sceneId, model)];
+        // One model at a time per scene so multi-model doesn't multiply the
+        // outer scene-wave concurrency (#1126).
+        const modelResults = await mapInWaves(imageModels, 1, async (model) => {
+          const perShotSnapshotInputHash =
+            snapshotHashByKey[snapshotHashKey(scene.sceneId, model)];
 
-            const childBody: ImageWorkflowInput = {
-              userId: input.userId,
-              teamId: input.teamId,
-              prompt: visualPrompt,
-              model,
-              imageSize,
-              aspectRatio,
-              numImages: 1,
-              shotId: matchedShot?.shotId,
-              // Materialized by scene-split and threaded through the mapping
-              // (#991) — the child never re-resolves the anchor.
-              frameId: matchedShot?.frameId ?? undefined,
-              sequenceId,
-              referenceImages:
-                allReferences.length > 0 ? allReferences : undefined,
-              sceneSnapshot,
-              snapshotInputHash: perShotSnapshotInputHash,
-            };
+          const childBody: ImageWorkflowInput = {
+            userId: input.userId,
+            teamId: input.teamId,
+            prompt: visualPrompt,
+            model,
+            imageSize,
+            aspectRatio,
+            numImages: 1,
+            shotId: matchedShot?.shotId,
+            // Materialized by scene-split and threaded through the mapping
+            // (#991) — the child never re-resolves the anchor.
+            frameId: matchedShot?.frameId ?? undefined,
+            sequenceId,
+            referenceImages:
+              allReferences.length > 0 ? allReferences : undefined,
+            sceneSnapshot,
+            snapshotInputHash: perShotSnapshotInputHash,
+          };
 
-            // Per-spawn unique IDs. Include the model so the per-(scene,
-            // model) fan-out gets distinct CF instance IDs — siblings
-            // would otherwise collide on `image:${sequenceId}:${shotId}`
-            // (CF instance IDs are global per Worker script).
-            const childIdSuffix = matchedShot?.shotId
-              ? `image:${sequenceId ?? 'no-seq'}:${matchedShot.shotId}:${model}`
-              : `image:${sequenceId ?? 'no-seq'}:${scene.sceneId}:${model}`;
+          // Per-spawn unique IDs. Include the model so the per-(scene,
+          // model) fan-out gets distinct CF instance IDs — siblings
+          // would otherwise collide on `image:${sequenceId}:${shotId}`
+          // (CF instance IDs are global per Worker script).
+          const childIdSuffix = matchedShot?.shotId
+            ? `image:${sequenceId ?? 'no-seq'}:${matchedShot.shotId}:${model}`
+            : `image:${sequenceId ?? 'no-seq'}:${scene.sceneId}:${model}`;
 
-            const childOutput = await spawnAndAwaitChild<
-              ImageWorkflowInput,
-              ImageChildResult
-            >(step, {
-              binding: imageBinding,
-              parentBindingName: 'SHOT_IMAGES_WORKFLOW',
-              parentInstanceId,
-              childId: childIdSuffix,
-              childPayload: childBody,
-              spawnStepName: `spawn-image-${scene.sceneId}-${model}`,
-              awaitStepName: `await-image-${scene.sceneId}-${model}`,
-              timeout: '30 minutes',
-            });
+          const childOutput = await spawnAndAwaitChild<
+            ImageWorkflowInput,
+            ImageChildResult
+          >(step, {
+            binding: imageBinding,
+            parentBindingName: 'SHOT_IMAGES_WORKFLOW',
+            parentInstanceId,
+            childId: childIdSuffix,
+            childPayload: childBody,
+            spawnStepName: `spawn-image-${scene.sceneId}-${model}`,
+            awaitStepName: `await-image-${scene.sceneId}-${model}`,
+            timeout: '30 minutes',
+          });
 
-            if (!childOutput.imageUrl) {
-              throw new WorkflowValidationError(
-                `Image generation failed for scene ${scene.sceneId} model ${model}`
+          if (!childOutput.imageUrl) {
+            throw new WorkflowValidationError(
+              `Image generation failed for scene ${scene.sceneId} model ${model}`
+            );
+          }
+
+          // Trigger variant (shot grid) workflow as a separate top-level
+          // run. Fire-and-forget — shot-images shouldn't block on it,
+          // since the variant just enriches the shot after the fact and
+          // its progress is tracked independently via
+          // `shot.variantImageStatus`.
+          await step.do(
+            `trigger-variant-${scene.sceneId}-${model}`,
+            async () => {
+              await triggerWorkflow<ShotVariantWorkflowInput>(
+                '/variant-image',
+                {
+                  userId: input.userId,
+                  teamId: input.teamId,
+                  sequenceId,
+                  shotId: matchedShot?.shotId,
+                  frameId: matchedShot?.frameId ?? undefined,
+                  thumbnailUrl: childOutput.imageUrl,
+                  scenePrompt: visualPrompt,
+                  characterReferences:
+                    characterRefs.length > 0 ? characterRefs : undefined,
+                  locationReferences:
+                    locationRefs.length > 0 ? locationRefs : undefined,
+                  elementReferences:
+                    elementRefs.length > 0 ? elementRefs : undefined,
+                  aspectRatio,
+                  model,
+                },
+                {
+                  label,
+                  retries: 3,
+                  retryDelay: 'pow(2, retried) * 1000',
+                  // Replay-stable: a retry of this step.do must reuse the
+                  // existing variant instance instead of spawning a second
+                  // paid job (see dedup-ids.ts).
+                  deduplicationId: shotVariantDedupId(
+                    parentInstanceId,
+                    matchedShot?.shotId ?? scene.sceneId,
+                    model
+                  ),
+                }
               );
             }
+          );
 
-            // Trigger variant (shot grid) workflow as a separate top-level
-            // run. Fire-and-forget — shot-images shouldn't block on it,
-            // since the variant just enriches the shot after the fact and
-            // its progress is tracked independently via
-            // `shot.variantImageStatus`.
-            await step.do(
-              `trigger-variant-${scene.sceneId}-${model}`,
-              async () => {
-                await triggerWorkflow<ShotVariantWorkflowInput>(
-                  '/variant-image',
-                  {
-                    userId: input.userId,
-                    teamId: input.teamId,
-                    sequenceId,
-                    shotId: matchedShot?.shotId,
-                    frameId: matchedShot?.frameId ?? undefined,
-                    thumbnailUrl: childOutput.imageUrl,
-                    scenePrompt: visualPrompt,
-                    characterReferences:
-                      characterRefs.length > 0 ? characterRefs : undefined,
-                    locationReferences:
-                      locationRefs.length > 0 ? locationRefs : undefined,
-                    elementReferences:
-                      elementRefs.length > 0 ? elementRefs : undefined,
-                    aspectRatio,
-                    model,
-                  },
-                  {
-                    label,
-                    retries: 3,
-                    retryDelay: 'pow(2, retried) * 1000',
-                    // Replay-stable: a retry of this step.do must reuse the
-                    // existing variant instance instead of spawning a second
-                    // paid job (see dedup-ids.ts).
-                    deduplicationId: shotVariantDedupId(
-                      parentInstanceId,
-                      matchedShot?.shotId ?? scene.sceneId,
-                      model
-                    ),
-                  }
-                );
-              }
-            );
-
-            return childOutput.imageUrl;
-          })
-        );
+          return childOutput.imageUrl;
+        });
 
         // Surface per-model failures. The primary (index 0) result is what
         // gets returned as this scene's `imageUrl`; if it failed we throw
@@ -363,7 +364,7 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
           }
         }
         return primary.value;
-      })
+      }
     );
 
     // Collect results ALIGNED to scene order — a rejected scene keeps its


### PR DESCRIPTION
## Summary

- Add `mapInWaves` + `FANOUT_CONCURRENCY` so parent workflows can cap concurrent child spawns
- Apply to `regenerate-shots` (image children + variant triggers) and `shot-images` (scene waves; models sequential)
- Keeps allSettled isolation and stable step/instance names for Workflow replay

Closes #1126

## Context

Hung-isolate bursts in prod correlated with unbounded `Promise.allSettled` fan-out. This is admission control on top of Cloudflare Workflows (not a second queue). Provider timeouts remain #826.

## Test plan

- [x] Unit tests for `mapInWaves` (concurrency peak, wave ordering, allSettled isolation)
- [x] typecheck + lint on changed files
- [ ] Optional: regenerate a multi-shot sequence and confirm waves in logs