### PR TITLE
fix(ui): fewer composer controls on phones so the script has room

### DIFF
--- a/src/components/element/element-selector.tsx
+++ b/src/components/element/element-selector.tsx
@@ -554,7 +554,7 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent align="end" className="w-[420px]">
+        <PopoverContent align="end" className="w-[min(420px,calc(100vw-2rem))]">
           <div className="flex flex-col gap-3">
             <div className="flex flex-col gap-1">
               <p className="text-sm font-medium">Upload reference elements</p>

--- a/src/components/script/new-sequence-page.tsx
+++ b/src/components/script/new-sequence-page.tsx
@@ -252,14 +252,21 @@ export function NewSequencePage({
   return (
     <div className="h-full">
       {billingGate}
-      <PageContainer maxWidth="narrow" padding="spacious" fullHeight>
-        <div className="flex shrink-0 flex-col items-center gap-4">
+      <PageContainer
+        maxWidth="narrow"
+        padding="spacious"
+        fullHeight
+        // Phones: every row saved here goes to the script editor inside the
+        // height-bounded composer below.
+        className="space-y-4 sm:space-y-8"
+      >
+        <div className="flex shrink-0 flex-col items-center gap-2 sm:gap-4">
           <OpenStoryLogo className="h-8 sm:h-12" />
           <div className="flex flex-col items-center gap-1">
             <h1 className="text-center text-xl font-semibold tracking-tight sm:text-2xl">
               Tell your whole story
             </h1>
-            <p className="text-center text-sm text-muted-foreground">
+            <p className="hidden text-center text-sm text-muted-foreground sm:block">
               Pay the models. See the code. Keep the film.
             </p>
           </div>

--- a/src/components/script/script-editor.tsx
+++ b/src/components/script/script-editor.tsx
@@ -61,9 +61,11 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({
 
   return (
     <>
-      {/* min-h-28 = 4 editor rows (24px line-height) + the editor's vertical
-          padding — the floor the flex layout can't crush the editor below. */}
-      <div className="min-h-28 flex-1 flex flex-col overflow-hidden">
+      {/* 4 editor rows (24px line-height) + the editor's vertical padding —
+          the floor the flex layout can't crush the editor below. Phones get 2
+          rows: ScriptView adds a Shuffle/Enhance row beneath, so together they
+          cost about the same 4 rows. */}
+      <div className="min-h-16 md:min-h-28 flex-1 flex flex-col overflow-hidden">
         <MarkdownEditor
           scrollRef={ref}
           id="script"
@@ -76,7 +78,7 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({
           disabled={disabled}
           aria-invalid={hasError}
           className={cn(
-            'min-h-[4lh] flex-1 bg-transparent dark:bg-transparent border-none shadow-none focus-within:ring-0 focus-within:border-input overscroll-contain pb-10',
+            'min-h-[2lh] md:min-h-[4lh] flex-1 bg-transparent dark:bg-transparent border-none shadow-none focus-within:ring-0 focus-within:border-input overscroll-contain pb-10',
             hasError && 'border-destructive focus-within:ring-destructive/20'
           )}
           data-testid="script-editor-textarea"

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -32,6 +32,15 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { enhanceScriptStreamFn } from '@/functions/ai';
 import { useAutoScroll } from '@/hooks/use-auto-scroll';
@@ -113,6 +122,7 @@ import {
   Sparkles,
   Square,
   Undo2,
+  Library,
   Wand2,
 } from 'lucide-react';
 import React, {
@@ -1090,6 +1100,49 @@ export const ScriptView: FC<{
   const isDisabled =
     !isFormValid || isSubmitting || isEnhancing || isElementBusy;
 
+  const isMobile = useIsMobile();
+  const [referencesSheetOpen, setReferencesSheetOpen] = useState(false);
+  const referenceCount =
+    selectedTalentIds.length +
+    selectedLocationIds.length +
+    (isEditing ? 0 : draftElements.length);
+  const referenceSelectors = (
+    <>
+      <TalentSuggestionSelector
+        selectedTalentIds={selectedTalentIds}
+        onSelectionChange={(v) =>
+          setSelections((s) => ({ ...s, talentIds: v }))
+        }
+        disabled={loading}
+      />
+      <LocationSuggestionSelector
+        selectedLocationIds={selectedLocationIds}
+        onSelectionChange={(v) =>
+          setSelections((s) => ({ ...s, locationIds: v }))
+        }
+        disabled={loading}
+      />
+      {/* `isEditing = !!sequence?.id`; the `?.` mirrors that derivation for narrowing on `sequence.id` below. */}
+      {/* oxlint-disable-next-line typescript/no-unnecessary-condition */}
+      {isEditing && sequence?.id ? (
+        <ElementSelector
+          ref={elementSelectorRef}
+          sequenceId={sequence.id}
+          disabled={loading}
+          onElementBusyChange={setIsElementBusy}
+        />
+      ) : (
+        <ElementSelector
+          ref={elementSelectorRef}
+          draftElements={draftElements}
+          onDraftElementsChange={setDraftElements}
+          onDraftTokenRename={handleDraftTokenRename}
+          disabled={loading}
+          onElementBusyChange={setIsElementBusy}
+        />
+      )}
+    </>
+  );
   // Resume a Generate click the sign-in gate interrupted (#1187): once the
   // user is authenticated and the composer is ready again (draft restored, or
   // the pristine sample re-seeded), re-run the submit flow so the next step —
@@ -1179,6 +1232,86 @@ export const ScriptView: FC<{
     audioModels,
   ]);
 
+  const enhanceControls = (
+    <>
+      {canUndoEnhance && !isEnhancing && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="gap-1.5 text-muted-foreground"
+          onClick={handleUndoEnhance}
+        >
+          <Undo2 className="size-3.5" />
+          Undo
+        </Button>
+      )}
+      {isEnhancing ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="gap-1.5 text-muted-foreground"
+          onClick={handleStopEnhance}
+        >
+          <span className="relative size-5">
+            <Loader2 className="absolute inset-0 size-5 animate-spin" />
+            <Square className="absolute inset-[5px] size-[10px] fill-current" />
+          </span>
+          Stop
+        </Button>
+      ) : (
+        <Popover open={enhancePopoverOpen} onOpenChange={setEnhancePopoverOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              disabled={!scriptValue || scriptValue.length < 10 || isSubmitting}
+            >
+              <Sparkles className="size-3.5 text-primary" />
+              Enhance Script
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="end" side="top" className="w-auto">
+            <div className="flex flex-col gap-3">
+              <p className="text-sm font-medium">Target video duration</p>
+              <ToggleGroup
+                type="single"
+                value={String(targetDuration)}
+                onValueChange={(v) => {
+                  if (v) setTargetDuration(Number(v));
+                }}
+                variant="outline"
+                size="sm"
+                spacing={0}
+              >
+                {DURATION_PRESETS.map((preset) => (
+                  <ToggleGroupItem key={preset.value} value={preset.value}>
+                    {preset.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+              <Button
+                type="button"
+                size="sm"
+                className="gap-1.5"
+                onClick={() => {
+                  setEnhancePopoverOpen(false);
+                  void handleEnhance();
+                }}
+              >
+                <Sparkles className="size-3.5" />
+                Enhance
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+    </>
+  );
+
   return (
     <PremiumCard
       className={cn(
@@ -1206,8 +1339,10 @@ export const ScriptView: FC<{
         onSubmit={(e) => void handleSubmit(e)}
         className="flex flex-col min-h-0 max-h-full"
       >
-        {/* Control bar */}
-        <CardHeader className="shrink-0 flex flex-col lg:flex-row items-start justify-between gap-3 px-6 py-4 border-b border-border/50 bg-card/40">
+        {/* Control bar. Below md the three reference selectors fold into one "References"
+            button that opens a sheet, so the bar is a single row next to the
+            settings trigger. */}
+        <CardHeader className="shrink-0 flex flex-row items-center md:flex-col md:items-start lg:flex-row justify-between gap-3 px-6 py-4 border-b border-border/50 bg-card/40">
           <GenerationSettings
             aspectRatio={aspectRatio}
             analysisModels={analysisModels}
@@ -1234,46 +1369,51 @@ export const ScriptView: FC<{
             appliedFromStyle={appliedFromStyle}
             onResetStyleDefaults={resetStyleDefaults}
           />
-          <div className="flex items-center gap-2 min-h-10">
-            <TalentSuggestionSelector
-              selectedTalentIds={selectedTalentIds}
-              onSelectionChange={(v) =>
-                setSelections((s) => ({ ...s, talentIds: v }))
-              }
-              disabled={loading}
-            />
-            <LocationSuggestionSelector
-              selectedLocationIds={selectedLocationIds}
-              onSelectionChange={(v) =>
-                setSelections((s) => ({ ...s, locationIds: v }))
-              }
-              disabled={loading}
-            />
-            {/* `isEditing = !!sequence?.id`; the `?.` mirrors that derivation for narrowing on `sequence.id` below. */}
-            {/* oxlint-disable-next-line typescript/no-unnecessary-condition */}
-            {isEditing && sequence?.id ? (
-              <ElementSelector
-                ref={elementSelectorRef}
-                sequenceId={sequence.id}
-                disabled={loading}
-                onElementBusyChange={setIsElementBusy}
-              />
-            ) : (
-              <ElementSelector
-                ref={elementSelectorRef}
-                draftElements={draftElements}
-                onDraftElementsChange={setDraftElements}
-                onDraftTokenRename={handleDraftTokenRename}
-                disabled={loading}
-                onElementBusyChange={setIsElementBusy}
-              />
-            )}
+          {/* The selectors own their dialogs and the element ref, so they
+              mount exactly once: inline on md+, inside the sheet below it.
+              Visibility is CSS; only the mount point follows the hook. */}
+          <div className="hidden md:flex items-center gap-2 min-h-10">
+            {!isMobile && referenceSelectors}
           </div>
+          <Sheet
+            open={referencesSheetOpen}
+            onOpenChange={setReferencesSheetOpen}
+          >
+            <SheetTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={loading}
+                className="md:hidden gap-1.5 shrink-0"
+              >
+                <Library className="size-3.5" />
+                References
+                {referenceCount > 0 && (
+                  <span className="ml-1 rounded-full bg-primary/10 px-1.5 text-xs">
+                    {referenceCount}
+                  </span>
+                )}
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="bottom" className="px-4 pb-6">
+              <SheetHeader className="px-0">
+                <SheetTitle>Talent, locations & elements</SheetTitle>
+                <SheetDescription>
+                  Pre-cast talent, pin locations, or add reference images.
+                  Anything you skip is extracted from the script.
+                </SheetDescription>
+              </SheetHeader>
+              <div className="flex flex-col items-start gap-3">
+                {isMobile && referenceSelectors}
+              </div>
+            </SheetContent>
+          </Sheet>
         </CardHeader>
 
         {/* Holds the script alone; the enhance row, style grid and footer are
             pinned below (outside), so long scripts scroll inside the editor
-            (min-h-28 floor, see the wrapper below) with the chrome fixed.
+            (editor floor, see the wrapper below) with the chrome fixed.
             overflow-y-auto is a fallback for viewports too short for even the
             editor floor + Sample-script row — it only engages then. */}
         <CardContent className="min-h-0 @container flex flex-col gap-4 px-6 pt-6 pb-4 overflow-y-auto overflow-x-hidden">
@@ -1289,9 +1429,10 @@ export const ScriptView: FC<{
           {/* Above the editor so the Shuffle button holds its position while
               samples of different lengths grow/shrink the editor below it.
               Always visible while composing — over the user's own text,
-              Shuffle confirms before replacing. */}
+              Shuffle confirms before replacing. Phones drop the caption and
+              put Shuffle in the Enhance strip below. */}
           {!isEditing && (
-            <div className="shrink-0 flex flex-wrap items-center justify-between gap-2">
+            <div className="hidden shrink-0 flex-wrap items-center justify-between gap-2 md:flex">
               <p className="text-xs text-muted-foreground">
                 {sampleStyleId ? (
                   <>
@@ -1324,10 +1465,10 @@ export const ScriptView: FC<{
               </Button>
             </div>
           )}
-          {/* Grows with content above the 4-row floor (min-h-28, see
-              ScriptEditor) — so the card resizes with the script, and samples
-              of different lengths change its height on Shuffle. */}
-          <div className="relative flex min-h-28 flex-col">
+          {/* Grows with content above the editor floor (2 rows on phones, 4 on
+              md+ — see ScriptEditor) — so the card resizes with the script,
+              and samples of different lengths change its height on Shuffle. */}
+          <div className="flex flex-col">
             <ScriptEditor
               ref={textareaRef}
               value={scriptValue}
@@ -1351,122 +1492,53 @@ export const ScriptView: FC<{
         </CardContent>
 
         {/* Pinned between the scrolling script and the Generate footer (#1187):
-            the enhance row and style tiles must never scroll away — or
-            half-clip — behind a long script. @container replaces the one on
-            CardContent for the responsive row below. */}
-        <div className="shrink-0 @container flex flex-col gap-3 px-6 pb-6">
-          <div className="flex flex-col gap-2 @min-[480px]:flex-row @min-[480px]:items-center @min-[480px]:justify-between">
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
+            the style row and tiles must never scroll away — or half-clip —
+            behind a long script. */}
+        <div className="shrink-0 flex flex-col gap-2 px-6 pb-3 sm:gap-3 sm:pb-6">
+          {/* Phones: Shuffle and Enhance share one pinned row right under the
+              script (the caption row and the style row's Enhance slot are md+). */}
+          <div className="flex items-center justify-end gap-2 md:hidden">
+            {!isEditing && (
               <Button
                 type="button"
                 variant="outline"
                 size="sm"
                 className="gap-1.5"
-                disabled={
-                  loading || currentScriptText.length < 3 || isRecommending
-                }
-                onClick={triggerRecommend}
+                disabled={loading || isEnhancing || isSubmitting}
+                onClick={requestShuffle}
               >
-                {isRecommending ? (
-                  <Loader2 className="size-3.5 animate-spin text-primary" />
-                ) : (
-                  <Sparkles className="size-3.5 text-primary" />
-                )}
-                {recommendButtonLabel}
+                <Shuffle className="size-3.5" />
+                Shuffle
               </Button>
-              <StyleCategorySelect
-                styles={styles}
-                value={styleCategoryFilter}
-                onChange={handleStyleCategoryChange}
-                disabled={loading || isLoadingStyles}
-              />
-            </div>
-            <div className="flex shrink-0 items-center justify-end gap-1">
-              {canUndoEnhance && !isEnhancing && (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 text-muted-foreground"
-                  onClick={handleUndoEnhance}
-                >
-                  <Undo2 className="size-3.5" />
-                  Undo
-                </Button>
-              )}
-              {isEnhancing ? (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1.5 text-muted-foreground"
-                  onClick={handleStopEnhance}
-                >
-                  <span className="relative size-5">
-                    <Loader2 className="absolute inset-0 size-5 animate-spin" />
-                    <Square className="absolute inset-[5px] size-[10px] fill-current" />
-                  </span>
-                  Stop
-                </Button>
+            )}
+            {isMobile && enhanceControls}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              disabled={
+                loading || currentScriptText.length < 3 || isRecommending
+              }
+              onClick={triggerRecommend}
+            >
+              {isRecommending ? (
+                <Loader2 className="size-3.5 animate-spin text-primary" />
               ) : (
-                <Popover
-                  open={enhancePopoverOpen}
-                  onOpenChange={setEnhancePopoverOpen}
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="gap-1.5"
-                      disabled={
-                        !scriptValue || scriptValue.length < 10 || isSubmitting
-                      }
-                    >
-                      <Sparkles className="size-3.5 text-primary" />
-                      Enhance Script
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent align="end" side="top" className="w-auto">
-                    <div className="flex flex-col gap-3">
-                      <p className="text-sm font-medium">
-                        Target video duration
-                      </p>
-                      <ToggleGroup
-                        type="single"
-                        value={String(targetDuration)}
-                        onValueChange={(v) => {
-                          if (v) setTargetDuration(Number(v));
-                        }}
-                        variant="outline"
-                        size="sm"
-                        spacing={0}
-                      >
-                        {DURATION_PRESETS.map((preset) => (
-                          <ToggleGroupItem
-                            key={preset.value}
-                            value={preset.value}
-                          >
-                            {preset.label}
-                          </ToggleGroupItem>
-                        ))}
-                      </ToggleGroup>
-                      <Button
-                        type="button"
-                        size="sm"
-                        className="gap-1.5"
-                        onClick={() => {
-                          setEnhancePopoverOpen(false);
-                          void handleEnhance();
-                        }}
-                      >
-                        <Sparkles className="size-3.5" />
-                        Enhance
-                      </Button>
-                    </div>
-                  </PopoverContent>
-                </Popover>
+                <Sparkles className="size-3.5 text-primary" />
               )}
+              {recommendButtonLabel}
+            </Button>
+            <StyleCategorySelect
+              styles={styles}
+              value={styleCategoryFilter}
+              onChange={handleStyleCategoryChange}
+              disabled={loading || isLoadingStyles}
+            />
+            <div className="ml-auto hidden md:flex items-center gap-1">
+              {!isMobile && enhanceControls}
             </div>
           </div>
           <StyleSelector
@@ -1490,7 +1562,7 @@ export const ScriptView: FC<{
           )}
         </div>
 
-        <CardFooter className="shrink-0 flex-col gap-4 border-t border-border/30 bg-transparent px-6 py-4">
+        <CardFooter className="shrink-0 flex-col gap-4 border-t border-border/30 bg-transparent px-6 py-3 sm:py-4">
           {/* Footer row - stacks on mobile, inline on desktop */}
           <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             {/* Meta info - hidden on mobile */}

--- a/src/components/settings/generation-settings-trigger.tsx
+++ b/src/components/settings/generation-settings-trigger.tsx
@@ -39,7 +39,7 @@ export const GenerationSettingsTrigger: FC<GenerationSettingsTriggerProps> = ({
       )}
       <span className="font-mono text-sm">{aspectRatio}</span>
       {autoLabels.length > 0 && (
-        <span className="text-xs text-muted-foreground">
+        <span className="hidden sm:inline text-xs text-muted-foreground">
           {autoLabels.join(' + ')}
         </span>
       )}

--- a/src/components/style/style-selector.tsx
+++ b/src/components/style/style-selector.tsx
@@ -101,21 +101,19 @@ export function StyleSelector({
     const container = gridRef.current;
     if (!container) return;
 
-    const calculateColumns = (width: number) => {
-      const tileSize = 65;
-      const gap = 12;
-      const columns = Math.floor((width + gap) / (tileSize + gap));
+    // Read the resolved track list rather than re-deriving it from the
+    // minmax/gap constants, which differ per breakpoint in the className.
+    const calculateColumns = () => {
+      const columns = getComputedStyle(container)
+        .gridTemplateColumns.split(' ')
+        .filter(Boolean).length;
       setVisibleCount(Math.max(3, columns));
       setMeasured(true);
     };
 
-    calculateColumns(container.clientWidth);
+    calculateColumns();
 
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      calculateColumns(entry.contentRect.width);
-    });
+    const observer = new ResizeObserver(() => calculateColumns());
 
     observer.observe(container);
     return () => observer.disconnect();
@@ -276,15 +274,15 @@ export function StyleSelector({
       <div
         ref={gridRef}
         className={cn(
-          'grid w-full grid-cols-[repeat(auto-fill,minmax(65px,1fr))] gap-3 py-2',
+          'grid w-full grid-cols-[repeat(auto-fill,minmax(56px,1fr))] gap-2 py-1 sm:grid-cols-[repeat(auto-fill,minmax(65px,1fr))] sm:gap-3 sm:py-2',
           // Unmeasured: clamp to one row so the guessed tile count can't wrap
           // and change the grid's height. Row 1 is an explicit auto track;
           // overflow rows get zero height + zero row-gap and are clipped; the
           // bottom padding moves outside the clip (pb-0 + mb-2) so overflow
           // tiles can't peek into it. Total height matches the measured state
-          // exactly: pt(8) + row + mb(8) == pt(8) + row + pb(8).
+          // exactly: pt + row + mb == pt + row + pb at each breakpoint.
           !measured &&
-            'grid-rows-[auto] [grid-auto-rows:0] gap-y-0 overflow-hidden pb-0 mb-2'
+            'grid-rows-[auto] [grid-auto-rows:0] gap-y-0 overflow-hidden pb-0 mb-1 sm:mb-2'
         )}
         role="grid"
         aria-label="Style selection"

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -243,7 +243,10 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             if (i < parts.length - 1) out.push(hardBreak.create());
             return out;
           });
-          view.dispatch(tr.replaceWith(selection.from, selection.to, nodes));
+          // Same delete-then-insert as handlePaste so a selected range doesn't
+          // stay selected around the inserted text.
+          if (!selection.empty) tr.deleteSelection();
+          view.dispatch(tr.insert(tr.selection.from, nodes));
           return true;
         },
       },
@@ -272,9 +275,11 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         });
         if (nodes.length === 0) return true;
 
-        view.dispatch(
-          tr.replaceWith(selection.from, selection.to, nodes).scrollIntoView()
-        );
+        // Delete first, then insert at the collapsed caret: a replaceWith over
+        // a range maps the old selection to span the inserted text (select-all
+        // + paste left the paste selected). A collapsed caret maps past it.
+        if (!selection.empty) tr.deleteSelection();
+        view.dispatch(tr.insert(tr.selection.from, nodes).scrollIntoView());
         return true;
       },
       // Backup path for non-handlePaste clipboard inserts: normalize + hard breaks.


### PR DESCRIPTION
## Related Issue

None — reported from a phone screenshot of openstory.so. Supersedes the earlier layout-only attempt on this branch (reverted).

## Summary of Changes

On phones the composer's fixed chrome (two-row control bar, caption row, enhance row, style tiles, footer) outsized the viewport and crushed the script editor to nothing. Instead of rearranging rows, this reduces the number of controls on phones. Desktop (`md+`) is pixel-identical to main.

- **Control bar → one row.** Talent / Locations / Elements fold into a single **References** button (count badge) that opens a bottom sheet with the three existing selectors. They mount once — inline on `md+`, in the sheet below — via `useIsMobile`; visibility is CSS so SSR doesn't flash. Settings trigger hides its "Motion + Music" text below `sm`.
- **Shuffle + Enhance Script share one pinned row** directly under the script on phones; the "Sample script" caption row is `md+` only. Enhance stays in the style row on desktop.
- **Smaller style tiles on phones** (`minmax(56px)` / `gap-2`, ~4 columns at 375px). The column count is now read from the computed grid instead of duplicating the minmax/gap constants in JS.
- **Tighter phone spacing**: lead-in (tagline hidden, smaller gaps), less padding between tiles and Generate.
- `ScriptEditor` floor: 2 rows on phones (the row beneath makes up the difference), 4 on `md+`.
- Elements popover width clamps to the viewport.

Also fixes **select-all + paste leaving the pasted text selected** (`markdown-editor.tsx`): `tr.replaceWith(from, to, …)` maps a range selection to span the inserted content. Now deletes the selection first and inserts at the collapsed caret; same fix on the `beforeinput` path.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Class changes plus a single-instance mount-point switch for the selectors and enhance controls. Typecheck, lint, format pass. No unit tests cover these components; Playwright runs at 1920×1080 so the desktop path is what e2e exercises.

Verified with screenshots at 375×667, 390×664, 390×844 (phone layout), 768×900 and 1280×800 (unchanged vs main). Paste fix verified in Chrome via Playwright (⌘A, ⌘V → collapsed selection, text replaced).

## Additional Notes

- "References" was chosen over "Cast" since all three are library items referenced from the script; easy to rename.
- The sheet lists the three existing triggers (Talent opens its dialog over the sheet). A tabbed sheet would need each selector split into trigger + content — out of scope here.
