### PR TITLE
fix(#1139): load the Video.js surface client-only, off the server's module graph

### DIFF
--- a/src/components/motion/video-player-surface.tsx
+++ b/src/components/motion/video-player-surface.tsx
@@ -1,0 +1,125 @@
+/**
+ * The Video.js-dependent half of {@link VideoPlayer}.
+ *
+ * This module exists to be a LOADING BOUNDARY, not just an organisational one:
+ * importing `@videojs/react` pulls in `@videojs/store`, whose `selector.js`
+ * builds a module-scope singleton containing `new AbortController()`. Workerd
+ * forbids constructing an I/O-bound object at global scope, so merely importing
+ * this module on the server throws "Disallowed operation called within global
+ * scope" — once per isolate cold start, ~179×/day in production (#1139).
+ *
+ * No lazy-call workaround can help, because the throw happens on IMPORT, before
+ * any of our code runs. Keeping every `@videojs/*` import in here lets
+ * `video-player.tsx` reach it through a client-only dynamic import, so the
+ * server never evaluates it.
+ *
+ * Nothing may import this module statically from a server-reachable path.
+ */
+
+import type { Media, Video as VideoMedia } from '@videojs/core';
+import { createPlayer, Poster, useMedia } from '@videojs/react';
+import { MinimalVideoSkin, Video, videoFeatures } from '@videojs/react/video';
+import { useEffect, useRef } from 'react';
+
+// useMedia() returns the base Media capability set; the <Video> component
+// renders an instance with the full Video capability set (seek/source/etc.).
+const isVideoMedia = (media: Media): media is VideoMedia =>
+  'duration' in media && 'currentTime' in media;
+
+// `createPlayer` also constructs an AbortController, so it stays out of module
+// scope even here: this module is only ever evaluated in the browser, but the
+// singleton is still the right shape — one player instance shared across every
+// mount, built on first render.
+let playerSingleton: ReturnType<typeof createPlayer> | undefined;
+const getPlayer = () =>
+  (playerSingleton ??= createPlayer({ features: videoFeatures }));
+
+export type VideoPlayerSurfaceProps = {
+  src: string;
+  chaptersUrl?: string;
+  posterSrc?: string | null;
+  autoPlay?: boolean;
+  onLoadedMetadata?: (duration: number) => void;
+  onTimeUpdate?: (currentTime: number) => void;
+  onPause?: () => void;
+  onEnded?: () => void;
+};
+
+const VideoPlayerInner: React.FC<VideoPlayerSurfaceProps> = ({
+  src,
+  chaptersUrl,
+  posterSrc,
+  autoPlay = false,
+  onLoadedMetadata,
+  onTimeUpdate,
+  onPause,
+  onEnded,
+}) => {
+  const media = useMedia();
+  const callbacksRef = useRef({
+    onLoadedMetadata,
+    onTimeUpdate,
+    onPause,
+    onEnded,
+  });
+  callbacksRef.current = { onLoadedMetadata, onTimeUpdate, onPause, onEnded };
+
+  useEffect(() => {
+    if (!media || !isVideoMedia(media)) return;
+    const el = media;
+
+    const handleLoadedMetadata = () => {
+      callbacksRef.current.onLoadedMetadata?.(el.duration);
+    };
+    const handleTimeUpdate = () => {
+      callbacksRef.current.onTimeUpdate?.(el.currentTime);
+    };
+    const handlePause = () => {
+      callbacksRef.current.onPause?.();
+    };
+    const handleEnded = () => {
+      callbacksRef.current.onEnded?.();
+    };
+
+    el.addEventListener('loadedmetadata', handleLoadedMetadata);
+    el.addEventListener('timeupdate', handleTimeUpdate);
+    el.addEventListener('pause', handlePause);
+    el.addEventListener('ended', handleEnded);
+
+    return () => {
+      el.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      el.removeEventListener('timeupdate', handleTimeUpdate);
+      el.removeEventListener('pause', handlePause);
+      el.removeEventListener('ended', handleEnded);
+    };
+  }, [media]);
+
+  return (
+    <MinimalVideoSkin>
+      <Video
+        src={src || undefined}
+        playsInline
+        autoPlay={autoPlay}
+        preload="metadata"
+      >
+        {chaptersUrl && <track kind="chapters" src={chaptersUrl} default />}
+      </Video>
+      {posterSrc && <Poster src={posterSrc} alt="Video thumbnail" />}
+    </MinimalVideoSkin>
+  );
+};
+
+/**
+ * Default export so `video-player.tsx` can reach this through `React.lazy`,
+ * which requires a module whose default is the component.
+ */
+const VideoPlayerSurface: React.FC<VideoPlayerSurfaceProps> = (props) => {
+  const Player = getPlayer();
+  return (
+    <Player.Provider>
+      <VideoPlayerInner {...props} />
+    </Player.Provider>
+  );
+};
+
+export default VideoPlayerSurface;

--- a/src/components/motion/video-player.tsx
+++ b/src/components/motion/video-player.tsx
@@ -5,27 +5,15 @@ import {
   type AspectRatio,
 } from '@/lib/constants/aspect-ratios';
 import { cn } from '@/lib/utils';
-import type { Media, Video as VideoMedia } from '@videojs/core';
-import { createPlayer, Poster, useMedia } from '@videojs/react';
-import { MinimalVideoSkin, Video, videoFeatures } from '@videojs/react/video';
-import { useEffect, useRef } from 'react';
+import { lazy, Suspense, useEffect, useState } from 'react';
 
-// useMedia() returns the base Media capability set; the <Video> component
-// renders an instance with the full Video capability set (seek/source/etc.).
-const isVideoMedia = (media: Media): media is VideoMedia =>
-  'duration' in media && 'currentTime' in media;
-
-// `createPlayer` constructs an AbortController, which the Cloudflare Workers
-// runtime only permits inside a request (i.e. during render), NOT at module /
-// global scope. Creating it at module scope crashes SSR ("Disallowed operation
-// … within global scope"). So build it lazily on first render and memoise it as
-// a singleton — the same request-scoped lazy-init pattern we use for the Drizzle
-// client and other Workers-sensitive resources. Video.js itself renders fine on
-// the server (markup now, interactivity after hydration); only this eager
-// construction was the problem.
-let playerSingleton: ReturnType<typeof createPlayer> | undefined;
-const getPlayer = () =>
-  (playerSingleton ??= createPlayer({ features: videoFeatures }));
+// Dynamic, and rendered only after mount — see video-player-surface.tsx. The
+// import must not be evaluated on the server: `@videojs/store` constructs an
+// AbortController at module scope, which Workerd rejects with "Disallowed
+// operation called within global scope" (#1139). `lazy()` alone is not enough,
+// because React invokes the loader during SSR too; the `mounted` gate below is
+// what actually keeps the server out of it.
+const VideoPlayerSurface = lazy(() => import('./video-player-surface'));
 
 type VideoPlayerProps = {
   src: string;
@@ -40,71 +28,41 @@ type VideoPlayerProps = {
   onEnded?: () => void;
 };
 
-const VideoPlayerInner: React.FC<
-  Omit<VideoPlayerProps, 'aspectRatio' | 'className'>
-> = ({
-  src,
-  chaptersUrl,
-  posterSrc,
-  autoPlay = false,
-  onLoadedMetadata,
-  onTimeUpdate,
-  onPause,
-  onEnded,
-}) => {
-  const media = useMedia();
-  const callbacksRef = useRef({
-    onLoadedMetadata,
-    onTimeUpdate,
-    onPause,
-    onEnded,
-  });
-  callbacksRef.current = { onLoadedMetadata, onTimeUpdate, onPause, onEnded };
+/**
+ * True once the component has mounted in the browser. `useEffect` never runs
+ * during SSR, so this stays false on the server and through the hydration pass
+ * — which is the point: it keeps the Video.js chunk out of the server's
+ * evaluated module graph, and keeps the hydrated tree identical to the
+ * server-rendered one.
+ */
+function useMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  return mounted;
+}
 
-  useEffect(() => {
-    if (!media || !isVideoMedia(media)) return;
-    const el = media;
-
-    const handleLoadedMetadata = () => {
-      callbacksRef.current.onLoadedMetadata?.(el.duration);
-    };
-    const handleTimeUpdate = () => {
-      callbacksRef.current.onTimeUpdate?.(el.currentTime);
-    };
-    const handlePause = () => {
-      callbacksRef.current.onPause?.();
-    };
-    const handleEnded = () => {
-      callbacksRef.current.onEnded?.();
-    };
-
-    el.addEventListener('loadedmetadata', handleLoadedMetadata);
-    el.addEventListener('timeupdate', handleTimeUpdate);
-    el.addEventListener('pause', handlePause);
-    el.addEventListener('ended', handleEnded);
-
-    return () => {
-      el.removeEventListener('loadedmetadata', handleLoadedMetadata);
-      el.removeEventListener('timeupdate', handleTimeUpdate);
-      el.removeEventListener('pause', handlePause);
-      el.removeEventListener('ended', handleEnded);
-    };
-  }, [media]);
-
-  return (
-    <MinimalVideoSkin>
-      <Video
-        src={src || undefined}
-        playsInline
-        autoPlay={autoPlay}
-        preload="metadata"
-      >
-        {chaptersUrl && <track kind="chapters" src={chaptersUrl} default />}
-      </Video>
-      {posterSrc && <Poster src={posterSrc} alt="Video thumbnail" />}
-    </MinimalVideoSkin>
+/**
+ * Poster (or skeleton) sized to the player's box. Doubles as the SSR output and
+ * the lazy-load fallback, so the player swapping in cannot shift layout.
+ */
+const PlayerPlaceholder: React.FC<{
+  posterSrc?: string | null;
+  alt: string;
+}> = ({ posterSrc, alt }) =>
+  posterSrc ? (
+    <AppImage
+      // key forces a fresh image when the still changes so the browser never
+      // keeps the previous shot's decoded bitmap after a switch.
+      key={posterSrc}
+      src={posterSrc}
+      alt={alt}
+      width={1280}
+      height={720}
+      className="absolute inset-0 h-full w-full object-cover"
+    />
+  ) : (
+    <Skeleton className="absolute inset-0 h-full w-full" />
   );
-};
 
 export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   src,
@@ -118,6 +76,8 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   onPause,
   onEnded,
 }) => {
+  const mounted = useMounted();
+
   // Show skeleton when there's no video source and no poster
   if (!src && !posterSrc) {
     return (
@@ -142,21 +102,14 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
           getAspectRatioClassName(aspectRatio)
         )}
       >
-        {/* key forces a fresh image when the still changes so the browser
-            never keeps the previous shot's decoded bitmap after a switch. */}
-        <AppImage
-          key={posterSrc}
-          src={posterSrc}
-          alt="Scene thumbnail"
-          width={1280}
-          height={720}
-          className="absolute inset-0 h-full w-full object-cover"
-        />
+        <PlayerPlaceholder posterSrc={posterSrc} alt="Scene thumbnail" />
       </div>
     );
   }
 
