### PR TITLE
refactor: migrate createServerFn().inputValidator() to .validator()

### DIFF
--- a/src/functions/admin-support.ts
+++ b/src/functions/admin-support.ts
@@ -6,7 +6,7 @@ import { systemAdminMiddleware } from './middleware';
 
 export const getAllAdminSequencesFn = createServerFn({ method: 'GET' })
   .middleware([systemAdminMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         limit: z.number().int().min(1).max(200).optional(),
@@ -21,7 +21,7 @@ export const getAllAdminSequencesFn = createServerFn({ method: 'GET' })
 
 export const getAdminShotsFn = createServerFn({ method: 'GET' })
   .middleware([systemAdminMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context, data }) => {
     return context.adminScopedDb.admin.getShotsForSequence(data.sequenceId);
   });

--- a/src/functions/ai.ts
+++ b/src/functions/ai.ts
@@ -134,7 +134,7 @@ const shortenPromptInputSchema = z.object({
 
 export const shortenPromptFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(shortenPromptInputSchema))
+  .validator(zodValidator(shortenPromptInputSchema))
   .handler(async ({ data, context }) => {
     enforceRateLimit(promptShorteningRateLimiter, getClientIP());
 
@@ -227,7 +227,7 @@ const estimateSceneDurationInputSchema = z.object({
 
 export const estimateSceneDurationFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(estimateSceneDurationInputSchema))
+  .validator(zodValidator(estimateSceneDurationInputSchema))
   .handler(async ({ data, context }) => {
     enforceRateLimit(sceneDurationEstimationRateLimiter, getClientIP());
 
@@ -462,7 +462,7 @@ export const enhanceScriptToString = createServerOnlyFn(
 
 export const enhanceScriptStreamFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(enhanceScriptInputSchema))
+  .validator(zodValidator(enhanceScriptInputSchema))
   .handler(async function* ({ data, context }) {
     // IP rate-limit the dashboard path here (kept out of the shared core so the
     // core stays free of request-scoped server-only APIs — see note above).
@@ -616,7 +616,7 @@ export function rankStyleRecommendations(
  */
 export const recommendStylesForScriptFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(recommendStylesInputSchema))
+  .validator(zodValidator(recommendStylesInputSchema))
   .handler(async ({ data, context }) => {
     enforceRateLimit(recommendStylesRateLimiter, getClientIP());
 

--- a/src/functions/api-keys.ts
+++ b/src/functions/api-keys.ts
@@ -25,7 +25,7 @@ const listApiKeysInputSchema = z.object({
  */
 export const listApiKeysFn = createServerFn({ method: 'GET' })
   .middleware([teamAdminAccessMiddleware])
-  .inputValidator(zodValidator(listApiKeysInputSchema))
+  .validator(zodValidator(listApiKeysInputSchema))
   .handler(async ({ context }) => {
     return context.scopedDb.apiKeys.listKeys();
   });
@@ -46,7 +46,7 @@ const saveApiKeyInputSchema = z.object({
  */
 export const saveApiKeyFn = createServerFn({ method: 'POST' })
   .middleware([teamAdminAccessMiddleware])
-  .inputValidator(zodValidator(saveApiKeyInputSchema))
+  .validator(zodValidator(saveApiKeyInputSchema))
   .handler(async ({ data, context }) => {
     // Validate the key first
     const validation = await context.scopedDb.apiKeys.validateKey(
@@ -81,7 +81,7 @@ const deleteApiKeyInputSchema = z.object({
  */
 export const deleteApiKeyFn = createServerFn({ method: 'POST' })
   .middleware([teamAdminAccessMiddleware])
-  .inputValidator(zodValidator(deleteApiKeyInputSchema))
+  .validator(zodValidator(deleteApiKeyInputSchema))
   .handler(async ({ data, context }) => {
     await context.scopedDb.apiKeys.deleteKey(data.provider);
   });
@@ -99,7 +99,7 @@ const checkApiKeyStatusInputSchema = z.object({
  */
 export const checkApiKeyStatusFn = createServerFn({ method: 'GET' })
   .middleware([teamAdminAccessMiddleware])
-  .inputValidator(zodValidator(checkApiKeyStatusInputSchema))
+  .validator(zodValidator(checkApiKeyStatusInputSchema))
   .handler(async ({ context }) => {
     const [hasOpenRouter, hasFal] = await Promise.all([
       context.scopedDb.apiKeys.hasKey('openrouter'),
@@ -128,7 +128,7 @@ const revalidateApiKeyInputSchema = z.object({
  */
 export const revalidateApiKeyFn = createServerFn({ method: 'POST' })
   .middleware([teamAdminAccessMiddleware])
-  .inputValidator(zodValidator(revalidateApiKeyInputSchema))
+  .validator(zodValidator(revalidateApiKeyInputSchema))
   .handler(async ({ data, context }) => {
     return context.scopedDb.apiKeys.revalidateStoredKey(data.provider);
   });

--- a/src/functions/billing.ts
+++ b/src/functions/billing.ts
@@ -40,7 +40,7 @@ const checkoutInputSchema = z.object({
 
 export const createCheckoutSessionFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(checkoutInputSchema))
+  .validator(zodValidator(checkoutInputSchema))
   .handler(async ({ data, context }) => {
     if (!isStripeEnabled()) {
       throw new ValidationError('Stripe is not configured');
@@ -148,7 +148,7 @@ const purchaseInputSchema = z.object({
  */
 export const purchaseCreditsFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(purchaseInputSchema))
+  .validator(zodValidator(purchaseInputSchema))
   .handler(async ({ data, context }) => {
     if (!isStripeEnabled()) {
       throw new ValidationError('Stripe is not configured');
@@ -328,7 +328,7 @@ const founderCreditsInputSchema = z.object({
 
 export const requestFounderCreditsFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(founderCreditsInputSchema))
+  .validator(zodValidator(founderCreditsInputSchema))
   .handler(async ({ data, context }) => {
     const balance = await context.scopedDb.billing.getBalance();
     const balanceDisplay = microsToDisplayUsd(balance);
@@ -410,7 +410,7 @@ type Transaction = {
 
 export const getTransactionsFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(transactionsInputSchema))
+  .validator(zodValidator(transactionsInputSchema))
   .handler(
     async ({
       data,
@@ -457,7 +457,7 @@ const autoTopUpInputSchema = z.object({
 
 export const updateAutoTopUpFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(autoTopUpInputSchema))
+  .validator(zodValidator(autoTopUpInputSchema))
   .handler(async ({ data, context }) => {
     if (!isStripeEnabled()) {
       throw new ValidationError('Stripe is not configured');

--- a/src/functions/character-sheet-variants.ts
+++ b/src/functions/character-sheet-variants.ts
@@ -43,7 +43,7 @@ export const getSequenceCharacterDivergentVariantsFn = createServerFn({
  */
 export const promoteCharacterSheetVariantFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.characterSheetVariants.getById(
       data.variantId
@@ -95,7 +95,7 @@ export const promoteCharacterSheetVariantFn = createServerFn({ method: 'POST' })
 
 export const discardCharacterSheetVariantFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.characterSheetVariants.getById(
       data.variantId
@@ -119,7 +119,7 @@ export const undiscardCharacterSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.characterSheetVariants.getById(
       data.variantId

--- a/src/functions/feedback.ts
+++ b/src/functions/feedback.ts
@@ -21,7 +21,7 @@ const feedbackInputSchema = z.object({
 
 export const submitFeedbackFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(feedbackInputSchema))
+  .validator(zodValidator(feedbackInputSchema))
   .handler(async ({ data, context }) => {
     const result = await sendFeedbackEmail({
       to: CONTACT_EMAIL,

--- a/src/functions/gift-tokens.ts
+++ b/src/functions/gift-tokens.ts
@@ -12,7 +12,7 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 export const createGiftTokenFn = createServerFn({ method: 'POST' })
   .middleware([systemAdminMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         amountUsd: z.number().positive(),
@@ -39,7 +39,7 @@ export const createGiftTokenFn = createServerFn({ method: 'POST' })
 
 export const batchCreateGiftTokensFn = createServerFn({ method: 'POST' })
   .middleware([systemAdminMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         count: z.number().int().min(1).max(500),
@@ -70,7 +70,7 @@ export const batchCreateGiftTokensFn = createServerFn({ method: 'POST' })
 
 export const redeemGiftTokenFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.object({ code: z.string().min(1) })))
+  .validator(zodValidator(z.object({ code: z.string().min(1) })))
   .handler(async ({ context, data }) => {
     return context.scopedDb.billing.redeemGiftToken({
       code: data.code,

--- a/src/functions/library-location-sheet-variants.ts
+++ b/src/functions/library-location-sheet-variants.ts
@@ -40,7 +40,7 @@ export const promoteLibraryLocationSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.locationSheetVariants.getById(
       data.variantId
@@ -93,7 +93,7 @@ export const discardLibraryLocationSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.locationSheetVariants.getById(
       data.variantId
@@ -115,7 +115,7 @@ export const undiscardLibraryLocationSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.locationSheetVariants.getById(
       data.variantId

--- a/src/functions/location-library.ts
+++ b/src/functions/location-library.ts
@@ -59,7 +59,7 @@ export const getPublicLibraryLocationsFn = createServerFn({
 
 export const getLibraryLocationByIdFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.object({ locationId: ulidSchema })))
+  .validator(zodValidator(z.object({ locationId: ulidSchema })))
   .handler(async ({ context, data }) => {
     const location = await requireLocation(context.scopedDb, data.locationId);
 
@@ -75,7 +75,7 @@ export const getLibraryLocationByIdFn = createServerFn({ method: 'GET' })
 // Get Single Public ("system") library location — no auth, for anonymous visitors
 
 export const getPublicLibraryLocationByIdFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(z.object({ locationId: ulidSchema })))
+  .validator(zodValidator(z.object({ locationId: ulidSchema })))
   .handler(async ({ data }) => {
     const location = await getPublicLibraryLocationById(data.locationId);
 
@@ -88,7 +88,7 @@ export const getPublicLibraryLocationByIdFn = createServerFn({ method: 'GET' })
 
 export const createLibraryLocationFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         name: z.string().min(1).max(255),
@@ -108,7 +108,7 @@ export const createLibraryLocationFn = createServerFn({ method: 'POST' })
 
 export const updateLibraryLocationFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         locationId: ulidSchema,
@@ -126,7 +126,7 @@ export const updateLibraryLocationFn = createServerFn({ method: 'POST' })
 
 export const deleteLibraryLocationFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.object({ locationId: ulidSchema })))
+  .validator(zodValidator(z.object({ locationId: ulidSchema })))
   .handler(async ({ context, data }) => {
     await requireLocation(context.scopedDb, data.locationId);
     await requireTeamAdminAccess(context.user.id, context.teamId);
@@ -136,7 +136,7 @@ export const deleteLibraryLocationFn = createServerFn({ method: 'POST' })
 
 export const presignLocationUploadFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         filename: z.string().min(1),
@@ -166,7 +166,7 @@ export const presignLocationUploadFn = createServerFn({ method: 'POST' })
 
 export const finalizeLocationUploadFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         locationId: ulidSchema,
@@ -192,7 +192,7 @@ export const finalizeLocationUploadFn = createServerFn({ method: 'POST' })
 
 export const addLocationSheetsFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         locationId: ulidSchema,
@@ -282,7 +282,7 @@ export const addLocationSheetsFn = createServerFn({ method: 'POST' })
 
 export const deleteLocationSheetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.object({ sheetId: ulidSchema })))
+  .validator(zodValidator(z.object({ sheetId: ulidSchema })))
   .handler(async ({ context, data }) => {
     const record = await context.scopedDb.locationSheets.getWithLocation(
       data.sheetId

--- a/src/functions/location-sheet-variants.ts
+++ b/src/functions/location-sheet-variants.ts
@@ -40,7 +40,7 @@ export const promoteSequenceLocationSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.locationSheetVariants.getById(
       data.variantId
@@ -92,7 +92,7 @@ export const discardSequenceLocationSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.locationSheetVariants.getById(
       data.variantId
@@ -116,7 +116,7 @@ export const undiscardSequenceLocationSheetVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.locationSheetVariants.getById(
       data.variantId

--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -527,7 +527,7 @@ export const systemAdminMiddleware = createMiddleware({ type: 'function' })
  */
 export const sequenceAccessMiddleware = createMiddleware({ type: 'function' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.looseObject({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.looseObject({ sequenceId: ulidSchema })))
   .server(async ({ next, context, data }) => {
     let sequence = await context.scopedDb.sequences.getById(data.sequenceId);
     let { teamId, scopedDb } = context;
@@ -560,7 +560,7 @@ export const sequenceAccessMiddleware = createMiddleware({ type: 'function' })
  */
 export const shotAccessMiddleware = createMiddleware({ type: 'function' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(z.looseObject({ sequenceId: ulidSchema, shotId: ulidSchema }))
   )
   .server(async ({ next, context, data }) => {
@@ -624,7 +624,7 @@ export const shotAccessMiddleware = createMiddleware({ type: 'function' })
  */
 export const teamMemberAccessMiddleware = createMiddleware({ type: 'function' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.looseObject({ teamId: ulidSchema })))
+  .validator(zodValidator(z.looseObject({ teamId: ulidSchema })))
   .server(async ({ next, context, data }) => {
     if (data.teamId !== context.teamId) {
       await requireTeamMemberAccess(context.user.id, data.teamId);
@@ -648,7 +648,7 @@ export const teamMemberAccessMiddleware = createMiddleware({ type: 'function' })
  */
 export const teamAdminAccessMiddleware = createMiddleware({ type: 'function' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.looseObject({ teamId: ulidSchema })))
+  .validator(zodValidator(z.looseObject({ teamId: ulidSchema })))
   .server(async ({ next, context, data }) => {
     await requireTeamAdminAccess(context.user.id, data.teamId);
 
@@ -670,7 +670,7 @@ export const teamAdminAccessMiddleware = createMiddleware({ type: 'function' })
  */
 export const teamOwnerAccessMiddleware = createMiddleware({ type: 'function' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.looseObject({ teamId: ulidSchema })))
+  .validator(zodValidator(z.looseObject({ teamId: ulidSchema })))
   .server(async ({ next, context, data }) => {
     await requireTeamOwnerAccess(context.user.id, data.teamId);
 

--- a/src/functions/model-assets.ts
+++ b/src/functions/model-assets.ts
@@ -199,7 +199,7 @@ export async function createGeneratedAsset(
 
 export const createGeneratedAssetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(createGeneratedAssetInputSchema))
+  .validator(zodValidator(createGeneratedAssetInputSchema))
   .handler(async ({ context, data }) => {
     assertModelsEnabled();
     return createGeneratedAsset(context.scopedDb, data);
@@ -220,7 +220,7 @@ const listGeneratedAssetsInputSchema = z.object({
 /** Team-scoped newest-first list, filterable by activity / endpoint. */
 export const listGeneratedAssetsFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(listGeneratedAssetsInputSchema.optional()))
+  .validator(zodValidator(listGeneratedAssetsInputSchema.optional()))
   .handler(async ({ context, data }) => {
     assertModelsEnabled();
     return context.scopedDb.generatedAssets.list({
@@ -238,7 +238,7 @@ const getGeneratedAssetInputSchema = z.object({
 /** Single run row — the client polls this while a run is in flight. */
 export const getGeneratedAssetFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(getGeneratedAssetInputSchema))
+  .validator(zodValidator(getGeneratedAssetInputSchema))
   .handler(async ({ context, data }) => {
     assertModelsEnabled();
     const asset = await context.scopedDb.generatedAssets.getById(data.id);

--- a/src/functions/model-catalog.ts
+++ b/src/functions/model-catalog.ts
@@ -31,7 +31,7 @@ const listCatalogModelFamiliesInputSchema = z.object({
  * @returns `{ families, nextCursor? }` — pass `nextCursor` back for more.
  */
 export const listCatalogModelFamiliesFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(listCatalogModelFamiliesInputSchema.optional()))
+  .validator(zodValidator(listCatalogModelFamiliesInputSchema.optional()))
   .handler(async ({ data }) => {
     assertModelsEnabled();
     return listCatalogModelFamilies(data ?? {});
@@ -48,7 +48,7 @@ const getModelFamilyInputSchema = z.object({
  * switcher); null when the endpoint isn't in the catalog.
  */
 export const getModelFamilyFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(getModelFamilyInputSchema))
+  .validator(zodValidator(getModelFamilyInputSchema))
   .handler(async ({ data }) => {
     assertModelsEnabled();
     return getModelFamily(data.endpointId, data.activity);
@@ -62,7 +62,7 @@ const getModelFamilyByPathInputSchema = z.object({
 
 /** A family by its id-path key (the family page); null when unknown. */
 export const getModelFamilyByPathFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(getModelFamilyByPathInputSchema))
+  .validator(zodValidator(getModelFamilyByPathInputSchema))
   .handler(async ({ data }) => {
     assertModelsEnabled();
     return getModelFamilyByPath(data.family, data.activity);
@@ -79,7 +79,7 @@ const getModelDetailInputSchema = z.object({
  * @returns `{ model, inputSchema, outputSchema }`
  */
 export const getModelDetailFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(getModelDetailInputSchema))
+  .validator(zodValidator(getModelDetailInputSchema))
   .handler(async ({ data }) => {
     assertModelsEnabled();
     return getModelDetail(data.endpointId, data.activity);

--- a/src/functions/motion-functions.ts
+++ b/src/functions/motion-functions.ts
@@ -47,7 +47,7 @@ const generateMotionInputSchema = generateMotionSchema.extend({
 
 export const generateShotMotionFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(generateMotionInputSchema))
+  .validator(zodValidator(generateMotionInputSchema))
   .handler(async ({ data, context }) => {
     const { shot, frame, sequence, teamId } = context;
 
@@ -237,7 +237,7 @@ const batchGenerateMotionInputSchema = z.object({
 
 export const batchGenerateMotionFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(batchGenerateMotionInputSchema))
+  .validator(zodValidator(batchGenerateMotionInputSchema))
   .handler(async ({ data, context }) => {
     const { sequence, teamId, user } = context;
 

--- a/src/functions/openrouter-oauth.ts
+++ b/src/functions/openrouter-oauth.ts
@@ -33,7 +33,7 @@ const initiateOAuthInputSchema = z.object({
  */
 export const initiateOpenRouterOAuthFn = createServerFn({ method: 'POST' })
   .middleware([teamAdminAccessMiddleware])
-  .inputValidator(zodValidator(initiateOAuthInputSchema))
+  .validator(zodValidator(initiateOAuthInputSchema))
   .handler(async ({ context }) => {
     const request = getRequest();
     const appUrl = getServerAppUrl(request);

--- a/src/functions/prompt-variants.ts
+++ b/src/functions/prompt-variants.ts
@@ -109,7 +109,7 @@ const shotListInput = z.object({
 
 export const listShotPromptVariantsFn = createServerFn({ method: 'GET' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotListInput))
+  .validator(zodValidator(shotListInput))
   .handler(
     async ({ context, data }): Promise<ShotPromptVariantWithAuthor[]> => {
       // Visual prompt history moved to frame_prompt_versions (#989); motion
@@ -153,7 +153,7 @@ export const listSequenceMusicPromptVariantsFn = createServerFn({
   method: 'GET',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(sequenceListInput))
+  .validator(zodValidator(sequenceListInput))
   .handler(
     async ({
       context,
@@ -182,7 +182,7 @@ const shotRestoreInput = z.object({
 
 export const restoreShotPromptVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotRestoreInput))
+  .validator(zodValidator(shotRestoreInput))
   .handler(async ({ context, data }) => {
     // Visual prompt history lives in frame_prompt_versions (#989); motion stays
     // on shot_prompt_versions. The caller says which — see `promptType` above.
@@ -248,7 +248,7 @@ export const restoreSequenceMusicPromptVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(sequenceRestoreInput))
+  .validator(zodValidator(sequenceRestoreInput))
   .handler(async ({ context, data }) => {
     const chosen =
       await context.scopedDb.sequenceMusicPromptVersions.getByIdForSequence(
@@ -287,7 +287,7 @@ const shotSaveInput = z.object({
 
 export const saveShotPromptFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotSaveInput))
+  .validator(zodValidator(shotSaveInput))
   .handler(async ({ context, data }) => {
     const { shot, frame, sequence, scopedDb, user, scene } = context;
     const text = data.text.trim();
@@ -420,7 +420,7 @@ async function settleFrameAfterImageCancel(
 
 export const cancelPendingArtifactFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(cancelPendingInput))
+  .validator(zodValidator(cancelPendingInput))
   .handler(async ({ context, data }) => {
     const { scopedDb, frame, shot } = context;
 
@@ -492,7 +492,7 @@ const shotRegenerateInput = z.object({
 
 export const regenerateShotPromptFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotRegenerateInput))
+  .validator(zodValidator(shotRegenerateInput))
   .handler(async ({ context, data }) => {
     const { shot, frame, sequence, scopedDb, user, teamId, scene } = context;
 
@@ -725,7 +725,7 @@ const sequenceRegenerateInput = z.object({ sequenceId: ulidSchema });
 
 export const regenerateMusicPromptFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(sequenceRegenerateInput))
+  .validator(zodValidator(sequenceRegenerateInput))
   .handler(async ({ context }) => {
     const { sequence, scopedDb, user, teamId } = context;
 
@@ -782,7 +782,7 @@ export const regenerateMusicPromptFn = createServerFn({ method: 'POST' })
 
 export const getMusicPromptStalenessFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(sequenceListInput))
+  .validator(zodValidator(sequenceListInput))
   .handler(async ({ context }) => {
     const { sequence, scopedDb } = context;
 
@@ -860,7 +860,7 @@ export const getDivergentVariantPromptDiffFn = createServerFn({
   method: 'GET',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantPromptDiffInput))
+  .validator(zodValidator(variantPromptDiffInput))
   .handler(async ({ context, data }): Promise<VariantPromptDiff> => {
     const variant = await context.scopedDb.shotVariants.getById(data.variantId);
     if (!variant) return null;

--- a/src/functions/public-api-keys.ts
+++ b/src/functions/public-api-keys.ts
@@ -61,7 +61,7 @@ export type PublicApiKeySummary = {
  */
 export const createPublicApiKeyFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(createPublicApiKeySchema))
+  .validator(zodValidator(createPublicApiKeySchema))
   .handler(
     async ({
       data,
@@ -112,7 +112,7 @@ export const listPublicApiKeysFn = createServerFn({ method: 'GET' })
 /** Permanently revoke (delete) a public-API key the signed-in user owns. */
 export const revokePublicApiKeyFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(revokePublicApiKeySchema))
+  .validator(zodValidator(revokePublicApiKeySchema))
   .handler(async ({ data, context }): Promise<{ success: boolean }> => {
     const auth = getAuth();
     await auth.api.deleteApiKey({

--- a/src/functions/realtime-history.ts
+++ b/src/functions/realtime-history.ts
@@ -17,7 +17,7 @@ const channelInputSchema = z.object({ channel: z.string().min(1) });
  */
 export const getChannelHistoryFn = createServerFn({ method: 'GET' })
   .middleware([authMiddleware])
-  .inputValidator(zodValidator(channelInputSchema))
+  .validator(zodValidator(channelInputSchema))
   .handler(async ({ data }) => {
     const messages = await getChannelHistory(data.channel);
 

--- a/src/functions/scenes.ts
+++ b/src/functions/scenes.ts
@@ -64,7 +64,7 @@ const updateSceneScriptSchema = z.object({
  */
 export const updateSceneScriptFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(updateSceneScriptSchema))
+  .validator(zodValidator(updateSceneScriptSchema))
   .handler(async ({ data, context }) => {
     const { sequence, scopedDb, user } = context;
 

--- a/src/functions/sequence-characters.ts
+++ b/src/functions/sequence-characters.ts
@@ -44,7 +44,7 @@ export const getSequenceCharactersFn = createServerFn({ method: 'GET' })
 /** Get shot IDs for all shots containing a specific character */
 export const getShotIdsForCharacterFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ characterId: z.string().min(1) })))
+  .validator(zodValidator(z.object({ characterId: z.string().min(1) })))
   .handler(async ({ context, data }) => {
     const shotIds = await context.scopedDb.characters.getShotIdsForCharacter(
       context.sequence.id,
@@ -56,7 +56,7 @@ export const getShotIdsForCharacterFn = createServerFn({ method: 'GET' })
 /** Recast a character with different talent, triggering sheet regeneration */
 export const recastCharacterFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({ characterId: z.string().min(1), talentId: ulidSchema })
     )

--- a/src/functions/sequence-elements.ts
+++ b/src/functions/sequence-elements.ts
@@ -82,7 +82,7 @@ async function triggerElementVision(params: {
 
 export const presignDraftElementUploadFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.object({ filename: z.string().min(1) })))
+  .validator(zodValidator(z.object({ filename: z.string().min(1) })))
   .handler(async ({ context, data }) => {
     const ext = getExtensionFromUrl(data.filename);
     const uploadId = generateId();
@@ -98,7 +98,7 @@ export const presignDraftElementUploadFn = createServerFn({ method: 'POST' })
 
 export const presignElementUploadFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -132,7 +132,7 @@ export const presignElementUploadFn = createServerFn({ method: 'POST' })
 
 export const analyzeDraftElementFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         publicUrl: mediaUrlSchema,
@@ -192,7 +192,7 @@ export const analyzeDraftElementFn = createServerFn({ method: 'POST' })
 
 export const finalizeElementUploadFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -254,14 +254,14 @@ export const finalizeElementUploadFn = createServerFn({ method: 'POST' })
 
 export const listSequenceElementsFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context }) => {
     return context.scopedDb.sequenceElements.list(context.sequence.id);
   });
 
 export const deleteSequenceElementFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(z.object({ sequenceId: ulidSchema, elementId: ulidSchema }))
   )
   .handler(async ({ context, data }) => {
@@ -277,7 +277,7 @@ export const deleteSequenceElementFn = createServerFn({ method: 'POST' })
 
 export const renameSequenceElementTokenFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -331,7 +331,7 @@ export const renameSequenceElementTokenFn = createServerFn({ method: 'POST' })
 /** Get shot IDs for all shots that reference an element by token */
 export const getShotIdsForElementFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(z.object({ sequenceId: ulidSchema, elementId: ulidSchema }))
   )
   .handler(async ({ context, data }) => {
@@ -349,7 +349,7 @@ export const getShotIdsForElementFn = createServerFn({ method: 'GET' })
  */
 export const getShotCountsByElementFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context }) => {
     return await context.scopedDb.sequenceElements.getShotCountsByElement(
       context.sequence.id
@@ -364,7 +364,7 @@ export const getShotCountsByElementFn = createServerFn({ method: 'GET' })
  */
 export const replaceSequenceElementFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,

--- a/src/functions/sequence-exports.ts
+++ b/src/functions/sequence-exports.ts
@@ -41,7 +41,7 @@ export const requestSequenceExportUploadUrlFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context }) => {
     const path = buildExportPath(context.teamId, context.sequence.id);
     const upload = await getSignedUploadUrl(
@@ -59,7 +59,7 @@ export const requestSequenceExportUploadUrlFn = createServerFn({
 
 export const commitSequenceExportFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -97,7 +97,7 @@ export const commitSequenceExportFn = createServerFn({ method: 'POST' })
 
 export const listSequenceExportsFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context }) => {
     return await context.scopedDb.sequenceExports.listBySequence(
       context.sequence.id

--- a/src/functions/sequence-locations.ts
+++ b/src/functions/sequence-locations.ts
@@ -65,7 +65,7 @@ const getShotIdsForLocationInputSchema = z.object({
 
 export const getShotIdsForLocationFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(getShotIdsForLocationInputSchema))
+  .validator(zodValidator(getShotIdsForLocationInputSchema))
   .handler(async ({ context, data }) => {
     const shotIds =
       await context.scopedDb.sequenceLocations.getShotIdsForLocation(
@@ -88,7 +88,7 @@ const recastLocationInputSchema = z.object({
  */
 export const recastLocationFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(recastLocationInputSchema))
+  .validator(zodValidator(recastLocationInputSchema))
   .handler(async ({ context, data }) => {
     const location = await context.scopedDb.sequenceLocations.getById(
       data.locationId

--- a/src/functions/sequence-variants.ts
+++ b/src/functions/sequence-variants.ts
@@ -86,7 +86,7 @@ export const getTeamDivergentSequenceVariantsFn = createServerFn({
 
 export const promoteSequenceMusicVariantFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const { sequence, scopedDb } = context;
     const variant = await scopedDb.sequenceVariants.getMusicById(
@@ -132,7 +132,7 @@ const setMusicFromVariantInputSchema = z.object({
  */
 export const setMusicFromVariantFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(setMusicFromVariantInputSchema))
+  .validator(zodValidator(setMusicFromVariantInputSchema))
   .handler(async ({ data, context }) => {
     const { sequence, scopedDb } = context;
     const variants = await scopedDb.sequenceVariants.listMusicBySequence(
@@ -176,7 +176,7 @@ export const setMusicFromVariantFn = createServerFn({ method: 'POST' })
 
 export const discardSequenceMusicVariantFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.sequenceVariants.getMusicById(
       data.variantId
@@ -193,7 +193,7 @@ export const undiscardSequenceMusicVariantFn = createServerFn({
   method: 'POST',
 })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.sequenceVariants.getMusicById(
       data.variantId

--- a/src/functions/sequences.ts
+++ b/src/functions/sequences.ts
@@ -81,7 +81,7 @@ export const getSequencesFn = createServerFn({ method: 'GET' })
 
 export const getSequenceFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context }) => {
     return context.sequence;
   });
@@ -96,7 +96,7 @@ export const getSequenceFn = createServerFn({ method: 'GET' })
  */
 export const createSequenceFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(createSequenceSchema))
+  .validator(zodValidator(createSequenceSchema))
   .handler(async ({ data, context }) => {
     const { sequences } = await createSequences(data, {
       scopedDb: context.scopedDb,
@@ -125,7 +125,7 @@ export const musicWithoutMotion = (
  */
 export const updateSequenceFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(updateSequenceSchema.extend({ sequenceId: ulidSchema }))
   )
   .handler(async ({ data, context }) => {
@@ -237,7 +237,7 @@ const setSequenceMusicInputSchema = z.object({
  */
 export const setSequenceMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(setSequenceMusicInputSchema))
+  .validator(zodValidator(setSequenceMusicInputSchema))
   .handler(async ({ data, context }) => {
     return await context.scopedDb.sequences.update({
       id: data.sequenceId,
@@ -259,7 +259,7 @@ const retryStoryboardInputSchema = z.object({
  */
 export const retryStoryboardFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(retryStoryboardInputSchema))
+  .validator(zodValidator(retryStoryboardInputSchema))
   .handler(async ({ context }) => {
     const { sequence, user, teamId } = context;
 
@@ -315,7 +315,7 @@ export const retryStoryboardFn = createServerFn({ method: 'POST' })
 /** Archive a sequence (hides from list, lets in-flight workflows finish) */
 export const archiveSequenceFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(async ({ context }) => {
     await context.scopedDb
       .sequence(context.sequence.id)
@@ -424,7 +424,7 @@ export function buildAddAudioMusicInput(args: {
  */
 export const addModelToSequenceFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -815,7 +815,7 @@ export const addModelToSequenceFn = createServerFn({ method: 'POST' })
  */
 export const setSequenceModelFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -965,7 +965,7 @@ function musicRunDedupId(args: {
  */
 export const generateMusicFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,

--- a/src/functions/shot-image.ts
+++ b/src/functions/shot-image.ts
@@ -103,7 +103,7 @@ const generateImageInputSchema = regenerateShotSchema.extend({
 
 export const generateShotImageFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(generateImageInputSchema))
+  .validator(zodValidator(generateImageInputSchema))
   .handler(async ({ context, data }) => {
     const {
       shot,
@@ -233,7 +233,7 @@ const generateVariantsInputSchema = generateVariantSchema.extend({
 
 export const generateShotVariantsFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(generateVariantsInputSchema))
+  .validator(zodValidator(generateVariantsInputSchema))
   .handler(async ({ context, data }) => {
     const { shot, frame, sequence, user, scene } = context;
 
@@ -335,7 +335,7 @@ function indexToRowCol(
 
 export const selectShotVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(selectVariantInputSchema))
+  .validator(zodValidator(selectVariantInputSchema))
   .handler(async ({ context, data }) => {
     const { shot, frame, sequence, user, scene } = context;
 
@@ -461,7 +461,7 @@ const setImageFromVariantInputSchema = z.object({
 
 export const setImageFromVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(setImageFromVariantInputSchema))
+  .validator(zodValidator(setImageFromVariantInputSchema))
   .handler(async ({ context, data }) => {
     const { shot, frame } = context;
 
@@ -506,7 +506,7 @@ const setVideoFromVariantInputSchema = z.object({
  */
 export const setVideoFromVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(setVideoFromVariantInputSchema))
+  .validator(zodValidator(setVideoFromVariantInputSchema))
   .handler(async ({ context, data }) => {
     const { shot, scopedDb } = context;
     // No render segment ⇒ the shot was never rendered, so no version to select.
@@ -548,7 +548,7 @@ const selectSegmentVideoVersionInputSchema = z.object({
  */
 export const selectSegmentVideoVersionFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(selectSegmentVideoVersionInputSchema))
+  .validator(zodValidator(selectSegmentVideoVersionInputSchema))
   .handler(async ({ context, data }) => {
     const { shot, scopedDb } = context;
     const version = await scopedDb.videoVariants.select(
@@ -606,7 +606,7 @@ const shotHistoryListInputSchema = z.object({
  */
 export const listShotImageVersionsFn = createServerFn({ method: 'GET' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotHistoryListInputSchema))
+  .validator(zodValidator(shotHistoryListInputSchema))
   .handler(async ({ context }): Promise<ShotImageVersionRow[]> => {
     const { frame, scopedDb } = context;
     const versions = await scopedDb.frameVariants.listByFrame(frame.id);
@@ -631,7 +631,7 @@ export const listShotImageVersionsFn = createServerFn({ method: 'GET' })
  */
 export const listShotVideoVersionsFn = createServerFn({ method: 'GET' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotHistoryListInputSchema))
+  .validator(zodValidator(shotHistoryListInputSchema))
   .handler(async ({ context }): Promise<ShotVideoVersionRow[]> => {
     const { shot, scopedDb } = context;
     if (!shot.renderSegmentId) return [];
@@ -667,7 +667,7 @@ const selectFrameImageVersionInputSchema = z.object({
  */
 export const selectFrameImageVersionFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(selectFrameImageVersionInputSchema))
+  .validator(zodValidator(selectFrameImageVersionInputSchema))
   .handler(async ({ context, data }) => {
     const { shot, frame, scopedDb } = context;
 

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -152,7 +152,7 @@ export const getShotsFn = createServerFn({ method: 'GET' })
  */
 export const getShotsForSequencesFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceIds: z.array(ulidSchema).max(5000),
@@ -246,7 +246,7 @@ export const getDivergentVariantsFn = createServerFn({ method: 'GET' })
  */
 export const promoteVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -263,7 +263,7 @@ export const promoteVariantFn = createServerFn({ method: 'POST' })
 
 export const discardVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -283,7 +283,7 @@ export const discardVariantFn = createServerFn({ method: 'POST' })
 
 export const undiscardVariantFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -363,16 +363,14 @@ export const getSequenceSelectedModelsFn = createServerFn({ method: 'GET' })
 
 export const createShotFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
-    zodValidator(singleShotSchema.extend({ sequenceId: ulidSchema }))
-  )
+  .validator(zodValidator(singleShotSchema.extend({ sequenceId: ulidSchema })))
   .handler(async ({ data, context }) => {
     return context.scopedDb.shots.create(data);
   });
 
 export const createShotsBulkFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -390,7 +388,7 @@ export const createShotsBulkFn = createServerFn({ method: 'POST' })
 
 export const updateShotFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       updateShotSchema.extend({ sequenceId: ulidSchema, shotId: ulidSchema })
     )
@@ -510,7 +508,7 @@ const updateShotDurationSchema = z.object({
  */
 export const updateShotDurationFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(updateShotDurationSchema))
+  .validator(zodValidator(updateShotDurationSchema))
   .handler(async ({ data, context }) => {
     const { shot, scopedDb } = context;
     const updated = await scopedDb.shots.update(shot.id, {
@@ -521,7 +519,7 @@ export const updateShotDurationFn = createServerFn({ method: 'POST' })
 
 export const deleteShotFn = createServerFn({ method: 'POST' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotIdInputSchema))
+  .validator(zodValidator(shotIdInputSchema))
   .handler(async ({ data, context }) => {
     await context.scopedDb.shots.delete(data.shotId);
     return { success: true, sequenceId: data.sequenceId };
@@ -542,7 +540,7 @@ export const deleteShotsBySequenceFn = createServerFn({ method: 'POST' })
  */
 export const getShotStalenessFn = createServerFn({ method: 'GET' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotIdInputSchema))
+  .validator(zodValidator(shotIdInputSchema))
   .handler(async ({ context }) => {
     const { shot, frame, sequence, scopedDb, scene } = context;
     return toWireStaleness(
@@ -576,7 +574,7 @@ const toWireStaleness = ({
  */
 export const getShotStalenessBatchFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({ sequenceId: ulidSchema, sceneId: ulidSchema.optional() })
     )
@@ -687,7 +685,7 @@ export const getShotStalenessBatchFn = createServerFn({ method: 'GET' })
  */
 export const updateStaleShotsFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         sequenceId: ulidSchema,
@@ -790,7 +788,7 @@ const updateStaleShotsResultSchema = z.object({
  */
 export const getUpdateStaleShotsRunFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({ sequenceId: ulidSchema, workflowRunId: z.string().min(1) })
     )
@@ -827,7 +825,7 @@ export const getUpdateStaleShotsRunFn = createServerFn({ method: 'GET' })
  */
 export const getShotDownloadUrlFn = createServerFn({ method: 'GET' })
   .middleware([shotAccessMiddleware])
-  .inputValidator(zodValidator(shotIdInputSchema))
+  .validator(zodValidator(shotIdInputSchema))
   .handler(async ({ context }) => {
     const { shot, scopedDb } = context;
 

--- a/src/functions/smart-retry.ts
+++ b/src/functions/smart-retry.ts
@@ -482,5 +482,5 @@ export async function executeSmartRetry(context: SmartRetryContext) {
 
 export const smartRetryFn = createServerFn({ method: 'POST' })
   .middleware([sequenceAccessMiddleware])
-  .inputValidator(zodValidator(z.object({ sequenceId: ulidSchema })))
+  .validator(zodValidator(z.object({ sequenceId: ulidSchema })))
   .handler(({ context }) => executeSmartRetry(context));

--- a/src/functions/styles.ts
+++ b/src/functions/styles.ts
@@ -25,7 +25,7 @@ import { authWithTeamMiddleware } from './middleware';
  */
 export const getStylesFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z
         .object({ orderBy: z.enum(['popular', 'sortOrder']).optional() })
@@ -66,7 +66,7 @@ const getStyleInputSchema = z.object({
  */
 export const getStyleFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(getStyleInputSchema))
+  .validator(zodValidator(getStyleInputSchema))
   .handler(async ({ data, context }) => {
     // Style lookup doesn't require team scoping (styles can be public)
     const style = await context.scopedDb.styles.getById(data.styleId);
@@ -88,7 +88,7 @@ export const getStyleFn = createServerFn({ method: 'GET' })
  */
 export const createStyleFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(createStyleSchema))
+  .validator(zodValidator(createStyleSchema))
   .handler(async ({ data, context }) => {
     return context.scopedDb.styles.create(data);
   });
@@ -107,7 +107,7 @@ const updateStyleInputSchema = updateStyleSchema.extend({
  */
 export const updateStyleFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(updateStyleInputSchema))
+  .validator(zodValidator(updateStyleInputSchema))
   .handler(async ({ data, context }) => {
     const { styleId, ...updateData } = data;
 
@@ -135,7 +135,7 @@ const deleteStyleInputSchema = z.object({
  */
 export const deleteStyleFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(deleteStyleInputSchema))
+  .validator(zodValidator(deleteStyleInputSchema))
   .handler(async ({ data, context }) => {
     // Style lookup without team scoping (need to discover the team first)
     const style = await context.scopedDb.styles.getById(data.styleId);

--- a/src/functions/talent-sheet-variants.ts
+++ b/src/functions/talent-sheet-variants.ts
@@ -37,7 +37,7 @@ export const getTeamTalentDivergentVariantsFn = createServerFn({
  */
 export const getTalentDivergentVariantsFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(z.object({ talentId: ulidSchema })))
+  .validator(zodValidator(z.object({ talentId: ulidSchema })))
   .handler(async ({ data, context }) => {
     const talent = await context.scopedDb.talent.getWithRelations(
       data.talentId
@@ -52,7 +52,7 @@ export const getTalentDivergentVariantsFn = createServerFn({ method: 'GET' })
 
 export const promoteTalentSheetVariantFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.talentSheetVariants.getById(
       data.variantId
@@ -110,7 +110,7 @@ export const promoteTalentSheetVariantFn = createServerFn({ method: 'POST' })
 
 export const discardTalentSheetVariantFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.talentSheetVariants.getById(
       data.variantId
@@ -136,7 +136,7 @@ export const discardTalentSheetVariantFn = createServerFn({ method: 'POST' })
 
 export const undiscardTalentSheetVariantFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(variantInputSchema))
+  .validator(zodValidator(variantInputSchema))
   .handler(async ({ data, context }) => {
     const variant = await context.scopedDb.talentSheetVariants.getById(
       data.variantId

--- a/src/functions/talent.ts
+++ b/src/functions/talent.ts
@@ -39,7 +39,7 @@ const characterIdSchema = z.object({ characterId: ulidSchema });
 
 export const getTalentFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(listTalentFilterSchema.optional()))
+  .validator(zodValidator(listTalentFilterSchema.optional()))
   .handler(async ({ context, data }): Promise<TalentWithSheets[]> => {
     return context.scopedDb.talent.list({
       favoritesOnly: data?.favoritesOnly,
@@ -49,7 +49,7 @@ export const getTalentFn = createServerFn({ method: 'GET' })
 // List Public ("system") Talent — no auth, for anonymous visitors
 
 export const getPublicTalentFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(listTalentFilterSchema.optional()))
+  .validator(zodValidator(listTalentFilterSchema.optional()))
   .handler(async ({ data }): Promise<TalentWithSheets[]> => {
     return listPublicTalent({ favoritesOnly: data?.favoritesOnly });
   });
@@ -58,7 +58,7 @@ export const getPublicTalentFn = createServerFn({ method: 'GET' })
 
 export const getTalentByIdFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(talentIdSchema))
+  .validator(zodValidator(talentIdSchema))
   .handler(async ({ context, data }) => {
     const talentRecord = await context.scopedDb.talent.getWithRelations(
       data.talentId
@@ -74,7 +74,7 @@ export const getTalentByIdFn = createServerFn({ method: 'GET' })
 // Get Single Public ("system") Talent — no auth, for anonymous visitors
 
 export const getPublicTalentByIdFn = createServerFn({ method: 'GET' })
-  .inputValidator(zodValidator(talentIdSchema))
+  .validator(zodValidator(talentIdSchema))
   .handler(async ({ data }) => {
     const talentRecord = await getPublicTalentWithRelations(data.talentId);
 
@@ -89,7 +89,7 @@ export const getPublicTalentByIdFn = createServerFn({ method: 'GET' })
 
 export const createTalentFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(createTalentSchema))
+  .validator(zodValidator(createTalentSchema))
   .handler(async ({ context, data }) => {
     return createLibraryTalent(data, {
       scopedDb: context.scopedDb,
@@ -106,7 +106,7 @@ const updateTalentInputSchema = updateTalentSchema.extend({
 
 export const updateTalentFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(updateTalentInputSchema))
+  .validator(zodValidator(updateTalentInputSchema))
   .handler(async ({ context, data }) => {
     const { talentId, ...updateData } = data;
 
@@ -123,7 +123,7 @@ export const updateTalentFn = createServerFn({ method: 'POST' })
 
 export const deleteTalentFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(talentIdSchema))
+  .validator(zodValidator(talentIdSchema))
   .handler(async ({ context, data }) => {
     await requireTeamAdminAccess(context.user.id, context.teamId);
 
@@ -141,7 +141,7 @@ export const deleteTalentFn = createServerFn({ method: 'POST' })
 
 export const toggleTalentFavoriteFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(talentIdSchema))
+  .validator(zodValidator(talentIdSchema))
   .handler(async ({ context, data }) => {
     const updated = await context.scopedDb.talent.toggleFavorite(data.talentId);
 
@@ -156,7 +156,7 @@ export const toggleTalentFavoriteFn = createServerFn({ method: 'POST' })
 
 export const createTalentSheetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(createTalentSheetSchema))
+  .validator(zodValidator(createTalentSheetSchema))
   .handler(async ({ context, data }) => {
     return context.scopedDb.talent.sheets.create({
       talentId: data.talentId,
@@ -178,7 +178,7 @@ export const createTalentSheetFn = createServerFn({ method: 'POST' })
 
 export const deleteTalentSheetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(sheetIdSchema))
+  .validator(zodValidator(sheetIdSchema))
   .handler(async ({ context, data }) => {
     const sheet = await context.scopedDb.talent.sheets.getById(data.sheetId);
     if (!sheet) {
@@ -197,7 +197,7 @@ export const deleteTalentSheetFn = createServerFn({ method: 'POST' })
 
 export const setDefaultSheetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(sheetIdSchema))
+  .validator(zodValidator(sheetIdSchema))
   .handler(async ({ context, data }) => {
     const sheet = await context.scopedDb.talent.sheets.getById(data.sheetId);
     if (!sheet) {
@@ -218,7 +218,7 @@ export const setDefaultSheetFn = createServerFn({ method: 'POST' })
 
 export const deleteTalentMediaFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(mediaIdSchema))
+  .validator(zodValidator(mediaIdSchema))
   .handler(async ({ context, data }) => {
     const media = await context.scopedDb.talent.media.getById(data.mediaId);
     if (!media) {
@@ -250,7 +250,7 @@ const mediaTypeSchema = z.enum(['image', 'video', 'recording']);
 
 export const presignTalentUploadFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         filename: z.string().min(1),
@@ -291,7 +291,7 @@ export const presignTalentUploadFn = createServerFn({ method: 'POST' })
 
 export const finalizeTalentUploadFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(
+  .validator(
     zodValidator(
       z.object({
         talentId: ulidSchema,
@@ -327,7 +327,7 @@ const generateSheetInputSchema = z.object({
 
 export const generateTalentSheetFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(generateSheetInputSchema))
+  .validator(zodValidator(generateSheetInputSchema))
   .handler(async ({ context, data }) => {
     const talentRecord = await context.scopedDb.talent.getWithRelations(
       data.talentId
@@ -376,7 +376,7 @@ export const generateTalentSheetFn = createServerFn({ method: 'POST' })
 
 export const addCharacterToLibraryFn = createServerFn({ method: 'POST' })
   .middleware([authWithTeamMiddleware])
-  .inputValidator(zodValidator(characterIdSchema))
+  .validator(zodValidator(characterIdSchema))
   .handler(async ({ context, data }) => {
     const character = await context.scopedDb.characters.getById(
       data.characterId


### PR DESCRIPTION
Closes #1158

`vite dev` logged a deprecation warning for every server fn that validates its input:

```
warning: src/functions/styles.ts?tss-serverfn-split:136:30
createServerFn().inputValidator() is deprecated. Use createServerFn().validator() instead.
```

## Pure rename

`@tanstack/start-client-core` declares the two with an **identical** signature — same `ValidatorFn`, same constraint types — and marks only the old one deprecated:

```ts
export interface ServerFnValidator<TRegister, TMethod, TMiddlewares, TStrict> {
  validator: ValidatorFn<TRegister, TMethod, TMiddlewares, TStrict>;
  /** @deprecated Use `validator` instead. */
  inputValidator: ValidatorFn<TRegister, TMethod, TMiddlewares, TStrict>;
}
```

`createMiddleware` carries the same deprecated alias, so its call sites rename identically. No signature change, no argument reshaping, no runtime difference.

## The diff

146 call sites across 31 files, all `src/functions/`. Mechanical:

```bash
rg -l '\.inputValidator\(' src/ | xargs perl -pi -e 's/\.inputValidator\(/.validator(/g'
bun format
```

Insertions (146) and deletions (148) differ by two because oxfmt collapsed one call that now fits the print width — the only line in the diff that isn't the rename itself:

```diff
-  .inputValidator(
-    zodValidator(singleShotSchema.extend({ sequenceId: ulidSchema }))
-  )
+  .validator(zodValidator(singleShotSchema.extend({ sequenceId: ulidSchema })))
```

## Deliberately untouched

`src/lib/mocks/tanstack-start.ts` lists both method names as strings on its Storybook stub builder. That is a defensive list, not a call site, and it emits no warning — renaming it would only narrow what the stub tolerates.

## Verification

- `bun typecheck` — clean
- `bun run test` — 2305 passed
- `bun lint` — no new errors (one pre-existing failure in `src/lib/workflows/scene-split-workflow.test.ts:175`, present on `main` and unrelated)
- `bun dead-code` — clean
- Lefthook pre-commit (format / lint / typecheck / dead-code) — all green


_Rebased onto `main` after #1144. The earlier second commit (a lint fix for a red `main`) is dropped — `main` fixed the same error itself in `31481f33`, so this PR is back to the single rename commit._
