### PR TITLE
chore(models): bump @tanstack/ai 0.44.0 → 0.44.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@posthog/react": "^1.10.3",
         "@react-email/components": "^1.0.12",
         "@tailwindcss/typography": "^0.5.20",
-        "@tanstack/ai": "^0.44.0",
+        "@tanstack/ai": "^0.44.1",
         "@tanstack/ai-fal": "^0.10.0",
         "@tanstack/ai-openrouter": "^0.16.0",
         "@tanstack/react-query": "^5.101.4",
@@ -1093,7 +1093,7 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
-    "@tanstack/ai": ["@tanstack/ai@0.44.0", "", { "dependencies": { "@ag-ui/core": "0.1.1-canary.beta.0", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "^0.8.0", "@tanstack/ai-utils": "^0.4.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-tSHFNYg+x+SQeUUjIOqNmM0Y41+3Fw08LDE3A0vvN4+5O5EG/0SCLl6neCEsPuLPPKCHIJQIItWAfqQeQXR5qA=="],
+    "@tanstack/ai": ["@tanstack/ai@0.44.1", "", { "dependencies": { "@ag-ui/core": "0.1.1-canary.beta.0", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "^0.8.0", "@tanstack/ai-utils": "^0.4.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-pF5JWRqz3qEcrcsJG76D8NEiv7dCaknPmL3HYbUrt2XJDxEbjkGgNDV+eQ9fmcBLqg7i66AjDjJlcSuREtJu/A=="],
 
     "@tanstack/ai-devtools-core": ["@tanstack/ai-devtools-core@0.5.2", "", { "dependencies": { "@tanstack/ai": "^0.44.0", "@tanstack/ai-event-client": "^0.8.0", "@tanstack/devtools-ui": "^0.5.1", "@tanstack/devtools-utils": "^0.4.0", "goober": "^2.1.18", "solid-js": "^1.9.10" } }, "sha512-8bGbMVM/V/Wfl6OpgzZ/6uYPxNifKM7Vi9WmOsBlI3Op0mz1AZPHXZOWFRfPM8YRS+gNIM7mLfKLmu0fRz5b5w=="],
 
@@ -2868,6 +2868,8 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@tailwindcss/typography/postcss-selector-parser": ["postcss-selector-parser@6.0.10", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w=="],
+
+    "@tanstack/ai-devtools-core/@tanstack/ai": ["@tanstack/ai@0.44.0", "", { "dependencies": { "@ag-ui/core": "0.1.1-canary.beta.0", "@standard-schema/spec": "^1.1.0", "@tanstack/ai-event-client": "^0.8.0", "@tanstack/ai-utils": "^0.4.0", "partial-json": "^0.1.7" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-tSHFNYg+x+SQeUUjIOqNmM0Y41+3Fw08LDE3A0vvN4+5O5EG/0SCLl6neCEsPuLPPKCHIJQIItWAfqQeQXR5qA=="],
 
     "@tanstack/ai-event-client/@tanstack/devtools-event-client": ["@tanstack/devtools-event-client@0.4.3", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw=="],
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@posthog/react": "^1.10.3",
     "@react-email/components": "^1.0.12",
     "@tailwindcss/typography": "^0.5.20",
-    "@tanstack/ai": "^0.44.0",
+    "@tanstack/ai": "^0.44.1",
     "@tanstack/ai-fal": "^0.10.0",
     "@tanstack/ai-openrouter": "^0.16.0",
     "@tanstack/react-query": "^5.101.4",


### PR DESCRIPTION
## Related Issue

Opened by the daily model-freshness routine (#792) — no tracking issue.

## Summary of Changes

Bumps the core `@tanstack/ai` SDK by one patch release.

| | Registry key | Old | New |
| --- | --- | --- | --- |
| Package | `@tanstack/ai` | `^0.44.0` (resolved `0.44.0`) | `^0.44.1` (resolved `0.44.1`) |

- **Why it's a genuine successor:** `0.44.1` is a **patch** release of the same package — the current `latest` dist-tag on npm, published 2026-08-14. Not a major/breaking bump.
- **Link:** https://www.npmjs.com/package/@tanstack/ai/v/0.44.1
- **Regenerated files:** none — `package.json` + `bun.lock` only. No model-id, registry, or fal-pricing change, so no `motion:codegen` / `update-fal-pricing` needed.
- **Catalog-lag:** N/A — this is the core `@tanstack/ai` package, not `@tanstack/ai-openrouter`, so `CATALOG_LAG_MODELS` is untouched.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Patch-only dependency bump; all gates below pass locally.

## Additional Notes

Quality gates (all green locally):

- `bun typecheck` ✅
- `bun lint` ✅ (only pre-existing warnings in unrelated files)
- `bun run test src/lib/ai src/lib/motion` ✅ — 40 files, 460 tests passed

🤖 Opened by the daily model-freshness routine (#792). Verify pricing & quality before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuftWy2HmZA34ykS4pxRkv)_