### PR TITLE
fix(#1149): a content-flagged preview no longer permanently fails the sequence

### DIFF
--- a/src/lib/workflow/instance-id.test.ts
+++ b/src/lib/workflow/instance-id.test.ts
@@ -89,6 +89,52 @@ describe('buildInstanceId', () => {
     expect(id.startsWith('openstory-so_image_')).toBe(true);
   });
 
+  // #1149: a dead instance must not pin its dedup key forever, so the trigger
+  // walks generations. Generation 1 has to stay byte-identical to the untagged
+  // id or every in-flight instance would be orphaned by the deploy.
+  test('generation 1 is the bare id (no tag)', () => {
+    const args = {
+      env: { VITE_APP_URL: 'https://openstory.so' },
+      workflowName: 'image',
+      suffix: 'preview-h4sh-shot7',
+    };
+    expect(buildInstanceId({ ...args, generation: 1 })).toBe(
+      buildInstanceId(args)
+    );
+  });
+
+  test('later generations append _g<n>', () => {
+    const args = {
+      env: { VITE_APP_URL: 'https://openstory.so' },
+      workflowName: 'image',
+      suffix: 'preview-h4sh-shot7',
+    };
+    expect(buildInstanceId({ ...args, generation: 2 })).toBe(
+      'openstory-so_image_preview-h4sh-shot7_g2'
+    );
+    expect(buildInstanceId({ ...args, generation: 3 })).toBe(
+      'openstory-so_image_preview-h4sh-shot7_g3'
+    );
+  });
+
+  // The tag is reserved for BEFORE the suffix is truncated. Appending it after
+  // a naive `slice(0, room)` would push the id over 100 chars — and clamping
+  // afterwards would shear the tag off, collapsing generation 2 onto
+  // generation 1's id and re-creating the tombstone this fixes.
+  test('a truncated suffix still yields a distinct, in-limit tagged id', () => {
+    const args = {
+      env: { VITE_APP_URL: 'https://openstory.so' },
+      workflowName: 'image',
+      suffix: 'x'.repeat(200),
+    };
+    const gen1 = buildInstanceId(args);
+    const gen2 = buildInstanceId({ ...args, generation: 2 });
+
+    expect(gen2.length).toBeLessThanOrEqual(100);
+    expect(gen2).not.toBe(gen1);
+    expect(gen2.endsWith('_g2')).toBe(true);
+  });
+
   test('throws when prefix alone exceeds the 100-char limit', () => {
     expect(() =>
       buildInstanceId({

--- a/src/lib/workflow/instance-id.ts
+++ b/src/lib/workflow/instance-id.ts
@@ -39,6 +39,14 @@ export function getEnvironmentSlug(env: { VITE_APP_URL?: string }): string {
  * suffix is collapsed to `-`, and the separator between envSlug /
  * workflowName / suffix is `_`.
  *
+ * `generation` (default 1) mints a *different* id for the same dedup key, so a
+ * trigger whose prior instance died can retry instead of colliding with its own
+ * corpse forever (#1149). Generation 1 is the bare id — existing instances keep
+ * their ids — and later generations append `_g<n>`. The tag is appended AFTER
+ * truncation reserves room for it: truncation cuts the suffix's tail, so a tag
+ * merely concatenated on could be sheared off and collapse two generations back
+ * into one id.
+ *
  * Truncates to 100 chars (CF limit). Truncation happens at the suffix
  * because the env slug + workflow name are needed for namespacing and the
  * suffix is the dedup key — if it gets cut, the worst case is two callers
@@ -48,20 +56,23 @@ export function buildInstanceId({
   env,
   workflowName,
   suffix,
+  generation = 1,
 }: {
   env: { VITE_APP_URL?: string };
   workflowName: string;
   suffix: string;
+  generation?: number;
 }): string {
   const envSlug = getEnvironmentSlug(env);
   const safeWorkflowName = workflowName.replace(/[^a-zA-Z0-9_-]+/g, '-');
   const prefix = `${envSlug}_${safeWorkflowName}_`;
-  const room = MAX_INSTANCE_ID_LENGTH - prefix.length;
+  const tag = generation > 1 ? `_g${generation}` : '';
+  const room = MAX_INSTANCE_ID_LENGTH - prefix.length - tag.length;
   if (room <= 0) {
     throw new Error(
       `Instance ID prefix '${prefix}' exceeds the ${MAX_INSTANCE_ID_LENGTH}-char limit; shorten the env slug or workflow name`
     );
   }
   const safeSuffix = suffix.replace(/[^a-zA-Z0-9_-]+/g, '-');
-  return `${prefix}${safeSuffix.slice(0, room)}`;
+  return `${prefix}${safeSuffix.slice(0, room)}${tag}`;
 }

--- a/src/lib/workflow/trigger-bindings.test.ts
+++ b/src/lib/workflow/trigger-bindings.test.ts
@@ -9,13 +9,18 @@
  * multi-create step can never complete once one sibling fails (issue #846
  * RC3). But dedup ids are not always run-scoped (`shotPromptDedupId` is
  * stable across user requests), so the swallow is gated on the existing
- * instance's status: alive-or-complete reuses it; errored/terminated/unknown/
- * unverifiable rethrows so a dead instance can't masquerade as "enqueued".
+ * instance's status: alive-or-complete reuses it, while terminated/unknown/
+ * unverifiable rethrow so a dead instance can't masquerade as "enqueued".
  * The random-suffix path can't collide legitimately, so it keeps throwing.
+ *
+ * `errored` is the exception, and the second describe block below covers it:
+ * rethrowing there made the dedup id a permanent tombstone (#1149), so an
+ * errored instance now yields a fresh generation id instead.
  */
 
 import { describe, expect, test, vi } from 'vitest';
 import { triggerCfWorkflow, workflowNameFromRunId } from './trigger-bindings';
+import { buildInstanceId } from '@/lib/workflow/instance-id';
 import type { CloudflareEnv } from '@/lib/workflow/types';
 
 // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal env stub: triggerCfWorkflow only reads VITE_APP_URL (via buildInstanceId)
@@ -44,6 +49,30 @@ function harness(
       id,
       status: () => Promise.resolve({ status: existingInstanceStatus }),
     };
+  });
+  const bindingStub = { create, get };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Workflow binding stub exposing only create + get
+  const binding = bindingStub as unknown as Workflow<typeof body>;
+  return { binding, create, get };
+}
+
+/**
+ * Harness whose per-id behaviour is scripted: `statuses` maps an instance id to
+ * the status a lookup should report, and any id present there rejects `create`
+ * with `already_exists`. Ids absent from the map are created normally. Models
+ * the #1149 shape — one dead generation, a live next one.
+ */
+function scriptedHarness(statuses: Record<string, InstanceStatus['status']>) {
+  const create = vi.fn(async (opts: { id: string; params: unknown }) => {
+    if (opts.id in statuses) {
+      throw new Error('(instance.already_exists) Instance already exists');
+    }
+    return { id: opts.id };
+  });
+  const get = vi.fn(async (id: string) => {
+    const status = statuses[id];
+    if (!status) throw new Error('instance not found');
+    return { id, status: () => Promise.resolve({ status }) };
   });
   const bindingStub = { create, get };
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal Workflow binding stub exposing only create + get
@@ -182,12 +211,14 @@ describe('triggerCfWorkflow', () => {
   );
 
   // A request-stable dedup id (e.g. shotPromptDedupId) colliding with a
-  // FAILED prior instance must stay loud: returning the dead instance's id
+  // FAILED prior instance must never RESOLVE to the dead id: returning it
   // would clear staleness banners while no workflow ever runs (#846 review).
-  test.each(['errored', 'terminated', 'unknown'] as const)(
+  // `terminated` is a user cancellation (#1085) and `unknown` is unverifiable,
+  // so both stay hard rethrows — only `errored` earns a fresh generation.
+  test.each(['terminated', 'unknown'] as const)(
     'rethrows already_exists when the existing instance is %s',
     async (status) => {
-      const { binding } = harness(alreadyExists, status);
+      const { binding, create } = harness(alreadyExists, status);
 
       await expect(
         triggerCfWorkflow({
@@ -198,6 +229,7 @@ describe('triggerCfWorkflow', () => {
           deduplicationId: 'prompt-visual-f1-h4sh',
         })
       ).rejects.toThrow(/already exists/i);
+      expect(create).toHaveBeenCalledTimes(1);
     }
   );
 
@@ -237,5 +269,136 @@ describe('triggerCfWorkflow', () => {
         deduplicationId: 'preview-shot1-h4sh',
       })
     ).rejects.toThrow('network down');
+  });
+});
+
+/**
+ * #1149: an `errored` deduplicated instance is a tombstone. Every retry of the
+ * calling step re-derives the same id, collides with the dead instance, and
+ * rethrows — so the retry can never succeed and one content-flagged preview
+ * image permanently failed its whole sequence. A non-reusable-because-errored
+ * status must mint a FRESH instance id instead.
+ */
+describe('triggerCfWorkflow generation retry after an errored instance', () => {
+  const dedup = 'preview-16b99z-01KZQFJH8VB3VPCRJEM0P2ZYM4';
+  const gen1 = `openstory-so_image_${dedup}`;
+
+  test('an errored instance does not block its own retry: a fresh id is created', async () => {
+    const { binding, create } = scriptedHarness({ [gen1]: 'errored' });
+
+    const result = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/image',
+      body,
+      env,
+      deduplicationId: dedup,
+    });
+
+    expect(result.workflowRunId).toBe(`${gen1}_g2`);
+    expect(create.mock.calls.map((c) => c[0].id)).toEqual([gen1, `${gen1}_g2`]);
+  });
+
+  test('the fresh generation carries the full payload', async () => {
+    const { binding, create } = scriptedHarness({ [gen1]: 'errored' });
+
+    await triggerCfWorkflow({
+      binding,
+      triggerPath: '/image',
+      body,
+      env,
+      deduplicationId: dedup,
+    });
+
+    expect(create.mock.calls[1]?.[0].params).toEqual(body);
+  });
+
+  // Replay safety: once generation 2 is live, a later attempt of the same step
+  // must land on it rather than spawn generation 3 — the double-billing guard
+  // has to survive the tombstone fix.
+  test.each(['running', 'complete'] as const)(
+    'reuses generation 2 when it is %s instead of spawning another paid job',
+    async (status) => {
+      const { binding, create } = scriptedHarness({
+        [gen1]: 'errored',
+        [`${gen1}_g2`]: status,
+      });
+
+      const result = await triggerCfWorkflow({
+        binding,
+        triggerPath: '/image',
+        body,
+        env,
+        deduplicationId: dedup,
+      });
+
+      expect(result.workflowRunId).toBe(`${gen1}_g2`);
+      // Two probes, zero successful creates — nothing new was paid for.
+      expect(create).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  test('walks past several errored generations to the first free id', async () => {
+    const { binding } = scriptedHarness({
+      [gen1]: 'errored',
+      [`${gen1}_g2`]: 'errored',
+    });
+
+    const result = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/image',
+      body,
+      env,
+      deduplicationId: dedup,
+    });
+
+    expect(result.workflowRunId).toBe(`${gen1}_g3`);
+  });
+
+  // The cap is what stops a deterministically-failing prompt (one the content
+  // checker will flag every time) from re-spawning paid jobs indefinitely.
+  test('fails loudly once every generation has errored', async () => {
+    const { binding, create } = scriptedHarness({
+      [gen1]: 'errored',
+      [`${gen1}_g2`]: 'errored',
+      [`${gen1}_g3`]: 'errored',
+    });
+
+    await expect(
+      triggerCfWorkflow({
+        binding,
+        triggerPath: '/image',
+        body,
+        env,
+        deduplicationId: dedup,
+      })
+    ).rejects.toThrow(/exhausted 3 instance generations/);
+    expect(create).toHaveBeenCalledTimes(3);
+  });
+
+  // A dedup id long enough to be truncated is where the generation tag could
+  // silently collapse back onto generation 1's id — the tag is appended after
+  // truncation reserves room, so the two must stay distinct AND under 100.
+  test('a truncated dedup id still yields a distinct, legal generation-2 id', async () => {
+    const longDedup = `preview-16b99z-${'x'.repeat(120)}`;
+    const longGen1 = buildInstanceId({
+      env,
+      workflowName: 'image',
+      suffix: longDedup,
+    });
+    const { binding, create } = scriptedHarness({ [longGen1]: 'errored' });
+
+    const result = await triggerCfWorkflow({
+      binding,
+      triggerPath: '/image',
+      body,
+      env,
+      deduplicationId: longDedup,
+    });
+
+    expect(result.workflowRunId).not.toBe(longGen1);
+    expect(create).toHaveBeenCalledTimes(2);
+    for (const call of create.mock.calls) {
+      expect(call[0].id.length).toBeLessThanOrEqual(100);
+    }
   });
 });

--- a/src/lib/workflow/trigger-bindings.ts
+++ b/src/lib/workflow/trigger-bindings.ts
@@ -141,9 +141,11 @@ export function getCfBindingForRunId(
  * that instance will never do the work, and pretending it was enqueued turns
  * a loud failure into a silent no-op. This matters because deduplication ids
  * are not always run-scoped: `shotPromptDedupId`/`musicPromptDedupId` are
- * stable across user requests, so a failed instance would otherwise pin every
- * retry to a dead id for CF's 30-day retention window. `unknown` is excluded
- * too — rethrow rather than trust an id we can't verify.
+ * stable across user requests. `unknown` is excluded too — rethrow rather than
+ * trust an id we can't verify.
+ *
+ * Excluded from reuse is not the same as terminal: see `triggerCfWorkflow` for
+ * what each excluded status does next.
  */
 const REUSABLE_INSTANCE_STATUSES: ReadonlySet<InstanceStatus['status']> =
   new Set([
@@ -154,6 +156,15 @@ const REUSABLE_INSTANCE_STATUSES: ReadonlySet<InstanceStatus['status']> =
     'waitingForPause',
     'complete',
   ]);
+
+/**
+ * How many instance ids one deduplication key may burn through. Each
+ * generation past the first is a fresh paid job, so the cap is what stops a
+ * deterministic failure (a prompt the content checker will always flag) from
+ * re-spawning until the step's retry budget runs out. Three = the original plus
+ * two retries, matching the reseed budget #881 uses on the render path.
+ */
+const MAX_TRIGGER_GENERATIONS = 3;
 
 /**
  * Status of an existing instance, or null when the lookup itself fails — the
@@ -178,8 +189,47 @@ async function getInstanceStatus<T>(
   }
 }
 
+async function createInstance<T extends Rpc.Serializable<T>>(
+  binding: Workflow<T>,
+  id: string,
+  body: T
+): Promise<CfTriggerResult> {
+  // The created WorkflowInstance is an RPC result; dispose it after reading
+  // its id so the runtime doesn't warn about an undisposed result.
+  const instance = await binding.create({ id, params: body });
+  try {
+    return { workflowRunId: instance.id };
+  } finally {
+    disposeRpcStub(instance);
+  }
+}
+
 /**
  * Trigger a workflow.
+ *
+ * With a `deduplicationId`, the id is deterministic and an
+ * `instance.already_exists` rejection is expected — typically a `step.do`
+ * replay re-running its closure. What happens next depends on the existing
+ * instance:
+ *
+ *   - alive or complete (REUSABLE_INSTANCE_STATUSES) → reuse its id. This is
+ *     the double-billing guard: a replay must not spawn a second paid job.
+ *   - `errored` → the id is a tombstone. The instance will never do the work,
+ *     and every retry of the calling step lands on the same corpse, so the
+ *     failure is permanently unretryable (#1149: one content-flagged preview
+ *     image took down whole sequences this way). Advance to the next
+ *     generation id and actually retry, up to MAX_TRIGGER_GENERATIONS.
+ *   - `terminated` → someone cancelled this run (`terminateSingleArtifactRun`,
+ *     #1085). Re-spawning would resurrect cancelled work, so it stays a
+ *     rethrow.
+ *   - `unknown`, or the status lookup itself failed → we cannot tell whether a
+ *     live instance is already doing this work. Rethrow rather than risk
+ *     paying for it twice.
+ *
+ * Generation probing is deterministic, so it stays replay-safe: a later attempt
+ * walks the same ids in the same order and stops at the first reusable one.
+ * The random-suffix path (no `deduplicationId`) can't collide legitimately, so
+ * it always rethrows.
  */
 export async function triggerCfWorkflow<T extends Rpc.Serializable<T>>({
   binding,
@@ -195,32 +245,37 @@ export async function triggerCfWorkflow<T extends Rpc.Serializable<T>>({
   deduplicationId?: string;
 }): Promise<CfTriggerResult> {
   const workflowName = normaliseTriggerPath(triggerPath);
-  const id = buildInstanceId({
-    env,
-    workflowName,
-    suffix: deduplicationId ?? `${Date.now()}-${crypto.randomUUID()}`,
-  });
 
-  try {
-    // The created WorkflowInstance is an RPC result; dispose it after reading
-    // its id so the runtime doesn't warn about an undisposed result.
-    const instance = await binding.create({ id, params: body });
+  if (!deduplicationId) {
+    return createInstance(
+      binding,
+      buildInstanceId({
+        env,
+        workflowName,
+        suffix: `${Date.now()}-${crypto.randomUUID()}`,
+      }),
+      body
+    );
+  }
+
+  let lastError: unknown;
+  for (
+    let generation = 1;
+    generation <= MAX_TRIGGER_GENERATIONS;
+    generation++
+  ) {
+    const id = buildInstanceId({
+      env,
+      workflowName,
+      suffix: deduplicationId,
+      generation,
+    });
     try {
-      return { workflowRunId: instance.id };
-    } finally {
-      disposeRpcStub(instance);
-    }
-  } catch (error) {
-    // A deterministic id (caller passed `deduplicationId`) hitting
-    // `instance.already_exists` usually means a prior attempt of this same
-    // logical trigger — typically a `step.do` replay — already created the
-    // instance, so the trigger should succeed instead of burning the step's
-    // retry budget on a permanent error. But only when the existing instance
-    // is verifiably alive or complete (see REUSABLE_INSTANCE_STATUSES):
-    // reusing an errored/terminated instance would silently report "enqueued"
-    // for work that will never happen. The random-suffix path can't collide
-    // legitimately, so it always rethrows.
-    if (deduplicationId && isInstanceAlreadyExistsError(error)) {
+      return await createInstance(binding, id, body);
+    } catch (error) {
+      if (!isInstanceAlreadyExistsError(error)) throw error;
+      lastError = error;
+
       const status = await getInstanceStatus(binding, id);
       if (status !== null && REUSABLE_INSTANCE_STATUSES.has(status)) {
         logger.info(
@@ -228,10 +283,20 @@ export async function triggerCfWorkflow<T extends Rpc.Serializable<T>>({
         );
         return { workflowRunId: id };
       }
+      if (status !== 'errored') {
+        logger.warn(
+          `[triggerCfWorkflow] ${id} already exists but is not reusable (status: ${status ?? 'unavailable'}); rethrowing for '${workflowName}'`
+        );
+        throw error;
+      }
       logger.warn(
-        `[triggerCfWorkflow] ${id} already exists but is not reusable (status: ${status ?? 'unavailable'}); rethrowing for '${workflowName}'`
+        `[triggerCfWorkflow] ${id} already exists and errored; advancing to generation ${generation + 1} for '${workflowName}'`
       );
     }
-    throw error;
   }
+
+  throw new Error(
+    `[triggerCfWorkflow] '${workflowName}' exhausted ${MAX_TRIGGER_GENERATIONS} instance generations for deduplication id '${deduplicationId}' — every one errored`,
+    { cause: lastError }
+  );
 }

--- a/src/lib/workflows/scene-split-workflow.test.ts
+++ b/src/lib/workflows/scene-split-workflow.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Blast-radius test for the preview-image fan-out (#1149).
+ *
+ * `scene-split` fires one decorative preview image per shot (`skipStorage:
+ * true`, nothing downstream reads the result). Before this fix a single one of
+ * them throwing — a content-checker hit on ~15% of runs in the #1143 load test
+ * — failed `scene-splitting-stream`, and with it `scene-split` →
+ * `analyze-script` → the whole sequence, discarding every still that had
+ * already rendered and been paid for.
+ *
+ * The contract asserted here: previews are attempted for every shot, a failing
+ * one is swallowed, and the split still returns its scenes and shot mapping.
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
+import type { SceneSplittingScene } from '@/lib/ai/streaming-scene-parser';
+import type { SceneSplitWorkflowInput } from '@/lib/workflow/types';
+import type { StyleConfig } from '@/lib/db/schema';
+
+const triggerWorkflow =
+  vi.fn<(path: string, body: unknown, options?: unknown) => Promise<string>>();
+vi.doMock('@/lib/workflow/client', () => ({ triggerWorkflow }));
+
+vi.doMock('@/lib/prompts', () => ({
+  getChatPrompt: vi.fn(() =>
+    Promise.resolve({ messages: [{ role: 'user', content: 'go' }] })
+  ),
+}));
+
+const emit = vi.fn(() => Promise.resolve());
+vi.doMock('@/lib/realtime', () => ({
+  getGenerationChannel: vi.fn(() => ({ emit })),
+}));
+
+vi.doMock('@/lib/billing/workflow-deduction', () => ({
+  deductWorkflowCredits: vi.fn(() => Promise.resolve()),
+}));
+
+// One chunk carrying the whole (already-validated) result; the parser mock
+// below is what turns it into per-scene events.
+vi.doMock('@/lib/ai/llm-client', () => ({
+  PROMPT_REASONING: undefined,
+  llmCostFromUsage: vi.fn(() => 0),
+  callLLMStream: vi.fn(() => ({
+    async *[Symbol.asyncIterator]() {
+      yield {
+        done: true,
+        accumulated: '{}',
+        parsed: PARSED_RESULT,
+        usage: undefined,
+      };
+    },
+  })),
+}));
+
+vi.doMock('@/lib/ai/streaming-scene-parser', async () => {
+  const real = await vi.importActual('@/lib/ai/streaming-scene-parser');
+  return {
+    ...real,
+    createStreamingSceneParser: () => ({
+      feed: () =>
+        SCENES.map((scene, index) => ({ type: 'scene', scene, index })),
+    }),
+  };
+});
+
+// Dynamic import so the mocks above apply (vi.doMock is not hoisted).
+const { SceneSplitWorkflow } = await import('./scene-split-workflow');
+
+function makeScene(n: number): SceneSplittingScene {
+  return {
+    sceneId: `scene_${n}`,
+    sceneNumber: n,
+    originalScript: { extract: `Scene ${n} action`, dialogue: [] },
+    metadata: {
+      title: `Scene ${n}`,
+      durationSeconds: 3,
+      location: 'A room',
+      timeOfDay: 'day',
+      storyBeat: 'setup',
+    },
+    continuity: {
+      characterTags: [],
+      environmentTag: '',
+      elementTags: null,
+      colorPalette: '',
+      lightingSetup: '',
+      styleTag: '',
+    },
+  };
+}
+
+const SCENES = [makeScene(1), makeScene(2), makeScene(3)];
+
+const PARSED_RESULT = {
+  scenes: SCENES,
+  projectMetadata: { title: 'Test Film' },
+  characterBible: [],
+  locationBible: [],
+  elementBible: [],
+};
+
+const STYLE_CONFIG: StyleConfig = {
+  mood: 'tense',
+  artStyle: 'photoreal',
+  lighting: 'hard key',
+  colorPalette: ['#101020'],
+  cameraWork: 'handheld',
+  referenceFilms: [],
+  colorGrading: 'cool shadows',
+};
+
+const INPUT: SceneSplitWorkflowInput = {
+  userId: 'u1',
+  teamId: 't1',
+  sequenceId: 'seq_1',
+  script: 'INT. ROOM - DAY',
+  modelId: 'anthropic/claude-sonnet-5',
+  promptName: 'scene-splitting',
+  styleConfig: STYLE_CONFIG,
+  aspectRatio: '16:9',
+  elements: [],
+};
+
+function makeScopedDb(): WorkflowScopedDb {
+  let shotSeq = 0;
+  const shot = () => {
+    shotSeq++;
+    return { id: `shot_${shotSeq}`, anchorFrameId: `frame_${shotSeq}` };
+  };
+  const scopedDb = {
+    credentials: {
+      resolveLlmKey: () =>
+        Promise.resolve({ source: 'platform', via: 'env', key: 'k' }),
+    },
+    scenes: {
+      upsert: (row: { orderIndex: number }) =>
+        Promise.resolve({
+          id: `dbscene_${row.orderIndex}`,
+          orderIndex: row.orderIndex,
+          createdAt: new Date(0),
+        }),
+      deleteFromOrderIndex: () => Promise.resolve(),
+    },
+    sceneScriptVersions: { seedSplitVersions: () => Promise.resolve() },
+    shots: {
+      upsert: () => Promise.resolve(shot()),
+      // Reconcile re-derives the mapping; keep ids stable per scene index.
+      bulkUpsert: (rows: Array<{ sceneId: string | null }>) =>
+        Promise.resolve(
+          rows.map((row, index) => ({
+            id: `shot_r${index}`,
+            anchorFrameId: `frame_r${index}`,
+            sceneId: row.sceneId,
+          }))
+        ),
+      update: () => Promise.resolve(true),
+      delete: () => Promise.resolve(),
+      deleteByScenesFromOrderIndex: () => Promise.resolve(),
+    },
+    sequences: {
+      updateTitle: () => Promise.resolve(),
+      updateWorkflow: () => Promise.resolve(),
+    },
+    sequenceElements: { updateFirstMention: () => Promise.resolve() },
+  };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- stub covering only the scoped-db surface runImpl touches
+  return scopedDb as unknown as WorkflowScopedDb;
+}
+
+function makeEvent(): Readonly<WorkflowEvent<SceneSplitWorkflowInput>> {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal WorkflowEvent stub: runImpl reads payload + instanceId
+  return {
+    payload: INPUT,
+    instanceId: 'split_run_A',
+    timestamp: new Date(0),
+  } as unknown as Readonly<WorkflowEvent<SceneSplitWorkflowInput>>;
+}
+
+function makeStep(): WorkflowStep {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal WorkflowStep stub: runImpl only uses `do`
+  return {
+    do: vi.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+  } as unknown as WorkflowStep;
+}
+
+/**
+ * Exposes the protected `runImpl` so the split runs without the base class's
+ * scoped-db construction and failure handling. Named `split`, not `run` — the
+ * base class already owns `run(event, step)`.
+ */
+class Probe extends SceneSplitWorkflow {
+  split(
+    event: Readonly<WorkflowEvent<SceneSplitWorkflowInput>>,
+    step: WorkflowStep,
+    scopedDb: WorkflowScopedDb
+  ) {
+    return this.runImpl(event, step, scopedDb);
+  }
+}
+
+function makeWorkflow(): Probe {
+  type Ctor = ConstructorParameters<typeof Probe>;
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- tests construct the entrypoint directly; runImpl never reads ctx
+  const ctx = undefined as unknown as Ctor[0];
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal env stub; runImpl never reads bindings
+  const env = {} as unknown as Ctor[1];
+  return new Probe(ctx, env);
+}
+
+const previewCalls = () =>
+  triggerWorkflow.mock.calls.filter((call) => call[0] === '/image');
+
+describe('SceneSplitWorkflow preview fan-out', () => {
+  test('triggers one preview per shot on the happy path', async () => {
+    triggerWorkflow.mockReset();
+    triggerWorkflow.mockResolvedValue('run_1');
+
+    const result = await makeWorkflow().split(
+      makeEvent(),
+      makeStep(),
+      makeScopedDb()
+    );
+
+    expect(previewCalls()).toHaveLength(SCENES.length);
+    expect(result.shotMapping).toHaveLength(SCENES.length);
+  });
+
+  // The #1149 failure exactly: one preview's ImageWorkflow instance is a
+  // tombstone, so its trigger throws `instance.already_exists` forever.
+  test('a failing preview does not fail the split', async () => {
+    triggerWorkflow.mockReset();
+    triggerWorkflow
+      .mockResolvedValueOnce('run_1')
+      .mockRejectedValueOnce(
+        new Error('(instance.already_exists) Instance already exists')
+      )
+      .mockResolvedValue('run_3');
+
+    const result = await makeWorkflow().split(
+      makeEvent(),
+      makeStep(),
+      makeScopedDb()
+    );
+
+    expect(result.title).toBe('Test Film');
+    expect(result.shotMapping).toHaveLength(SCENES.length);
+  });
+
+  // A swallow that also stopped the fan-out would silently lose every later
+  // preview — the remaining shots must still be attempted.
+  test('a failing preview does not stop the ones after it', async () => {
+    triggerWorkflow.mockReset();
+    triggerWorkflow
+      .mockRejectedValueOnce(new Error('content checker flagged this prompt'))
+      .mockResolvedValue('run_ok');
+
+    await makeWorkflow().split(makeEvent(), makeStep(), makeScopedDb());
+
+    expect(previewCalls()).toHaveLength(SCENES.length);
+  });
+
+  test('every preview fails: the split still completes', async () => {
+    triggerWorkflow.mockReset();
+    triggerWorkflow.mockRejectedValue(new Error('preview generation failed'));
+
+    const result = await makeWorkflow().split(
+      makeEvent(),
+      makeStep(),
+      makeScopedDb()
+    );
+
+    expect(result.scenes).toHaveLength(SCENES.length);
+  });
+});

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -111,6 +111,70 @@ async function persistStreamedSceneAndShot(
 }
 
 /**
+ * Fire-and-forget preview image for one shot, routed through `triggerWorkflow`
+ * so the engine registry picks whichever engine is configured for `/image` at
+ * runtime. The deduplicationId makes a replay of the mega-step idempotent (see
+ * dedup-ids.ts).
+ *
+ * Failures are swallowed by design (#1149). Previews are decorative
+ * (`skipStorage: true`) and nothing downstream reads the result, but a throw
+ * here fails `scene-splitting-stream` → `scene-split` → `analyze-script` → the
+ * whole sequence, discarding every still that already rendered and cost money.
+ * A content-checker hit on one of ~18 previews is a routine outcome, not a
+ * reason to lose the run.
+ */
+async function triggerPreviewImage({
+  input,
+  sequenceId,
+  parentInstanceId,
+  shot,
+  scene,
+}: {
+  input: SceneSplitWorkflowInput;
+  sequenceId: string;
+  parentInstanceId: string;
+  shot: { id: string; frameId: string };
+  scene: SceneSplittingScene;
+}): Promise<void> {
+  const sceneText =
+    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
+    scene.originalScript?.extract ??
+    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
+    scene.metadata?.title ??
+    'A cinematic scene';
+
+  try {
+    await triggerWorkflow(
+      '/image',
+      {
+        userId: input.userId,
+        teamId: input.teamId,
+        sequenceId,
+        prompt: buildPreviewPrompt(sceneText, input.styleConfig),
+        model: PREVIEW_IMAGE_MODEL,
+        imageSize: aspectRatioToImageSize(input.aspectRatio),
+        numImages: 1,
+        shotId: shot.id,
+        // Without this the run stands down before generating — and before
+        // #1101 it generated, billed, then dropped the preview at
+        // `record-preview-variant` (#1119).
+        frameId: shot.frameId,
+        skipStorage: true,
+      } satisfies ImageWorkflowInput,
+      {
+        label: buildWorkflowLabel(sequenceId),
+        deduplicationId: previewImageDedupId(parentInstanceId, shot.id),
+      }
+    );
+  } catch (error) {
+    logger.warn(
+      `[SceneSplitWorkflow:cf] preview image trigger failed for shot ${shot.id}; continuing without it`,
+      { sequenceId, err: error }
+    );
+  }
+}
+
+/**
  * Shape produced by the streaming step (post JSON round-trip). Mirrors the
  * QStash `streamResult` value — note `projectMetadata` is preserved so the
  * reconcile step can extract the title, and `shotMapping` reflects only the
@@ -144,13 +208,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
     scopedDb: WorkflowScopedDb
   ): Promise<SceneSplitWorkflowResult> {
     const input = event.payload;
-    const {
-      sequenceId,
-      modelId,
-      styleConfig,
-      aspectRatio,
-      elements = [],
-    } = input;
+    const { sequenceId, modelId, aspectRatio, elements = [] } = input;
 
     // Gap C: this single `step.do` owns the prompt fetch + the entire
     // streaming session. Inside, the partial-JSON parser, per-chunk DB writes
@@ -353,44 +411,15 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
                   }
                 );
                 if (prevScene && prevShot) {
-                  const sceneText =
-                    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
-                    prevScene.originalScript?.extract ??
-                    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
-                    prevScene.metadata?.title ??
-                    'A cinematic scene';
-                  const prompt = buildPreviewPrompt(sceneText, styleConfig);
-
-                  // Fire-and-forget preview-image trigger for the previous
-                  // scene. Routed through `triggerWorkflow` so the engine
-                  // registry picks whichever engine is configured for
-                  // `/image` at runtime. The deduplicationId makes a replay
-                  // of this mega-step idempotent (see dedup-ids.ts).
-                  await triggerWorkflow(
-                    '/image',
-                    {
-                      userId: input.userId,
-                      teamId: input.teamId,
-                      sequenceId,
-                      prompt,
-                      model: PREVIEW_IMAGE_MODEL,
-                      imageSize: aspectRatioToImageSize(aspectRatio),
-                      numImages: 1,
-                      shotId: prevShot.id,
-                      // Without this the run stands down before generating —
-                      // and before #1101 it generated, billed, then dropped the
-                      // preview at `record-preview-variant` (#1119).
-                      frameId: prevShot.frameId,
-                      skipStorage: true,
-                    } satisfies ImageWorkflowInput,
-                    {
-                      label: buildWorkflowLabel(sequenceId),
-                      deduplicationId: previewImageDedupId(
-                        event.instanceId,
-                        prevShot.id
-                      ),
-                    }
-                  );
+                  // Preview for the PREVIOUS scene — the loop always trails by
+                  // one so a scene's text is complete before it's rendered.
+                  await triggerPreviewImage({
+                    input,
+                    sequenceId,
+                    parentInstanceId: event.instanceId,
+                    shot: prevShot,
+                    scene: prevScene,
+                  });
                 }
 
                 prevShot = { id: shot.id, frameId: shot.anchorFrameId };
@@ -402,36 +431,13 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
 
         // Trigger preview for the last scene (the loop only triggers N-1).
         if (prevScene && prevShot && sequenceId) {
-          const sceneText =
-            // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
-            prevScene.originalScript?.extract ??
-            // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
-            prevScene.metadata?.title ??
-            'A cinematic scene';
-          const prompt = buildPreviewPrompt(sceneText, styleConfig);
-
-          await triggerWorkflow(
-            '/image',
-            {
-              userId: input.userId,
-              teamId: input.teamId,
-              sequenceId,
-              prompt,
-              model: PREVIEW_IMAGE_MODEL,
-              imageSize: aspectRatioToImageSize(aspectRatio),
-              numImages: 1,
-              shotId: prevShot.id,
-              frameId: prevShot.frameId,
-              skipStorage: true,
-            } satisfies ImageWorkflowInput,
-            {
-              label: buildWorkflowLabel(sequenceId),
-              deduplicationId: previewImageDedupId(
-                event.instanceId,
-                prevShot.id
-              ),
-            }
-          );
+          await triggerPreviewImage({
+            input,
+            sequenceId,
+            parentInstanceId: event.instanceId,
+            shot: prevShot,
+            scene: prevScene,
+          });
         }
 
         if (!parsedResult) {


### PR DESCRIPTION
Closes #1149

One content-flagged preview image took down 3 of 20 sequences in the #1143 load test. Two independent bugs; both fixed here.

## 1. Blast radius (`scene-split-workflow.ts`)

`scene-split` fires ~18 decorative preview images per run — `skipStorage: true`, nothing downstream reads the result. One of them throwing failed `scene-splitting-stream` → `scene-split` → `analyze-script` → the whole sequence, discarding every still that had already rendered and been paid for.

The two inline triggers collapse into one `triggerPreviewImage()` helper that catches and logs. The fan-out now also continues past a failure, so one bad shot no longer silently drops every preview after it.

## 2. Tombstone (`trigger-bindings.ts`, `instance-id.ts`)

On `instance.already_exists`, `triggerCfWorkflow` read the existing instance's status and rethrew anything outside `REUSABLE_INSTANCE_STATUSES`. The reasoning was right — reusing a dead instance would report "enqueued" for work that will never happen — but for `errored` the outcome was wrong: every retry of the calling step re-derived the same dedup id and hit the same corpse, turning a *retryable* failure into a *permanently unretryable* one for CF's 30-day retention window.

`errored` now advances to a fresh generation id, capped at 3 (the same budget #881 uses for reseed retries on the render path).

| existing instance | behaviour |
|---|---|
| queued / running / paused / waiting / complete | reuse the id — unchanged |
| `errored` | **new**: advance to `_g2`, `_g3`, up to the cap |
| `terminated` | rethrow — user cancellation (#1085); re-spawning would resurrect cancelled work |
| `unknown` / lookup failed | rethrow — unverifiable, so don't risk paying twice |

### Can this spawn two paid jobs?

No. Probing is deterministic, so a later step attempt walks the same ids in the same order and stops at the first reusable one — once generation 2 is `running` or `complete`, every replay reuses it rather than spawning generation 3. Both statuses are covered by tests. Exhausting the cap throws a descriptive error carrying the original as `cause`.

### The truncation trap

`buildInstanceId` gained an optional `generation`. Generation 1 is byte-identical to today's id, so in-flight instances keep theirs across the deploy. Later generations reserve room for the `_g<n>` tag **before** truncating the suffix — truncation cuts the tail, so a tag merely concatenated on would be sheared off a long dedup id and collapse generation 2 back onto generation 1, re-creating the exact bug. Pinned by a test.

## Coverage

- `trigger-bindings.test.ts` — errored → fresh id, payload carried through, reuse of a live generation 2 (`running` and `complete`), walking past two errored generations, loud failure at the cap, and the truncated-dedup-id case.
- `instance-id.test.ts` — generation 1 is untagged, `_g<n>` shape, truncation keeps the tag distinct and under CF's 100-char limit.
- `scene-split-workflow.test.ts` (new) — drives `runImpl` against stubbed LLM/parser/scoped-db. Verified as a real regression test: reverting the swallow fails 3 of its 4 cases.

Gates: `typecheck`, `lint` (0 errors), `dead-code`, full suite 2260/2260.

## Known gap, deliberately not fixed

`terminated` still tombstones its dedup id. Harmless for run-scoped ids (previews get a new parent hash per run), but `shotPromptDedupId` is stable across user requests — cancel a prompt generation, click generate again, and it collides with the terminated instance. Left alone because re-spawning after a deliberate cancel is what cancel exists to prevent, and this layer can't distinguish "cancelled, leave it dead" from "cancelled, now wants a fresh one".
