### PR TITLE
fix(#1220): script composer paste, scroll, and placeholder overlay

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -119,6 +119,8 @@
   "overrides": {
     "@better-auth/core": "1.6.26",
     "@better-auth/utils": "0.4.2",
+    "prosemirror-model": "1.25.11",
+    "prosemirror-view": "1.42.2",
     "qs": "6.15.2",
     "ws": "^8.21.0",
   },
@@ -2753,31 +2755,7 @@
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
-    "prosemirror-commands/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-dropcursor/prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
-
-    "prosemirror-gapcursor/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-gapcursor/prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
-
-    "prosemirror-history/prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
-
     "prosemirror-markdown/@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
-
-    "prosemirror-markdown/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-schema-list/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-state/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-state/prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
-
-    "prosemirror-tables/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-tables/prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
-
-    "prosemirror-transform/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
 
     "redent/strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -3036,10 +3014,6 @@
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "prosemirror-dropcursor/prosemirror-view/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
-
-    "prosemirror-history/prosemirror-view/prosemirror-model": ["prosemirror-model@1.25.7", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug=="],
 
     "prosemirror-markdown/@types/markdown-it/@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 

--- a/e2e/tests/sequences.spec.ts
+++ b/e2e/tests/sequences.spec.ts
@@ -7,6 +7,7 @@
  */
 
 import { test, expect } from 'playwright/test';
+import { waitForScriptEditor } from '../fixtures/test-utils';
 
 test.describe('Sequences', () => {
   test('can access sequences list page', async ({ page }) => {
@@ -24,6 +25,43 @@ test.describe('Sequences', () => {
     // resilient to internal ProseMirror DOM shape.
     const editor = page.locator('[data-slot="markdown-editor"]');
     await expect(editor).toBeVisible();
+  });
+
+  test('long multi-scene script scrolls inside the editor', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    const prose = await waitForScriptEditor(page);
+    const script = Array.from(
+      { length: 30 },
+      (_, i) => `INT. SCENE ${i + 1} - NIGHT\n\nAction line ${i + 1}.`
+    ).join('\n\n');
+
+    await prose.click();
+    await page.keyboard.press('ControlOrMeta+A');
+    await prose.evaluate((el, text) => {
+      const dt = new DataTransfer();
+      dt.setData('text/plain', text);
+      const ev = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(ev, 'clipboardData', { value: dt });
+      el.dispatchEvent(ev);
+    }, script);
+
+    const paragraphs = page.locator(
+      '[data-slot="markdown-editor"] .ProseMirror p'
+    );
+    await expect(paragraphs).toHaveCount(60);
+
+    const editor = page.locator('[data-slot="markdown-editor"]');
+    const metrics = await editor.evaluate((el) => {
+      el.scrollTop = 400;
+      return {
+        canScroll: el.scrollHeight > el.clientHeight + 1,
+        scrollTopAfter: el.scrollTop,
+      };
+    });
+    expect(metrics.canScroll).toBe(true);
+    expect(metrics.scrollTopAfter).toBeGreaterThan(100);
   });
 
   test('composer style row defaults to cinematic and can switch family', async ({

--- a/package.json
+++ b/package.json
@@ -205,6 +205,8 @@
   "overrides": {
     "@better-auth/core": "1.6.26",
     "@better-auth/utils": "0.4.2",
+    "prosemirror-model": "1.25.11",
+    "prosemirror-view": "1.42.2",
     "qs": "6.15.2",
     "ws": "^8.21.0"
   },

--- a/src/components/script/script-editor.tsx
+++ b/src/components/script/script-editor.tsx
@@ -37,11 +37,9 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({
 }) => {
   const handleChange = useCallback(
     (markdown: string) => {
-      if (!maxLength || markdown.length <= maxLength) {
-        onValueChange(markdown);
-      }
+      onValueChange(markdown);
     },
-    [onValueChange, maxLength]
+    [onValueChange]
   );
 
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
@@ -78,7 +76,7 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({
           disabled={disabled}
           aria-invalid={hasError}
           className={cn(
-            'min-h-[2lh] md:min-h-[4lh] flex-1 bg-transparent dark:bg-transparent border-none shadow-none focus-within:ring-0 focus-within:border-input overscroll-contain pb-10',
+            'min-h-[2lh] md:min-h-[4lh] flex-1 bg-transparent dark:bg-transparent border-none shadow-none focus-within:ring-0 focus-within:border-input pb-10',
             hasError && 'border-destructive focus-within:ring-destructive/20'
           )}
           data-testid="script-editor-textarea"

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -1484,9 +1484,10 @@ export const ScriptView: FC<{
             </div>
           )}
           {/* Grows with content above the editor floor (2 rows on phones, 4 on
-              md+ — see ScriptEditor) — so the card resizes with the script,
-              and samples of different lengths change its height on Shuffle. */}
-          <div className="flex flex-col">
+              md+ — see ScriptEditor) until the card hits max-h-full, then the
+              editor scrolls. min-h-0 lets this flex child shrink so overflow
+              stays on the editor, not CardContent (#1220). */}
+          <div className="flex min-h-0 flex-1 flex-col">
             <ScriptEditor
               ref={textareaRef}
               value={scriptValue}

--- a/src/components/text-editor/markdown-editor-placeholder.test.tsx
+++ b/src/components/text-editor/markdown-editor-placeholder.test.tsx
@@ -14,4 +14,15 @@ describe('MarkdownEditor empty placeholder', () => {
     expect(html).toContain('A one-liner is enough');
     expect(html).toContain('<p');
   });
+
+  it('does not SSR the placeholder over seeded content', () => {
+    const html = renderToStaticMarkup(
+      <MarkdownEditor
+        value="INT. ROOM - NIGHT"
+        onValueChange={() => undefined}
+        placeholder="A one-liner is enough"
+      />
+    );
+    expect(html).not.toContain('A one-liner is enough');
+  });
 });

--- a/src/components/text-editor/markdown-editor.test.ts
+++ b/src/components/text-editor/markdown-editor.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  normalizeScreenplayNewlines,
-  plainTextPasteAsMarkdown,
-  toHardBreakMarkdown,
-} from './markdown-editor';
+import { normalizeScreenplayNewlines } from './markdown-editor';
 
 describe('normalizeScreenplayNewlines', () => {
   it('converts CRLF and CR to LF', () => {
@@ -14,49 +10,5 @@ describe('normalizeScreenplayNewlines', () => {
     expect(normalizeScreenplayNewlines('Scene 1\u2028Body\u2029Scene 2')).toBe(
       'Scene 1\nBody\nScene 2'
     );
-  });
-});
-
-describe('toHardBreakMarkdown', () => {
-  it('converts single newlines to markdown hard breaks', () => {
-    expect(toHardBreakMarkdown('INT. ROOM\nA man enters.')).toBe(
-      'INT. ROOM  \nA man enters.'
-    );
-  });
-
-  it('leaves paragraph-separating blank lines intact', () => {
-    expect(toHardBreakMarkdown('Scene one.\n\nScene two.')).toBe(
-      'Scene one.\n\nScene two.'
-    );
-  });
-
-  it('handles mixed single and double newlines', () => {
-    expect(toHardBreakMarkdown('a\nb\n\nc')).toBe('a  \nb\n\nc');
-  });
-
-  it('normalizes Unicode line separators before hard-break conversion', () => {
-    expect(toHardBreakMarkdown('Scene 1\u2028Body')).toBe('Scene 1  \nBody');
-  });
-});
-
-describe('plainTextPasteAsMarkdown', () => {
-  it('coerces rich (text/html) paste to its plain-text markdown form', () => {
-    const html = '<p style="color:red"><b>Bold</b> line</p>';
-    expect(plainTextPasteAsMarkdown(html, 'Bold line')).toBe('Bold line');
-  });
-
-  it('strips styling but preserves multi-line structure as hard breaks', () => {
-    const html = '<h1>Title</h1><p>Body</p>';
-    expect(plainTextPasteAsMarkdown(html, 'Title\nBody')).toBe('Title  \nBody');
-  });
-
-  it('uses plain text even when HTML is empty (still coerces newlines)', () => {
-    expect(plainTextPasteAsMarkdown('', '# Heading\nline')).toBe(
-      '# Heading  \nline'
-    );
-  });
-
-  it('defers image-only / non-text paste to the default handler', () => {
-    expect(plainTextPasteAsMarkdown('<img src="x">', '')).toBeNull();
   });
 });

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -1,6 +1,6 @@
 import HardBreak from '@tiptap/extension-hard-break';
 import { Placeholder } from '@tiptap/extensions/placeholder';
-import { type Editor, EditorContent, useEditor } from '@tiptap/react';
+import { EditorContent, useEditor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import {
   Markdown,
@@ -13,43 +13,21 @@ import { useEffect, useMemo, useRef } from 'react';
 import type { MentionOptions } from '@tiptap/extension-mention';
 import type { MentionItem } from '@/components/scenes/prompt-mention/mention-items';
 import { PromptMention } from './mention/mention-extension';
+import { createMentionSuggestion } from './mention/mention-suggestion';
+import { tagifyMarkdown } from './mention/tagify';
 
 type MentionConfigure = Partial<MentionOptions>;
 
 /**
  * Collapse every line-break form to `\n`. Web/Docs/Word often put U+2028
- * (LINE SEPARATOR) between lines — that is not matched by `\n` splits, so
- * multi-line paste looked empty or landed as one run-on line.
+ * (LINE SEPARATOR) between lines — ProseMirror's default paste splitter only
+ * matches `\n` / `\r`, so those pastes looked empty or run-on.
  */
 export const normalizeScreenplayNewlines = (text: string): string =>
   text
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
-    // LINE SEPARATOR, PARAGRAPH SEPARATOR, NEXT LINE (NEL)
     .replace(/[\u2028\u2029\u0085]/g, '\n');
-
-// markdown-it parses two trailing spaces + `\n` as a hard break, so converting
-// single newlines (but not paragraph-separating blank lines) keeps a pasted
-// multi-line screenplay block in one paragraph instead of shredding each line
-// into its own paragraph. Exported for unit testing.
-export const toHardBreakMarkdown = (text: string): string =>
-  normalizeScreenplayNewlines(text).replace(/(?<!\n)\n(?!\n)/g, '  \n');
-
-// Decide what to insert for a paste. The script editor must only ever ingest
-// plain text — never the arbitrary inline styling (fonts, colours, sizes) that
-// rich `text/html` clipboard payloads from Word / Google Docs / web pages
-// carry. Returns null when there is no usable text (image-only paste). Exported
-// for unit testing.
-export const plainTextPasteAsMarkdown = (
-  html: string,
-  text: string
-): string | null => {
-  if (!text) return null; // image-only / non-text paste — leave to default
-  void html;
-  return toHardBreakMarkdown(text);
-};
-import { createMentionSuggestion } from './mention/mention-suggestion';
-import { tagifyMarkdown } from './mention/tagify';
 
 declare module '@tiptap/core' {
   interface Storage {
@@ -148,10 +126,6 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const onFocusRef = useRef(onFocus);
   onFocusRef.current = onFocus;
 
-  // handlePaste is captured at editor init (before `editor` is assigned), so it
-  // reads the live instance through this ref to insert markdown at the caret.
-  const editorRef = useRef<Editor | null>(null);
-
   // The suggestion plugin fires on every `@` keystroke; the items it pulls
   // must reflect the parent's latest list (it grows as the user adds cast /
   // elements / locations to the sequence) even though the editor's extensions
@@ -183,7 +157,9 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         html: hasMentions,
         linkify: true,
         breaks: true,
-        transformPastedText: true,
+        // Off: tiptap-markdown's clipboard parser uses `{ inline: true }`,
+        // which drops multi-line paste. Default ProseMirror paste is enough.
+        transformPastedText: false,
         transformCopiedText: true,
       }),
       Placeholder.configure({
@@ -218,79 +194,13 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         class: cn(proseClasses, placeholderClasses),
       },
       handleKeyDown: (_view, event) => onKeyDownRef.current?.(event) === true,
-      // Bulk inputs that carry embedded newlines (Playwright .fill, drag-drop
-      // of multi-line text, programmatic execCommand('insertText', …)) would
-      // otherwise split each line into a separate paragraph and shred
-      // screenplay structure. Intercept beforeinput and convert single \n
-      // into HardBreak nodes so the line layout survives the round-trip;
-      // getMarkdown() then emits each as a single \n (with breaks:true).
-      // Enter keypresses arrive as a separate inputType ('insertParagraph')
-      // and aren't touched here, so typing a new paragraph still works.
-      handleDOMEvents: {
-        beforeinput: (view, event) => {
-          if (!(event instanceof InputEvent)) return false;
-          if (event.inputType !== 'insertText' || !event.data?.includes('\n')) {
-            return false;
-          }
-          const { schema, tr, selection } = view.state;
-          const hardBreak = schema.nodes.hardBreak;
-          if (!hardBreak) return false;
-          event.preventDefault();
-          const parts = event.data.split('\n');
-          const nodes = parts.flatMap((part, i) => {
-            const out = [];
-            if (part.length > 0) out.push(schema.text(part));
-            if (i < parts.length - 1) out.push(hardBreak.create());
-            return out;
-          });
-          // Same delete-then-insert as handlePaste so a selected range doesn't
-          // stay selected around the inserted text.
-          if (!selection.empty) tr.deleteSelection();
-          view.dispatch(tr.insert(tr.selection.from, nodes));
-          return true;
-        },
-      },
-      // Always paste plain text only (strip Word/Docs/HTML styling). Use the
-      // same hard-break insertion path as beforeinput — do not use
-      // insertContent: tiptap-markdown forces inline markdown parse and drops
-      // multi-line pastes after preventDefault. Also normalize U+2028 etc.
-      handlePaste: (view, event) => {
-        const clipboard = event.clipboardData;
-        if (!clipboard) return false;
-        const raw = clipboard.getData('text/plain');
-        if (!raw) return false; // image-only / non-text — leave to default
-        event.preventDefault();
-
-        const text = normalizeScreenplayNewlines(raw);
-        const { schema, tr, selection } = view.state;
-        const hardBreak = schema.nodes.hardBreak;
-        if (!hardBreak) return false;
-
-        const lines = text.split('\n');
-        const nodes = lines.flatMap((line, i) => {
-          const out = [];
-          if (line.length > 0) out.push(schema.text(line));
-          if (i < lines.length - 1) out.push(hardBreak.create());
-          return out;
-        });
-        if (nodes.length === 0) return true;
-
-        // Delete first, then insert at the collapsed caret: a replaceWith over
-        // a range maps the old selection to span the inserted text (select-all
-        // + paste left the paste selected). A collapsed caret maps past it.
-        if (!selection.empty) tr.deleteSelection();
-        view.dispatch(tr.insert(tr.selection.from, nodes).scrollIntoView());
-        return true;
-      },
-      // Backup path for non-handlePaste clipboard inserts: normalize + hard breaks.
-      transformPastedText: (text) => toHardBreakMarkdown(text),
+      transformPastedText: (text) => normalizeScreenplayNewlines(text),
     },
     onUpdate: ({ editor: e }) => {
       onValueChange(e.storage.markdown.getMarkdown());
     },
     onFocus: () => onFocusRef.current?.(),
   });
-  editorRef.current = editor;
 
   // Canonical Tiptap external-value sync (mirrors the Vue v-model example in
   // their docs): only setContent if the editor's current markdown differs
@@ -369,7 +279,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         editor.commands.focus('end');
       }}
     >
-      {!value && placeholder ? (
+      {placeholder && (editor ? editor.isEmpty : !value) ? (
         <p className="pointer-events-none absolute inset-x-0 top-0 px-2.5 py-2 text-base text-muted-foreground md:text-sm">
           {placeholder}
         </p>

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -1,6 +1,7 @@
 import HardBreak from '@tiptap/extension-hard-break';
 import { Placeholder } from '@tiptap/extensions/placeholder';
 import { EditorContent, useEditor } from '@tiptap/react';
+import type { EditorView } from '@tiptap/pm/view';
 import StarterKit from '@tiptap/starter-kit';
 import {
   Markdown,
@@ -28,6 +29,29 @@ export const normalizeScreenplayNewlines = (text: string): string =>
     .replace(/\r\n/g, '\n')
     .replace(/\r/g, '\n')
     .replace(/[\u2028\u2029\u0085]/g, '\n');
+
+/**
+ * Playwright `.fill()` (and other `insertText` with embedded newlines) cannot
+ * put `\n` in a ProseMirror text node. Map each newline to a hard break so
+ * `getMarkdown()` round-trips the source script — including the recorded
+ * aimock enhance body. Paste is not handled here; ProseMirror owns that.
+ */
+const insertTextWithNewlines = (view: EditorView, text: string): boolean => {
+  const normalized = normalizeScreenplayNewlines(text);
+  const { schema, tr, selection } = view.state;
+  const hardBreak = schema.nodes.hardBreak;
+  if (!hardBreak) return false;
+  const nodes = normalized.split('\n').flatMap((line, i, lines) => {
+    const out = [];
+    if (line.length > 0) out.push(schema.text(line));
+    if (i < lines.length - 1) out.push(hardBreak.create());
+    return out;
+  });
+  if (nodes.length === 0) return true;
+  if (!selection.empty) tr.deleteSelection();
+  view.dispatch(tr.insert(tr.selection.from, nodes).scrollIntoView());
+  return true;
+};
 
 declare module '@tiptap/core' {
   interface Storage {
@@ -194,6 +218,16 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         class: cn(proseClasses, placeholderClasses),
       },
       handleKeyDown: (_view, event) => onKeyDownRef.current?.(event) === true,
+      handleDOMEvents: {
+        beforeinput: (view, event) => {
+          if (!(event instanceof InputEvent)) return false;
+          if (event.inputType !== 'insertText' || !event.data?.includes('\n')) {
+            return false;
+          }
+          event.preventDefault();
+          return insertTextWithNewlines(view, event.data);
+        },
+      },
       transformPastedText: (text) => normalizeScreenplayNewlines(text),
     },
     onUpdate: ({ editor: e }) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -157,6 +157,15 @@ function envIcons(): Plugin {
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
+    // TipTap/ProseMirror use instanceof Node. Nested 1.25.7 copies next to
+    // @tiptap/pm's 1.25.11 make wrap/split (default paste) fail and log
+    // "prosemirror-model is loaded more than once".
+    dedupe: [
+      'prosemirror-model',
+      'prosemirror-state',
+      'prosemirror-view',
+      'prosemirror-transform',
+    ],
   },
   server: {
     port: 3000,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,12 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
+    dedupe: [
+      'prosemirror-model',
+      'prosemirror-state',
+      'prosemirror-view',
+      'prosemirror-transform',
+    ],
     alias: {
       // `cloudflare:*` are Workerd-only virtual modules. Stub them so unit
       // tests that transitively import workflow entrypoint classes resolve in


### PR DESCRIPTION
Closes #1220

## What was broken

Pasting a screenplay into the composer produced a stuck, unscrollable box with the empty-state placeholder drawn on top of the text.

Three stacked hacks:

1. **Paste** — `tiptap-markdown` with `transformPastedText: true` parses clipboard text as `{ inline: true }`, which drops multi-line paste. A custom `handlePaste` then `preventDefault`’d and inserted nodes by hand, which made that worse (one giant `<br>` paragraph).
2. **Scroll** — the editor wrapper was not a shrinking flex child (`min-h-0`). Long content grew the editor; `overscroll-contain` trapped the wheel so `CardContent` never moved.
3. **Placeholder** — the LCP overlay is keyed on React `value`. Pastes over the 50k `maxLength` were silently dropped, so `value` stayed `''` while TipTap already had the screenplay.

## Fix

- Let ProseMirror handle paste. Turn off markdown `transformPastedText`. Only normalize Unicode line separators.
- Editor wrapper is `flex-1 min-h-0`; drop `overscroll-contain`. Long scripts scroll inside the editor; style tiles + Generate stay pinned.
- Hide the placeholder when the editor is not empty. Always propagate `onValueChange` so parent state matches the doc.

## Test plan

- [ ] Empty composer: placeholder shows, Shuffle still works.
- [ ] Paste a short multi-scene script: paragraphs land, no overlay, editor grows with content.
- [ ] Paste a long screenplay (e.g. 2001): editor scrolls, placeholder gone, Generate/style row stay on screen.
- [ ] Phone width: same — script scrolls inside the box.
- [ ] Copy-from (`/sequences/new?from=…`): long derived script scrolls.