### PR TITLE
chore(models): stop the model-freshness routine from checking npm packages

### DIFF
--- a/.claude/skills/update-model-versions/SKILL.md
+++ b/.claude/skills/update-model-versions/SKILL.md
@@ -2,11 +2,12 @@
 name: update-model-versions
 description: >
   Check whether newer versions of the AI models we already use (fal.ai image,
-  video/motion, audio; OpenRouter text) or our @tanstack/ai* packages have
-  shipped, and open a PR bumping any genuine successor. Use when asked to
-  "check for model updates", "are our models current", "bump models", or when
-  run by the daily model-freshness routine. Only bumps EXISTING models to a
-  newer version of the same model — it does not add net-new models.
+  video/motion, audio; OpenRouter text) have shipped, and open a PR bumping any
+  genuine successor. Use when asked to "check for model updates", "are our models
+  current", "bump models", or when run by the daily model-freshness routine.
+  Only bumps EXISTING models to a newer version of the same model — it does not
+  add net-new models. npm dependency bumps (including @tanstack/ai*) are out of
+  scope: Dependabot owns those.
 ---
 
 # Update model versions
@@ -19,21 +20,24 @@ Our model registries are the single source of truth:
 | Image (fal.ai)          | `src/lib/ai/models.ts`        | `IMAGE_MODELS`           |
 | Video / motion (fal.ai) | `src/lib/ai/models.ts`        | `IMAGE_TO_VIDEO_MODELS`  |
 | Audio (fal.ai)          | `src/lib/ai/models.ts`        | `AUDIO_MODELS`           |
-| AI SDK packages         | `package.json`                | `@tanstack/ai*`          |
 
 The goal each run: detect newer versions → verify each is a real successor →
 open a focused PR that bumps it → leave everything green.
+
+**npm dependencies are out of scope.** Bumping `@tanstack/ai*` (or any other npm
+package) is Dependabot's job, not this routine's — the detector no longer checks
+the npm registry. Don't open model-freshness PRs or issues for package versions.
 
 ## 1. Detect candidates
 
 ```bash
 bun models:check          # human-readable report
-bun models:check --json   # { ok, errorCount, hasUpdates, models[], packages[] }
+bun models:check --json   # { ok, errorCount, hasUpdates, models[] }
 ```
 
 `scripts/check-model-updates.ts` reads the registries and queries public,
-unauthenticated catalogs (fal.ai `/api/models`, OpenRouter `/api/v1/models`, npm
-registry). It is HTTP-only so it runs anywhere — no `FAL_KEY` or MCP needed.
+unauthenticated catalogs (fal.ai `/api/models`, OpenRouter `/api/v1/models`).
+It is HTTP-only so it runs anywhere — no `FAL_KEY` or MCP needed.
 Behind a proxy it routes through `curl` (Bun's fetch can't traverse a
 TLS-intercepting proxy), so `curl` must be on PATH in that case.
 
@@ -95,6 +99,16 @@ Per class, edit and follow through:
 - **Text** (`models.config.ts`): update `id`, `name`, `description`,
   `contextWindow`. If you bump `DEFAULT_ANALYSIS_MODEL`'s model, the constant
   references a key, so it's unaffected.
+  **Catalog-lag bridge:** the `@tanstack/ai-openrouter` adapter ships a codegen
+  snapshot of OpenRouter's model list that lags new releases, so a freshly
+  shipped id may not be in its typed union yet. When a text-model bump adopts an
+  id the installed catalog lacks, `bun typecheck` fails at the `createAdapter`
+  call sites — add a `createModel` entry for the id to `CATALOG_LAG_MODELS`
+  (`src/lib/ai/create-adapter.ts`) with the correct `input` modalities, plus
+  `features: ['reasoning', 'structured_outputs']` when the model supports them.
+  (The reverse — pruning a bridged id once the adapter package catches up — is
+  handled by Dependabot's package bump, guided by `catalog-lag.test.ts`, not by
+  this routine.)
 - **Image** (`models.ts` `IMAGE_MODELS`): update `id`, `name`, `description`,
   `maxPromptLength`. If the model has an `EDIT_ENDPOINTS` entry, update that
   endpoint id too. Confirm the new endpoint still supports the edit/reference
