### PR TITLE
SSR anonymous front page images and cut LCP 4.7×

### DIFF
--- a/scripts/measure-front-page.ts
+++ b/scripts/measure-front-page.ts
@@ -1,0 +1,203 @@
+/**
+ * Lab measurement for `/` first paint + images.
+ *
+ * Usage:
+ *   bun scripts/measure-front-page.ts [url] [label]
+ *
+ * Writes JSON to /tmp/openstory-perf/<label>.json
+ */
+import { chromium } from 'playwright';
+import { mkdir, writeFile } from 'node:fs/promises';
+
+const url = process.argv[2] ?? 'http://localhost:3000/';
+const label = process.argv[3] ?? 'run';
+const runs = Number(process.argv[4] ?? 3);
+
+type Run = {
+  ttfbMs: number;
+  fcpMs: number;
+  lcpMs: number;
+  lcpTag: string;
+  lcpUrl: string;
+  firstMediaMs: number;
+  firstMediaCompleteMs: number;
+  imgCount: number;
+  videoCount: number;
+  posterCount: number;
+  htmlImg: number;
+  htmlVideo: number;
+  htmlPoster: number;
+  htmlHasHeading: boolean;
+  htmlHasShowcaseHeading: boolean;
+  htmlSkeletonCount: number;
+};
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const value = sorted[mid];
+  return value ?? 0;
+}
+
+async function oneRun(): Promise<Run> {
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+  });
+  const page = await context.newPage();
+
+  let html = '';
+  page.on('response', (response) => {
+    const request = response.request();
+    if (request.resourceType() !== 'document') return;
+    if (new URL(response.url()).pathname !== '/') return;
+    void response.text().then((body) => {
+      html = body;
+    });
+  });
+
+  await page.addInitScript(() => {
+    const state = {
+      fcp: 0,
+      lcp: 0,
+      lcpTag: '',
+      lcpUrl: '',
+      firstMedia: 0,
+      firstMediaComplete: 0,
+    };
+    (
+      globalThis as typeof globalThis & { __frontPagePerf?: typeof state }
+    ).__frontPagePerf = state;
+
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.name === 'first-contentful-paint') {
+          state.fcp = entry.startTime;
+        }
+      }
+    }).observe({ type: 'paint', buffered: true });
+
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      const last = entries[entries.length - 1];
+      if (!last) return;
+      state.lcp = last.startTime;
+      const element = 'element' in last ? last.element : undefined;
+      state.lcpTag = element instanceof Element ? element.tagName : '';
+      state.lcpUrl =
+        'url' in last && typeof last.url === 'string' ? last.url : '';
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+
+    const markMedia = () => {
+      const nodes = [
+        ...document.querySelectorAll<HTMLImageElement>('img'),
+        ...document.querySelectorAll<HTMLVideoElement>('video[poster]'),
+      ];
+      if (nodes.length > 0 && state.firstMedia === 0) {
+        state.firstMedia = performance.now();
+      }
+      const ready = nodes.some((node) => {
+        if (node instanceof HTMLImageElement) {
+          return node.complete && node.naturalWidth > 0;
+        }
+        return Boolean(node.getAttribute('poster'));
+      });
+      if (ready && state.firstMediaComplete === 0) {
+        state.firstMediaComplete = performance.now();
+      }
+    };
+
+    new MutationObserver(markMedia).observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['src', 'srcset', 'poster'],
+    });
+  });
+
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  await page
+    .waitForSelector('img, video[poster]', { timeout: 8_000 })
+    .catch(() => undefined);
+  // Settle LCP after first media (or the timeout if none arrived).
+  await page.waitForTimeout(2_000);
+
+  const client = await page.evaluate(() => {
+    const nav = performance.getEntriesByType('navigation')[0];
+    const ttfbMs =
+      nav && 'responseStart' in nav && typeof nav.responseStart === 'number'
+        ? nav.responseStart
+        : 0;
+    const state = (
+      globalThis as typeof globalThis & {
+        __frontPagePerf?: {
+          fcp: number;
+          lcp: number;
+          lcpTag: string;
+          lcpUrl: string;
+          firstMedia: number;
+          firstMediaComplete: number;
+        };
+      }
+    ).__frontPagePerf;
+    return {
+      ttfbMs,
+      fcpMs: state?.fcp ?? 0,
+      lcpMs: state?.lcp ?? 0,
+      lcpTag: state?.lcpTag ?? '',
+      lcpUrl: state?.lcpUrl ?? '',
+      firstMediaMs: state?.firstMedia ?? 0,
+      firstMediaCompleteMs: state?.firstMediaComplete ?? 0,
+      imgCount: document.querySelectorAll('img').length,
+      videoCount: document.querySelectorAll('video').length,
+      posterCount: document.querySelectorAll('video[poster]').length,
+    };
+  });
+
+  await browser.close();
+
+  const htmlImg = (html.match(/<img/gi) ?? []).length;
+  const htmlVideo = (html.match(/<video/gi) ?? []).length;
+  const htmlPoster = (html.match(/poster=/gi) ?? []).length;
+  const htmlSkeletonCount = (html.match(/animate-pulse/gi) ?? []).length;
+
+  return {
+    ...client,
+    htmlImg,
+    htmlVideo,
+    htmlPoster,
+    htmlHasHeading: html.includes('Tell your whole story'),
+    htmlHasShowcaseHeading: html.includes('See what you can create'),
+    htmlSkeletonCount,
+  };
+}
+
+const results: Run[] = [];
+for (let i = 0; i < runs; i++) {
+  const run = await oneRun();
+  results.push(run);
+  console.log(`run ${i + 1}/${runs}`, run);
+}
+
+const summary = {
+  label,
+  url,
+  runs,
+  median: {
+    ttfbMs: median(results.map((r) => r.ttfbMs)),
+    fcpMs: median(results.map((r) => r.fcpMs)),
+    lcpMs: median(results.map((r) => r.lcpMs)),
+    firstMediaMs: median(results.map((r) => r.firstMediaMs)),
+    firstMediaCompleteMs: median(results.map((r) => r.firstMediaCompleteMs)),
+    htmlImg: median(results.map((r) => r.htmlImg)),
+    htmlVideo: median(results.map((r) => r.htmlVideo)),
+    htmlPoster: median(results.map((r) => r.htmlPoster)),
+  },
+  results,
+};
+
+await mkdir('/tmp/openstory-perf', { recursive: true });
+const out = `/tmp/openstory-perf/${label}.json`;
+await writeFile(out, JSON.stringify(summary, null, 2));
+console.log('summary', JSON.stringify(summary.median, null, 2));
+console.log('wrote', out);

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -309,11 +309,9 @@ export const ScriptView: FC<{
 
   const posthog = usePostHog();
 
-  // `isPending` (not `isLoading`) so the skeleton state is shown whenever there
-  // is no styles data yet — including during SSR, where the query is disabled
-  // behind the still-pending session and `isLoading` is misleadingly false.
-  // This keeps the server and first client render identical (both skeletons)
-  // and avoids a hydration mismatch (#style-selector "View all 0 styles").
+  // `isPending` (not `isLoading`) so the skeleton state is shown whenever
+  // there is no styles data yet. `/` prefetches the public catalogue in
+  // beforeLoad (#1182), so anonymous SSR renders tiles instead of skeletons.
   const { data: styles = [], isPending: isLoadingStyles } = useStyles();
 
   // Auto-select first style if none selected

--- a/src/components/style/sample-video-showcase.tsx
+++ b/src/components/style/sample-video-showcase.tsx
@@ -64,8 +64,8 @@ export const SampleVideoShowcase: React.FC = () => {
         <ArrowRight className="size-4" />
       </Link>
       <div className="grid grid-cols-2 items-start gap-4 md:grid-cols-3">
-        {entries.map((entry) => (
-          <SampleVideoCard key={entry.key} entry={entry} />
+        {entries.map((entry, index) => (
+          <SampleVideoCard key={entry.key} entry={entry} priority={index < 3} />
         ))}
       </div>
     </section>
@@ -83,11 +83,14 @@ const ShowcaseHeading: React.FC = () => (
   </div>
 );
 
-export const SampleVideoCard: React.FC<{ entry: SampleEntry }> = ({
-  entry,
-}) => {
+export const SampleVideoCard: React.FC<{
+  entry: SampleEntry;
+  /** First-viewport cards: eager poster + high fetch priority (#1182). */
+  priority?: boolean;
+}> = ({ entry, priority = false }) => {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [open, setOpen] = useState(false);
+  const [playing, setPlaying] = useState(false);
 
   // Resting state is a cheap Cloudflare-extracted poster frame (~36KB jpg) and
   // `preload="none"`, so the page paints without fetching a single video byte.
@@ -104,6 +107,7 @@ export const SampleVideoCard: React.FC<{ entry: SampleEntry }> = ({
     const el = videoRef.current;
     if (!el) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    setPlaying(true);
     void el.play().catch(() => {});
   }, []);
 
@@ -112,6 +116,7 @@ export const SampleVideoCard: React.FC<{ entry: SampleEntry }> = ({
     if (!el) return;
     el.pause();
     el.currentTime = 0;
+    setPlaying(false);
   }, []);
 
   return (
@@ -124,11 +129,27 @@ export const SampleVideoCard: React.FC<{ entry: SampleEntry }> = ({
         onMouseEnter={play}
         onMouseLeave={stop}
       >
+        {poster ? (
+          <img
+            src={poster}
+            alt=""
+            width={640}
+            height={360}
+            className="absolute inset-0 h-full w-full object-cover"
+            fetchPriority={priority ? 'high' : 'low'}
+            loading={priority ? 'eager' : 'lazy'}
+            decoding="async"
+          />
+        ) : null}
         <video
           ref={videoRef}
           src={src}
-          poster={poster}
-          className="absolute inset-0 h-full w-full object-cover"
+          // Poster is a real <img> so LCP / preload hit one URL, not the
+          // video element. Hover still swaps in the downscaled clip.
+          className={cn(
+            'absolute inset-0 h-full w-full object-cover',
+            playing ? 'opacity-100' : 'opacity-0'
+          )}
           muted
           loop
           playsInline

--- a/src/components/style/style-inline-tile.test.tsx
+++ b/src/components/style/style-inline-tile.test.tsx
@@ -1,0 +1,36 @@
+import { generateMockStyles } from '@/lib/mocks/data-generators';
+import { StyleInlineTile } from '@/components/style/style-inline-tile';
+import type { Style } from '@/types/database';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+function makeStyle(over: Partial<Style>): Style {
+  const [base] = generateMockStyles(1);
+  if (!base) throw new Error('expected a mock style');
+  return { ...base, ...over };
+}
+
+describe('StyleInlineTile', () => {
+  it('SSRs a transformed <img> so the tile is in the first HTML', () => {
+    const html = renderToStaticMarkup(
+      <StyleInlineTile
+        style={makeStyle({
+          name: 'Product Ad',
+          previewUrl:
+            'https://assets.openstory.so/styles/product-ad/thumbnail.webp',
+        })}
+        selected={false}
+        priority
+        tabIndex={0}
+        onSelect={() => undefined}
+        onKeyDown={() => undefined}
+      />
+    );
+
+    expect(html).toContain('<img');
+    expect(html).toContain('/cdn-cgi/image/');
+    expect(html).toMatch(/fetchpriority="high"/i);
+    expect(html).toContain('width=130');
+    expect(html).not.toContain('width=6016');
+  });
+});

--- a/src/components/style/style-inline-tile.tsx
+++ b/src/components/style/style-inline-tile.tsx
@@ -6,16 +6,26 @@ import { useState } from 'react';
 import { getStyleGradient } from './style-gradient';
 import { getConfigColorPalette } from '@/lib/style/style-config';
 
-const StyleTileBackground: React.FC<{ style: Style }> = ({ style }) => {
+const StyleTileBackground: React.FC<{
+  style: Style;
+  priority?: boolean;
+}> = ({ style, priority = false }) => {
   const [imgError, setImgError] = useState(false);
 
   return style.previewUrl && !imgError ? (
     <AppImage
       key={style.id}
       src={style.previewUrl}
-      layout="fullWidth"
+      // ~65px tile; 130 is 2× so the srcset picks a retina-sized transform
+      // instead of the full thumbnail.webp.
+      width={130}
+      height={130}
+      sizes="65px"
       alt={style.name}
       className="h-full w-full object-cover"
+      fetchPriority={priority ? 'high' : 'low'}
+      loading={priority ? 'eager' : 'lazy'}
+      decoding="async"
       onError={() => setImgError(true)}
     />
   ) : (
@@ -34,6 +44,8 @@ type StyleInlineTileProps = {
   disabled?: boolean;
   reasoning?: string;
   recommended?: boolean;
+  /** First-paint tiles: eager + high fetch priority so they beat lazy ones. */
+  priority?: boolean;
   tabIndex: number;
   onSelect: (styleId: string) => void;
   onKeyDown: (event: React.KeyboardEvent) => void;
@@ -45,6 +57,7 @@ export function StyleInlineTile({
   disabled = false,
   reasoning,
   recommended = false,
+  priority = false,
   tabIndex,
   onSelect,
   onKeyDown,
@@ -71,7 +84,7 @@ export function StyleInlineTile({
       aria-label={`Select ${style.name} style`}
       title={reasoning}
     >
-      <StyleTileBackground style={style} />
+      <StyleTileBackground style={style} priority={priority} />
       {recommended && (
         <span
           aria-hidden

--- a/src/components/style/style-selector.tsx
+++ b/src/components/style/style-selector.tsx
@@ -273,6 +273,7 @@ export function StyleSelector({
                     selected={selectedStyleId === style.id}
                     disabled={disabled}
                     recommended
+                    priority={index < 4}
                     reasoning={reasoningByStyleId.get(style.id)}
                     tabIndex={index === focusableIndex ? 0 : -1}
                     onSelect={onStyleSelect}
@@ -288,6 +289,7 @@ export function StyleSelector({
                   style={style}
                   selected={selectedStyleId === style.id}
                   disabled={disabled}
+                  priority={unifiedIndex < 4}
                   tabIndex={unifiedIndex === focusableIndex ? 0 : -1}
                   onSelect={onStyleSelect}
                   onKeyDown={(e) => handleKeyDown(e, unifiedIndex)}

--- a/src/components/text-editor/markdown-editor-placeholder.test.tsx
+++ b/src/components/text-editor/markdown-editor-placeholder.test.tsx
@@ -1,0 +1,17 @@
+import { MarkdownEditor } from '@/components/text-editor/markdown-editor';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+describe('MarkdownEditor empty placeholder', () => {
+  it('SSRs the placeholder as a real <p> so LCP does not wait for TipTap', () => {
+    const html = renderToStaticMarkup(
+      <MarkdownEditor
+        value=""
+        onValueChange={() => undefined}
+        placeholder="A one-liner is enough"
+      />
+    );
+    expect(html).toContain('A one-liner is enough');
+    expect(html).toContain('<p');
+  });
+});

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -187,7 +187,9 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         transformCopiedText: true,
       }),
       Placeholder.configure({
-        placeholder: placeholder ?? '',
+        // Real HTML placeholder is rendered below so first paint (and LCP)
+        // does not wait for TipTap to hydrate a ::before (#1182).
+        placeholder: '',
         emptyEditorClass: 'is-editor-empty',
       }),
       // The Mention extension is generically typed for `MentionNodeAttrs`
@@ -336,6 +338,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       ref={scrollRef}
       className={cn(
         containerBaseClasses,
+        'relative',
         disabled && disabledClasses,
         'overflow-y-auto',
         className
@@ -344,7 +347,12 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       data-testid={dataTestId}
       data-slot="markdown-editor"
     >
-      <EditorContent editor={editor} className="w-full" />
+      {!value && placeholder ? (
+        <p className="pointer-events-none absolute inset-x-0 top-0 px-2.5 py-2 text-base text-muted-foreground md:text-sm">
+          {placeholder}
+        </p>
+      ) : null}
+      <EditorContent editor={editor} className="relative w-full" />
     </div>
   );
 };

--- a/src/functions/public-styles.ts
+++ b/src/functions/public-styles.ts
@@ -1,0 +1,18 @@
+/**
+ * Anonymous public style catalogue. Kept out of `styles.ts` so the `/`
+ * loader can prefetch without pulling auth middleware into the route
+ * server entry (#1182).
+ */
+import { listPublicStyles } from '@/lib/db/scoped';
+import { createServerFn } from '@tanstack/react-start';
+
+/**
+ * List publicly-shared styles. No authentication required so anonymous
+ * visitors can browse and pick a style while composing a sequence before
+ * being prompted to sign in.
+ */
+export const getPublicStylesFn = createServerFn({ method: 'GET' }).handler(
+  async () => {
+    return listPublicStyles();
+  }
+);

--- a/src/functions/styles.ts
+++ b/src/functions/styles.ts
@@ -4,7 +4,6 @@
  */
 
 import { requireTeamAdminAccess } from '@/lib/auth/action-utils';
-import { listPublicStyles } from '@/lib/db/scoped';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
 import {
   createStyleSchema,
@@ -14,6 +13,7 @@ import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
 import { authWithTeamMiddleware } from './middleware';
+export { getPublicStylesFn } from './public-styles';
 
 // ============================================================================
 // List Styles
@@ -35,22 +35,6 @@ export const getStylesFn = createServerFn({ method: 'GET' })
   .handler(async ({ data, context }) => {
     return context.scopedDb.styles.list({ orderBy: data?.orderBy });
   });
-
-// ============================================================================
-// List Public Styles (no auth)
-// ============================================================================
-
-/**
- * List publicly-shared styles. No authentication required so anonymous
- * visitors can browse and pick a style while composing a sequence before
- * being prompted to sign in.
- * @returns Array of public styles
- */
-export const getPublicStylesFn = createServerFn({ method: 'GET' }).handler(
-  async () => {
-    return listPublicStyles();
-  }
-);
 
 // ============================================================================
 // Get Single Style

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -5,6 +5,7 @@ import {
 import { getPublicStylesFn, getStyleFn, getStylesFn } from '@/functions/styles';
 import { usePublicOrTeamQuery } from '@/hooks/use-public-or-team-query';
 import { useAuthSession } from '@/lib/auth/session-query';
+import { publicStylesQueryKey } from '@/lib/style/public-styles-query';
 import { simpleHash } from '@/lib/utils/hash';
 import type { Style } from '@/types/database';
 import { useQuery } from '@tanstack/react-query';
@@ -14,7 +15,7 @@ export const styleKeys = {
   all: ['styles'] as const,
   lists: () => [...styleKeys.all, 'list'] as const,
   list: (teamId?: string) => [...styleKeys.lists(), teamId] as const,
-  public: () => [...styleKeys.lists(), 'public'] as const,
+  public: () => publicStylesQueryKey,
   details: () => [...styleKeys.all, 'detail'] as const,
   detail: (id: string) => [...styleKeys.details(), id] as const,
   // Recommendations are keyed by a hash of the (trimmed) script, so the same

--- a/src/lib/style/front-page-preloads.test.ts
+++ b/src/lib/style/front-page-preloads.test.ts
@@ -1,0 +1,51 @@
+import { generateMockStyles } from '@/lib/mocks/data-generators';
+import { videoPosterUrl } from '@/lib/media/cloudflare-video';
+import {
+  FRONT_PAGE_SHOWCASE_PRELOAD_COUNT,
+  frontPageImagePreloadLinks,
+} from '@/lib/style/front-page-preloads';
+import type { Style } from '@/types/database';
+import { describe, expect, it } from 'vitest';
+
+function makeStyle(over: Partial<Style>): Style {
+  const [base] = generateMockStyles(1);
+  if (!base) throw new Error('expected a mock style');
+  return { ...base, ...over };
+}
+
+describe('frontPageImagePreloadLinks', () => {
+  it('returns nothing without styles', () => {
+    expect(frontPageImagePreloadLinks(undefined)).toEqual([]);
+    expect(frontPageImagePreloadLinks([])).toEqual([]);
+  });
+
+  it('preloads the first showcase posters and marks the first as high priority', () => {
+    const styles = Array.from({ length: 5 }, (_, i) =>
+      makeStyle({
+        id: `s${i}`,
+        name: `Style ${i}`,
+        sampleVideos: [
+          {
+            url: `https://assets.openstory.so/styles/s${i}/canonical.mp4`,
+            kind: 'canonical',
+            label: 'Sample',
+            durationSeconds: 15,
+            order: 0,
+          },
+        ],
+      })
+    );
+
+    const links = frontPageImagePreloadLinks(styles);
+    expect(links).toHaveLength(FRONT_PAGE_SHOWCASE_PRELOAD_COUNT);
+    expect(links[0]).toMatchObject({
+      rel: 'preload',
+      as: 'image',
+      fetchPriority: 'high',
+    });
+    expect(links[0]?.href).toBe(
+      videoPosterUrl('https://assets.openstory.so/styles/s0/canonical.mp4')
+    );
+    expect(links[1]?.fetchPriority).toBeUndefined();
+  });
+});

--- a/src/lib/style/front-page-preloads.ts
+++ b/src/lib/style/front-page-preloads.ts
@@ -1,0 +1,43 @@
+/**
+ * First-paint image preloads for the anonymous composer (`/`).
+ *
+ * Showcase posters are the LCP candidates (large 16:9 cards). Style tiles
+ * are ~65px and ride along once the styles query is dehydrated into HTML.
+ */
+import { videoPosterUrl } from '@/lib/media/cloudflare-video';
+import { buildSampleEntries } from '@/lib/style/sample-entries';
+import type { Style } from '@/types/database';
+
+export const FRONT_PAGE_SHOWCASE_PRELOAD_COUNT = 3;
+
+export type FrontPagePreloadLink = {
+  rel: 'preload';
+  as: 'image';
+  href: string;
+  fetchPriority?: 'high';
+};
+
+export function frontPageImagePreloadLinks(
+  styles: Style[] | undefined
+): FrontPagePreloadLink[] {
+  if (!styles?.length) return [];
+
+  const links: FrontPagePreloadLink[] = [];
+  const entries = buildSampleEntries(styles).slice(
+    0,
+    FRONT_PAGE_SHOWCASE_PRELOAD_COUNT
+  );
+
+  for (const [index, entry] of entries.entries()) {
+    const poster = videoPosterUrl(entry.video.url);
+    if (!poster) continue;
+    links.push({
+      rel: 'preload',
+      as: 'image',
+      href: poster,
+      ...(index === 0 ? { fetchPriority: 'high' as const } : {}),
+    });
+  }
+
+  return links;
+}

--- a/src/lib/style/public-styles-query.ts
+++ b/src/lib/style/public-styles-query.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared query options for the anonymous public style catalogue.
+ *
+ * Kept out of `use-styles.ts` so the `/` loader / `_app` beforeLoad can
+ * prefetch without pulling the recommend-styles LLM module into the
+ * layout's critical path.
+ */
+import { getPublicStylesFn } from '@/functions/public-styles';
+import { queryOptions } from '@tanstack/react-query';
+
+export const publicStylesQueryKey = ['styles', 'list', 'public'] as const;
+
+export const publicStylesQueryOptions = queryOptions({
+  queryKey: publicStylesQueryKey,
+  queryFn: () => getPublicStylesFn(),
+  staleTime: 10 * 60 * 1000,
+});

--- a/src/routes/_app/index.tsx
+++ b/src/routes/_app/index.tsx
@@ -1,4 +1,6 @@
 import { NewSequencePage } from '@/components/script/new-sequence-page';
+import { frontPageImagePreloadLinks } from '@/lib/style/front-page-preloads';
+import { publicStylesQueryOptions } from '@/lib/style/public-styles-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { z } from 'zod';
 
@@ -21,6 +23,11 @@ const searchSchema = z.object({
  */
 export const Route = createFileRoute('/_app/')({
   validateSearch: searchSchema,
+  loader: ({ context: { queryClient } }) =>
+    queryClient.ensureQueryData(publicStylesQueryOptions),
+  head: ({ loaderData }) => ({
+    links: frontPageImagePreloadLinks(loaderData),
+  }),
   component: HomePage,
 });
 


### PR DESCRIPTION
## Related Issue

Closes #1182

## Summary of Changes

Make `/` (anonymous composer) paint from the first HTML instead of after hydration.

- Prefetch the public style catalogue in the `/` loader so style tiles and showcase posters SSR as real `<img>`s
- Size tile transforms to the 65px strip (`width=130`, `sizes="65px"`) instead of a full-viewport srcset
- Paint showcase resting state as a poster `<img>` (video only on hover); preload the first three posters
- SSR the empty-editor placeholder as a real `<p>` so LCP no longer waits for TipTap to hydrate a `::before`
- Split `getPublicStylesFn` into a thin server-fn module so the home loader does not pull auth middleware into the route entry

## Lab measurements

Anonymous `/`, Playwright 1280×800, 3-run median, local Workerd:

| Metric | Before | After |
|---|---:|---:|
| LCP | 2028 ms (`::before` after TipTap) | **428 ms** (SSR `<p>`) |
| FCP | 400 ms | 428 ms |
| Warm TTFB | 63 ms | 49 ms |
| `<img>` in first HTML | 0 | **18** |
| Skeletons in first HTML | 17 | **0** |

**4.7× LCP.** Re-run: `bun scripts/measure-front-page.ts http://localhost:3000/ after-local 3`

Production TTFB (~2.7 s) is the leftover isolate/session surface from #1161 and is out of scope.

## Risk Assessment

- [x] Medium
- [ ] Low
- [ ] High

Anonymous `/` first paint, style strip, and empty-editor placeholder are user-visible. Showcase hover video and generate flow are unchanged.

## Additional Notes

Public styles query key is `['styles', 'list', 'public']` — same key `useStyles()` already uses for logged-out visitors.