### PR TITLE
feat(#1180): default the composer style row to cinematic families

### DIFF
--- a/e2e/fixtures/test-utils.ts
+++ b/e2e/fixtures/test-utils.ts
@@ -29,6 +29,29 @@ export async function waitForScriptEditor(page: Page): Promise<Locator> {
 }
 
 /**
+ * Pick a named style on the composer strip.
+ *
+ * The row defaults to Film & Cinematic (#1180). Styles in another family
+ * need the category dropdown first — `family` is the radio label
+ * (e.g. "E-commerce").
+ */
+export async function selectComposerStyle(
+  page: Page,
+  styleName: string,
+  family?: string
+): Promise<void> {
+  if (family) {
+    await page.getByRole('button', { name: /^Style category:/ }).click();
+    await page.getByRole('menuitemradio', { name: family }).click();
+  }
+  const tile = page
+    .getByRole('grid', { name: 'Style selection' })
+    .getByRole('button', { name: `Select ${styleName} style` });
+  await expect(tile).toBeVisible({ timeout: HYDRATION_TIMEOUT });
+  await tile.click();
+}
+
+/**
  * Wait until every file picked in an add/edit dialog has finished uploading.
  *
  * Order matters. The submit button is only disabled while

--- a/e2e/tests/full-sequence.spec.ts
+++ b/e2e/tests/full-sequence.spec.ts
@@ -34,7 +34,10 @@ import {
   getSystemTalentByName,
   type TestTalent,
 } from '../fixtures/talent.fixture';
-import { waitForScriptEditor } from '../fixtures/test-utils';
+import {
+  selectComposerStyle,
+  waitForScriptEditor,
+} from '../fixtures/test-utils';
 import { t } from '../recording-mode';
 
 const fullPipeline = process.env.PLAYWRIGHT_FULL_PIPELINE === 'true';
@@ -194,19 +197,11 @@ testWithUser.describe('Full Sequence Pipeline', () => {
       // 1. Open the new-sequence page.
       await page.goto('/sequences/new');
 
-      // 2. Select the first style tile. Target the tile by its accessible
-      // name (`Select <name> style`) and wait for it to exist — the grid
-      // container renders immediately (before styles load) and its only
-      // button is then the "View all" browse trigger, which would open the
-      // style dialog instead of selecting.
-      // Waiting for a real tile also confirms the styles query resolved and
-      // React has hydrated.
-      const firstStyle = page
-        .getByRole('grid', { name: 'Style selection' })
-        .getByRole('button', { name: /^Select .* style$/ })
-        .first();
-      await expect(firstStyle).toBeVisible({ timeout: 15_000 });
-      await firstStyle.click();
+      // 2. Recorded image/motion fixtures were captured against Product Ad.
+      // The composer now defaults to Film & Cinematic (#1180), so switch
+      // the row and pick that style by name — clicking `.first()` would
+      // land on Action and miss every fal fixture.
+      await selectComposerStyle(page, 'Product Ad', 'E-commerce');
 
       // 3. Type a short script — a 30-second makeup ad.
       const script = `

--- a/e2e/tests/sequences.spec.ts
+++ b/e2e/tests/sequences.spec.ts
@@ -26,6 +26,24 @@ test.describe('Sequences', () => {
     await expect(editor).toBeVisible();
   });
 
+  test('composer style row defaults to cinematic and can switch family', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await expect(
+      page.getByRole('button', { name: 'Style category: Film & Cinematic' })
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByRole('button', { name: 'Select Action style' })
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: /^Style category:/ }).click();
+    await page.getByRole('menuitemradio', { name: 'E-commerce' }).click();
+    await expect(
+      page.getByRole('button', { name: 'Select Product Ad style' })
+    ).toBeVisible();
+  });
+
   test('signed-in user can access /sequences/new', async ({ page }) => {
     // chromium project loads e2e/.auth/user.json — this is the logged-in alias
     // of the home composer (#1104). Anonymous redirect is in auth.spec.ts.

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -10,6 +10,7 @@ import { GenerateSequenceIcon } from '@/components/icons/generate-sequence-icon'
 import { LocationSuggestionSelector } from '@/components/location-library/location-suggestion-selector';
 import { buildMentionItems } from '@/components/scenes/prompt-mention/mention-items';
 import { GenerationSettings } from '@/components/settings/generation-settings';
+import { StyleCategorySelect } from '@/components/style/style-category-select';
 import { StyleSelector } from '@/components/style/style-selector';
 import { TalentSuggestionSelector } from '@/components/talent/talent-suggestion-selector';
 import {
@@ -80,6 +81,13 @@ import {
 } from '@/lib/constants/aspect-ratios';
 import { estimateSceneCount } from '@/lib/generation/time-estimate';
 import { replaceTokenInText } from '@/lib/sequence-elements/cascade-rename';
+import {
+  ALL_COMPOSER_STYLE_CATEGORIES,
+  DEFAULT_COMPOSER_STYLE_CATEGORY,
+  defaultComposerStyle,
+  styleAfterComposerCategoryChange,
+  styleCategoryGroupKey,
+} from '@/lib/style/composer-style-row';
 import { cn } from '@/lib/utils';
 import {
   dataTransferHasImages,
@@ -179,11 +187,11 @@ export const ScriptView: FC<{
   const setStyleId = (v: string | null) =>
     setContentState((s) => ({ ...s, styleId: v }));
   // A user-initiated style pick: update local state and mirror it to the URL.
-  // The auto-selected default calls `setStyleId` directly, so a bare
+  // The auto-selected default calls `setStyleId` directly, so a
   // bare composer URL stays bare until the user actually chooses.
-  const selectStyle = (styleId: string) => {
-    setStyleId(styleId);
-    onStyleChange?.(styleId);
+  const selectStyle = (nextStyleId: string) => {
+    setStyleId(nextStyleId);
+    onStyleChange?.(nextStyleId);
   };
 
   // Load saved settings from localStorage
@@ -316,14 +324,6 @@ export const ScriptView: FC<{
   // and avoids a hydration mismatch (#style-selector "View all 0 styles").
   const { data: styles = [], isPending: isLoadingStyles } = useStyles();
 
-  // Auto-select first style if none selected
-  useEffect(() => {
-    const firstStyle = styles[0];
-    if (!isLoadingStyles && firstStyle && !styleId && !sequence?.styleId) {
-      setStyleId(firstStyle.id);
-    }
-  }, [styles, isLoadingStyles, styleId, sequence?.styleId]);
-
   // Derive style metadata for motion model filtering + recommendation badges
   const selectedStyle = useMemo(
     () => styles.find((s) => s.id === (styleId || sequence?.styleId)),
@@ -331,6 +331,45 @@ export const ScriptView: FC<{
   );
   const styleCategory = selectedStyle?.category ?? undefined;
   const styleName = selectedStyle?.name ?? undefined;
+
+  // The row follows the selected style, except while the user parks on All
+  // styles (`categoryOverride`). Draft / `?style=` / tile picks then show
+  // that family's strip without a snap effect.
+  const [categoryOverride, setCategoryOverride] = useState<string | null>(null);
+  const styleCategoryFilter =
+    categoryOverride ??
+    (selectedStyle
+      ? styleCategoryGroupKey(selectedStyle, styles)
+      : DEFAULT_COMPOSER_STYLE_CATEGORY);
+
+  const handleStyleSelect = (nextStyleId: string) => {
+    selectStyle(nextStyleId);
+    // Follow the pick's family unless the user is browsing All styles.
+    if (categoryOverride !== ALL_COMPOSER_STYLE_CATEGORIES) {
+      setCategoryOverride(null);
+    }
+  };
+
+  const handleStyleCategoryChange = (next: string) => {
+    setCategoryOverride(next);
+    // Named families replace the pick; All only changes the strip.
+    const first = styleAfterComposerCategoryChange(styles, next);
+    if (first) selectStyle(first.id);
+  };
+
+  // Auto-select the first style in the current row when the composer has
+  // no pick yet (the row starts as Film & Cinematic).
+  useEffect(() => {
+    if (isLoadingStyles || styleId || sequence?.styleId) return;
+    const firstStyle = defaultComposerStyle(styles, styleCategoryFilter);
+    if (firstStyle) setStyleId(firstStyle.id);
+  }, [
+    styles,
+    isLoadingStyles,
+    styleId,
+    sequence?.styleId,
+    styleCategoryFilter,
+  ]);
 
   // Sequence cast/elements/locations drive @-mention pills in the script
   // editor — same canonical tags the scene prompt editors use. An existing
@@ -1048,25 +1087,33 @@ export const ScriptView: FC<{
           )}
 
           <div className="shrink-0 flex flex-col gap-3">
-            <div className="flex items-center justify-between gap-3">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                disabled={
-                  loading || currentScriptText.length < 3 || isRecommending
-                }
-                onClick={triggerRecommend}
-              >
-                {isRecommending ? (
-                  <Loader2 className="size-3.5 animate-spin text-primary" />
-                ) : (
-                  <Sparkles className="size-3.5 text-primary" />
-                )}
-                {recommendButtonLabel}
-              </Button>
-              <div className="flex items-center gap-1 shrink-0">
+            <div className="flex flex-col gap-2 @min-[480px]:flex-row @min-[480px]:items-center @min-[480px]:justify-between">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  disabled={
+                    loading || currentScriptText.length < 3 || isRecommending
+                  }
+                  onClick={triggerRecommend}
+                >
+                  {isRecommending ? (
+                    <Loader2 className="size-3.5 animate-spin text-primary" />
+                  ) : (
+                    <Sparkles className="size-3.5 text-primary" />
+                  )}
+                  {recommendButtonLabel}
+                </Button>
+                <StyleCategorySelect
+                  styles={styles}
+                  value={styleCategoryFilter}
+                  onChange={handleStyleCategoryChange}
+                  disabled={loading || isLoadingStyles}
+                />
+              </div>
+              <div className="flex shrink-0 items-center justify-end gap-1">
                 {canUndoEnhance && !isEnhancing && (
                   <Button
                     type="button"
@@ -1159,10 +1206,11 @@ export const ScriptView: FC<{
             <StyleSelector
               styles={styles}
               selectedStyleId={styleId || sequence?.styleId || null}
-              onStyleSelect={selectStyle}
+              onStyleSelect={handleStyleSelect}
               loading={isLoadingStyles}
               recommendations={activeRecommendations}
               recommendationsLoading={isRecommending && !recommendationsStale}
+              categoryFilter={styleCategoryFilter}
             />
             {(recommendEmpty || recommendFailed) && (
               <p className="text-xs text-muted-foreground">

--- a/src/components/style/style-category-select.stories.tsx
+++ b/src/components/style/style-category-select.stories.tsx
@@ -1,0 +1,55 @@
+import { MOCK_SYSTEM_STYLES } from '@/lib/style/style-templates';
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { DEFAULT_COMPOSER_STYLE_CATEGORY } from '@/lib/style/composer-style-row';
+import { StyleCategorySelect } from './style-category-select';
+
+const meta: Meta<typeof StyleCategorySelect> = {
+  title: 'Style/StyleCategorySelect',
+  component: StyleCategorySelect,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StyleCategorySelect>;
+
+export const Default: Story = {
+  render: function RenderDefault() {
+    const [value, setValue] = useState(DEFAULT_COMPOSER_STYLE_CATEGORY);
+    return (
+      <StyleCategorySelect
+        styles={MOCK_SYSTEM_STYLES}
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};
+
+export const AllStyles: Story = {
+  render: function RenderAllStyles() {
+    const [value, setValue] = useState('all');
+    return (
+      <StyleCategorySelect
+        styles={MOCK_SYSTEM_STYLES}
+        value={value}
+        onChange={setValue}
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: function RenderDisabled() {
+    return (
+      <StyleCategorySelect
+        styles={MOCK_SYSTEM_STYLES}
+        value={DEFAULT_COMPOSER_STYLE_CATEGORY}
+        onChange={() => undefined}
+        disabled
+      />
+    );
+  },
+};

--- a/src/components/style/style-category-select.tsx
+++ b/src/components/style/style-category-select.tsx
@@ -1,0 +1,69 @@
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  ALL_COMPOSER_STYLE_CATEGORIES,
+  composerStyleCategoryOptions,
+} from '@/lib/style/composer-style-row';
+import { styleCategoryLabel } from '@/lib/style/style-assets';
+import type { Style } from '@/types/database';
+import { ChevronDown } from 'lucide-react';
+
+type StyleCategorySelectProps = {
+  styles: Style[];
+  value: string;
+  onChange: (category: string) => void;
+  disabled?: boolean;
+  size?: 'sm' | 'default' | 'lg';
+};
+
+export function StyleCategorySelect({
+  styles,
+  value,
+  onChange,
+  disabled = false,
+  size = 'sm',
+}: StyleCategorySelectProps) {
+  const families = composerStyleCategoryOptions(styles);
+  const isAll = value === ALL_COMPOSER_STYLE_CATEGORIES;
+  const selected = families.find((option) => option.value === value);
+  const label = isAll
+    ? 'All styles'
+    : (selected?.label ?? styleCategoryLabel(value));
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size={size}
+          disabled={disabled}
+          aria-label={`Style category: ${label}`}
+        >
+          <span className="max-w-40 truncate">{label}</span>
+          <ChevronDown className="size-3.5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuRadioGroup value={value} onValueChange={onChange}>
+          {families.map((option) => (
+            <DropdownMenuRadioItem key={option.value} value={option.value}>
+              {option.label}
+            </DropdownMenuRadioItem>
+          ))}
+          {families.length > 0 ? <DropdownMenuSeparator /> : null}
+          <DropdownMenuRadioItem value={ALL_COMPOSER_STYLE_CATEGORIES}>
+            All styles
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/style/style-selector.stories.tsx
+++ b/src/components/style/style-selector.stories.tsx
@@ -1,4 +1,6 @@
 import { generateMockStyles } from '@/lib/mocks/data-generators';
+import { DEFAULT_COMPOSER_STYLE_CATEGORY } from '@/lib/style/composer-style-row';
+import { MOCK_SYSTEM_STYLES } from '@/lib/style/style-templates';
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
@@ -35,6 +37,36 @@ export const Default: Story = {
         styles={mockStyles}
         selectedStyleId={selectedStyleId}
         onStyleSelect={setSelectedStyleId}
+      />
+    );
+  },
+};
+
+const firstFilmStyle = MOCK_SYSTEM_STYLES.find(
+  (style) => style.category === DEFAULT_COMPOSER_STYLE_CATEGORY
+);
+if (!firstFilmStyle) {
+  throw new Error('story setup: expected a film style in MOCK_SYSTEM_STYLES');
+}
+
+export const CinematicRow: Story = {
+  args: {
+    styles: MOCK_SYSTEM_STYLES,
+    selectedStyleId: firstFilmStyle.id,
+    onStyleSelect: fn(),
+    categoryFilter: DEFAULT_COMPOSER_STYLE_CATEGORY,
+  },
+  render: function RenderCinematicRow() {
+    const [selectedStyleId, setSelectedStyleId] = useState<string | null>(
+      firstFilmStyle.id
+    );
+
+    return (
+      <StyleSelector
+        styles={MOCK_SYSTEM_STYLES}
+        selectedStyleId={selectedStyleId}
+        onStyleSelect={setSelectedStyleId}
+        categoryFilter={DEFAULT_COMPOSER_STYLE_CATEGORY}
       />
     );
   },

--- a/src/components/style/style-selector.tsx
+++ b/src/components/style/style-selector.tsx
@@ -4,6 +4,11 @@ import { Info, MoreHorizontal } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { StyleRecommendation } from '@/hooks/use-styles';
 import {
+  ALL_COMPOSER_STYLE_CATEGORIES,
+  composerCategoryHiddenCount,
+  stylesForComposerCategory,
+} from '@/lib/style/composer-style-row';
+import {
   buildRecommendationReasoningMap,
   catalogueWithoutRecommendations,
   RECOMMENDED_STYLE_SLOT_COUNT,
@@ -18,8 +23,7 @@ import type { Style } from '@/lib/db/schema/libraries';
  * Keep specific styles on screen without reordering the strip: any catalogue
  * style in `keep` that fell outside the visible head is swapped into the tail
  * slots (deduped, order preserved). Used so the current selection and the last
- * browse-dialog pick always stay reachable, even when they sit deep in the
- * catalogue.
+ * browse-dialog pick stay reachable *within the current category catalogue*.
  */
 function keepStylesVisible(
   head: Style[],
@@ -57,6 +61,8 @@ type StyleSelectorProps = {
   disabled?: boolean;
   recommendations?: StyleRecommendation[];
   recommendationsLoading?: boolean;
+  /** Filters the catalogue tiles. Recommendations and the browse dialog stay unfiltered. */
+  categoryFilter?: string;
 };
 
 export function StyleSelector({
@@ -67,12 +73,13 @@ export function StyleSelector({
   disabled = false,
   recommendations,
   recommendationsLoading = false,
+  categoryFilter = ALL_COMPOSER_STYLE_CATEGORIES,
 }: StyleSelectorProps) {
   const [dialogOpen, setDialogOpen] = useState(false);
   const [detailStyle, setDetailStyle] = useState<Style | null>(null);
   // The last style chosen from the "browse all" dialog. It stays pinned into
-  // the strip even after other tiles are selected, and only clears when the
-  // composer remounts (i.e. a fresh sequence).
+  // the strip when it belongs to the current category, and only clears when
+  // the composer remounts (i.e. a fresh sequence).
   const [pinnedStyleId, setPinnedStyleId] = useState<string | null>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const [focusableIndex, setFocusableIndex] = useState(0);
@@ -130,13 +137,18 @@ export function StyleSelector({
       : recommendedStyles.length
     : 0;
 
+  const categoryStyles = useMemo(
+    () => stylesForComposerCategory(styles, categoryFilter),
+    [styles, categoryFilter]
+  );
+
   const catalogueStyles = useMemo(
     () =>
       catalogueWithoutRecommendations(
-        styles,
+        categoryStyles,
         showRecommendations ? recommendations : undefined
       ),
-    [styles, recommendations, showRecommendations]
+    [categoryStyles, recommendations, showRecommendations]
   );
 
   const selectedStyle = styles.find((s) => s.id === selectedStyleId) ?? null;
@@ -169,7 +181,10 @@ export function StyleSelector({
     return ids;
   }, [recommendedStyles, visibleCatalogueStyles]);
 
-  const hiddenCount = Math.max(0, styles.length - shownStyleIds.size);
+  const hiddenCount = composerCategoryHiddenCount(
+    categoryStyles,
+    shownStyleIds
+  );
 
   useEffect(() => {
     const recIndex = recommendedStyles.findIndex(

--- a/src/lib/style/composer-style-row.test.ts
+++ b/src/lib/style/composer-style-row.test.ts
@@ -1,0 +1,183 @@
+import {
+  ALL_COMPOSER_STYLE_CATEGORIES,
+  composerCategoryHiddenCount,
+  composerStyleCategoryOptions,
+  defaultComposerStyle,
+  styleAfterComposerCategoryChange,
+  stylesForComposerCategory,
+} from '@/lib/style/composer-style-row';
+import type { Style } from '@/types/database';
+import { describe, expect, it } from 'vitest';
+
+function makeStyle(overrides: Partial<Style> = {}): Style {
+  return {
+    id: 'style_1',
+    teamId: 'team_1',
+    name: 'Product Ad',
+    description: 'A polished product spot.',
+    config: {
+      mood: 'premium',
+      artStyle: 'clean',
+      lighting: 'soft',
+      colorPalette: ['#000000', '#FFFFFF'],
+      cameraWork: 'slow push',
+      referenceFilms: [],
+      colorGrading: 'neutral',
+    },
+    category: 'commercial',
+    tags: [],
+    isPublic: true,
+    isTemplate: true,
+    previewUrl: 'https://assets.openstory.so/styles/product-ad/thumbnail.webp',
+    sampleVideos: [],
+    recommendedImageModel: null,
+    recommendedVideoModel: null,
+    defaultAspectRatio: null,
+    useCases: [],
+    sortOrder: 0,
+    usageCount: 0,
+    version: 1,
+    createdAt: new Date('2026-01-01'),
+    updatedAt: new Date('2026-01-01'),
+    createdBy: null,
+    ...overrides,
+  };
+}
+
+function trio(category: string): Style[] {
+  return [0, 1, 2].map((i) =>
+    makeStyle({
+      id: `${category}-${i}`,
+      category,
+      name: `${category} ${i}`,
+    })
+  );
+}
+
+describe('composerStyleCategoryOptions', () => {
+  it('puts Film & Cinematic first', () => {
+    const options = composerStyleCategoryOptions([
+      ...trio('tech'),
+      ...trio('ecommerce'),
+      ...trio('film'),
+    ]);
+    expect(options[0]).toEqual({
+      value: 'film',
+      label: 'Film & Cinematic',
+    });
+    expect(options.map((option) => option.value)).toEqual([
+      'film',
+      'ecommerce',
+      'tech',
+    ]);
+  });
+
+  it('omits film when the catalogue has none', () => {
+    const values = composerStyleCategoryOptions(trio('ecommerce')).map(
+      (option) => option.value
+    );
+    expect(values).toEqual(['ecommerce']);
+  });
+});
+
+describe('stylesForComposerCategory', () => {
+  const styles = [...trio('ecommerce'), ...trio('film')];
+
+  it('keeps catalogue order inside the requested family', () => {
+    expect(
+      stylesForComposerCategory(styles, 'film').map((style) => style.id)
+    ).toEqual(['film-0', 'film-1', 'film-2']);
+  });
+
+  it('returns the full list in catalogue order for all', () => {
+    expect(
+      stylesForComposerCategory(styles, ALL_COMPOSER_STYLE_CATEGORIES).map(
+        (style) => style.id
+      )
+    ).toEqual([
+      'ecommerce-0',
+      'ecommerce-1',
+      'ecommerce-2',
+      'film-0',
+      'film-1',
+      'film-2',
+    ]);
+  });
+
+  it('uses Specialized for small leftover families', () => {
+    const catalogue = [
+      ...trio('film'),
+      makeStyle({ id: 'travel', category: 'travel', name: 'Travel' }),
+    ];
+    expect(
+      stylesForComposerCategory(catalogue, 'specialized').map(
+        (style) => style.id
+      )
+    ).toEqual(['travel']);
+  });
+});
+
+describe('defaultComposerStyle', () => {
+  const styles = [...trio('ecommerce'), ...trio('film')];
+
+  it('picks the first cinematic style, not the commercial-first catalogue head', () => {
+    expect(defaultComposerStyle(styles)?.id).toBe('film-0');
+  });
+
+  it('honors an explicit family', () => {
+    expect(defaultComposerStyle(styles, 'ecommerce')?.id).toBe('ecommerce-0');
+  });
+
+  it('falls back to the catalogue head when the family is empty', () => {
+    expect(
+      defaultComposerStyle(
+        [
+          makeStyle({
+            id: 'product',
+            category: 'ecommerce',
+            name: 'Product Ad',
+          }),
+        ],
+        'film'
+      )?.id
+    ).toBe('product');
+  });
+});
+
+describe('styleAfterComposerCategoryChange', () => {
+  const styles = [...trio('ecommerce'), ...trio('film')];
+
+  it('selects the first style of the new family', () => {
+    expect(styleAfterComposerCategoryChange(styles, 'ecommerce')?.id).toBe(
+      'ecommerce-0'
+    );
+  });
+
+  it('does not change the pick when switching to All styles', () => {
+    expect(
+      styleAfterComposerCategoryChange(styles, ALL_COMPOSER_STYLE_CATEGORIES)
+    ).toBeUndefined();
+  });
+});
+
+describe('composerCategoryHiddenCount', () => {
+  const film = [
+    makeStyle({ id: 'action', category: 'film', name: 'Action' }),
+    makeStyle({ id: 'award', category: 'film', name: 'Award Season' }),
+    makeStyle({ id: 'doc', category: 'film', name: 'Documentary' }),
+  ];
+
+  it('counts family tiles that are not on the strip', () => {
+    expect(composerCategoryHiddenCount(film, ['action'])).toBe(2);
+  });
+
+  it('ignores recommended tiles from other families', () => {
+    expect(composerCategoryHiddenCount(film, ['product', 'action'])).toBe(2);
+  });
+
+  it('is zero when the whole family is visible', () => {
+    expect(composerCategoryHiddenCount(film, ['action', 'award', 'doc'])).toBe(
+      0
+    );
+  });
+});

--- a/src/lib/style/composer-style-row.ts
+++ b/src/lib/style/composer-style-row.ts
@@ -1,0 +1,92 @@
+import {
+  groupStylesByCategory,
+  styleCategoryGroupKey,
+} from '@/lib/style/style-assets';
+import type { Style } from '@/types/database';
+
+/**
+ * Composer strip default. Catalogue `sortOrder` is commercial-first (#355);
+ * the script-view row promotes the cinematic family instead and lets the
+ * category dropdown reach everything else.
+ */
+export const DEFAULT_COMPOSER_STYLE_CATEGORY = 'film';
+
+/** Dropdown sentinel — not a `styles.category` value and not a group key. */
+export const ALL_COMPOSER_STYLE_CATEGORIES = 'all';
+
+export type ComposerStyleCategoryOption = {
+  value: string;
+  label: string;
+};
+
+/** Film & Cinematic first, then the usual grouped catalogue. All styles is UI. */
+export function composerStyleCategoryOptions(
+  styles: Style[]
+): ComposerStyleCategoryOption[] {
+  const groups = groupStylesByCategory(styles);
+  return [
+    ...groups.filter(
+      (group) => group.category === DEFAULT_COMPOSER_STYLE_CATEGORY
+    ),
+    ...groups.filter(
+      (group) => group.category !== DEFAULT_COMPOSER_STYLE_CATEGORY
+    ),
+  ].map((group) => ({ value: group.category, label: group.label }));
+}
+
+/**
+ * Catalogue tiles for the current composer-row filter. Uses the same group
+ * keys as the dropdown (`specialized`, `other`, `film`, …) so a family and
+ * its strip always agree.
+ */
+export function stylesForComposerCategory(
+  styles: Style[],
+  category: string
+): Style[] {
+  if (category === ALL_COMPOSER_STYLE_CATEGORIES) return styles;
+  return styles.filter(
+    (style) => styleCategoryGroupKey(style, styles) === category
+  );
+}
+
+/**
+ * First style in the filtered row, falling back to the catalogue head when
+ * the requested family is empty (custom teams with no cinematic styles).
+ */
+export function defaultComposerStyle(
+  styles: Style[],
+  category: string = DEFAULT_COMPOSER_STYLE_CATEGORY
+): Style | undefined {
+  return stylesForComposerCategory(styles, category)[0] ?? styles[0];
+}
+
+/**
+ * Style to apply when the dropdown changes. `all` keeps the current pick
+ * (`undefined` here) so All styles never resets to Product Ad.
+ */
+export function styleAfterComposerCategoryChange(
+  styles: Style[],
+  next: string
+): Style | undefined {
+  if (next === ALL_COMPOSER_STYLE_CATEGORIES) return undefined;
+  return defaultComposerStyle(styles, next);
+}
+
+/**
+ * How many styles in the current family are not on the strip. Recommended
+ * tiles from other families do not count as shown for this family, so
+ * "+N More" stays a count of hidden cinematic (etc.) tiles.
+ */
+export function composerCategoryHiddenCount(
+  categoryStyles: Style[],
+  shownIds: Iterable<string>
+): number {
+  const shown = shownIds instanceof Set ? shownIds : new Set(shownIds);
+  let shownFromCategory = 0;
+  for (const style of categoryStyles) {
+    if (shown.has(style.id)) shownFromCategory += 1;
+  }
+  return Math.max(0, categoryStyles.length - shownFromCategory);
+}
+
+export { styleCategoryGroupKey };

--- a/src/lib/style/style-assets.test.ts
+++ b/src/lib/style/style-assets.test.ts
@@ -3,6 +3,7 @@ import type { Style } from '@/types/database';
 import {
   groupStylesByCategory,
   styleCanonicalVideoUrl,
+  styleCategoryGroupKey,
   styleCategoryLabel,
   styleHoverVideoUrl,
   stylePreviewImageUrls,
@@ -128,6 +129,7 @@ describe('styleCategoryLabel', () => {
   it('maps known categories to friendly labels', () => {
     expect(styleCategoryLabel('ecommerce')).toBe('E-commerce');
     expect(styleCategoryLabel('influencer')).toBe('Influencer & UGC');
+    expect(styleCategoryLabel('film')).toBe('Film & Cinematic');
   });
 
   it('title-cases unknown categories and labels missing as Other', () => {
@@ -184,5 +186,27 @@ describe('groupStylesByCategory', () => {
       'Banana',
       'Cherry',
     ]);
+  });
+});
+
+describe('styleCategoryGroupKey', () => {
+  it('returns the raw category when the family is large enough', () => {
+    const catalogue = [...trio('film'), ...trio('ecommerce')];
+    expect(
+      styleCategoryGroupKey(makeStyle({ category: 'film' }), catalogue)
+    ).toBe('film');
+  });
+
+  it('collapses small families into Specialized', () => {
+    const catalogue = [
+      ...trio('film'),
+      makeStyle({ id: 'travel', category: 'travel' }),
+    ];
+    expect(
+      styleCategoryGroupKey(
+        makeStyle({ id: 'travel', category: 'travel' }),
+        catalogue
+      )
+    ).toBe('specialized');
   });
 });

--- a/src/lib/style/style-assets.ts
+++ b/src/lib/style/style-assets.ts
@@ -157,6 +157,20 @@ export function styleCategoryLabel(
   );
 }
 
+/**
+ * The group key a style lands in after small-category collapse. Matches
+ * `groupStylesByCategory` so a composer filter and the browse-page sections
+ * agree on Specialized vs a named family.
+ */
+export function styleCategoryGroupKey(
+  style: Style,
+  catalogue: Style[]
+): string {
+  const rawKey = style.category ?? UNCATEGORIZED_KEY;
+  if (smallCategoryKeys(catalogue).has(rawKey)) return SPECIALIZED_CATEGORY;
+  return style.category ?? 'other';
+}
+
 export type StyleCategoryGroup = {
   category: string;
   label: string;


### PR DESCRIPTION
## Summary
- Start the script-view style strip on **Film & Cinematic** (Action) instead of commercial-first Product Ad.
- Add a category dropdown next to **Recommend styles** so users can switch the row by family, or show All styles.
- The row follows the selected style (`?style=`, draft, tile/browse pick). All styles is a view-only override and does not reset the pick.
- Recommend, More, and `/styles` stay unfiltered.

Closes #1180.

## Test plan
- [x] Fresh `/` shows Film & Cinematic and auto-selects Action
- [x] Dropdown switches the row (E-commerce, All styles, back to Film)
- [x] `/?style=product-ad` snaps the dropdown to E-commerce
- [x] Mobile stacks Recommend / category / Enhance without overlap
- [x] `/styles` browse dialog still groups by category
- [x] Unit tests for options, default pick, All-styles no-op, hidden-count