@@ -109,19 +123,6 @@ Per class, edit and follow through:
   (auto-generated). After any fal id change run **`bun scripts/update-fal-pricing.ts`**
   (needs `FAL_KEY`). If it can't run, add the new id's pricing manually via the
   override path documented in that script and flag it in the PR.
-- **Packages:** bump the `@tanstack/ai*` range in `package.json`, then
-  `bun install`. Skip major bumps (breaking) — open an issue for those instead.
-  **Catalog-lag prune (`@tanstack/ai-openrouter` bumps):** registry ids that
-  the adapter's generated model catalog doesn't know yet are bridged in
-  `CATALOG_LAG_MODELS` (`src/lib/ai/create-adapter.ts`). When a bump ships one
-  of those ids upstream, `bun typecheck` fails in
-  `src/lib/ai/catalog-lag.test.ts` naming the id — delete its entry from
-  `CATALOG_LAG_MODELS` in the same PR and note the prune in the PR body.
-  Conversely, when a text-model bump adopts an id the installed catalog lacks
-  (typecheck fails at the `createAdapter` call sites), add a `createModel`
-  entry for it to `CATALOG_LAG_MODELS` — correct `input` modalities, plus
-  `features: ['reasoning', 'structured_outputs']` when the model supports
-  them.
 
 ## 4. Quality gates (must pass before opening the PR)
 
@@ -145,7 +146,7 @@ gh pr create --title "chore(models): bump <name> <old> → <new>" --body "<body>
 ```
 
 PR body must include, per change: registry key, old id → new id, why it's a
-genuine successor, links (fal model page / OpenRouter / npm), pricing delta, and
+genuine successor, links (fal model page / OpenRouter), pricing delta, and
 which generated files / pricing were regenerated. End with: "🤖 Opened by the
 daily model-freshness routine (#792). Verify pricing & quality before merge."
 

--- a/scripts/check-model-updates.ts
+++ b/scripts/check-model-updates.ts
@@ -1,11 +1,14 @@
 /**
- * Detect newer versions of the AI models (and AI SDK packages) we already use.
+ * Detect newer versions of the AI models we already use.
  *
- * Reads our four model registries plus the @tanstack/ai* deps in package.json,
- * then queries public, unauthenticated endpoints to find newer sibling versions:
+ * Reads our four model registries, then queries public, unauthenticated
+ * endpoints to find newer sibling versions:
  *   - fal.ai catalog      → https://fal.ai/api/models?keywords=…&category=…
  *   - OpenRouter catalog  → https://openrouter.ai/api/v1/models
- *   - npm registry        → https://registry.npmjs.org/<pkg>
+ *
+ * npm package updates (including our @tanstack/ai* deps) are intentionally NOT
+ * checked here — Dependabot owns dependency bumps. This routine is only about
+ * bumping model registry ids to a newer version of the same model.
  *
  * This is the deterministic backbone of the `update-model-versions` skill and
  * the daily "model freshness" routine. It only REPORTS candidates — deciding
@@ -34,8 +37,6 @@
  */
 
 import { execFile } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 import { promisify } from 'node:util';
 
 import {
@@ -66,16 +67,6 @@ type ModelReport = {
   newer: Candidate[];
   /** All same-family siblings, for context (may include older/variants). */
   family: Candidate[];
-  error?: string;
-};
-
-type PackageReport = {
-  source: 'npm';
-  name: string;
-  currentRange: string;
-  currentResolved: string;
-  latest: string | null;
-  isOutdated: boolean;
   error?: string;
 };
 
@@ -401,56 +392,6 @@ async function checkTextModels(): Promise<ModelReport[]> {
 }
 
 // ---------------------------------------------------------------------------
-// npm package checks (@tanstack/ai*)
-// ---------------------------------------------------------------------------
-
-async function checkPackages(): Promise<PackageReport[]> {
-  const pkgPath = join(process.cwd(), 'package.json');
-  const pkg: {
-    dependencies?: Record<string, string>;
-    devDependencies?: Record<string, string>;
-  } = JSON.parse(readFileSync(pkgPath, 'utf8'));
-  const allDeps: Record<string, string> = {
-    ...pkg.dependencies,
-    ...pkg.devDependencies,
-  };
-  const targets = Object.keys(allDeps).filter((name) =>
-    name.startsWith('@tanstack/ai')
-  );
-
-  return Promise.all(
-    targets.map(async (name): Promise<PackageReport> => {
-      const range = allDeps[name] ?? '';
-      const resolved = range.replace(/^[\^~>=<\s]+/, '');
-      try {
-        const data = await fetchJson<{ 'dist-tags'?: { latest?: string } }>(
-          `https://registry.npmjs.org/${name}`
-        );
-        const latest = data['dist-tags']?.latest ?? null;
-        return {
-          source: 'npm',
-          name,
-          currentRange: range,
-          currentResolved: resolved,
-          latest,
-          isOutdated: latest != null && compareVersions(latest, resolved) > 0,
-        };
-      } catch (error) {
-        return {
-          source: 'npm',
-          name,
-          currentRange: range,
-          currentResolved: resolved,
-          latest: null,
-          isOutdated: false,
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-    })
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -467,25 +408,20 @@ async function main() {
     ),
   ];
 
