### PR TITLE
fix(#1116): apply app-level default for sequences.analysisModel

### DIFF
--- a/src/lib/db/schema/sequences.ts
+++ b/src/lib/db/schema/sequences.ts
@@ -78,7 +78,13 @@ export const sequences = snakeCase.table(
       .default(DEFAULT_ASPECT_RATIO)
       .notNull(),
 
-    // TB-20260804: DB-Audit: I don't love that there's a default here and that it's a specific model identifier
+    // SQL default pinned to the literal 'anthropic/claude-haiku-4.5' to match
+    // every deployed DB's column default. DEFAULT_ANALYSIS_MODEL (see
+    // models.config.ts) must NOT be written here: SQLite can't ALTER a
+    // column default without a full table rebuild, which CASCADE-deletes
+    // child rows on D1 (#612). The scoped create (db/scoped/sequences.ts)
+    // substitutes DEFAULT_ANALYSIS_MODEL for an omitted analysisModel,
+    // mirroring imageModel / videoModel below.
     analysisModel: text({ length: 100 })
       .default('anthropic/claude-haiku-4.5')
       .notNull(),

--- a/src/lib/db/scoped/sequences-create-defaults.test.ts
+++ b/src/lib/db/scoped/sequences-create-defaults.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Scoped `sequences.create` must write app-level model defaults, not the
+ * stale SQL column literals (#1116 / imageModel+videoModel pattern).
+ */
+
+import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
+import { DEFAULT_IMAGE_MODEL, DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
+import type { Database } from '@/lib/db/client';
+import { generateId } from '@/lib/db/id';
+import { sequences, styles, teams, user } from '@/lib/db/schema';
+import { relations } from '@/lib/db/schema/relations';
+import { type Client, createClient } from '@libsql/client';
+import { eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { migrate } from 'drizzle-orm/libsql/migrator';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createSequencesMethods } from './sequences';
+
+let client: Client;
+let db: Database;
+let teamId = '';
+let userId = '';
+let styleId = '';
+
+beforeAll(async () => {
+  client = createClient({ url: ':memory:' });
+  db = drizzle({ client, relations });
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+});
+
+afterAll(() => {
+  client.close();
+});
+
+beforeEach(async () => {
+  await db.delete(sequences);
+  await db.delete(styles);
+  await db.delete(teams);
+  await db.delete(user);
+
+  teamId = generateId();
+  userId = generateId();
+  await db.insert(user).values({
+    id: userId,
+    name: 'U',
+    email: `${userId}@example.com`,
+  });
+  await db.insert(teams).values({ id: teamId, name: 'T', slug: 't' });
+  const [style] = await db
+    .insert(styles)
+    .values({
+      teamId,
+      name: 'default',
+      config: {
+        mood: 'neutral',
+        artStyle: 'cinematic',
+        lighting: 'natural',
+        colorPalette: ['#000', '#fff'],
+        cameraWork: 'static',
+        referenceFilms: [],
+        colorGrading: 'neutral',
+      },
+    })
+    .returning();
+  if (!style) throw new Error('test setup: style insert returned nothing');
+  styleId = style.id;
+});
+
+describe('sequences.create model defaults', () => {
+  it('does not change the SQL column default for analysisModel', async () => {
+    const id = generateId();
+    await db.insert(sequences).values({
+      id,
+      teamId,
+      title: 'raw',
+      styleId,
+    });
+    const [row] = await db
+      .select({ analysisModel: sequences.analysisModel })
+      .from(sequences)
+      .where(eq(sequences.id, id));
+    expect(row?.analysisModel).toBe('anthropic/claude-haiku-4.5');
+    expect(row?.analysisModel).not.toBe(DEFAULT_ANALYSIS_MODEL);
+  });
+
+  it('substitutes app-level defaults when models are omitted', async () => {
+    const methods = createSequencesMethods(db, teamId, userId);
+    const created = await methods.create({
+      title: 'omitted',
+      styleId,
+    });
+    expect(created.analysisModel).toBe(DEFAULT_ANALYSIS_MODEL);
+    expect(created.imageModel).toBe(DEFAULT_IMAGE_MODEL);
+    expect(created.videoModel).toBe(DEFAULT_VIDEO_MODEL);
+  });
+
+  it('persists an explicit analysisModel', async () => {
+    const methods = createSequencesMethods(db, teamId, userId);
+    const created = await methods.create({
+      title: 'explicit',
+      styleId,
+      analysisModel: 'anthropic/claude-sonnet-4.6',
+    });
+    expect(created.analysisModel).toBe('anthropic/claude-sonnet-4.6');
+  });
+});

--- a/src/lib/db/scoped/sequences.ts
+++ b/src/lib/db/scoped/sequences.ts
@@ -3,6 +3,7 @@
  * Team-scoped sequence CRUD and per-sequence update methods.
  */
 
+import { DEFAULT_ANALYSIS_MODEL } from '@/lib/ai/models.config';
 import { DEFAULT_IMAGE_MODEL, DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
 import {
   type AspectRatio,
@@ -261,7 +262,7 @@ export function createSequencesMethods(
       script?: string | null;
       styleId: string;
       aspectRatio?: AspectRatio;
-      analysisModel: string;
+      analysisModel?: string;
       imageModel?: string;
       videoModel?: string;
       musicModel?: string;
@@ -278,11 +279,12 @@ export function createSequencesMethods(
         script: params.script,
         styleId: params.styleId,
         aspectRatio: params.aspectRatio ?? DEFAULT_ASPECT_RATIO,
-        analysisModel: params.analysisModel,
-        // The sequences SQL column defaults are stale literals ('nano_banana_2'
-        // for image, 'kling_v3_pro' for video — see schema/sequences.ts) that
-        // can't be changed without a D1 table rebuild, so resolve the app's real
-        // default here instead of relying on the column default.
+        // The sequences SQL column defaults are stale literals
+        // ('anthropic/claude-haiku-4.5' for analysis, 'nano_banana_2' for
+        // image, 'kling_v3_pro' for video — see schema/sequences.ts) that
+        // can't be changed without a D1 table rebuild, so resolve the app's
+        // real defaults here instead of relying on the column default.
+        analysisModel: params.analysisModel ?? DEFAULT_ANALYSIS_MODEL,
         imageModel: params.imageModel ?? DEFAULT_IMAGE_MODEL,
         videoModel: params.videoModel ?? DEFAULT_VIDEO_MODEL,
         musicModel: params.musicModel,


### PR DESCRIPTION
Closes #1116.

## Summary
- Leave `sequences.analysisModel`'s SQL default as `'anthropic/claude-haiku-4.5'`. Changing it would force a D1 table rebuild (#612 CASCADE trap).
- Scoped `sequences.create` now writes `DEFAULT_ANALYSIS_MODEL` when `analysisModel` is omitted, same as `imageModel` / `videoModel`.
- Doc comment pins the SQL literal so the next model bump does not try to migrate the default.

## Test plan
- [ ] `bun run test src/lib/db/scoped/sequences-create-defaults.test.ts`
- [ ] `bun typecheck`
- [ ] Create a sequence with no explicit analysis model and confirm the row stores `DEFAULT_ANALYSIS_MODEL` (`x-ai/grok-4.6`), not Haiku
- [ ] Confirm `bun db:generate` is a no-op (no new migration)