### PR TITLE
fix(#1137): project the ShotView query, don't select every joined column

### DIFF
--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -26,7 +26,11 @@ import {
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import { resolveSceneForShotFromDb } from '@/lib/scenes/scene-script';
 import { NotFoundError } from '@/lib/errors';
-import { getLogger, toErrorPayload } from '@/lib/observability/logger';
+import {
+  errorHeadline,
+  getLogger,
+  toErrorPayload,
+} from '@/lib/observability/logger';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import type { Frame } from '@/lib/db/schema';
 import type { SequenceStatus } from '@/lib/db/schema/sequences';
@@ -186,7 +190,10 @@ export const loggerMiddleware = createMiddleware({ type: 'function' }).server(
         fnName,
         durationMs,
         errCode: err.code,
-        errMessage: err.message,
+        // Reason-first and length-capped: a raw driver message (drizzle puts
+        // the whole SQL statement there) would otherwise fill the body's
+        // truncation budget and evict the cause — see errorHeadline (#1135).
+        errMessage: errorHeadline(err),
         err,
       };
       // Expected business rejections are outcomes, not failures: warn, so prod

--- a/src/lib/db/scoped/no-bare-select-with-join.test.ts
+++ b/src/lib/db/scoped/no-bare-select-with-join.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Repo guard: no bare `db.select()` in a chain that joins.
+ *
+ * D1 rejects any query whose RESULT SET exceeds 100 columns ("too many columns
+ * in result set"). A bare `.select()` projects every column of every joined
+ * table, so a wide join drifts toward that ceiling as unrelated PRs add
+ * columns — and nothing local ever complains, because libSQL (what these tests
+ * run on) returns a 104-column row happily. #1135 shipped exactly that way and
+ * broke every shot read in production.
+ *
+ * An explicit projection makes the width a decision instead of a side effect,
+ * and it also caps what a caller's own join can add.
+ */
+
+import { globSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const JOIN = /\.(left|inner|right|full)Join\(/i;
+const BARE_SELECT = /\.select\(\s*\)/g;
+
+/**
+ * Find bare selects whose OWN method chain contains a join.
+ *
+ * Scoping to the chain is the whole difficulty: sibling queries share a
+ * statement whenever they sit in one `Promise.all([...])`, so splitting the
+ * source on `;` reports a bare single-table select next to an unrelated
+ * explicitly-projected join. Walking bracket depth from the `.select()` and
+ * stopping at the first depth-0 `,`/`;` — or at the bracket that closes the
+ * expression containing it — ends the span exactly where the chain does.
+ */
+export function findBareSelectWithJoin(source: string): string[] {
+  const code = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+  const found: string[] = [];
+  for (const match of code.matchAll(BARE_SELECT)) {
+    const start = (match.index ?? 0) + match[0].length;
+    let depth = 0;
+    let end = code.length;
+    for (let i = start; i < code.length; i++) {
+      const char = code[i];
+      if (char === '(' || char === '[' || char === '{') depth++;
+      else if (char === ')' || char === ']' || char === '}') {
+        // A closer we never opened ends the expression holding this chain.
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+        depth--;
+      } else if ((char === ',' || char === ';') && depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    const chain = code.slice(start, end);
+    if (JOIN.test(chain)) found.push(chain.trim().slice(0, 120));
+  }
+  return found;
+}
+
+describe('findBareSelectWithJoin', () => {
+  it('flags a bare select that joins', () => {
+    expect(
+      findBareSelectWithJoin('db.select().from(a).leftJoin(b, eq(b.id, a.b));')
+    ).toHaveLength(1);
+  });
+
+  it('ignores an explicit projection that joins', () => {
+    expect(
+      findBareSelectWithJoin(
+        'db.select({ id: a.id }).from(a).leftJoin(b, eq(b.id, a.b));'
+      )
+    ).toEqual([]);
+  });
+
+  it('ignores a bare select whose sibling in the same statement joins', () => {
+    // The shape that defeats splitting on `;` — one statement, two queries.
+    expect(
+      findBareSelectWithJoin(
+        `await Promise.all([
+           db.select().from(a).where(eq(a.id, x)),
+           db.select({ id: b.id }).from(b).innerJoin(c, eq(c.id, b.c)),
+         ]);`
+      )
+    ).toEqual([]);
+  });
+});
+
+it('no bare select joins anywhere in src', () => {
+  const offenders = globSync('src/**/*.ts')
+    .filter((file) => !file.includes('.test.'))
+    .flatMap((file) =>
+      findBareSelectWithJoin(readFileSync(file, 'utf8')).map(
+        (chain) => `${file}: ${chain}`
+      )
+    );
+  expect(offenders).toEqual([]);
+});

--- a/src/lib/db/scoped/shot-view-query.test.ts
+++ b/src/lib/db/scoped/shot-view-query.test.ts
@@ -177,3 +177,25 @@ it('resolves previewThumbnailUrl through the whole assembly path', async () => {
   // A preview is never the still.
   expect((await assemble())[0]?.image).toBeNull();
 });
+
+/**
+ * The regression guard for #1135. libSQL (and every other SQLite this suite
+ * runs on) happily returns a 104-column row, so nothing here would ever fail on
+ * width — only D1 rejects it, and only in production. Assert the count instead.
+ */
+it('projects fewer columns than D1 accepts, including a caller join', async () => {
+  const { sql } = selectShotViewRows(db)
+    // What `sequences.listShotsByIds` adds for its team filter. Under a bare
+    // `db.select()` this join dragged in every `sequences` column too.
+    .innerJoin(sequences, eq(shots.sequenceId, sequences.id))
+    .toSQL();
+  const projected = sql
+    .slice('select '.length, sql.indexOf(' from '))
+    .split(', ');
+  expect(projected.length).toBeLessThanOrEqual(100);
+
+  // A left-joined group with no matching row must be null, not an object of
+  // nulls: `assembleShotViews` branches on truthiness, so the latter would
+  // rebuild a motion prompt out of nothing.
+  expect((await selectShotViewRows(db))[0]?.shot_prompt_versions).toBeNull();
+});

--- a/src/lib/db/scoped/shot-view-query.ts
+++ b/src/lib/db/scoped/shot-view-query.ts
@@ -48,7 +48,15 @@ export type ShotViewRow = {
   frames: Frame | null;
   frame_variants: FrameVariant | null;
   frame_prompt_versions: FramePromptVersion | null;
-  shot_prompt_versions: ShotPromptVersion | null;
+  /**
+   * Narrowed to what {@link motionPromptFromVersion} reads — the query projects
+   * these three columns rather than the whole row, to stay clear of D1's
+   * 100-column result-set cap (see {@link selectShotViewRows}).
+   */
+  shot_prompt_versions: Pick<
+    ShotPromptVersion,
+    'text' | 'dialogue' | 'audio'
+  > | null;
   video_variants: VideoVariant | null;
 };
 
@@ -73,7 +81,30 @@ export const shotHierarchicalOrder = [
 export function selectShotViewRows(db: Database) {
   return (
     db
-      .select()
+      // Explicit projection, NOT a bare `db.select()`. D1 rejects any result
+      // set wider than 100 columns ("too many columns in result set", #1135),
+      // and a bare select projects every column of every joined table — here
+      // that included `render_segments` and `scenes`, joined only for their
+      // pointers and the ORDER BY, never read. The 8-table walk reached 104
+      // columns and every shot read in prod started failing.
+      //
+      // Naming the tables also caps the cost of a caller's own join:
+      // `listShotsByIds` adds `sequences` for its team filter, and under a bare
+      // select that pushed the same query another ~12 columns wider.
+      .select({
+        shots,
+        frames,
+        frame_variants: frameVariants,
+        frame_prompt_versions: framePromptVersions,
+        // Only the three fields `motionPromptFromVersion` rebuilds a prompt
+        // from — `components`/`parameters` are history, not render input.
+        shot_prompt_versions: {
+          text: shotPromptVersions.text,
+          dialogue: shotPromptVersions.dialogue,
+          audio: shotPromptVersions.audio,
+        },
+        video_variants: videoVariants,
+      })
       .from(shots)
       // Anchor frame holds the image surface (#989) — the shot's first frame
       // (orderIndex 0), joined by shotId (NOT id-reuse).

--- a/src/lib/observability/logger.ts
+++ b/src/lib/observability/logger.ts
@@ -302,3 +302,41 @@ export function toErrorPayload(error: unknown): {
   }
   return { code: 'UNKNOWN', message: String(error) };
 }
+
+/**
+ * How much of any one error message a log BODY may carry. The ingest pipeline
+ * truncates a body at ~4,000 chars, so an oversized message doesn't just bloat
+ * the line — it evicts everything after it.
+ */
+const HEADLINE_MESSAGE_MAX = 400;
+
+/**
+ * The reason-first, length-capped headline for a log body.
+ *
+ * `DrizzleQueryError.message` is the entire SQL statement ("Failed query:
+ * select …") and the actual database reason lives on `.cause`. Interpolating
+ * the raw message into a log body therefore spends the whole 4,000-char budget
+ * on column names and truncates the one part that explains anything: a
+ * 104-column D1 rejection (#1135) logged 3,793 times as an unexplained
+ * "Failed query: select …", and the cause had to be recovered by re-running the
+ * query against production by hand.
+ *
+ * The full untruncated message and the whole cause chain still ship
+ * structurally under `{ err }` — this only governs the interpolated body.
+ */
+export function errorHeadline(payload: {
+  message: string;
+  cause?: SerializedError | string;
+}): string {
+  const causeMessage =
+    typeof payload.cause === 'string' ? payload.cause : payload.cause?.message;
+  const parts = causeMessage
+    ? // Cause first: it is the reason, and it is what survives truncation.
+      [causeMessage, payload.message]
+    : [payload.message];
+  return parts.map((part) => truncate(part, HEADLINE_MESSAGE_MAX)).join(' — ');
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max)}…`;
+}


### PR DESCRIPTION
Fixes #1137.

Every shot read in production has been failing since 2026-08-09 04:40 UTC with
D1's `too many columns in result set: SQLITE_ERROR [code: 7500]`.

## The bug

`selectShotViewRows` used a bare `db.select()`, which projects every column of
every joined table across its 8-table walk — **104 columns**, over D1's
100-column result-set cap. `render_segments` and `scenes` are joined only to
walk pointers and supply the `ORDER BY`; neither is ever read.

It hit both read paths, and the user-facing one was worse: `listShotsByIds`
adds `innerJoin(sequences)` for its team filter, pushing the same query to ~116.

## The fix

Explicit projection of the six tables `ShotView` actually exposes, with
`shot_prompt_versions` narrowed to the three fields `motionPromptFromVersion`
reads. **104 → 73 columns**, and naming the tables means a caller's own join now
costs nothing.

`ShotViewRow.shot_prompt_versions` becomes
`Pick<ShotPromptVersion, 'text' | 'dialogue' | 'audio'>`. drizzle still nulls
the whole group on a left-join miss — asserted at runtime in the test, so
`assembleShotViews`' truthiness branch stays correct.

## Logging

The cause was invisible for two days. drizzle puts the entire ~4KB SQL statement
in `Error.message` and the actual reason in `.cause`; the middleware
interpolated that raw message into the log body, which the ingest pipeline
truncates at ~4,000 chars. All 3,793 error lines read as an unexplained
`Failed query: select …`, and the real error had to be recovered by re-running
the query against production D1 by hand.

`errorHeadline` puts the cause first and caps each part at 400 chars. The full
message and whole cause chain still ship structurally under `{ err }`.

## Guards

Unit tests run on libSQL, which returns a 104-column row happily — the entire
suite passed while production was down. Same blind spot as the 100-bound-
parameter ceiling in #1019. So:

1. A column-count assertion on this query, including the `sequences` caller join.
2. A repo-wide check that no bare `db.select()` sits in a chain that joins.
   Scoped by bracket-depth walk rather than splitting on `;`, because sibling
   queries share a statement inside `Promise.all([...])` — that shape produced a
   false positive on `sequence-elements.ts` in a first cut.

Guard 2 was verified by reverting the fix: it fails with the bare select and
passes with the projection.

## Verification

- Ran the exact failing query against production D1: returned `too many columns
  in result set` before, **39 rows** after.
- Full suite: 2,236 tests / 213 files green. Typecheck and lint clean.

## Out of scope

- `Disallowed operation called within global scope` — 179/day, steady, unrelated
  (async I/O or a random value at Worker module scope). Needs its own issue.
- Alerting gaps this exposed are fixed in PostHog, not code: a sustained
  60-in-60min error floor and a serverFn-failure alert, both backtested over 3
  days (they fire on the 2026-08-09 onset and today, with no false positives).
