### PR TITLE
fix(#1133): narrow the model-list filter so in-flight and failed models still show

### DIFF
--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -1096,6 +1096,38 @@ describe("frameVariants kind: 'preview' (#1101)", () => {
     ]);
   });
 
+  it('still lists in-flight and all-failed models (#1133)', async () => {
+    const m = createFrameVariantsMethods(db);
+    // Neither has a url, so the blunt `url IS NOT NULL` filter would hide both:
+    // an in-flight render would drop out of the model bar until its image
+    // landed, and a model whose attempts all failed would hide the failure.
+    await db.insert(frameVariants).values([
+      {
+        id: 'inflight-row',
+        frameId,
+        sequenceId,
+        kind: 'model',
+        model: 'gpt_image_2',
+        status: 'generating',
+        url: null,
+      },
+      {
+        id: 'allfailed-row',
+        frameId,
+        sequenceId,
+        kind: 'model',
+        model: 'flux_2_dev',
+        status: 'failed',
+        url: null,
+      },
+    ]);
+
+    expect((await m.listModelsForSequence(sequenceId)).sort()).toEqual([
+      'flux_2_dev',
+      'gpt_image_2',
+    ]);
+  });
+
   it('orders by createdAt, so a non-ULID legacy id cannot win (#1132)', async () => {
     const m = createFrameVariantsMethods(db);
     const real = await m.recordPreview({

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -35,6 +35,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  ne,
   or,
 } from 'drizzle-orm';
 import { LIVE_PENDING_STATUSES } from './frame-prompt-versions';
@@ -553,14 +554,19 @@ export function createFrameVariantsMethods(db: Database) {
      * Distinct `kind:'model'` model names that actually RENDERED something in a
      * sequence — this drives the user-facing image-model dropdown.
      *
-     * `url IS NOT NULL` is load-bearing, not tidiness (#1133). Without it the
-     * dropdown's correctness depends on the #1101 reclassify having caught
-     * every `flux_2_turbo` row, and it did not: 58 rows across 15 sequences are
-     * still `kind:'model'` because a frame selects them, which leaks the
-     * internal preview model into those sequences as a selectable option. A
-     * model whose only rows are empty husks produced nothing, so requiring an
-     * actual image fixes this for any hidden/internal model rather than
-     * depending on migration coverage.
+     * Excluding the husk shape is load-bearing, not tidiness (#1133). Without
+     * it the dropdown's correctness depends on the #1101 reclassify having
+     * caught every `flux_2_turbo` row, and it did not: 58 rows across 15
+     * sequences are still `kind:'model'` because a frame selects them, which
+     * leaks the internal preview model in as a selectable option.
+     *
+     * The predicate is `NOT (completed AND no url)` rather than the blunter
+     * `url IS NOT NULL`, which would also hide two kinds of row the user needs
+     * to see: an in-flight render (pending/generating has no url yet, so a
+     * model would vanish from the bar until its image landed) and a render
+     * whose attempts all failed (hiding it hides the failure). Measured against
+     * production, the narrow form removes the same 15 leaking sequences while
+     * losing 0 legitimate models; the blunt form also dropped 11.
      */
     listModelsForSequence: async (sequenceId: string): Promise<string[]> => {
       const rows = await db
@@ -570,7 +576,12 @@ export function createFrameVariantsMethods(db: Database) {
           and(
             eq(frameVariants.sequenceId, sequenceId),
             eq(frameVariants.kind, 'model'),
-            isNotNull(frameVariants.url),
+            // De Morgan of NOT (completed AND no url) — `status` is NOT NULL,
+            // so the inequality is safe without a null guard.
+            or(
+              ne(frameVariants.status, 'completed'),
+              isNotNull(frameVariants.url)
+            ),
             isNull(frameVariants.discardedAt)
           )
         );

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -551,8 +551,9 @@ export function createFrameVariantsMethods(db: Database) {
     },
 
     /**
-     * Distinct `kind:'model'` model names that actually RENDERED something in a
-     * sequence — this drives the user-facing image-model dropdown.
+     * Distinct `kind:'model'` model names ATTEMPTED in a sequence — in-flight,
+     * failed, cancelled, or rendered — this drives the user-facing image-model
+     * dropdown. Only the completed-without-image husk is excluded.
      *
      * Excluding the husk shape is load-bearing, not tidiness (#1133). Without
      * it the dropdown's correctness depends on the #1101 reclassify having
@@ -564,7 +565,9 @@ export function createFrameVariantsMethods(db: Database) {
      * `url IS NOT NULL`, which would also hide two kinds of row the user needs
      * to see: an in-flight render (pending/generating has no url yet, so a
      * model would vanish from the bar until its image landed) and a render
-     * whose attempts all failed (hiding it hides the failure). Measured against
+     * whose attempts all failed (hiding it hides the failure). `cancelled`
+     * (#1085, never attempted) passes for the same reason as `failed`: a
+     * terminal no-output state the user should see, not a husk. Measured against
      * production, the narrow form removes the same 15 leaking sequences while
      * losing 0 legitimate models; the blunt form also dropped 11.
      */


### PR DESCRIPTION
## Related Issue

Part of #1133 — corrects the fix merged in #1134.

## What's wrong with what I merged

The `url IS NOT NULL` predicate in #1134 was blunter than the bug required. It excludes **any** row without a url, and two kinds of row legitimately have none:

- **In-flight renders.** `pending`/`generating` rows get their url on completion, so a freshly added model would disappear from the model bar until its image landed.
- **All-failed models.** If every attempt for a model failed, hiding it hides the failure from the user.

## Fix

`NOT (completed AND no url)` — written as its De Morgan equivalent, since `status` is `NOT NULL`. That targets the husk shape precisely: a row claiming to have finished while having produced nothing.

## Measured against production

| | leaking sequences removed | legitimate models lost |
|---|---|---|
| `url IS NOT NULL` (merged in #1134) | 15 | **11** |
| `NOT (completed AND no url)` (this PR) | 15 | **0** |

The 11 lost pairs were `nano_banana_2` ×9, `gpt_image_2` ×1, `flux_2_dev` ×1. All 167 rows behind them are `status='failed'` (newest 2026-06-27), so nothing in production is currently in-flight and no user has actually lost a model in the interim — but the in-flight hole would have bitten the next time someone added a model to a sequence.

## Test

New test pins both halves: the husk stays out, in-flight and all-failed models stay in. It fails against the merged predicate:

```
× still lists in-flight and all-failed models (#1133)
  expected [] to deeply equal [ 'flux_2_dev', 'gpt_image_2' ]
```

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

One read-side predicate, no schema change, no migration, no data mutation. Strictly widens what #1134 returns, back to the intended set.
