### PR TITLE
fix(#1132, #1133): order frame_variants by createdAt, keep image-less husks out of the model list

### DIFF
--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -1073,4 +1073,57 @@ describe("frameVariants kind: 'preview' (#1101)", () => {
     const modelVersions = await m.listModelVersionsBySequence(sequenceId);
     expect(modelVersions.map((v) => v.model)).toEqual(['nano_banana_2']);
   });
+
+  it('keeps an image-less husk out of the model dropdown (#1133)', async () => {
+    const m = createFrameVariantsMethods(db);
+    await m.appendVersion(variantInput({ model: 'nano_banana_2' }));
+    // The shape the #1101 reclassify could not move because a frame selects it:
+    // kind 'model', completed, but it never produced an image. 58 of these are
+    // live in production and leak `flux_2_turbo` into 15 sequences' dropdown.
+    await db.insert(frameVariants).values({
+      id: 'husk-selected',
+      frameId,
+      sequenceId,
+      kind: 'model',
+      model: 'flux_2_turbo',
+      status: 'completed',
+      url: null,
+      storagePath: null,
+    });
+
+    expect(await m.listModelsForSequence(sequenceId)).toEqual([
+      'nano_banana_2',
+    ]);
+  });
+
+  it('orders by createdAt, so a non-ULID legacy id cannot win (#1132)', async () => {
+    const m = createFrameVariantsMethods(db);
+    const real = await m.recordPreview({
+      frameId,
+      sequenceId,
+      model: 'flux_2_turbo',
+      url: 'https://fal.media/real.png',
+      promptHash: null,
+      workflowRunId: 'run-ordering-1',
+    });
+
+    // A QStash-era row: 26-char hex id that sorts above EVERY ULID, but is
+    // genuinely older. Ordering by id alone hands it the "newest" slot.
+    await db.insert(frameVariants).values({
+      id: 'ffdabf476d92ad8114fb89c8be',
+      frameId,
+      sequenceId,
+      kind: 'preview',
+      model: 'flux_2_turbo',
+      status: 'completed',
+      url: 'https://fal.media/stale-2026-03.png',
+      createdAt: new Date(real.createdAt.getTime() - 60_000),
+    });
+
+    expect((await m.getLatestPreview(frameId))?.url).toBe(
+      'https://fal.media/real.png'
+    );
+    const byFrame = await m.listLatestPreviewsByFrameIds([frameId]);
+    expect(byFrame.get(frameId)?.url).toBe('https://fal.media/real.png');
+  });
 });

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -105,6 +105,20 @@ type VariantGroup = {
   sourceVariantId?: string | null;
 };
 
+/**
+ * Chronological order for this table. `id` ALONE IS NOT SAFE here: 1355 legacy
+ * rows from the QStash era carry 26-char hex ids instead of ULIDs (#1132), so
+ * they sort arbitrarily against every ULID — one beginning `ff` outranks every
+ * id ever minted. `createdAt` is populated and correct on every row including
+ * those, and `id` breaks same-second ties, which is the ordering ULIDs already
+ * give within a second.
+ *
+ * Every "newest version wins" read in this module depends on this being right;
+ * #1131 is what it looks like when it isn't.
+ */
+const newestFirst = [desc(frameVariants.createdAt), desc(frameVariants.id)];
+const oldestFirst = [asc(frameVariants.createdAt), asc(frameVariants.id)];
+
 // One bound param per frame, so chunk below D1's 100-param ceiling — this runs
 // on the shots read path with every anchor frame of a sequence (matches
 // VIDEO_BY_SHOTS_BATCH). Unit tests run on libsql, which has no such cap, so an
@@ -152,7 +166,7 @@ export async function getLatestPreviewByFrameIds(
           isNull(frameVariants.discardedAt)
         )
       )
-      .orderBy(asc(frameVariants.id));
+      .orderBy(...oldestFirst);
     for (const row of rows) byFrame.set(row.frameId, row);
   }
   return byFrame;
@@ -344,7 +358,7 @@ export function createFrameVariantsMethods(db: Database) {
             )
           )
         )
