### PR TITLE
refactor(auth): read session from one server-fn cache

### DIFF
--- a/src/components/auth/auth-gate-provider.tsx
+++ b/src/components/auth/auth-gate-provider.tsx
@@ -92,8 +92,8 @@ export function AuthGateProvider({ children }: { children: ReactNode }) {
   const { data: user, error: sessionError } = useUser();
   // A failed session lookup must NOT be conflated with "anonymous" — rethrow
   // to the route errorComponent instead of silently popping the login dialog
-  // at a signed-in user whose session refetch blipped (see getSessionFn,
-  // which throws on lookup failure for exactly this reason).
+  // at a signed-in user whose session refetch blipped (`getSessionFn`
+  // throws on lookup failure for exactly this reason).
   if (sessionError) {
     throw new Error(`Failed to fetch session: ${sessionError.message}`, {
       cause: sessionError,

--- a/src/components/billing/add-credits-dialog.tsx
+++ b/src/components/billing/add-credits-dialog.tsx
@@ -43,7 +43,7 @@ import {
 import { closeBillingGate } from '@/hooks/use-billing-gate-dialog';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
-import { useSession } from '@/lib/auth/client';
+import { useAuthSession } from '@/lib/auth/session-query';
 import {
   formatPlatformFeePercent,
   MAX_TOPUP_AMOUNT_USD,
@@ -67,7 +67,7 @@ function formatBrand(brand: string): string {
 
 export function AddCreditsDialog() {
   const open = useAddCreditsDialogOpen();
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
   const queryClient = useQueryClient();
   const posthog = usePostHog();
 

--- a/src/hooks/use-billing-balance.ts
+++ b/src/hooks/use-billing-balance.ts
@@ -4,17 +4,14 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { sessionQueryOptions } from '@/lib/auth/session-query';
+import { useAuthSession } from '@/lib/auth/session-query';
 import { LOW_BALANCE_THRESHOLD_USD } from '@/lib/billing/constants';
 import { getBillingBalanceFn } from '@/functions/billing';
 
 export const BILLING_BALANCE_KEY = ['billing-balance'] as const;
 
 export function useBillingBalance() {
-  // Same session cache as useUser / _app beforeLoad — not better-auth's
-  // useSession(), which can lag or stay empty while the RQ session is ready
-  // (that left WelcomeCreditsDialog stuck on !isFetched forever).
-  const { data: session } = useQuery(sessionQueryOptions);
+  const { data: session } = useAuthSession();
 
   const query = useQuery({
     queryKey: [...BILLING_BALANCE_KEY],

--- a/src/hooks/use-billing-gate.ts
+++ b/src/hooks/use-billing-gate.ts
@@ -4,7 +4,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { useSession } from '@/lib/auth/client';
+import { useAuthSession } from '@/lib/auth/session-query';
 import { getBillingGateStatusFn } from '@/functions/billing-gate';
 import { openBillingGate } from './use-billing-gate-dialog';
 
@@ -22,7 +22,7 @@ type BillingGateStatus = {
 };
 
 export function useBillingGateQuery() {
-  const { data: session } = useSession();
+  const { data: session } = useAuthSession();
 
   return useQuery({
     queryKey: [...BILLING_GATE_KEY],

--- a/src/hooks/use-public-or-team-query.ts
+++ b/src/hooks/use-public-or-team-query.ts
@@ -10,7 +10,7 @@
  */
 
 import { useQuery, type QueryKey } from '@tanstack/react-query';
-import { useSession } from '@/lib/auth/client';
+import { useAuthSession } from '@/lib/auth/session-query';
 
 export function usePublicOrTeamQuery<T>(options: {
   teamKey: QueryKey;
@@ -20,7 +20,7 @@ export function usePublicOrTeamQuery<T>(options: {
   enabled?: boolean;
   staleTime?: number;
 }) {
-  const { data: session, isPending, error: sessionError } = useSession();
+  const { data: session, isPending, error: sessionError } = useAuthSession();
   const isAuthenticated = !!session;
 
   return useQuery<T>({

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -4,7 +4,7 @@ import {
 } from '@/functions/ai';
 import { getPublicStylesFn, getStyleFn, getStylesFn } from '@/functions/styles';
 import { usePublicOrTeamQuery } from '@/hooks/use-public-or-team-query';
-import { useSession } from '@/lib/auth/client';
+import { useAuthSession } from '@/lib/auth/session-query';
 import { simpleHash } from '@/lib/utils/hash';
 import type { Style } from '@/types/database';
 import { useQuery } from '@tanstack/react-query';
@@ -68,7 +68,7 @@ export function useRecommendedStyles(
   script: string | null | undefined,
   options?: { enabled?: boolean; limit?: number }
 ) {
-  const { data: session, isPending } = useSession();
+  const { data: session } = useAuthSession();
   const isAuthenticated = !!session;
 
   const trimmed = (script ?? '').trim();
@@ -82,7 +82,6 @@ export function useRecommendedStyles(
     enabled:
       (options?.enabled ?? true) &&
       isAuthenticated &&
-      !isPending &&
       trimmed.length >= MIN_RECOMMEND_SCRIPT_LENGTH,
     staleTime: Infinity,
   });

--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -4,8 +4,7 @@ import { sessionQueryOptions } from '@/lib/auth/session-query';
 /**
  * Hook for client components that need user data. Reads from the session cache
  * populated by `_app/route.tsx` `beforeLoad` so SSR and client agree on
- * the auth state — see `getSessionFn` (isomorphic, reads cookies via
- * `getRequestHeaders()` on the server).
+ * the auth state — see `getSessionFn` (server-only `createServerFn`).
  */
 export function useUser() {
   return useQuery({

--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -1,6 +1,7 @@
 /**
  * BetterAuth client configuration for React components
- * Provides client-side authentication methods and hooks
+ * Provides client-side sign-in methods (OTP, Google, passkeys).
+ * Session *reads* use `useAuthSession` / `getSessionFn`, not `useSession`.
  */
 
 import { passkeyClient } from '@better-auth/passkey/client';
@@ -53,9 +54,5 @@ export const authClient = createAuthClient({
   ],
 });
 
-// Export hooks and methods for easy use
-export const {
-  useSession,
-
-  // useListSessions,
-} = authClient;
+// Sign-in / OTP / Google / passkeys only. Session *reads* go through
+// `useAuthSession` / `sessionQueryOptions` (see `src/lib/auth/server.ts`).

--- a/src/lib/auth/server.ts
+++ b/src/lib/auth/server.ts
@@ -1,37 +1,21 @@
 /**
- * Server-side authentication utilities for BetterAuth
- * Provides session management for Server Actions and API routes
+ * Session read for TanStack Start.
+ *
+ * Server-only `createServerFn` — Better Auth + Start's recommended pattern.
+ * Call from `beforeLoad` / React Query; the handler runs in-process on SSR
+ * and as an RPC on the client. Do not use `authClient.useSession()` for
+ * "am I logged in" — that is a second store that refetches on mount.
  */
 
-import { createIsomorphicFn } from '@tanstack/react-start';
+import { createServerFn } from '@tanstack/react-start';
 import { getRequestHeaders } from '@tanstack/react-start/server';
-import { authClient } from './client';
 import { getAuth } from './config';
 
-/**
- * Get the current session from server context
- * Works in Server Actions, API routes, and Server Components
- */
-export const getSessionFn = createIsomorphicFn()
-  .server(async () => {
-    const headers = getRequestHeaders();
+export const getSessionFn = createServerFn({ method: 'GET' }).handler(
+  async () => {
     const sessionData = await getAuth().api.getSession({
-      headers: headers,
+      headers: getRequestHeaders(),
     });
     return sessionData ?? null;
-  })
-  .client(async () => {
-    const { data: sessionData, error } = await authClient.getSession();
-
-    // A *failed* session lookup must not be conflated with "no session" —
-    // returning null here would make every consumer treat a signed-in user
-    // as anonymous (wrong data, bogus /login redirects) and hide the error.
-    if (error) {
-      throw new Error(
-        `Failed to fetch session: ${error.message ?? error.statusText}`,
-        { cause: error }
-      );
-    }
-
-    return sessionData ?? null;
-  });
+  }
+);

--- a/src/lib/auth/session-query.ts
+++ b/src/lib/auth/session-query.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from '@tanstack/react-query';
+import { queryOptions, useQuery } from '@tanstack/react-query';
 import { getSessionFn } from './server';
 
 export const sessionQueryOptions = queryOptions({
@@ -6,3 +6,12 @@ export const sessionQueryOptions = queryOptions({
   queryFn: () => getSessionFn(),
   staleTime: 5 * 60 * 1000,
 });
+
+/**
+ * Session from the React Query cache seeded by `_app` / `_auth` / gift
+ * `beforeLoad`. Prefer this over `authClient.useSession()`, which hits
+ * `/api/auth/get-session` on every mount and ignores the SSR payload.
+ */
+export function useAuthSession() {
+  return useQuery(sessionQueryOptions);
+}

--- a/src/routes/_app/route.tsx
+++ b/src/routes/_app/route.tsx
@@ -20,6 +20,11 @@ export const Route = createFileRoute('/_app')({
         to: '/login',
       });
     }
+
+    // Route context is the Start/Better Auth pattern; the RQ seed above
+    // keeps shared hooks (useUser, useAuthSession) in sync without a
+    // second client fetch after hydration.
+    return { session };
   },
 });
 

--- a/src/routes/_auth/route.tsx
+++ b/src/routes/_auth/route.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute('/_auth')({
     }
 
     const authOptions = await getAuthOptionsFn();
-    return { authOptions };
+    return { session, authOptions };
   },
   component: AuthLayout,
 });

--- a/src/routes/gift/$code.tsx
+++ b/src/routes/gift/$code.tsx
@@ -40,7 +40,8 @@ export const Route = createFileRoute('/gift/$code')({
     if (code.length !== 6) {
       throw redirect({ to: '/' });
     }
-    await queryClient.ensureQueryData(sessionQueryOptions);
+    const session = await queryClient.ensureQueryData(sessionQueryOptions);
+    return { session };
   },
   component: GiftCodePage,
 });


### PR DESCRIPTION
## Summary
- Replace the isomorphic `getSessionFn` (client path called `authClient.getSession()`) with a server-only `createServerFn`, matching the Better Auth × TanStack Start pattern.
- `_app`, `_auth`, and gift `beforeLoad` still seed React Query and now also `return { session }` for route context.
- All “am I logged in?” reads use `useAuthSession()` instead of `authClient.useSession()`. `authClient` stays for OTP / Google / passkeys / sign-out.

This was the homepage waterfall: HTML already knew anonymous, then JS waited on `/api/auth/get-session` before styles/talent/locations could start.

## Test plan
- [ ] `bun typecheck` / `bun lint`
- [ ] Hard-refresh `/` logged out: no `GET /api/auth/get-session` on first paint; showcase styles still load
- [ ] Hard-refresh `/` signed in: sidebar user, billing pill, and composer match the session with no flash to anonymous
- [ ] Sign out: UI flips to “Sign in” without a loading skeleton
- [ ] Gift code page and `/login` still redirect correctly when already signed in
- [ ] Suspended user still lands on `/login`