-  const Player = getPlayer();
+  const placeholder = (
+    <PlayerPlaceholder posterSrc={posterSrc} alt="Video thumbnail" />
+  );
 
   return (
     <div
@@ -166,18 +119,22 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
         getAspectRatioClassName(aspectRatio)
       )}
     >
-      <Player.Provider>
-        <VideoPlayerInner
-          src={src}
-          chaptersUrl={chaptersUrl}
-          posterSrc={posterSrc}
-          autoPlay={autoPlay}
-          onLoadedMetadata={onLoadedMetadata}
-          onTimeUpdate={onTimeUpdate}
-          onPause={onPause}
-          onEnded={onEnded}
-        />
-      </Player.Provider>
+      {mounted ? (
+        <Suspense fallback={placeholder}>
+          <VideoPlayerSurface
+            src={src}
+            chaptersUrl={chaptersUrl}
+            posterSrc={posterSrc}
+            autoPlay={autoPlay}
+            onLoadedMetadata={onLoadedMetadata}
+            onTimeUpdate={onTimeUpdate}
+            onPause={onPause}
+            onEnded={onEnded}
+          />
+        </Suspense>
+      ) : (
+        placeholder
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Fixes #1139.

Production logged ~179 of these a day, one per isolate cold start:

```
Error: Disallowed operation called within global scope.
```

## Root cause

Importing `@videojs/react` pulls in `@videojs/store`, whose `selector.js` builds
a singleton at **module scope**:

```js
var stateContext = {
  signals: new AbortControllerRegistry(),   // ← field initializer: new AbortController()
  ...
};
```

Workerd forbids constructing an I/O-bound object at global scope, so the throw
fires on **import** — no application code involved.

`video-player.tsx` already deferred `createPlayer` out of module scope for this
exact error (there was a comment naming it). That workaround could never fix
this one, because the offending construction runs before any of our code does.
The module simply must not be evaluated on the server.

## Fix

Every `@videojs/*` import moves into `video-player-surface.tsx`, reached through
a dynamic import gated on a mounted flag.

`lazy()` on its own is **not** sufficient — React invokes the lazy loader during
SSR as well. The `mounted` gate is what actually keeps the server out of the
module, since `useEffect` never runs there. That subtlety is commented at both
ends so the next person doesn't "simplify" the gate away and quietly reintroduce
this.

The skeleton and image-only branches touch no Video.js code and still render on
the server, unchanged.

## Behaviour change

The player subtree no longer emits SSR markup — it mounts after hydration behind
a poster/skeleton placeholder in the same aspect-ratio container, so there is no
layout shift. Little is lost in practice: the module-scope throw already degraded
that subtree on the server. E2E video assertions are client-side (post-hydration
`<video>` metadata checks in `e2e/tests/full-sequence.spec.ts`) and are
unaffected.

## Verification

This only reproduces against the **built** worker — `bun dev` uses Vite's lazy
SSR module runner and never evaluates the module, which is presumably why it
survived so long. So `bun run build` + `wrangler dev`:

| | before | after |
|---|---|---|
| `Disallowed operation` occurrences | 1 | **0** |
| `GET /` | 200 | 200 |

Also 0 across `/login` and `/pricing`, with the Video.js code emitted to its own
chunk (`video-player-surface-*.js`) that the server entry never statically
imports.

Full suite: 2,240 tests / 214 files green. Typecheck and lint clean.

## Follow-on

This was the largest single contributor to the production error baseline
(~7.5/hr of a 3–11/hr floor). With it gone, the error-rate alert thresholds tuned
in #1137 can likely come down — worth re-backtesting once this has been in prod
a few days.