-  const [falReports, textReports, packageReports] = await Promise.all([
+  const [falReports, textReports] = await Promise.all([
     Promise.all(falChecks),
     checkTextModels(),
-    checkPackages(),
   ]);
 
   const modelReports = [...falReports, ...textReports];
   const modelsWithUpdates = modelReports.filter((r) => r.newer.length > 0);
-  const packagesWithUpdates = packageReports.filter((r) => r.isOutdated);
-  const hasUpdates =
-    modelsWithUpdates.length > 0 || packagesWithUpdates.length > 0;
+  const hasUpdates = modelsWithUpdates.length > 0;
 
   // A failed lookup is NOT "no update". Count failures so neither a human nor
   // automation can read a network/proxy outage as "all models current" — the
   // exact silent false-negative that hid behind `hasUpdates: false` when every
   // fetch errored. `ok: false` ⇒ the report is incomplete; exit non-zero too.
-  const errorCount =
-    modelReports.filter((r) => r.error).length +
-    packageReports.filter((r) => r.error).length;
+  const errorCount = modelReports.filter((r) => r.error).length;
   const ok = errorCount === 0;
   if (!ok) process.exitCode = 1;
 
@@ -497,7 +433,6 @@ async function main() {
           errorCount,
           hasUpdates,
           models: modelReports,
-          packages: packageReports,
         },
         null,
         2
@@ -506,12 +441,11 @@ async function main() {
     return;
   }
 
-  printReport(modelReports, packageReports, hasUpdates, errorCount);
+  printReport(modelReports, hasUpdates, errorCount);
 }
 
 function printReport(
   modelReports: ModelReport[],
-  packageReports: PackageReport[],
   hasUpdates: boolean,
   errorCount: number
 ) {
@@ -551,17 +485,6 @@ function printReport(
       }
     }
     console.log('');
-  }
-
-  console.log('## Packages (npm)');
-  for (const r of packageReports) {
-    if (r.error) {
-      console.log(`  ⚠️  ${r.name} — lookup failed: ${r.error}`);
-    } else if (r.isOutdated) {
-      console.log(`  🆕 ${r.name}: ${r.currentResolved} → ${r.latest}`);
-    } else {
-      console.log(`  ✅ ${r.name}: ${r.currentResolved} (latest ${r.latest})`);
-    }
   }
 
   if (errorCount > 0) {

--- a/src/lib/ai/catalog-lag.test.ts
+++ b/src/lib/ai/catalog-lag.test.ts
@@ -2,11 +2,11 @@
  * Guards for CATALOG_LAG_MODELS (create-adapter.ts) — the registry model ids
  * that @tanstack/ai-openrouter's generated catalog doesn't know yet.
  *
- * The prune check is compile-time: when a package bump ships a lag id in the
- * upstream catalog, `bun typecheck` fails here naming the id — delete its
- * entry from CATALOG_LAG_MODELS in the same PR. The model-freshness routine
- * (#792) runs these gates on every @tanstack/ai* bump, so the cleanup lands
- * in the bump PR automatically.
+ * The prune check is compile-time: when an @tanstack/ai-openrouter bump ships a
+ * lag id in the upstream catalog, `bun typecheck` fails here naming the id —
+ * delete its entry from CATALOG_LAG_MODELS in the same PR. That dependency bump
+ * is Dependabot's (the model-freshness routine, #792, no longer touches npm
+ * deps), so the prune lands alongside the version bump that made it stale.
  */
 import type { OpenRouterModelOptionsByName } from '@tanstack/ai-openrouter';
 import { describe, expectTypeOf, it } from 'vitest';

--- a/src/lib/ai/create-adapter.ts
+++ b/src/lib/ai/create-adapter.ts
@@ -68,9 +68,11 @@ let loggedRetryMode = false;
  * catalog is a codegen snapshot of OpenRouter's live list and lags new
  * releases. `extendAdapter` widens the factories' typed model union so a
  * registry id that is in NEITHER list is a compile error instead of an
- * unsafe cast. `catalog-lag.test.ts` fails once a package bump ships an id
- * below, telling the bumper (usually the model-freshness routine, #792) to
- * prune it here. Add entries with `createModel` from '@tanstack/ai':
+ * unsafe cast. `catalog-lag.test.ts` fails once an `@tanstack/ai-openrouter`
+ * bump ships an id below, telling whoever lands that dependency bump (Dependabot)
+ * to prune it here. Entries are ADDED by the model-freshness routine (#792) when
+ * a text-model bump adopts an id the installed catalog doesn't know yet. Add
+ * entries with `createModel` from '@tanstack/ai':
  * `createModel('vendor/model-id', { input: [...], features: [...] })`.
  */
 export const CATALOG_LAG_MODELS = [


### PR DESCRIPTION
## Why

Dependabot already owns dependency bumps, so the daily model-freshness routine shouldn't also be flagging `@tanstack/ai*` (or any other) package updates. This removes package-update detection from the routine's machinery, leaving it focused on its actual job: bumping AI **model registry ids** to a newer version of the same model.

Context: yesterday's run had to file a tracking issue (#1211) for the `@tanstack/ai*` package updates because the detector kept surfacing them — that's exactly the noise Dependabot should be handling instead.

## Changes

**`scripts/check-model-updates.ts`** — drop npm-registry checking entirely:
- Removed `checkPackages()`, the `PackageReport` type, the `packages[]` field of the `--json` output, and the `## Packages (npm)` section of the human-readable report.
- Removed the now-unused `node:fs` / `node:path` imports.
- `hasUpdates` / `errorCount` / `ok` now derive from model reports only.
- Updated the header doc comment to state npm bumps are Dependabot's, not this routine's.
- New `--json` shape: `{ ok, errorCount, hasUpdates, models[] }` (the `packages[]` key is gone).

**`.claude/skills/update-model-versions/SKILL.md`**:
- Description + intro now say npm dependency bumps (including `@tanstack/ai*`) are out of scope.
- Removed the "Packages" bump bullet and the registry table's "AI SDK packages" row.
- **Kept** the catalog-lag *bridge* guidance — still needed when a **text-model** bump adopts an id the installed `@tanstack/ai-openrouter` catalog snapshot doesn't know yet (folded into the Text bullet). The catalog-lag *prune* is now framed as Dependabot's job.

**`src/lib/ai/create-adapter.ts` + `src/lib/ai/catalog-lag.test.ts`** — reattributed the `CATALOG_LAG_MODELS` prune in the doc comments from "the model-freshness routine" to the `@tanstack/ai-openrouter` dependency bump (Dependabot), since the routine no longer touches npm deps. The `ADD` direction stays with the model-freshness routine.

## What's unchanged

Model detection (fal.ai image/video/audio, OpenRouter text) and the whole verify-and-bump workflow are untouched. The catalog-lag typecheck guard still works in both directions.

## Note for the reviewer

This changes the repo-side machinery only. The scheduled routine's stored prompt (in the scheduler, not the repo) still lists `@tanstack/ai*` package checks in its steps — but with the detector no longer returning a `packages[]` field, those steps are now inert. Worth trimming the scheduler prompt too for clarity; I can't edit it from here.

## Quality gates
- ✅ `bun typecheck`
- ✅ `bun lint` (touched files clean)
- ✅ `bun run test src/lib/ai` — 353 passed (incl. `catalog-lag.test.ts`)
- ✅ `bun models:check --json` — verified output no longer contains a `packages` key; `bun models:check` no longer prints a Packages section

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwQwKCnxjPRXXHBiQoMwkA)_