### PR TITLE
chore(models): bump @tanstack/ai-openrouter 0.16.0 → 0.16.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tanstack/ai": "^0.44.0",
         "@tanstack/ai-fal": "^0.10.0",
-        "@tanstack/ai-openrouter": "^0.16.0",
+        "@tanstack/ai-openrouter": "^0.16.1",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.25",
         "@tanstack/react-router-ssr-query": "^1.167.1",
@@ -1101,7 +1101,7 @@
 
     "@tanstack/ai-fal": ["@tanstack/ai-fal@0.10.0", "", { "dependencies": { "@fal-ai/client": "^1.10.1", "@tanstack/ai-utils": "^0.4.0" }, "peerDependencies": { "@tanstack/ai": "^0.44.0" } }, "sha512-0nP0hpSQImUEWTm0Kl69ca+tIWdMbSBD/q2V0y8vuzF27N5kCUIhchvNadjBtmktXfMJ6C1QjroN40UkVrGRgw=="],
 
-    "@tanstack/ai-openrouter": ["@tanstack/ai-openrouter@0.16.0", "", { "dependencies": { "@openrouter/sdk": "0.13.20", "@tanstack/ai-utils": "^0.4.0" }, "peerDependencies": { "@tanstack/ai": "^0.44.0" } }, "sha512-qjNPQSG3ZJIQGUEmAR5HGnVug6IiwtjfKKnuuGPh4kv8JwuMV/LpRIKpFkoJa5MA5tqKbWDPJAa8ODEi1ZdLDA=="],
+    "@tanstack/ai-openrouter": ["@tanstack/ai-openrouter@0.16.1", "", { "dependencies": { "@openrouter/sdk": "0.13.20", "@tanstack/ai-utils": "^0.4.0" }, "peerDependencies": { "@tanstack/ai": "^0.44.0" } }, "sha512-/71STIl3lsR5suGSvOSl/sHuktY6co7SBP+24c66Gdai1ptDvNgA+lql/aLM67P8pMvD4aNTWi/xh6lr8mLhaw=="],
 
     "@tanstack/ai-utils": ["@tanstack/ai-utils@0.4.0", "", {}, "sha512-xqvAgPJkIuGk1m+jZKyb7vBTQIaBmUD9EVzlPkDWWMp80n69uwL0TnBZCVk+OwL9goTQiFy648dnBfLsiJgl6A=="],
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tanstack/ai": "^0.44.0",
     "@tanstack/ai-fal": "^0.10.0",
-    "@tanstack/ai-openrouter": "^0.16.0",
+    "@tanstack/ai-openrouter": "^0.16.1",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.25",
     "@tanstack/react-router-ssr-query": "^1.167.1",


### PR DESCRIPTION
## Related Issue

Part of the daily model-freshness routine (#792). No dedicated issue.

## Summary of Changes

Patch bump of the OpenRouter AI SDK adapter.

| Package | Old range | New range | Resolved |
| --- | --- | --- | --- |
| `@tanstack/ai-openrouter` | `^0.16.0` | `^0.16.1` | `0.16.1` |

- `0.16.1` is the current npm `latest` (verified against the npm registry); it is a **patch** release (not a major), so it's in scope for an auto-PR rather than an issue.
- No `CATALOG_LAG_MODELS` prune required — `bun typecheck` (which includes `src/lib/ai/catalog-lag.test.ts`) is clean, so no bridged registry id shipped upstream in this release.
- No registry-key or model-id changes; `bun.lock` regenerated via `bun install`.

Link: https://www.npmjs.com/package/@tanstack/ai-openrouter/v/0.16.1

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Low: patch bump of a single adapter, all gates green, no id/key changes.

## Additional Notes

Quality gates run in this environment:
- `bun typecheck` — pass
- `bun lint` — pass for changed files (one **pre-existing** error in `src/lib/workflows/scene-split-workflow.test.ts` also present on clean `main`, unrelated to this change)
- `bun run test src/lib/ai src/lib/motion` — 454 passed

🤖 Opened by the daily model-freshness routine (#792). Verify pricing & quality before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Az1ikV54i75cGR9b6mpNAe)_