### PR TITLE
fix(#1161): stop scene-split and the v1 sequences list blowing the isolate memory limit

### DIFF
--- a/src/lib/api-v1/list.test.ts
+++ b/src/lib/api-v1/list.test.ts
@@ -31,6 +31,7 @@ import {
   encodeCursor,
   parseLimitParam,
 } from './list';
+import { toShotReadiness } from './state';
 
 // toShareableUrl reads R2_PUBLIC_STORAGE_DOMAIN; pin local serving so the
 // origin-fallback assertions are environment-independent (see state.test.ts).
@@ -173,9 +174,17 @@ function makeStyle(overrides: Partial<Style> = {}): Style {
  */
 function depsWithShots(shots: ShotView[], styles: Style[] = [makeStyle()]) {
   return {
-    // `listShotsByIds` hands back assembled views, so the page builder only
-    // groups them by sequence.
-    sequences: { listShotsByIds: async () => shots },
+    // The page builder reads readiness only (#1161). Fixtures stay full
+    // `ShotView`s and are projected through the same `toShotReadiness` the
+    // status document uses, so these assertions also pin the two paths to the
+    // same readiness derivation.
+    sequences: {
+      listShotReadinessByIds: async () =>
+        shots.map((shot) => ({
+          ...toShotReadiness(shot),
+          sequenceId: shot.sequenceId,
+        })),
+    },
     styles: { listByIds: async () => styles },
   };
 }

--- a/src/lib/api-v1/list.ts
+++ b/src/lib/api-v1/list.ts
@@ -12,7 +12,7 @@
 import type { ScopedDb } from '@/lib/db/scoped';
 import type { Style } from '@/lib/db/schema/libraries';
 import { ValidationError } from '@/lib/errors';
-import type { ShotView } from '@/lib/shots/shot-view';
+import type { ShotReadiness } from '@/lib/shots/shot-view';
 import type { Sequence } from '@/types/database';
 import { createSequenceLink } from './discovery';
 import { API_V1_BASE, getLink, type HalResource, withLinks } from './hal';
@@ -77,7 +77,7 @@ export function decodeCursor(raw: string): SequenceCursor {
 
 function buildListItem(
   sequence: Sequence,
-  shots: ShotView[],
+  shots: ShotReadiness[],
   style: Style | null,
   origin: string
 ): HalResource<SequenceListItem> {
@@ -100,7 +100,7 @@ function buildListItem(
  */
 export async function buildSequenceListPage(params: {
   scopedDb: {
-    sequences: Pick<ScopedDb['sequences'], 'listShotsByIds'>;
+    sequences: Pick<ScopedDb['sequences'], 'listShotReadinessByIds'>;
     styles: Pick<ScopedDb['styles'], 'listByIds'>;
   };
   sequences: Sequence[];
@@ -113,16 +113,17 @@ export async function buildSequenceListPage(params: {
   // One batched shot fetch and one batched style fetch across the whole page,
   // rather than N round-trips per sequence.
   const [allShots, allStyles] = await Promise.all([
-    scopedDb.sequences.listShotsByIds(sequences.map((s) => s.id)),
+    // Readiness only, NOT the full `ShotView`: this document reports four
+    // integers per sequence, and materialising every shot's metadata and
+    // prompts to get them is what let a page of 100 sequences approach the
+    // 128 MB isolate ceiling (#1161).
+    scopedDb.sequences.listShotReadinessByIds(sequences.map((s) => s.id)),
     scopedDb.styles.listByIds(sequences.map((s) => s.styleId)),
   ]);
 
-  // `listShotsByIds` already assembles each shot's view (anchor frame + its
-  // selected versions), so these only need grouping by sequence. This used to
-  // re-fetch the anchors and re-assemble on top — a redundant round-trip that
-  // also silently DROPPED frameless shots, which the batch read deliberately
-  // keeps (`shotViewMissingFrame`).
-  const shotsById = new Map<string, ShotView[]>();
+  // Frameless shots are deliberately kept by the batch read (as they are by
+  // `shotViewMissingFrame` on the full path) — they still count as shots.
+  const shotsById = new Map<string, ShotReadiness[]>();
   for (const shot of allShots) {
     const bucket = shotsById.get(shot.sequenceId);
     if (bucket) bucket.push(shot);

--- a/src/lib/api-v1/state.ts
+++ b/src/lib/api-v1/state.ts
@@ -12,7 +12,13 @@ import { SHOT_GENERATION_STATUSES } from '@/lib/db/schema/shots';
 import type { Style } from '@/lib/db/schema/libraries';
 import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
 import { getLogger } from '@/lib/observability/logger';
-import { type ShotView, toShotView } from '@/lib/shots/shot-view';
+import {
+  readinessImageUrl,
+  readinessVideoStatus,
+  type ShotReadiness,
+  type ShotView,
+  toShotView,
+} from '@/lib/shots/shot-view';
 import { toShareableUrl } from '@/lib/storage/buckets';
 import type { Sequence } from '@/types/database';
 import { API_V1_BASE, type HalResource, waitLink, withLinks } from './hal';
@@ -95,23 +101,40 @@ export type SequenceState = SequenceSummary & {
 
 /** The image URL a shot exposes once its still is ready (else null). */
 function shotImageUrl(shot: ShotView): string | null {
-  // Readiness is signalled by the presence of a still URL: the selected
-  // variant's stored R2 url, else the fast preview variant's CDN url.
-  return shot.image?.url ?? shot.previewThumbnailUrl ?? null;
+  return readinessImageUrl({
+    selectedImageUrl: shot.image?.url ?? null,
+    previewImageUrl: shot.previewThumbnailUrl,
+  });
+}
+
+/** The readiness slice of an already-assembled view. */
+export function toShotReadiness(shot: ShotView): ShotReadiness {
+  return {
+    selectedImageUrl: shot.image?.url ?? null,
+    previewImageUrl: shot.previewThumbnailUrl,
+    hasSelectedVideo: shot.video !== null,
+    primaryVideoStatus: shot.primaryVideo?.status ?? null,
+  };
 }
 
 /**
  * Readiness tallies over a sequence's shots — the single source of truth for
  * the `counts` block shared by the status document and the list summary.
+ *
+ * Takes the narrow {@link ShotReadiness} rather than a full `ShotView` so the
+ * list page can count without materialising every shot's prompts and metadata
+ * (#1161). The status document, which needs the full views anyway, maps them
+ * through {@link toShotReadiness}.
  */
-export function summarizeShotCounts(shots: ShotView[]): SequenceCounts {
+export function summarizeShotCounts(shots: ShotReadiness[]): SequenceCounts {
   let imagesReady = 0;
   let videosReady = 0;
   let videosFailed = 0;
   for (const shot of shots) {
-    if (shotImageUrl(shot) !== null) imagesReady += 1;
-    if (shot.videoStatus === 'completed') videosReady += 1;
-    if (shot.videoStatus === 'failed') videosFailed += 1;
+    if (readinessImageUrl(shot) !== null) imagesReady += 1;
+    const videoStatus = readinessVideoStatus(shot);
+    if (videoStatus === 'completed') videosReady += 1;
+    if (videoStatus === 'failed') videosFailed += 1;
   }
   return { shots: shots.length, imagesReady, videosReady, videosFailed };
 }
@@ -269,7 +292,7 @@ export async function buildSequenceState(
     ...buildSequenceSummary({
       sequence,
       style,
-      counts: summarizeShotCounts(ordered),
+      counts: summarizeShotCounts(ordered.map(toShotReadiness)),
       origin,
     }),
     shots: stateShots,

--- a/src/lib/db/scoped/sequences.ts
+++ b/src/lib/db/scoped/sequences.ts
@@ -14,10 +14,19 @@ import {
   selectShotViewRows,
   shotHierarchicalOrder,
 } from './shot-view-query';
-import { sequences, shots } from '@/lib/db/schema';
+import {
+  frames,
+  frameVariants,
+  renderSegments,
+  sequences,
+  shots,
+  videoVariants,
+} from '@/lib/db/schema';
 import type { NewSequence, Sequence } from '@/lib/db/schema';
 import type { MusicStatus, SequenceStatus } from '@/lib/db/schema/sequences';
-import type { ShotView } from '@/lib/shots/shot-view';
+import type { ShotReadiness, ShotView } from '@/lib/shots/shot-view';
+import { getLatestPreviewByFrameIds } from './frame-variants';
+import { getPrimaryVideoByShotIds } from './video-variants';
 import { ValidationError } from '@/lib/errors';
 import { and, asc, desc, eq, inArray, isNull, lt, not, or } from 'drizzle-orm';
 
@@ -141,6 +150,100 @@ function createSequencesReadMethods(db: Database, teamId: string) {
         )
       );
       return results.flat();
+    },
+
+    /**
+     * Readiness-only twin of {@link listShotsByIds}, for callers that report
+     * `counts` and never touch a shot's content.
+     *
+     * `listShotsByIds` projects ~100 columns per shot — `shots.metadata`, the
+     * visual prompt, the motion prompt, both variant rows. `GET
+     * /api/v1/sequences` paged up to 100 sequences through it to compute four
+     * integers each, and the shots-per-sequence fan-out is unbounded, so the
+     * page's peak footprint had no ceiling — one of the reads that reached the
+     * 128 MB isolate limit (#1161). This selects the five scalars
+     * {@link ShotReadiness} is derived from instead.
+     *
+     * The two group-wise maxes ride the SAME helpers as the full view, so
+     * neither path can drift on which render counts as primary.
+     */
+    listShotReadinessByIds: async (
+      sequenceIds: string[]
+    ): Promise<Array<ShotReadiness & { sequenceId: string }>> => {
+      if (sequenceIds.length === 0) return [];
+      const batches: string[][] = [];
+      for (let i = 0; i < sequenceIds.length; i += SHOTS_BY_IDS_BATCH) {
+        batches.push(sequenceIds.slice(i, i + SHOTS_BY_IDS_BATCH));
+      }
+      const batched = await Promise.all(
+        batches.map((batch) =>
+          db
+            .select({
+              sequenceId: shots.sequenceId,
+              shotId: shots.id,
+              frameId: frames.id,
+              selectedImageUrl: frameVariants.url,
+              selectedVideoId: videoVariants.id,
+            })
+            .from(shots)
+            // teamId is filtered through the join, so caller-supplied ids from
+            // another team return nothing rather than leak.
+            .innerJoin(sequences, eq(shots.sequenceId, sequences.id))
+            // Same anchor-frame and selection joins as `selectShotViewRows`:
+            // all left, with `discardedAt` in the JOIN condition, so a shot
+            // with no frame or a discarded selection still counts as a shot.
+            .leftJoin(
+              frames,
+              and(eq(frames.shotId, shots.id), eq(frames.orderIndex, 0))
+            )
+            .leftJoin(
+              frameVariants,
+              and(
+                eq(frameVariants.id, frames.selectedImageVersionId),
+                isNull(frameVariants.discardedAt)
+              )
+            )
+            .leftJoin(
+              renderSegments,
+              eq(renderSegments.id, shots.renderSegmentId)
+            )
+            .leftJoin(
+              videoVariants,
+              and(
+                eq(videoVariants.id, renderSegments.selectedVideoVersionId),
+                isNull(videoVariants.discardedAt)
+              )
+            )
+            .where(
+              and(
+                inArray(shots.sequenceId, batch),
+                eq(sequences.teamId, teamId)
+              )
+            )
+        )
+      );
+      const rows = batched.flat();
+
+      const [primaryByShot, previewByFrame] = await Promise.all([
+        getPrimaryVideoByShotIds(
+          db,
+          rows.map((row) => row.shotId)
+        ),
+        getLatestPreviewByFrameIds(
+          db,
+          rows.flatMap((row) => (row.frameId ? [row.frameId] : []))
+        ),
+      ]);
+
+      return rows.map((row) => ({
+        sequenceId: row.sequenceId,
+        selectedImageUrl: row.selectedImageUrl ?? null,
+        previewImageUrl: row.frameId
+          ? (previewByFrame.get(row.frameId)?.url ?? null)
+          : null,
+        hasSelectedVideo: row.selectedVideoId !== null,
+        primaryVideoStatus: primaryByShot.get(row.shotId)?.status ?? null,
+      }));
     },
   };
 }

--- a/src/lib/shots/shot-view.ts
+++ b/src/lib/shots/shot-view.ts
@@ -17,6 +17,52 @@ import type {
   VideoVariant,
 } from '@/lib/db/schema';
 
+/**
+ * The narrow slice of a shot's sources that readiness tallies are derived from
+ * — a still url and a video lifecycle, nothing else.
+ *
+ * Exists so a caller that only needs counts (`GET /api/v1/sequences`) can read
+ * five scalar columns instead of materialising a full {@link ShotView} per
+ * shot: the wide view carries `shots.metadata`, the visual prompt and the
+ * motion prompt, which together made listing a page of sequences approach the
+ * 128 MB isolate ceiling (#1161). The derivations below are shared with
+ * {@link toShotView}, so the two paths cannot report different readiness.
+ */
+export type ShotReadiness = {
+  /** `frame_variants.url` of the anchor frame's SELECTED image version. */
+  selectedImageUrl: string | null;
+  /** `frame_variants.url` of the anchor frame's newest `kind: 'preview'` row. */
+  previewImageUrl: string | null;
+  /** Whether `render_segments.selectedVideoVersionId` resolves to a version. */
+  hasSelectedVideo: boolean;
+  /** `status` of the newest non-`variantOnly` render, or null if none exists. */
+  primaryVideoStatus: VideoVariant['status'] | null;
+};
+
+/**
+ * The still url a shot exposes, or null while it has none: the selected
+ * variant's stored url, else the fast preview variant's CDN url.
+ */
+export function readinessImageUrl(
+  readiness: Pick<ShotReadiness, 'selectedImageUrl' | 'previewImageUrl'>
+): string | null {
+  return readiness.selectedImageUrl ?? readiness.previewImageUrl ?? null;
+}
+
+/**
+ * A shot's video status. The newest primary render's lifecycle wins; a shot
+ * with no primary render behind its selection reads `completed` (pre-#1067
+ * rows), and one with neither reads `pending` — see {@link ShotView.videoStatus}.
+ */
+export function readinessVideoStatus(
+  readiness: Pick<ShotReadiness, 'hasSelectedVideo' | 'primaryVideoStatus'>
+): VideoVariant['status'] {
+  return (
+    readiness.primaryVideoStatus ??
+    (readiness.hasSelectedVideo ? 'completed' : 'pending')
+  );
+}
+
 export type ShotGridSheet = {
   url: string | null;
   // Sourced from a `frame_variants` row, whose status union is wider than the
@@ -136,7 +182,10 @@ export function toShotView(
     imagePromptVersion,
     video,
     primaryVideo,
-    videoStatus: primaryVideo?.status ?? (video ? 'completed' : 'pending'),
+    videoStatus: readinessVideoStatus({
+      hasSelectedVideo: video !== null,
+      primaryVideoStatus: primaryVideo?.status ?? null,
+    }),
     gridSheet: sources.gridSheet ?? null,
     motionPrompt: sources.motionPrompt ?? null,
   };

--- a/src/lib/workflows/scene-split-workflow.test.ts
+++ b/src/lib/workflows/scene-split-workflow.test.ts
@@ -10,10 +10,18 @@
  *
  * The contract asserted here: previews are attempted for every shot, a failing
  * one is swallowed, and the split still returns its scenes and shot mapping.
+ *
+ * Plus the streaming-parse contract (#1161): the accumulated buffer is parsed
+ * on a coalesced schedule rather than once per delta, and the final chunk is
+ * always parsed.
  */
 
-import { describe, expect, test, vi } from 'vitest';
-import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type {
+  WorkflowEvent,
+  WorkflowStep,
+  WorkflowStepConfig,
+} from 'cloudflare:workers';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import type { SceneSplittingScene } from '@/lib/ai/streaming-scene-parser';
 import type { SceneSplitWorkflowInput } from '@/lib/workflow/types';
@@ -38,31 +46,60 @@ vi.doMock('@/lib/billing/workflow-deduction', () => ({
   deductWorkflowCredits: vi.fn(() => Promise.resolve()),
 }));
 
-// One chunk carrying the whole (already-validated) result; the parser mock
-// below is what turns it into per-scene events.
+type StreamChunk = {
+  done: boolean;
+  accumulated: string;
+  parsed?: typeof PARSED_RESULT;
+  usage?: undefined;
+};
+
+/**
+ * Chunks the mocked stream yields. Defaults to a single `done` chunk carrying
+ * the whole (already-validated) result; the parser mock below is what turns it
+ * into per-scene events. The coalescing test swaps in a long delta stream.
+ */
+let streamChunks: StreamChunk[] = [];
+function singleDoneChunk(): StreamChunk[] {
+  return [
+    { done: true, accumulated: '{}', parsed: PARSED_RESULT, usage: undefined },
+  ];
+}
+
 vi.doMock('@/lib/ai/llm-client', () => ({
   PROMPT_REASONING: undefined,
   llmCostFromUsage: vi.fn(() => 0),
   callLLMStream: vi.fn(() => ({
     async *[Symbol.asyncIterator]() {
-      yield {
-        done: true,
-        accumulated: '{}',
-        parsed: PARSED_RESULT,
-        usage: undefined,
-      };
+      for (const chunk of streamChunks) yield chunk;
     },
   })),
 }));
 
+/**
+ * Scenes are emitted on the FIRST feed only. The real parser tracks how many
+ * scenes it has already emitted; without that here, a multi-feed stream would
+ * re-emit all three every time and inflate the shot mapping.
+ */
+const feed = vi.fn();
 vi.doMock('@/lib/ai/streaming-scene-parser', async () => {
   const real = await vi.importActual('@/lib/ai/streaming-scene-parser');
   return {
     ...real,
-    createStreamingSceneParser: () => ({
-      feed: () =>
-        SCENES.map((scene, index) => ({ type: 'scene', scene, index })),
-    }),
+    createStreamingSceneParser: () => {
+      let emitted = false;
+      return {
+        feed: (accumulated: string) => {
+          feed(accumulated);
+          if (emitted) return [];
+          emitted = true;
+          return SCENES.map((scene, index) => ({
+            type: 'scene',
+            scene,
+            index,
+          }));
+        },
+      };
+    },
   };
 });
 
@@ -183,7 +220,15 @@ function makeEvent(): Readonly<WorkflowEvent<SceneSplitWorkflowInput>> {
 function makeStep(): WorkflowStep {
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- minimal WorkflowStep stub: runImpl only uses `do`
   return {
-    do: vi.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+    // Both `do` overloads: steps that pass a retry config (the streaming step
+    // caps its budget — see STREAM_STEP_RETRIES) hand the callback third.
+    do: vi.fn(
+      (
+        _name: string,
+        configOrFn: WorkflowStepConfig | (() => Promise<unknown>),
+        maybeFn?: () => Promise<unknown>
+      ) => (typeof configOrFn === 'function' ? configOrFn() : maybeFn?.())
+    ),
   } as unknown as WorkflowStep;
 }
 
@@ -215,6 +260,11 @@ const previewCalls = () =>
   triggerWorkflow.mock.calls.filter((call) => call[0] === '/image');
 
 describe('SceneSplitWorkflow preview fan-out', () => {
+  beforeEach(() => {
+    streamChunks = singleDoneChunk();
+    feed.mockReset();
+  });
+
   test('triggers one preview per shot on the happy path', async () => {
     triggerWorkflow.mockReset();
     triggerWorkflow.mockResolvedValue('run_1');
@@ -274,5 +324,62 @@ describe('SceneSplitWorkflow preview fan-out', () => {
     );
 
     expect(result.scenes).toHaveLength(SCENES.length);
+  });
+});
+
+/**
+ * `parser.feed` re-parses the WHOLE accumulated response and re-validates every
+ * scene emitted so far, so calling it once per delta is O(n²) — the isolate
+ * OOM that failed 2 of 20 sequences in the #1143 load run (#1161).
+ */
+describe('SceneSplitWorkflow stream parsing', () => {
+  const DELTA = 'x'.repeat(4); // one token's worth, as a real stream arrives
+  const DELTA_COUNT = 2_000;
+
+  function deltaStream(): StreamChunk[] {
+    const chunks: StreamChunk[] = [];
+    let accumulated = '';
+    for (let i = 0; i < DELTA_COUNT; i++) {
+      accumulated += DELTA;
+      chunks.push({ done: false, accumulated });
+    }
+    chunks.push({
+      done: true,
+      accumulated,
+      parsed: PARSED_RESULT,
+      usage: undefined,
+    });
+    return chunks;
+  }
+
+  beforeEach(() => {
+    triggerWorkflow.mockReset();
+    triggerWorkflow.mockResolvedValue('run_1');
+    streamChunks = deltaStream();
+    feed.mockReset();
+  });
+
+  test('coalesces feeds instead of re-parsing on every delta', async () => {
+    await makeWorkflow().split(makeEvent(), makeStep(), makeScopedDb());
+
+    const streamedChars = DELTA.length * DELTA_COUNT;
+    // One feed per PARSE_COALESCE_CHARS (256) of stream, plus the forced final
+    // one — not one per delta. Asserted as a bound, not an exact count, so the
+    // threshold can be retuned without rewriting the test.
+    expect(feed.mock.calls.length).toBeLessThanOrEqual(streamedChars / 256 + 2);
+    expect(feed.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  test('always parses the final chunk so a late scene is not dropped', async () => {
+    const result = await makeWorkflow().split(
+      makeEvent(),
+      makeStep(),
+      makeScopedDb()
+    );
+
+    const lastFeed = feed.mock.calls.at(-1)?.[0];
+    expect(lastFeed).toHaveLength(DELTA.length * DELTA_COUNT);
+    expect(result.shotMapping).toHaveLength(SCENES.length);
+    expect(previewCalls()).toHaveLength(SCENES.length);
   });
 });

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -61,11 +61,41 @@ import type {
   SceneSplitWorkflowInput,
   SceneSplitWorkflowResult,
 } from '@/lib/workflow/types';
-import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import type {
+  WorkflowEvent,
+  WorkflowStep,
+  WorkflowStepConfig,
+} from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'scene-split']);
+
+/**
+ * Re-parse the accumulated stream at most once per this many new characters.
+ *
+ * `parser.feed` is O(buffer): it re-parses the WHOLE response so far and
+ * re-validates every scene already emitted. Called on every delta — one token,
+ * ~4 chars — that is O(n²) over a split that reaches ~100 KB, i.e. tens of
+ * thousands of full parses each allocating a complete object graph. That is
+ * what exceeded the 128 MB isolate ceiling and failed whole sequences (#1161).
+ * Coalescing cuts the parse count ~60× and costs under a second of extra
+ * latency before a finished scene appears.
+ */
+const PARSE_COALESCE_CHARS = 256;
+
+/**
+ * Retry budget for `scene-splitting-stream`.
+ *
+ * Lower than the engine default on purpose. This step owns the entire LLM
+ * call, so every retry re-runs and re-bills a full generation — and the
+ * failure that motivated the cap (an isolate OOM) is deterministic, so the
+ * later attempts only spend money and delay the sequence's failure by minutes.
+ * Two retries still cover a genuinely transient provider error.
+ */
+const STREAM_STEP_RETRIES = {
+  retries: { limit: 2, delay: '10 seconds', backoff: 'exponential' },
+} as const satisfies WorkflowStepConfig;
 
 const PHASE = { number: 1, name: 'Analyzing script…' } as const;
 const STEP_NAME = 'scene-splitting';
@@ -224,6 +254,7 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
     // typecheck.
     const streamResultJson = await step.do(
       'scene-splitting-stream',
+      STREAM_STEP_RETRIES,
       async (): Promise<string> => {
         const elementsBlock =
           elements.length > 0
@@ -265,6 +296,8 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
         }> = [];
         let finalText = '';
         let chunkCount = 0;
+        /** Buffer length at the last `parser.feed` — see PARSE_COALESCE_CHARS. */
+        let parsedChars = 0;
         let prevScene: SceneSplittingScene | undefined = undefined;
         /**
          * The previous scene's shot AND its anchor frame, as one value: the
@@ -295,13 +328,23 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
           }
           chunkCount++;
           finalText = chunk.accumulated;
-          const events = parser.feed(chunk.accumulated);
 
           if (chunkCount % 20 === 0) {
             logger.info(
               `[SceneSplitWorkflow:cf] [Stream:${LOG_NAME}] chunk #${chunkCount} | ${finalText.length} chars | ${shotMapping.length} shots so far`
             );
           }
+
+          // The final chunk always parses, so a scene finished by the last few
+          // deltas is still emitted (and gets its preview) before the loop ends.
+          if (
+            !chunk.done &&
+            finalText.length - parsedChars < PARSE_COALESCE_CHARS
+          ) {
+            continue;
+          }
+          parsedChars = finalText.length;
+          const events = parser.feed(finalText);
 
           for (const ev of events) {
             if (ev.type === 'title' && sequenceId) {


### PR DESCRIPTION
Part of #1161

Two of the three surfaces in the issue. Both are about **transient allocation
during a single request**, which is where the OOM signature actually lives. One
commit each.

## 1. `scene-split` re-parsed the whole stream on every delta

`parser.feed` is O(buffer) — it re-parses the entire accumulated response and
re-validates every scene emitted so far. It ran on **every streamed delta** (one
token, ~4 chars), so a split reaching ~100 KB did tens of thousands of full
parses, each allocating a complete object graph. O(n²) in allocation and CPU,
and the origin of the pipeline OOMs: it failed 2 of 20 sequences outright in the
#1143 load run, and the `storyboard` / `analyze-script` events in the issue are
parents inheriting it.

Now coalesced to one parse per 256 new characters (~64× fewer), with the final
chunk always parsed so a scene finished by the last few deltas still emits and
still gets its preview image. Costs under a second of extra latency before a
finished scene appears.

**Also caps that step's retry budget.** `scene-splitting-stream` owns the entire
LLM call, so every retry re-runs and **re-bills a full generation** — and an OOM
is deterministic, so the default budget spent eight generations losing to the
same failure before giving up. Now 2, which still covers a transient provider
error.

## 2. `GET /api/v1/sequences` materialised every `ShotView` to count four integers

The list document reports `{shots, imagesReady, videosReady, videosFailed}` per
sequence, and was building a full `ShotView` per shot to get them — a ~100-column
projection carrying `shots.metadata`, the visual prompt, the motion prompt and
both variant rows. `?limit` caps sequences at 100; **nothing caps
shots-per-sequence**, so the page's peak footprint had no ceiling.

New `listShotReadinessByIds` selects the five scalars the tallies actually derive
from, over the same anchor-frame and selection joins (all left, `discardedAt` in
the JOIN condition, so a frameless shot or a discarded selection still counts as
a shot). The two group-wise maxes ride the SAME helpers as the full view, so
neither path can drift on which render counts as primary.

The derivations move into `shot-view.ts` (`readinessImageUrl` /
`readinessVideoStatus`) and `toShotView` now calls them too — otherwise the list
and the status document would each own a copy of "does this shot have a still"
and drift the first time either rule changed.

## What this PR deliberately does NOT include

An earlier revision added a third commit that made the 33 workflow entrypoints
and the cron jobs load lazily, cutting the Worker entry's eagerly-evaluated
module graph from 5.97 MB to 2.00 MB of source. **It was dropped after
measuring it.**

Reading the workerd isolate's heap directly over CDP (`Runtime.getHeapUsage`),
three repetitions per arm, same build pipeline both sides:

| | heap at boot | after 5 × `GET /` |
|---|---|---|
| lazy workflows | 132.44 / 132.55 / 132.47 MB | 149.49 / 149.43 / 149.57 MB |
| static exports | 133.76 / 133.57 / 133.81 MB | 150.30 / 150.38 / 150.44 MB |
| delta | **~1.2 MB (0.9%)** | **~0.87 MB (0.6%)** |

Deferring 3.97 MB of source bought ~1.2 MB of heap. All chunks ship in the
Worker and are resident regardless; skipping evaluation only avoids the objects
top-level code creates, and most of a module's bulk is function bodies V8
compiles lazily either way. ~1% is not worth a nonstandard export shape, two
guard tests, and a build-only footgun (a leaked string export on the entry stops
workerd booting, reproducible only via `bun run build` + `bun cf:dev`).

The `GET /` surface therefore remains open on #1161 — hence "Part of", not
"Closes". What is now known about it:

- SSR compute is not the cause: warm `/` is **6 ms** locally on a byte-identical
  73.5 KB page.
- Data fetching is not the cause: a homepage render makes **zero D1 queries**
  (`useStyles` resolves client-side).
- The seed check is not the cause: 30-sample distributions for `/robots.txt`
  (which does the `ensureSeededOnce` D1 call) and `/r2/probe` (which skips it)
  are identical — p50 ~75 ms, p90 ~0.22 s.
- Production warm requests are ~75 ms. The cost is entirely in how often
  isolates are cold, and a production cold start is ~2 s against ~50 ms locally.

## Verification

- `bun typecheck` clean · `bun run test` 2328/2328 · `bun lint` 0 errors · `bun dead-code` clean
- `bun run build` + `bun cf:dev` boots and serves
- `bun test:e2e:full` green against real Cloudflare Workflows in workerd
- `bun test:e2e` green apart from `talent.spec.ts` "can create talent without
  media", which also fails on an unmodified baseline (pre-existing flake)
