### PR TITLE
fix(#1101): a preview with no url is not a preview — 2150 previews shadowed in prod

### DIFF
--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -140,10 +140,15 @@ export async function getLatestPreviewByFrameIds(
             frameIds.slice(i, i + PREVIEW_BY_FRAMES_BATCH)
           ),
           eq(frameVariants.kind, 'preview'),
-          // `recordPreview` only ever writes 'completed' with a url, so this
-          // costs nothing forward — it excludes the url-less husks the #1101
-          // migration retagged, which would otherwise read as "no preview".
+          // A preview with no url is not a preview. `status` alone is NOT
+          // enough: the #1101 reclassify retagged url-less rows regardless of
+          // status, and 2150 of them were already 'completed'. Those carry
+          // real ULIDs (`01…`) while the backfilled rows carry synthetic `00…`
+          // ids, so a husk outranks the row holding the actual image and the
+          // preview reads as absent — which is exactly what happened to 2150
+          // of 3009 frames in production.
           eq(frameVariants.status, 'completed'),
+          isNotNull(frameVariants.url),
           isNull(frameVariants.discardedAt)
         )
       )
@@ -628,6 +633,7 @@ export function createFrameVariantsMethods(db: Database) {
             eq(frameVariants.kind, 'preview'),
             // Matches the batch read — see getLatestPreviewByFrameIds.
             eq(frameVariants.status, 'completed'),
+            isNotNull(frameVariants.url),
             isNull(frameVariants.discardedAt)
           )
         )

--- a/src/lib/db/scoped/shot-view-query.test.ts
+++ b/src/lib/db/scoped/shot-view-query.test.ts
@@ -133,7 +133,7 @@ it('resolves previewThumbnailUrl through the whole assembly path', async () => {
   );
 
   // A url-less husk (what the #1101 migration retags) sorts newest but must not
-  // shadow the real preview — this is what the `status = 'completed'` filter buys.
+  // shadow the real preview.
   await db.insert(frameVariants).values({
     id: 'preview-3',
     frameId,
@@ -141,6 +141,24 @@ it('resolves previewThumbnailUrl through the whole assembly path', async () => {
     kind: 'preview',
     model: 'flux_2_turbo',
     status: 'generating',
+    url: null,
+  });
+  expect((await assemble())[0]?.previewThumbnailUrl).toBe(
+    'https://cdn.example/new.png'
+  );
+
+  // The shape that actually shipped: the reclassify retagged url-less rows
+  // WITHOUT regard to status, so 2150 of them were already 'completed'. Those
+  // carry real ULIDs while backfilled rows carry synthetic `00…` ids, so the
+  // husk outranks the image and `status` alone let it win — 2150 of 3009
+  // frames lost their preview in production. Only `url IS NOT NULL` stops it.
+  await db.insert(frameVariants).values({
+    id: 'preview-4',
+    frameId,
+    sequenceId,
+    kind: 'preview',
+    model: 'flux_2_turbo',
+    status: 'completed',
     url: null,
   });
   expect((await assemble())[0]?.previewThumbnailUrl).toBe(


### PR DESCRIPTION
## Related Issue

Part of #1101 — a production follow-up to #1125, which is already merged and deployed.

## What's wrong

**2150 of 3009 frames are showing no preview in production right now.** The images are in the database; the read can't see them.

Measured against `openstory-prd` after the #1125 deploy:

| | frames |
|---|---|
| have a real backfilled preview | 3009 |
| preview actually visible | **859** |
| **preview shadowed / lost** | **2150** |

## Why

The reclassify migration retags url-less `flux_2_turbo` rows regardless of status, and **2150 of them were already `status = 'completed'`**. So filtering the preview reads on `status = 'completed'` — which is what #1125 shipped — does not exclude them.

Those husks carry real ULIDs (`01…`). The backfilled rows carry synthetic `00…` ids, chosen deliberately so that a later *real* preview would outrank a backfilled one. That ordering is correct for the case it was designed for, and exactly wrong here: the husk isn't a later preview, it's older junk that happens to sort above.

So `ORDER BY id DESC LIMIT 1` picks the husk, `preview?.url ?? null` yields `null`, and the UI renders "no preview" — indistinguishable from a frame that never had one.

## Fix

Add `url IS NOT NULL` to both preview reads (`getLatestPreview` and the batch `getLatestPreviewByFrameIds`). A preview with no url is not a preview, whatever its status says.

Verified directly against production: the same query that returns **859** visible previews today returns **3009** with this predicate, with **0** frames left without one.

## Test

The existing test seeded its url-less husk as `generating`, which `status` alone already caught — so it never exercised the shape that actually shipped. It now seeds a `completed` url-less row with a higher id (the production shape). Confirmed to fail without this change:

```
AssertionError: expected null to be 'https://cdn.example/new.png'
```

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Two added `WHERE` clauses on read paths, no schema change, no migration, no data mutation. Strictly widens what the reads return (from 859 to 3009 frames), and cannot surface a row that lacks an image.

## Notes

No data repair is needed — the backfill preserved every url correctly. This is purely a read-side selection bug.

Separately worth a look, not fixed here: 58 `flux_2_turbo` rows across 15 sequences remain `kind: 'model'` because a frame selects them, so `flux_2_turbo` can still appear in those sequences' image-model dropdown now that #1125 removed the `hidden`-model filter. All 58 have a null url, so those frames also have a selection pointer at a row with no image — which looks like pre-existing data damage rather than anything #1125 caused. The #1125 migration comment asserts "Production has 0 selected flux_2_turbo rows"; the actual count is 58.
