### PR TITLE
fix(upscale): promote through the pending-promote claim

### DIFF
--- a/src/lib/workflow/no-mid-run-reads.test.ts
+++ b/src/lib/workflow/no-mid-run-reads.test.ts
@@ -462,9 +462,14 @@ const ALLOWED_LIVE_READS: Record<string, SanctionedRead[]> = {
   ],
   'upscale-shot-variant-workflow.ts': [
     {
+      read: 'frameVariants.getById',
+      bucket: 'CLAIM-BY-ID',
+      why: "On the failure path only: the frame's pending-promote claim row, read by the id the frame holds, to check this run owns it before clearing (#1129).",
+    },
+    {
       read: 'frames.getById',
       bucket: 'EXISTENCE-GUARD',
-      why: "The trigger's frame, checked but never re-resolved, so the render step and the select step write to the same one.",
+      why: "The trigger's frame, checked but never re-resolved, so the render step and the promote step write to the same one. On the failure path it also yields the pending-promote claim id.",
     },
   ],
   'wait-for-sheets.ts': [

--- a/src/lib/workflows/upscale-shot-variant-workflow.test.ts
+++ b/src/lib/workflows/upscale-shot-variant-workflow.test.ts
@@ -1,20 +1,23 @@
 /**
- * Behavioural test for the upscale select step (#989).
+ * Behavioural test for the upscale promote step (#989 / #1129).
  *
  * `selectShotVariantFn` no longer writes the still synchronously — it triggers
- * this workflow, which upscales the chosen 3×3 tile and then REPOINTS the
- * frame's primary still at the upscaled version (pointer + mirror via
- * `frameVariants.select`). The e2e suite can't observe that async repoint
- * hermetically, so the outcome is pinned here: `persistUpscaleSelection`
- * completes the in-flight version and repoints the TRIGGER's frame (never
- * re-resolved from the shot) — skipping the repoint, but still completing the
- * version, if that frame vanished mid-flight.
+ * this workflow, which upscales the chosen 3×3 tile and then promotes the
+ * upscaled version to the frame's primary still. The promote rides the
+ * auto-promote claim minted at kickoff (#1070), NOT a bare `frameVariants.select`:
+ * an upscale runs for minutes, and a still the user picks from history in the
+ * meantime clears the claim and must win. The e2e suite can't observe that async
+ * promote hermetically, so the outcome is pinned here: `persistUpscaleSelection`
+ * completes the in-flight version and promotes the TRIGGER's frame (never
+ * re-resolved from the shot) only while the claim still points at this version —
+ * on a miss the upscale stays in history and the frame is left alone.
  *
  * The new still no longer drops the segment's chosen render (#1067 phase 2d):
  * the old video keeps playing and the manifest-staleness system flags it.
  */
 
-import type { NewFrameVariant, NewShot } from '@/lib/db/schema';
+import type { NewFrameVariant } from '@/lib/db/schema';
+import { frameVariantFixture } from '@/lib/mocks/frame-fixtures';
 import { describe, expect, it } from 'vitest';
 import {
   persistUpscaleSelection,
@@ -22,77 +25,59 @@ import {
 } from './upscale-shot-variant-workflow';
 
 type VariantUpdateCall = { versionId: string; data: Partial<NewFrameVariant> };
-type SelectCall = {
+type PromoteCall = {
   frameId: string;
   versionId: string;
   actorId: string | null;
 };
-type ShotUpdateCall = { shotId: string; data: Partial<NewShot> };
 type CallName =
   | 'frameVariants.update'
-  | 'frames.getById'
-  | 'frameVariants.select'
-  | 'shots.update';
+  | 'frameVariants.selectIfPendingPromoteIs';
 
-function buildScopedDbSpy(opts: { frameMissing?: boolean } = {}): {
+function buildScopedDbSpy(opts: { claimMoved?: boolean } = {}): {
   scopedDb: PersistUpscaleScopedDb;
   variantUpdates: VariantUpdateCall[];
-  selects: SelectCall[];
-  shotUpdates: ShotUpdateCall[];
+  promotes: PromoteCall[];
   callOrder: CallName[];
 } {
   const variantUpdates: VariantUpdateCall[] = [];
-  const selects: SelectCall[] = [];
-  const shotUpdates: ShotUpdateCall[] = [];
+  const promotes: PromoteCall[] = [];
   const callOrder: CallName[] = [];
+  // The methods return full rows; the helper only reads truthiness and `.id`,
+  // so the defaults carry the rest.
+  const row = (id: string) =>
+    frameVariantFixture({
+      id,
+      frameId: 'anchor-frame-id',
+      sequenceId: 'seq-1',
+    });
   const scopedDb: PersistUpscaleScopedDb = {
     frameVariants: {
       update: async (versionId, data) => {
         variantUpdates.push({ versionId, data });
         callOrder.push('frameVariants.update');
-        return { id: versionId };
+        return row(versionId);
       },
-      select: async (frameId, versionId, optsArg) => {
-        selects.push({ frameId, versionId, actorId: optsArg.actorId });
-        callOrder.push('frameVariants.select');
-        return { id: versionId };
-      },
-    },
-    liveRead: {
-      frames: {
-        getById: async (frameId) => {
-          callOrder.push('frames.getById');
-          return opts.frameMissing ? null : { id: frameId };
-        },
-      },
-    },
-    shots: {
-      update: async (shotId, data) => {
-        shotUpdates.push({ shotId, data });
-        callOrder.push('shots.update');
-        return { id: shotId };
+      selectIfPendingPromoteIs: async (frameId, versionId, optsArg) => {
+        promotes.push({ frameId, versionId, actorId: optsArg.actorId });
+        callOrder.push('frameVariants.selectIfPendingPromoteIs');
+        return opts.claimMoved ? null : row(versionId);
       },
     },
   };
-  return {
-    scopedDb,
-    variantUpdates,
-    selects,
-    shotUpdates,
-    callOrder,
-  };
+  return { scopedDb, variantUpdates, promotes, callOrder };
 }
 
 const NOW = new Date('2026-06-26T00:00:00Z');
 
 describe('persistUpscaleSelection', () => {
-  it('completes the version, repoints the frame at it, emits completed', async () => {
-    const { scopedDb, variantUpdates, selects, shotUpdates, callOrder } =
+  it('completes the version, promotes it through the claim, emits the new still', async () => {
+    const { scopedDb, variantUpdates, promotes, callOrder } =
       buildScopedDbSpy();
     const emits: Array<{
       shotId: string;
       status: string;
-      thumbnailUrl: string;
+      thumbnailUrl?: string;
     }> = [];
 
     const result = await persistUpscaleSelection({
@@ -109,13 +94,15 @@ describe('persistUpscaleSelection', () => {
       },
     });
 
-    expect(result).toEqual({ selected: true });
+    expect(result).toEqual({
+      promoted: true,
+      thumbnailUrl: 'https://r2/upscaled.png',
+    });
 
-    // Version is completed BEFORE the frame is checked + repointed.
+    // Version is completed BEFORE the claim-consuming promote.
     expect(callOrder).toEqual([
       'frameVariants.update',
-      'frames.getById',
-      'frameVariants.select',
+      'frameVariants.selectIfPendingPromoteIs',
     ]);
 
     const [versionUpdate] = variantUpdates;
@@ -129,16 +116,12 @@ describe('persistUpscaleSelection', () => {
       error: null,
     });
 
-    // Repoint targets the TRIGGER's frame id (≠ shotId), not the shot id.
-    const [select] = selects;
-    if (!select) throw new Error('expected frameVariants.select call');
-    expect(select.frameId).toBe('anchor-frame-id');
-    expect(select.versionId).toBe('ver-1');
-    expect(select.actorId).toBe('user-1');
-
-    // The existing render survives a new still (#1067 phase 2d) — no selection
-    // is dropped and nothing is written to the shot.
-    expect(shotUpdates).toEqual([]);
+    // Promote targets the TRIGGER's frame id (≠ shotId), not the shot id.
+    const [promote] = promotes;
+    if (!promote) throw new Error('expected a promote call');
+    expect(promote.frameId).toBe('anchor-frame-id');
+    expect(promote.versionId).toBe('ver-1');
+    expect(promote.actorId).toBe('user-1');
 
     expect(emits).toEqual([
       {
@@ -149,13 +132,14 @@ describe('persistUpscaleSelection', () => {
     ]);
   });
 
-  it('still completes the version but skips the repoint when the frame vanished', async () => {
-    const { scopedDb, variantUpdates, selects, shotUpdates, callOrder } =
-      buildScopedDbSpy({ frameMissing: true });
+  it('leaves the frame alone when the claim moved (manual selection wins)', async () => {
+    const { scopedDb, variantUpdates, promotes, callOrder } = buildScopedDbSpy({
+      claimMoved: true,
+    });
     const emits: Array<{
       shotId: string;
       status: string;
-      thumbnailUrl: string;
+      thumbnailUrl?: string;
     }> = [];
 
     const result = await persistUpscaleSelection({
@@ -172,13 +156,18 @@ describe('persistUpscaleSelection', () => {
       },
     });
 
-    expect(result).toEqual({ selected: false });
-    // The version is finished, but with no frame there is nothing to repoint:
-    // no select, no completed emit (a false "ready" signal).
-    expect(callOrder).toEqual(['frameVariants.update', 'frames.getById']);
+    expect(result).toEqual({ promoted: false });
+    // The version is still finished (it stays selectable from the picker), and
+    // the promote was attempted but conceded — one WHERE-guarded write, no
+    // read-then-select that could lose the race.
+    expect(callOrder).toEqual([
+      'frameVariants.update',
+      'frameVariants.selectIfPendingPromoteIs',
+    ]);
     expect(variantUpdates).toHaveLength(1);
-    expect(selects).toEqual([]);
-    expect(shotUpdates).toEqual([]);
-    expect(emits).toEqual([]);
+    expect(promotes).toHaveLength(1);
+    // Settle the spinner, but WITHOUT a thumbnail: pushing the unselected
+    // upscale's url would show the user something the frame doesn't point at.
+    expect(emits).toEqual([{ shotId: 'shot-1', status: 'completed' }]);
   });
 });

--- a/src/lib/workflows/upscale-shot-variant-workflow.ts
+++ b/src/lib/workflows/upscale-shot-variant-workflow.ts
@@ -4,9 +4,10 @@
  * The picked tile is cropped (a Cloudflare Image Resizing URL) by
  * `selectShotVariantFn`, then this workflow upscales it and records the result
  * as a `kind:'framing'` `frame_variants` version (`sourceVariantId` = the grid
- * sheet it came from) and SELECTS it — a pointer repoint that mirrors the new
- * still onto the frame, never an overwrite. Downstream video (still on `shots`
- * until Phase 3) is reset because the anchor still changed.
+ * sheet it came from) and promotes it to the frame's still — a pointer repoint
+ * that mirrors the new still onto the frame, never an overwrite. The promote
+ * rides the auto-promote claim (#1070/#1129), so a still the user picked from
+ * history mid-upscale wins and the upscale lands in history instead.
  */
 
 import { IMAGE_MODELS } from '@/lib/ai/models';
@@ -20,8 +21,8 @@ import {
   aspectRatioToImageSize,
   DEFAULT_IMAGE_SIZE,
 } from '@/lib/constants/aspect-ratios';
+import type { ScopedDb } from '@/lib/db/scoped';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
-import type { NewFrameVariant, NewShot } from '@/lib/db/schema';
 import { generateImageWithProvider } from '@/lib/image/image-generation';
 import { recordProvenance } from '@/lib/compliance/provenance';
 import { uploadImageToStorage } from '@/lib/image/image-storage';
@@ -65,50 +66,65 @@ OUTPUT
 - Resolution: upscale to animation-ready quality.
 - No text overlays, borders, watermarks, or new graphics added by the model.`;
 
-/** The frame/variant/shot writes `persistUpscaleSelection` needs — a narrow
- * slice of {@link ScopedDb} so unit tests can inject a small spy. */
+/**
+ * The frame/variant writes `persistUpscaleSelection` needs — a narrow slice of
+ * {@link ScopedDb} so unit tests can inject a small spy. `Pick`ed off the real
+ * thing rather than hand-written, per scoped-workflow.ts: the signatures stay
+ * in lockstep with the query module instead of restating it.
+ *
+ * What this still does NOT catch is a change in RETURN semantics — e.g.
+ * `selectIfPendingPromoteIs` returning the current selection instead of `null`
+ * on a miss would keep compiling and silently turn every claim miss into a
+ * wrong-thumbnail promote. The `…If` naming convention is the only guard there.
+ */
 export type PersistUpscaleScopedDb = {
-  frameVariants: {
-    update: (
-      versionId: string,
-      data: Partial<NewFrameVariant>
-    ) => Promise<{ id: string }>;
-    select: (
-      frameId: string,
-      versionId: string,
-      opts: { actorId: string | null }
-    ) => Promise<{ id: string }>;
-  };
-  liveRead: {
-    frames: {
-      // Existence only — the frame is the trigger's, never re-resolved here.
-      getById: (frameId: string) => Promise<{ id: string } | null>;
-    };
-  };
-  shots: {
-    update: (
-      shotId: string,
-      data: Partial<NewShot>,
-      options?: { throwOnMissing?: boolean }
-    ) => Promise<{ id: string } | undefined>;
-  };
+  frameVariants: Pick<
+    ScopedDb['frameVariants'],
+    'update' | 'selectIfPendingPromoteIs'
+  >;
 };
 
 type UpscaleImageProgress = {
   shotId: string;
   status: 'completed';
-  thumbnailUrl: string;
+  thumbnailUrl?: string;
 };
 
 /**
- * Complete the in-flight upscaled framing version and REPOINT the frame's
- * primary still at it (pointer + mirror, via `frameVariants.select`). Extracted
- * from the workflow's `select-upscaled-version` step so the repoint outcome is
- * unit-testable without the fal/storage/credit steps. The frame is the trigger's
- * (frame id ≠ shot id, #989) — resolving the anchor here would let a mid-run
- * anchor change move the still onto a different frame than the run claimed. It
- * is checked for existence only; `{ selected: false }` (a no-op past the version
- * completion) means it was deleted mid-flight.
+ * Two-outcome result of the promote, mirroring `PersistMotionOutcome`
+ * (motion-workflow-persist.ts). The "a promoted upscale always has a still"
+ * invariant lives HERE rather than on the emit payload: the wire schema
+ * (`image:progress`) has to keep `thumbnailUrl` optional because the claim-miss
+ * emit deliberately omits it, so the outcome type is the only place the pairing
+ * is actually true.
+ */
+export type UpscalePromoteOutcome =
+  | { promoted: true; thumbnailUrl: string }
+  | { promoted: false };
+
+/**
+ * Complete the in-flight upscaled framing version and promote it to the frame's
+ * primary still THROUGH the auto-promote claim minted at kickoff (#1129) — the
+ * same door every other primary-still writer uses (#1070). A bare
+ * `frameVariants.select` here would clobber a still the user picked from
+ * history while the upscale ran (minutes); the claim encodes *later intent
+ * wins*, and that manual pick clears it.
+ *
+ * A claim miss — the user selected something else, or a newer kickoff took the
+ * claim — finalizes the upscale into history instead. Nothing is lost: the row
+ * stays selectable from the picker.
+ *
+ * A frame deleted mid-flight is NOT this path: `frames.id` cascades to
+ * `frame_variants`, so the version row is gone too and the `update` above
+ * throws before the claim is ever consulted. That surfaces as a run failure,
+ * which is what the old explicit existence check here could never actually
+ * catch — the same `update` threw first.
+ *
+ * Extracted from the workflow's `select-upscaled-version` step so the promote
+ * outcome is unit-testable without the fal/storage/credit steps. The frame is
+ * the trigger's (frame id ≠ shot id, #989) — resolving the anchor here would
+ * let a mid-run anchor change move the still onto a different frame than the
+ * run claimed.
  */
 export async function persistUpscaleSelection(params: {
   scopedDb: PersistUpscaleScopedDb;
@@ -120,7 +136,7 @@ export async function persistUpscaleSelection(params: {
   actorId: string;
   generatedAt: Date;
   emit: (payload: UpscaleImageProgress) => Promise<void>;
-}): Promise<{ selected: boolean }> {
+}): Promise<UpscalePromoteOutcome> {
   const {
     scopedDb,
     shotId,
@@ -141,18 +157,24 @@ export async function persistUpscaleSelection(params: {
     error: null,
   });
 
-  const frame = await scopedDb.liveRead.frames.getById(frameId);
-  if (!frame) {
+  const promoted = await scopedDb.frameVariants.selectIfPendingPromoteIs(
+    frameId,
+    versionId,
+    { actorId }
+  );
+
+  if (!promoted) {
     logger.info(
-      `[UpscaleShotVariantWorkflow] Frame ${frameId} vanished, skipping select`
+      `[UpscaleShotVariantWorkflow] Promote claim on frame ${frameId} moved; upscale ${versionId} stays in history`
     );
-    return { selected: false };
+    // Settle the spinner without a thumbnail: the client refetches and shows
+    // whatever the frame actually points at now, not this unselected still.
+    await emit({ shotId, status: 'completed' });
+    return { promoted: false };
   }
 
-  await scopedDb.frameVariants.select(frameId, versionId, { actorId });
-
   await emit({ shotId, status: 'completed', thumbnailUrl: url });
-  return { selected: true };
+  return { promoted: true, thumbnailUrl: url };
 }
 
 export class UpscaleShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<UpscaleShotVariantWorkflowInput> {
@@ -209,6 +231,11 @@ export class UpscaleShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<Upsc
         status: 'generating',
         workflowRunId,
       });
+
+      // Claim auto-promote for this upscale (#1129); last kickoff wins (#1070).
+      // Without the claim the completion below is an unconditional repoint that
+      // overwrites a still the user picked from history while the upscale ran.
+      await scopedDb.frames.setPendingPromoteVersionId(frame.id, version.id);
 
       // The cropped tile rides through the builder as the primary reference so
       // the prompt's Image numbering matches the image_urls array — prepending
@@ -325,8 +352,8 @@ export class UpscaleShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<Upsc
     });
 
     await step.do('select-upscaled-version', async () => {
-      // Completes the version + repoints the frame's still + resets video.
-      const { selected } = await persistUpscaleSelection({
+      // Completes the version, then promotes it through this run's claim.
+      const outcome = await persistUpscaleSelection({
         scopedDb,
         shotId,
         frameId: input.frameId,
@@ -342,9 +369,9 @@ export class UpscaleShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<Upsc
           ),
       });
 
-      if (selected) {
+      if (outcome.promoted) {
         logger.info(
-          `[UpscaleShotVariantWorkflow] Upscale completed + selected for shot ${shotId}`
+          `[UpscaleShotVariantWorkflow] Upscale completed + selected for shot ${shotId}: ${outcome.thumbnailUrl}`
         );
       }
     });
@@ -377,9 +404,26 @@ export class UpscaleShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<Upsc
       event.instanceId,
       error
     );
+
+    // Drop the auto-promote claim, but only if THIS run still owns it (#1129) —
+    // a newer kickoff's claim must survive an older upscale's failure.
+    const frame = await scopedDb.liveRead.frames.getById(input.frameId);
+    if (frame?.pendingPromoteVersionId) {
+      const pending = await scopedDb.claims.frameVariants.getById(
+        frame.pendingPromoteVersionId
+      );
+      if (pending?.workflowRunId === event.instanceId) {
+        await scopedDb.frames.clearPendingPromoteVersionIdIf(
+          frame.id,
+          pending.id
+        );
+      }
+    }
+
     if (input.sequenceId) {
-      // The upscale just became the frame's selection; read the still back
-      // off that version rather than a frame column (#1067).
+      // A failed upscale never promoted, so the frame still points at whatever
+      // it did before; read that still off the selected version rather than a
+      // frame column (#1067).
       const thumbnailUrl = await getAnchorImageUrl(
         scopedDb.liveRead,
         input.shotId


### PR DESCRIPTION
## Problem

The upscale workflow was the only primary-still writer that bypassed the pending-promote claim machinery (#1070). It appended the upscaled variant row and then, at completion, repointed the primary via a direct `frameVariants.select` — no claim at kickoff, no claim-consuming select at completion.

The race: a user triggers an upscale (runs for minutes), selects a different still from history while it's in flight (an explicit choice, which clears any pending claims), and the upscale lands and unconditionally repoints over that choice.

## Fix

Adopt the standard claim flow, the same door every other primary-still path uses:

- **Kickoff** (`upscale-image` step, right after `appendVersion`): `frames.setPendingPromoteVersionId(frame.id, version.id)` — last kickoff wins.
- **Completion** (`persistUpscaleSelection`): `selectIfPendingPromoteIs` replaces the bare `select`. On a claim miss the version is still completed and stays selectable from the picker — no data loss, just no silent override. It emits `status: 'completed'` with **no** `thumbnailUrl`, which settles the spinner and trips the `query-cache-updater` invalidate so the client refetches the frame's real selection rather than being shown an unselected still.
- **Failure** (`onFailure`): clears the claim only when this run owns it — resolves the frame's `pendingPromoteVersionId` through `scopedDb.claims.frameVariants.getById` and compares `workflowRunId` to `event.instanceId` (same shape as `ImageWorkflow`). A newer kickoff's claim survives.

On the issue's open question, this implements *later intent wins*: an upscale still normally becomes the primary (nothing else touches the claim in the happy path — the grid-sheet workflow neither selects nor claims), but a manual pick made after the upscale kickoff now beats it.

Two incidental cleanups fell out: the `liveRead.frames.getById` existence guard inside `persistUpscaleSelection` is now redundant (the claim-consuming UPDATE matches zero rows if the frame vanished, giving the same claim-miss path), and `PersistUpscaleScopedDb`'s `shots` member was dead.

## Tests

- `upscale-shot-variant-workflow.test.ts` rewritten around the promote outcome: claim held (promotes, emits the new still) vs. claim moved (frame left alone, version completed, spinner settled without a thumbnail).
- `no-mid-run-reads.test.ts`: new `frameVariants.getById` / `CLAIM-BY-ID` entry for the failure-path read.

Gates: `bun typecheck` clean, `bun run test` 2403 passed / 232 files, format clean on the changed files.

Closes #1129
Part of #1067
