### PR TITLE
Improve script reveal while splitting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -97,6 +97,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "chalk": "^6.0.0",
         "json5": "^2.2.3",
+        "jsonc-parser": "3.3.1",
         "knip": "^6.32.2",
         "lefthook": "^2.1.10",
         "msw": "^2.15.0",

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "chalk": "^6.0.0",
     "json5": "^2.2.3",
+    "jsonc-parser": "3.3.1",
     "knip": "^6.32.2",
     "lefthook": "^2.1.10",
     "msw": "^2.15.0",

--- a/src/components/scenes/scene-script-document.test.ts
+++ b/src/components/scenes/scene-script-document.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildScriptBlocks,
+  unsplitScriptTail,
   type ScriptBlockScene,
 } from './scene-script-document';
 import { dbSceneId } from '@/lib/db/schema';
@@ -41,5 +42,43 @@ describe('buildScriptBlocks', () => {
 
     expect(blocks).toHaveLength(1);
     expect(blocks[0]?.extract).toBe('');
+  });
+});
+
+describe('unsplitScriptTail', () => {
+  const script =
+    'INT. ONE\n\nfirst.\n\nEXT. TWO\n\nsecond.\n\nINT. THREE\n\nthird.';
+
+  it('returns the whole script before any scene lands', () => {
+    expect(unsplitScriptTail(script, [])).toBe(script);
+  });
+
+  it('shrinks to what follows the last split scene', () => {
+    expect(
+      unsplitScriptTail(script, [
+        { extract: 'INT. ONE\n\nfirst.' },
+        { extract: 'EXT. TWO\n\nsecond.' },
+      ])
+    ).toBe('INT. THREE\n\nthird.');
+  });
+
+  it('is empty once every scene is split', () => {
+    expect(
+      unsplitScriptTail(script, [
+        { extract: 'INT. ONE\n\nfirst.' },
+        { extract: 'EXT. TWO\n\nsecond.' },
+        { extract: 'INT. THREE\n\nthird.' },
+      ])
+    ).toBe('');
+  });
+
+  it('skips an extract it cannot find instead of resetting', () => {
+    expect(
+      unsplitScriptTail(script, [
+        { extract: 'INT. ONE\n\nfirst.' },
+        { extract: 'edited away' },
+        { extract: 'EXT. TWO\n\nsecond.' },
+      ])
+    ).toBe('INT. THREE\n\nthird.');
   });
 });

--- a/src/components/scenes/scene-script-document.tsx
+++ b/src/components/scenes/scene-script-document.tsx
@@ -58,6 +58,25 @@ export function buildScriptBlocks(
     }));
 }
 
