### PR TITLE
chore(models): bump GLM-5.2 → GLM-5.3

### DIFF
--- a/src/lib/ai/__tests__/vision-model-routing.test.ts
+++ b/src/lib/ai/__tests__/vision-model-routing.test.ts
@@ -7,12 +7,12 @@ import {
 
 // Text-only analysis models can't see the rendered still the motion-prompt pass
 // conditions on (#929), so an image-bearing call on one routes to
-// DEFAULT_VISION_MODEL. GLM-4.6V was tried as GLM-5.2's companion (#942) but
+// DEFAULT_VISION_MODEL. GLM-4.6V was tried as GLM-5.x's companion (#942) but
 // can't do strict structured outputs, so we fall back to the default (#944).
 describe('vision-model routing', () => {
   it('routes a text-only model with an image to DEFAULT_VISION_MODEL', () => {
-    expect(analysisModelSupportsVision('z-ai/glm-5.2')).toBe(false);
-    expect(resolveVisionModel('z-ai/glm-5.2', true)).toBe(DEFAULT_VISION_MODEL);
+    expect(analysisModelSupportsVision('z-ai/glm-5.3')).toBe(false);
+    expect(resolveVisionModel('z-ai/glm-5.3', true)).toBe(DEFAULT_VISION_MODEL);
     // Also any other text-only model — the fallback is universal, not per-model.
     expect(resolveVisionModel('deepseek/deepseek-v3.2', true)).toBe(
       DEFAULT_VISION_MODEL
@@ -20,7 +20,7 @@ describe('vision-model routing', () => {
   });
 
   it('leaves a text-only model unchanged when there is no image', () => {
-    expect(resolveVisionModel('z-ai/glm-5.2', false)).toBe('z-ai/glm-5.2');
+    expect(resolveVisionModel('z-ai/glm-5.3', false)).toBe('z-ai/glm-5.3');
   });
 
   it('leaves a vision-capable model unchanged even with an image', () => {

--- a/src/lib/ai/create-adapter.ts
+++ b/src/lib/ai/create-adapter.ts
@@ -78,6 +78,10 @@ export const CATALOG_LAG_MODELS = [
     input: ['text', 'image'],
     features: ['reasoning', 'structured_outputs'],
   }),
+  createModel('z-ai/glm-5.3', {
+    input: ['text'],
+    features: ['reasoning', 'structured_outputs'],
+  }),
 ] as const;
 
 const openRouterTextExtended = extendAdapter(

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -234,7 +234,7 @@ const STRUCTURED_OUTPUT_MODELS = new Set([
   'x-ai/grok-4.20',
   'anthropic/claude-opus-4.8',
   'deepseek/deepseek-v3.2',
-  'z-ai/glm-5.2',
+  'z-ai/glm-5.3',
   'google/gemini-3.1-pro-preview',
   'openai/gpt-5.5',
   'google/gemini-3-flash-preview',

--- a/src/lib/ai/models.config.ts
+++ b/src/lib/ai/models.config.ts
@@ -80,13 +80,13 @@ export const SCRIPT_ANALYSIS_MODELS = [
     description: 'MIT license, MMLU 94.2, GPT-5 class reasoning',
   },
   {
-    id: 'z-ai/glm-5.2',
-    name: 'GLM-5.2',
+    id: 'z-ai/glm-5.3',
+    name: 'GLM-5.3',
     provider: 'Z.ai',
     license: 'open-source' as const,
     qualityRank: 8,
     contextWindow: 1_048_576,
-    // GLM-5.2 is text-only. Image-bearing calls (the vision-conditioned motion
+    // GLM-5.3 is text-only. Image-bearing calls (the vision-conditioned motion
     // path, #929) transparently route to `DEFAULT_VISION_MODEL` — see
     // `resolveVisionModel`. GLM's own vision sibling GLM-4.6V was tried (#942)
     // but can't do strict structured outputs, which the motion-prompt call

--- a/src/lib/ai/openrouter-pricing-data.ts
+++ b/src/lib/ai/openrouter-pricing-data.ts
@@ -51,10 +51,10 @@ export const OPENROUTER_PRICING: Record<string, OpenRouterPricing> = {
     promptPerMillionTokens: 0.26899999999999996,
     completionPerMillionTokens: 0.39999999999999997,
   },
-  'z-ai/glm-5.2': {
-    name: 'Z.ai: GLM 5.2',
-    promptPerMillionTokens: 0.9057999999999999,
-    completionPerMillionTokens: 2.8468,
+  'z-ai/glm-5.3': {
+    name: 'Z.ai: GLM 5.3',
+    promptPerMillionTokens: 1.4,
+    completionPerMillionTokens: 4.4,
   },
   'google/gemini-3.1-pro-preview': {
     name: 'Google: Gemini 3.1 Pro Preview',


### PR DESCRIPTION
## Model update: GLM-5.2 → GLM-5.3

Detected by the daily model-freshness routine (#792). GLM-5.3 shipped on OpenRouter as the direct successor to GLM-5.2 in our text-analysis registry.

### Change
- **Registry key:** `GLM-5.2` → renamed to `GLM-5.3` **(display name only — the registry KEY is not a persisted DB key for text models; the model `id` is the identity, which the skill directs us to update)**
- **Old id → new id:** `z-ai/glm-5.2` → `z-ai/glm-5.3`
- **Registry:** `SCRIPT_ANALYSIS_MODELS` in `src/lib/ai/models.config.ts` (`id`, `name`, comment). `qualityRank`, `contextWindow` (1M), `vision: false`, and `description` unchanged — same tier, same modality, same context window.

### Why it's a genuine successor
- `z-ai/glm-5.3` resolves on the OpenRouter catalog (`Z.ai: GLM 5.3`), a plain-tier text model — **not** a `:free`, `:batch`, `-turbo`, or `-v` (vision) variant.
- Same modality (text-only) and same 1,048,576-token context window as 5.2.
- One minor version newer within the same GLM-5.x product line — not a tier/variant swap or preview build.
- Rejected siblings confirming the tier match: `z-ai/glm-5.3` is the only same-tier successor; `glm-5v-turbo`, `glm-5-turbo`, `glm-5.2:free`, `glm-5.2:batch` are different tiers/variants and were not adopted.

### Follow-through
- `src/lib/ai/llm-client.ts` — `STRUCTURED_OUTPUT_MODELS` allowlist updated `glm-5.2` → `glm-5.3` (5.3 supports structured outputs, same as 5.2).
- `src/lib/ai/create-adapter.ts` — added a `CATALOG_LAG_MODELS` bridge for `z-ai/glm-5.3` (`input: ['text']`, `features: ['reasoning', 'structured_outputs']`). The installed `@tanstack/ai-openrouter` catalog snapshot predates 5.3, so the id is not yet in its typed model union; typecheck fails at the `createAdapter` call sites without this. Prune when the package bump ships the id.
- `src/lib/ai/__tests__/vision-model-routing.test.ts` — updated the exercised analysis-model id to `glm-5.3`.
- `src/lib/ai/openrouter-pricing-data.ts` (auto-generated) — regenerated the GLM entry manually (the generator uses Bun `fetch`, which can't traverse this environment's TLS-intercepting proxy). Values fetched live via `curl` from the OpenRouter models API.

### Pricing delta (OpenRouter, per 1M tokens)
| | prompt | completion |
| --- | --- | --- |
| GLM-5.2 | $0.906 | $2.847 |
| GLM-5.3 | $1.40 | $4.40 |

GLM-5.3 is ~55% more expensive per token — worth a reviewer's note before merge.

### Quality gates (all green)
- ✅ `bun typecheck`
- ✅ `bun lint` (pre-existing warnings only; none in touched files)
- ✅ `bun run test src/lib/ai src/lib/motion` — 491 passed
- ✅ `bun run test src/lib/billing` — 69 passed (OpenRouter pricing data touched)

### Links
- OpenRouter model: https://openrouter.ai/z-ai/glm-5.3

🤖 Opened by the daily model-freshness routine (#792). Verify pricing & quality before merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwQwKCnxjPRXXHBiQoMwkA)_