-        .orderBy(desc(frameVariants.id));
+        .orderBy(...newestFirst);
     },
 
     /**
@@ -506,7 +520,7 @@ export function createFrameVariantsMethods(db: Database) {
         .select()
         .from(frameVariants)
         .where(and(...conditions))
-        .orderBy(asc(frameVariants.id));
+        .orderBy(...oldestFirst);
     },
 
     /**
@@ -531,11 +545,23 @@ export function createFrameVariantsMethods(db: Database) {
             isNull(frameVariants.discardedAt)
           )
         )
-        .orderBy(asc(frameVariants.id));
+        .orderBy(...oldestFirst);
       return rows.map((r) => ({ ...r.variant, shotId: r.shotId }));
     },
 
-    /** Distinct `kind:'model'` model names that have a version in a sequence. */
+    /**
+     * Distinct `kind:'model'` model names that actually RENDERED something in a
+     * sequence — this drives the user-facing image-model dropdown.
+     *
+     * `url IS NOT NULL` is load-bearing, not tidiness (#1133). Without it the
+     * dropdown's correctness depends on the #1101 reclassify having caught
+     * every `flux_2_turbo` row, and it did not: 58 rows across 15 sequences are
+     * still `kind:'model'` because a frame selects them, which leaks the
+     * internal preview model into those sequences as a selectable option. A
+     * model whose only rows are empty husks produced nothing, so requiring an
+     * actual image fixes this for any hidden/internal model rather than
+     * depending on migration coverage.
+     */
     listModelsForSequence: async (sequenceId: string): Promise<string[]> => {
       const rows = await db
         .selectDistinct({ model: frameVariants.model })
@@ -544,6 +570,7 @@ export function createFrameVariantsMethods(db: Database) {
           and(
             eq(frameVariants.sequenceId, sequenceId),
             eq(frameVariants.kind, 'model'),
+            isNotNull(frameVariants.url),
             isNull(frameVariants.discardedAt)
           )
         );
@@ -563,7 +590,7 @@ export function createFrameVariantsMethods(db: Database) {
         .select()
         .from(frameVariants)
         .where(and(...conditions))
-        .orderBy(asc(frameVariants.id));
+        .orderBy(...oldestFirst);
     },
 
     /**
@@ -586,7 +613,7 @@ export function createFrameVariantsMethods(db: Database) {
             isNull(frameVariants.discardedAt)
           )
         )
-        .orderBy(desc(frameVariants.id))
+        .orderBy(...newestFirst)
         .limit(1);
       return rows[0] ?? null;
     },
@@ -610,7 +637,7 @@ export function createFrameVariantsMethods(db: Database) {
             isNull(frameVariants.discardedAt)
           )
         )
-        .orderBy(asc(frameVariants.id));
+        .orderBy(...oldestFirst);
       // asc by id (≈ time) → last write per frame wins.
       const byFrame = new Map<string, FrameVariant>();
       for (const row of rows) byFrame.set(row.frameId, row);
@@ -637,7 +664,7 @@ export function createFrameVariantsMethods(db: Database) {
             isNull(frameVariants.discardedAt)
           )
         )
-        .orderBy(desc(frameVariants.id))
+        .orderBy(...newestFirst)
         .limit(1);
       return rows[0] ?? null;
     },
@@ -711,7 +738,7 @@ export function createFrameVariantsMethods(db: Database) {
             isNull(frameVariants.discardedAt)
           )
         )
-        .orderBy(asc(frameVariants.id));
+        .orderBy(...oldestFirst);
       // asc by id (≈ time) → last write per shot wins.
       const byShot = new Map<string, string>();
       for (const row of rows) byShot.set(row.shotId, row.model);
@@ -778,7 +805,7 @@ export function createFrameVariantsMethods(db: Database) {
             isNull(frameVariants.discardedAt)
           )
         )
-        .orderBy(desc(frameVariants.id))
+        .orderBy(...newestFirst)
         .limit(1);
       return rows[0] ?? null;
     },


### PR DESCRIPTION
## Related Issues

Closes #1132
Closes #1133

Both found while verifying the #1101 production deploy (#1125 / #1131).

## #1132 — `ORDER BY id` is not chronological on `frame_variants`

1355 of 10366 rows carry 26-char lowercase hex ids instead of ULIDs. Their `workflow_run_id` values are QStash run ids (`wfr_O8yXm2tvgtRMdrqtxHn7Q`), so they predate the move to Cloudflare Workflows and reached this table through the #989 copy, which preserved both id and `created_at`.

Nothing in the codebase generates them today — `generateId()` is a correct monotonic ULID factory, Better Auth is wired to it, and the last one was written 2026-04-14. But a legacy id beginning `ff` outranks **every ULID ever minted**, and ten reads in `frame-variants.ts` use id order to decide which version is newest — `getLatestPreview`, `getLatestPreviewByFrameIds`, `getLatestGridSheet`, `getLastFailed`, and the variant history listings.

#1131 is what that looks like when it goes wrong: 2150 of 3009 frames showed no preview.

**Fix:** ordering goes through `newestFirst` / `oldestFirst`, which sort by `createdAt` and fall back to `id`. `createdAt` is populated and correct on every row including the legacy ones, and the id tiebreak reproduces exactly what ULIDs already give within a second.

Rewriting the 1355 ids was rejected: they're referenced by `frames.selectedImageVersionId`, `pendingPromoteVersionId`, `sourceVariantId` and the `video_variants` render manifests, so a primary-key rewrite risks orphaning render history to fix an ordering bug.

## #1133 — image-less husks leak into the model dropdown

58 rows across 15 sequences are `kind:'model'`, `flux_2_turbo`, `completed`, with a null url. The #1101 reclassify couldn't move them because a frame selects each one — every other discriminator matched.

#1125 removed the `hidden`-model filter from `getSequenceImageModelsFn` on the stated basis that reclassification takes every `flux_2_turbo` row out of `kind:'model'`. It didn't for these, so those 15 sequences now offer the internal preview model as a selectable option.

**Fix:** `listModelsForSequence` requires `url IS NOT NULL`. A model whose only rows are empty husks produced nothing, so this holds for any hidden/internal model rather than depending on migration coverage.

## Tests

Both fail without their fix — verified by reverting each independently:

```
× keeps an image-less husk out of the model dropdown (#1133)
  expected [ 'nano_banana_2', 'flux_2_turbo' ] to deeply equal [ 'nano_banana_2' ]

× orders by createdAt, so a non-ULID legacy id cannot win (#1132)
  expected 'https://fal.media/stale-2026-03.png' to be 'https://fal.media/real.png'
```

The ordering test seeds a real production-shaped id (`ffdabf476d92ad8114fb89c8be`) with an older `createdAt`, which is exactly the row class that breaks id ordering.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Read-side only — no schema change, no migration, no data mutation. The ordering change affects one module and is a strict correction: for the ~87% of rows that are ULIDs, `createdAt` then `id` yields the same order it already did.

## Not included

The 58 dangling `frames.selectedImageVersionId` pointers are left in place. Clearing them is data repair, needs `imageStatus` reconciled in the same statement so those frames don't sit in a permanent generating state, and deserves its own reviewed change. Those frames render no image today either way. Noted on #1133.