+/**
+ * The part of the full script no scene has claimed yet (#1225). Extracts are
+ * verbatim, in-order substrings of the script, so walk them forward and return
+ * what follows the last one. An extract that can't be located (edited after
+ * the split) is skipped rather than resetting the cursor.
+ */
+export function unsplitScriptTail(
+  script: string,
+  blocks: readonly Pick<ScriptBlock, 'extract'>[]
+): string {
+  let cursor = 0;
+  for (const { extract } of blocks) {
+    if (!extract) continue;
+    const at = script.indexOf(extract, cursor);
+    if (at !== -1) cursor = at + extract.length;
+  }
+  return script.slice(cursor).trim();
+}
+
 type SceneScriptBlockProps = {
   block: ScriptBlock;
   sequenceId: string;
@@ -177,6 +196,9 @@ type SceneScriptDocumentProps = {
   /** Scene ids highlighted by the current selection. */
   selectedSceneIds: readonly string[];
   onSelectScene: (sceneId: string) => void;
+  /** The full script while it is still being split: the not-yet-split tail is
+   *  shown read-only below the scene blocks and shrinks as scenes land. */
+  splittingScript?: string | null;
 };
 
 export const SceneScriptDocument: React.FC<SceneScriptDocumentProps> = ({
@@ -184,8 +206,13 @@ export const SceneScriptDocument: React.FC<SceneScriptDocumentProps> = ({
   scenes,
   selectedSceneIds,
   onSelectScene,
+  splittingScript,
 }) => {
   const { items: mentionItems } = useSequenceMentionItems(sequenceId);
+  const blocks = scenes ? buildScriptBlocks(scenes) : [];
+  const tail = splittingScript
+    ? unsplitScriptTail(splittingScript, blocks)
+    : '';
 
   if (!scenes) {
     return (
@@ -197,10 +224,9 @@ export const SceneScriptDocument: React.FC<SceneScriptDocumentProps> = ({
     );
   }
 
-  const blocks = buildScriptBlocks(scenes);
   const selected = new Set(selectedSceneIds);
 
-  if (blocks.length === 0) {
+  if (blocks.length === 0 && !tail) {
     return (
       <div className="flex h-full items-center justify-center p-6">
         <p className="text-sm text-muted-foreground">
@@ -223,6 +249,21 @@ export const SceneScriptDocument: React.FC<SceneScriptDocumentProps> = ({
             mentionItems={mentionItems}
           />
         ))}
+        {tail && (
+          <section
+            aria-label="Script not yet split into scenes"
+            aria-busy="true"
+            className="flex flex-col gap-2 rounded-lg border border-dashed p-4"
+          >
+            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Splitting into scenes…
+            </div>
+            <pre className="whitespace-pre-wrap font-sans text-sm text-muted-foreground">
+              {tail}
+            </pre>
+          </section>
+        )}
       </div>
     </ScrollArea>
   );

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -1345,6 +1345,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
                 scenes={scenes}
                 selectedSceneIds={selectedScenes.map((s) => s.id)}
                 onSelectScene={handleFocusScene}
+                splittingScript={isProcessing ? sequence.script : undefined}
               />
             ) : (
               <SceneCanvas

--- a/src/functions/scenes.ts
+++ b/src/functions/scenes.ts
@@ -30,7 +30,9 @@ export const getScenesFn = createServerFn({ method: 'GET' })
 // editor is a per-request choice that becomes durable when the version it
 // produces is selected; see `@/lib/ai/resolve-asset-models`.
 
-/** Composed sequence script from selected scene versions (#1030). */
+/** Composed sequence script from selected scene versions (#1030). Before the
+ *  split has seeded any versions (mid-analysis, #1225) fall back to the
+ *  original script so "Copy script" isn't dead until the scenes land. */
 export const getComposedScriptFn = createServerFn({ method: 'GET' })
   .middleware([sequenceAccessMiddleware])
   .handler(async ({ context }) => {
@@ -38,7 +40,7 @@ export const getComposedScriptFn = createServerFn({ method: 'GET' })
       context.scopedDb,
       context.sequence.id
     );
-    return { script: composed };
+    return { script: composed || (context.sequence.script ?? '') };
   });
 
 const updateSceneScriptSchema = z.object({

--- a/src/lib/api-v1/device-routes.test.ts
+++ b/src/lib/api-v1/device-routes.test.ts
@@ -20,8 +20,8 @@ vi.doMock('@/lib/db/scoped', () => ({
 const real = await import('@/lib/api-v1/device-auth');
 vi.doMock('@/lib/api-v1/device-auth', () => ({ ...real, exchangeDeviceCode }));
 
-const { Route: TokenRoute } = await import('../device.token');
-const { Route: CodeRoute } = await import('../device.code');
+const { Route: TokenRoute } = await import('@/routes/api/v1/device.token');
+const { Route: CodeRoute } = await import('@/routes/api/v1/device.code');
 
 type Handler = (ctx: { request: Request }) => Promise<Response>;
 const handlerSchema = z.custom<Handler>((v) => typeof v === 'function');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ function wranglerBindingsBanner(): Plugin {
         );
         // Real JSONC parse: a regex stripper choked on `/*` inside a `//`
         // comment (a glob like `/api/v1/device/*` swallowed the file).
-        const cfg = parseJsonc(raw) as WranglerConfig;
+        const cfg: WranglerConfig = parseJsonc(raw);
 
         const rows: Array<[string, string, boolean]> = [];
         for (const b of cfg.d1_databases ?? [])

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -199,6 +199,8 @@ export default defineConfig({
       srcDirectory: 'src',
       router: {
         routesDirectory: 'routes',
+        // `__tests__/` sits alongside routes (CLAUDE.md); don't treat tests as routes.
+        routeFileIgnorePattern: '\\.test\\.tsx?$',
       },
     }),
     viteReact(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 // vite.config.ts
 import { copyFileSync, readFileSync } from 'node:fs';
+import { parse as parseJsonc } from 'jsonc-parser';
 import { resolve } from 'node:path';
 import { cloudflare } from '@cloudflare/vite-plugin';
 import contentCollections from '@content-collections/vite';
@@ -38,12 +39,9 @@ function wranglerBindingsBanner(): Plugin {
           resolve(import.meta.dirname, 'wrangler.jsonc'),
           'utf-8'
         );
-        // Strip line + block comments + trailing commas so JSON.parse accepts it.
-        const stripped = raw
-          .replace(/\/\*[\s\S]*?\*\//g, '')
-          .replace(/^\s*\/\/.*$/gm, '')
-          .replace(/,(\s*[}\]])/g, '$1');
-        const cfg: WranglerConfig = JSON.parse(stripped);
+        // Real JSONC parse: a regex stripper choked on `/*` inside a `//`
+        // comment (a glob like `/api/v1/device/*` swallowed the file).
+        const cfg = parseJsonc(raw) as WranglerConfig;
 
         const rows: Array<[string, string, boolean]> = [];
         for (const b of cfg.d1_databases ?? [])
@@ -199,8 +197,6 @@ export default defineConfig({
       srcDirectory: 'src',
       router: {
         routesDirectory: 'routes',
-        // `__tests__/` sits alongside routes (CLAUDE.md); don't treat tests as routes.
-        routeFileIgnorePattern: '\\.test\\.tsx?$',
       },
     }),
     viteReact(),


### PR DESCRIPTION
Closes #1225

## Summary
- **Script view during a split**: shows the un-split tail of the original script below the scene blocks (read-only, "Splitting into scenes…"), shrinking as each scene lands. Before any scene exists it shows the whole script instead of "This sequence has no scenes yet." New pure helper `unsplitScriptTail` + unit tests.
- **Copy script mid-split**: `getComposedScriptFn` falls back to `sequence.script` until the split seeds scene versions, so the button isn't dead until scenes land.
- **Dev crash fix**: `bun dev` died with `SyntaxError … JSON at position 1126` — the wrangler-bindings banner stripped JSONC comments with a regex, and #1219's `// (/api/v1/device/*, #1219)` comment opened a phantom block comment. Now parsed with `jsonc-parser` (devDep, already in the tree via wrangler).
- Moved `device.test.ts` out of `src/routes/api/v1/__tests__` → `src/lib/api-v1/device-routes.test.ts` so the router stops warning that it isn't a route.

## Test plan
- [x] `bun run test` for `scene-script-document.test.ts` (7) and `device-routes.test.ts` (10)
- [x] `bun typecheck`, `bun lint`, lefthook pre-commit
- [x] `vite dev` boots: no SyntaxError, no route warning, banner shows `D1 DB → local`
- [ ] Manually: create a sequence, watch the Script view during the split; tap Copy script before scenes land