### PR TITLE
fix(#1242): collapse optimised prompts to the selected model

### DIFF
--- a/docs/user-guide/scenes.md
+++ b/docs/user-guide/scenes.md
@@ -71,6 +71,7 @@ Full control over the scene's image generation:
 - **Editable prompt** — The full visual prompt used to generate the image. Edit it to refine the composition, lighting, or details.
 - **Character count** — Displayed in real-time as you edit
 - **Model selector** — Switch between image models for this specific scene
+- **Optimised prompt** — A collapsed panel for the currently selected model only. Expand it to read the assembled prompt (reference bindings included); toggle **JSON** to copy the exact request body.
 - **Shorten Prompt** — AI-powered prompt compression that preserves intent while reducing length. Shows the reduction percentage (e.g., "Prompt shortened by 35% (2400 to 1560 chars)")
 - **Generate Image** / **Regenerate Image** — Create a new image with the current prompt and model
 - **Set Image** — When previewing a variant from a different model, set it as the scene's primary image
@@ -82,7 +83,7 @@ Control over the scene's video generation:
 
 - **Editable prompt** — The motion direction prompt (camera movements, character actions). Edit to change the animation style.
 - **Model selector** — Switch between video models for this scene. Models are filtered by aspect ratio compatibility and style category.
-- **Optimised prompt preview** — Shows the fully assembled prompt that will be sent to the model, including dialogue and audio cues from the script. Displays character count against the model's maximum prompt length.
+- **Optimised prompt** — A collapsed panel for the currently selected model only. The header shows character count against that model's maximum prompt length (highlighted if over). Expand it to read the assembled prompt (dialogue, audio cues, reference bindings); toggle **JSON** to copy the exact request body.
 - **Generate Motion** / **Regenerate Motion** — Create a new video clip
 - **Copy Prompt** — Copy the assembled prompt to clipboard
 

--- a/src/components/scenes/optimised-prompt-panel.stories.tsx
+++ b/src/components/scenes/optimised-prompt-panel.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { OptimisedPromptPanel } from './optimised-prompt-panel';
+
+const meta: Meta<typeof OptimisedPromptPanel> = {
+  title: 'Scenes/OptimisedPromptPanel',
+  component: OptimisedPromptPanel,
+  parameters: { layout: 'centered' },
+  args: {
+    copiedKey: null,
+    onCopy: fn(),
+    idPrefix: 'image-request',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof OptimisedPromptPanel>;
+
+export const Collapsed: Story = {
+  args: {
+    preview: {
+      modelName: 'GPT Image 2',
+      endpointId: 'openai/gpt-image-2',
+      prompt: 'Wide shot of Sarah at a sunlit coffee shop, typing furiously.',
+      json: JSON.stringify(
+        {
+          prompt:
+            'Wide shot of Sarah at a sunlit coffee shop, typing furiously.',
+          image_size: 'landscape_16_9',
+        },
+        null,
+        2
+      ),
+      promptLength: 64,
+      maxPromptLength: 32000,
+    },
+  },
+};
+
+export const OverLimit: Story = {
+  args: {
+    preview: {
+      modelName: 'FLUX.2 Max',
+      endpointId: 'fal-ai/flux-2-max',
+      prompt: 'A very long assembled prompt that exceeds the model cap.',
+      json: JSON.stringify({ prompt: 'truncated…' }, null, 2),
+      promptLength: 2480,
+      maxPromptLength: 2000,
+    },
+  },
+};
+
+export const AssembledTextOnly: Story = {
+  args: {
+    preview: {
+      modelName: 'Seedance 2.0',
+      endpointId: 'bytedance/seedance-2.0/enterprise/v2/image-to-video',
+      prompt:
+        'Slow push in as Sarah types.\n\nDialogue: SARAH: "This deadline is going to kill me."',
+      json: null,
+      promptLength: 92,
+      maxPromptLength: 4096,
+    },
+  },
+};

--- a/src/components/scenes/optimised-prompt-panel.test.tsx
+++ b/src/components/scenes/optimised-prompt-panel.test.tsx
@@ -1,0 +1,90 @@
+import {
+  OptimisedPromptPanel,
+  promptFromFalInput,
+  type OptimisedPromptPreview,
+} from '@/components/scenes/optimised-prompt-panel';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+const selected: OptimisedPromptPreview = {
+  modelName: 'GPT Image 2',
+  endpointId: 'openai/gpt-image-2',
+  prompt: 'Sarah types at a sunlit coffee shop',
+  json: JSON.stringify(
+    { prompt: 'SECRET_JSON_MARKER', image_size: 'landscape_16_9' },
+    null,
+    2
+  ),
+  promptLength: 36,
+  maxPromptLength: 32000,
+};
+
+function renderPanel(preview: OptimisedPromptPreview) {
+  return renderToStaticMarkup(
+    <OptimisedPromptPanel
+      preview={preview}
+      copiedKey={null}
+      onCopy={() => undefined}
+      idPrefix="image-request"
+    />
+  );
+}
+
+describe('promptFromFalInput', () => {
+  it('reads the prompt string off a fal request body', () => {
+    expect(
+      promptFromFalInput(
+        { prompt: 'bound (Image 1) sheet', seed: 1 },
+        'fallback'
+      )
+    ).toBe('bound (Image 1) sheet');
+  });
+
+  it('falls back when the body has no prompt string', () => {
+    expect(promptFromFalInput({ image_urls: [] }, 'assembled')).toBe(
+      'assembled'
+    );
+    expect(promptFromFalInput(null, 'assembled')).toBe('assembled');
+  });
+});
+
+describe('OptimisedPromptPanel', () => {
+  it('SSRs a collapsed header for the selected model only', () => {
+    const html = renderPanel(selected);
+
+    expect(html).toContain('Optimised prompt');
+    expect(html).toContain('GPT Image 2');
+    expect(html).toContain('36');
+    expect(html).toContain('32000');
+    expect(html).toContain('aria-expanded="false"');
+    // Other catalog models must not leak in — the panel is given one preview.
+    expect(html).not.toContain('Nano Banana');
+    expect(html).not.toContain('FLUX.2 Max');
+    expect(html).not.toContain('Seedance');
+  });
+
+  it('does not SSR the request JSON while collapsed on the prompt view', () => {
+    const html = renderPanel(selected);
+    expect(html).not.toContain('SECRET_JSON_MARKER');
+  });
+
+  it('flags an over-limit count on the collapsed header', () => {
+    const html = renderPanel({
+      ...selected,
+      promptLength: 2501,
+      maxPromptLength: 2500,
+    });
+    expect(html).toContain('text-destructive');
+    expect(html).toContain('2501');
+    expect(html).toContain('2500');
+  });
+
+  it('leaves the closed collapsible body empty so the inspector stays short', () => {
+    const html = renderPanel(selected);
+    expect(html).toContain('data-slot="collapsible-content"');
+    expect(html).toContain('hidden');
+    expect(html).not.toContain('Sarah types at a sunlit coffee shop');
+    expect(html).not.toContain('Prompt');
+    expect(html).not.toContain('JSON');
+  });
+});

--- a/src/components/scenes/optimised-prompt-panel.tsx
+++ b/src/components/scenes/optimised-prompt-panel.tsx
@@ -1,0 +1,177 @@
+/**
+ * Collapsed-by-default preview of the assembled prompt the selected model
+ * will actually receive (#1242). The inspector used to accordion every
+ * catalog model; most of that JSON was for models the user had not picked.
+ */
+
+import { Button } from '@/components/ui/button';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { cn } from '@/lib/utils';
+import { ChevronRight, CopyIcon } from 'lucide-react';
+import { useState } from 'react';
+
+export type OptimisedPromptPreview = {
+  modelName: string;
+  endpointId: string;
+  /** Assembled prompt text the model reads (after refs / audio sections). */
+  prompt: string;
+  /** Pretty-printed fal request body, or null when only the text exists. */
+  json: string | null;
+  promptLength: number;
+  maxPromptLength: number;
+};
+
+type PreviewView = 'prompt' | 'json';
+
+/**
+ * Pull `input.prompt` off a fal request body. Shared by the image and motion
+ * builders so the panel shows the same string the endpoint receives.
+ */
+export function promptFromFalInput(input: unknown, fallback: string): string {
+  if (
+    input !== null &&
+    typeof input === 'object' &&
+    'prompt' in input &&
+    typeof input.prompt === 'string'
+  ) {
+    return input.prompt;
+  }
+  return fallback;
+}
+
+export const OptimisedPromptPanel: React.FC<{
+  preview: OptimisedPromptPreview;
+  copiedKey: string | null;
+  onCopy: (text: string | undefined, key: string) => void;
+  footnote?: string | null;
+  idPrefix: string;
+}> = ({ preview, copiedKey, onCopy, footnote, idPrefix }) => {
+  const [open, setOpen] = useState(false);
+  const [view, setView] = useState<PreviewView>('prompt');
+  const overLimit = preview.promptLength > preview.maxPromptLength;
+  const headingId = `${idPrefix}-heading`;
+  const previewId = `${idPrefix}-preview`;
+  const copyKey = `${idPrefix}-${view}`;
+  const showingJson = view === 'json' && preview.json !== null;
+  const copyText = showingJson ? preview.json : preview.prompt;
+
+  return (
+    <Collapsible
+      open={open}
+      onOpenChange={setOpen}
+      className="rounded-md border"
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="flex min-h-11 w-full items-center gap-2 px-3 py-2 text-left text-sm outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+        >
+          <ChevronRight
+            className={cn(
+              'size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none',
+              open && 'rotate-90'
+            )}
+            aria-hidden
+          />
+          <span className="flex min-w-0 flex-1 items-baseline justify-between gap-2">
+            <span id={headingId} className="font-medium">
+              Optimised prompt
+            </span>
+            <span className="flex min-w-0 items-baseline gap-2">
+              <span className="truncate text-xs font-normal text-muted-foreground">
+                {preview.modelName}
+              </span>
+              <span
+                className={cn(
+                  'shrink-0 text-xs font-normal tabular-nums',
+                  overLimit
+                    ? 'font-medium text-destructive'
+                    : 'text-muted-foreground'
+                )}
+              >
+                {preview.promptLength}&nbsp;/&nbsp;{preview.maxPromptLength}
+              </span>
+            </span>
+          </span>
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="flex flex-col gap-2 border-t px-3 py-2">
+          <div className="flex items-center justify-between gap-2">
+            {preview.json !== null ? (
+              <ToggleGroup
+                type="single"
+                value={view}
+                onValueChange={(next) => {
+                  if (next === 'prompt' || next === 'json') setView(next);
+                }}
+                variant="outline"
+                size="sm"
+                spacing={0}
+                aria-label="Optimised prompt view"
+              >
+                <ToggleGroupItem value="prompt">Prompt</ToggleGroupItem>
+                <ToggleGroupItem value="json">JSON</ToggleGroupItem>
+              </ToggleGroup>
+            ) : (
+              <span className="font-mono text-xs text-muted-foreground">
+                {preview.endpointId}
+              </span>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-6 w-6"
+              onClick={() => onCopy(copyText ?? undefined, copyKey)}
+              disabled={!copyText}
+              aria-label={
+                showingJson
+                  ? `Copy ${preview.modelName} request JSON`
+                  : `Copy ${preview.modelName} optimised prompt`
+              }
+            >
+              {copiedKey === copyKey ? (
+                <span aria-hidden className="text-xs">
+                  ✓
+                </span>
+              ) : (
+                <CopyIcon className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </div>
+          {preview.json !== null && (
+            <span className="font-mono text-xs text-muted-foreground">
+              {preview.endpointId}
+            </span>
+          )}
+          {showingJson ? (
+            <pre
+              id={previewId}
+              aria-labelledby={headingId}
+              className="max-h-96 overflow-auto whitespace-pre-wrap rounded-md bg-muted/50 p-3 font-mono text-xs leading-relaxed text-foreground"
+            >
+              {preview.json}
+            </pre>
+          ) : (
+            <p
+              id={previewId}
+              aria-labelledby={headingId}
+              className="max-h-96 overflow-auto whitespace-pre-wrap rounded-md bg-muted/50 p-3 text-sm leading-relaxed text-foreground"
+            >
+              {preview.prompt}
+            </p>
+          )}
+          {footnote && (
+            <p className="text-xs text-muted-foreground">{footnote}</p>
+          )}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+};

--- a/src/components/scenes/scene-script-prompts.stories.tsx
+++ b/src/components/scenes/scene-script-prompts.stories.tsx
@@ -166,6 +166,53 @@ export const LongPrompts: Story = {
   },
 };
 
+export const ImagePromptTab: Story = {
+  args: {
+    shot: {
+      ...mockShot,
+      imagePromptVersion: {
+        id: 'fpv-1',
+        frameId: anchorFrame.id,
+        text: 'Wide shot of Sarah at a sunlit coffee shop, typing furiously, steam rising from an untouched latte.',
+        components: null,
+        source: 'ai-generated',
+        inputHash: null,
+        analysisModel: null,
+        status: 'completed',
+        pendingInputHash: null,
+        workflowRunId: null,
+        createdAt: new Date(),
+        createdBy: null,
+      },
+    },
+    selectedTab: 'image-prompt',
+  },
+};
+
+export const MotionPromptTab: Story = {
+  args: {
+    shot: {
+      ...mockShot,
+      motionPrompt: {
+        fullPrompt:
+          'Slow push in as Sarah types; her eyes flick to the silenced phone.',
+        dialogue: {
+          presence: true,
+          lines: [
+            {
+              character: 'SARAH',
+              line: 'This deadline is going to kill me.',
+              tone: '',
+            },
+          ],
+        },
+        audio: null,
+      },
+    },
+    selectedTab: 'motion-prompt',
+  },
+};
+
 export const ShortScript: Story = {
   args: {
     shot: {

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -74,11 +74,10 @@ import {
 } from '@/lib/constants/aspect-ratios';
 import { getStorageDomainFn } from '@/functions/storage-config';
 import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
+  OptimisedPromptPanel,
+  promptFromFalInput,
+  type OptimisedPromptPreview,
+} from '@/components/scenes/optimised-prompt-panel';
 import { buildImageRequest } from '@/lib/image/build-image-request';
 import { buildMotionRequest } from '@/lib/motion/build-model-input';
 import {
@@ -88,7 +87,6 @@ import {
 import { buildReferenceImagePrompt } from '@/lib/prompts/reference-image-prompt';
 import { resolveMotionPrompt } from '@/lib/motion/resolve-motion-prompt';
 import { resolveShotDuration } from '@/lib/motion/resolve-shot-duration';
-import { typedEntries } from '@/lib/utils/typed-object';
 import type { AssemblableMotionPrompt } from '@/lib/ai/scene-analysis.schema';
 import { useShotPromptStream } from '@/lib/realtime/use-shot-prompt-stream';
 import type { ShotView } from '@/lib/shots/shot-view';
@@ -186,92 +184,6 @@ const PromptCopyButton: React.FC<{
     )}
   </Button>
 );
-
-/** One model's exact fal request, ready for display. */
-type ModelRequestPreview = {
-  modelKey: string;
-  modelName: string;
-  endpointId: string;
-  json: string;
-  promptLength: number;
-  maxPromptLength: number;
-};
-
-/**
- * Per-model accordion of the exact fal request bodies — the selected model's
- * item is open by default; every entry is copyable. Shared by the image and
- * motion tabs.
- */
-const ModelRequestPreviews: React.FC<{
-  idPrefix: string;
-  requests: ModelRequestPreview[];
-  selectedModel: string;
-  copiedTab: string | null;
-  onCopy: (text: string | undefined, key: string) => void;
-  footnote?: string | null;
-}> = ({ idPrefix, requests, selectedModel, copiedTab, onCopy, footnote }) => {
-  // Selected model first so its open item sits at the top of the list.
-  const ordered = [...requests].sort(
-    (a, b) =>
-      Number(b.modelKey === selectedModel) -
-      Number(a.modelKey === selectedModel)
-  );
-  return (
-    <div className="space-y-1">
-      <Accordion
-        type="multiple"
-        defaultValue={[`${idPrefix}-${selectedModel}`]}
-        className="rounded-md border"
-      >
-        {ordered.map((req) => (
-          <AccordionItem
-            key={req.modelKey}
-            value={`${idPrefix}-${req.modelKey}`}
-            className="px-3"
-          >
-            <AccordionTrigger className="py-2 text-sm">
-              <span className="flex flex-1 items-center justify-between gap-2 pr-2">
-                <span>
-                  {req.modelName}
-                  {req.modelKey === selectedModel && (
-                    <span className="text-muted-foreground"> · selected</span>
-                  )}
-                </span>
-                <span
-                  className={`text-xs font-normal tabular-nums ${
-                    req.promptLength > req.maxPromptLength
-                      ? 'text-destructive font-medium'
-                      : 'text-muted-foreground'
-                  }`}
-                >
-                  {req.promptLength}&nbsp;/&nbsp;{req.maxPromptLength}
-                </span>
-              </span>
-            </AccordionTrigger>
-            <AccordionContent className="space-y-1 pb-3">
-              <div className="flex items-center justify-between">
-                <span className="font-mono text-xs text-muted-foreground">
-                  {req.endpointId}
-                </span>
-                <PromptCopyButton
-                  text={req.json}
-                  copyKey={`${idPrefix}-${req.modelKey}`}
-                  copiedTab={copiedTab}
-                  onCopy={onCopy}
-                  label={`Copy ${req.modelName} request JSON`}
-                />
-              </div>
-              <pre className="max-h-96 overflow-auto whitespace-pre-wrap rounded-md bg-muted/50 p-3 font-mono text-xs leading-relaxed text-foreground">
-                {req.json}
-              </pre>
-            </AccordionContent>
-          </AccordionItem>
-        ))}
-      </Accordion>
-      {footnote && <p className="text-xs text-muted-foreground">{footnote}</p>}
-    </div>
-  );
-};
 
 type SceneScriptPromptsProps = {
   shot?: ShotView | undefined;
@@ -1108,8 +1020,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     effectiveMotionModel,
   ]);
 
-  const motionModel = effectiveMotionModel;
-
   // Transparent pricing under Generate Image / Generate Motion (#1140).
   const { pricing: falPricing } = useFalPricing();
   const imageCostEstimate = useMemo(() => {
@@ -1167,15 +1077,15 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     [storageDomain]
   );
 
-  // The exact fal request per video model — same builder submitMotionJob
-  // uses, so the preview shows the real endpoint payload including reference
-  // bindings (@ImageN/@ElementN substitution, image_urls/elements arrays).
-  // The prompt is re-assembled per model (audio-capable models get
-  // dialogue/audio sections). A model whose transform rejects the draft input
-  // (e.g. no rendered still yet) is skipped — an empty list falls back to the
-  // plain-text assembled prompt.
-  const motionRequestPreviews = useMemo((): ModelRequestPreview[] => {
-    if (!shot) return [];
+  // Exact fal request for the *selected* video model — same builder
+  // submitMotionJob uses, including reference bindings. Other catalog
+  // models are omitted (#1242): they inflate the inspector for picks the
+  // user has not made. A transform rejection (e.g. no still yet) falls
+  // back to the plain-text assembled prompt at render.
+  const motionRequestPreview = useMemo((): OptimisedPromptPreview | null => {
+    if (!shot) return null;
+    const modelKey = effectiveMotionModel;
+    const config = IMAGE_TO_VIDEO_MODELS[modelKey];
     const referenceImages = buildMotionReferenceImages({
       scene: sceneReference,
       characters: mentionCharacters ?? [],
@@ -1193,50 +1103,47 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       : overrideText
         ? { fullPrompt: overrideText, dialogue: null, audio: null }
         : null;
-    return typedEntries(IMAGE_TO_VIDEO_MODELS).flatMap(([modelKey, config]) => {
-      try {
-        const modelPrompt = resolveMotionPrompt(
-          {
-            motionPrompt: mp,
-            characterTags,
-            description: sceneDescription,
-          },
-          modelKey
-        );
-        if (!modelPrompt) return [];
-        const request = buildMotionRequest(
-          {
-            prompt: modelPrompt,
-            imageUrl: absolutizeUrl(shot.image?.url ?? ''),
-            duration: resolveShotDuration({
-              explicit: undefined,
-              durationMs: shot.durationMs,
-              model: modelKey,
-            }),
-            aspectRatio,
-            generateAudio: videoModelSupportsAudio(modelKey)
-              ? generateAudio
-              : undefined,
-            referenceImages,
-          },
-          modelKey
-        );
-        return [
-          {
-            modelKey,
-            modelName: config.name,
-            endpointId: request.endpointId,
-            json: JSON.stringify(request.input, null, 2),
-            promptLength: modelPrompt.length,
-            maxPromptLength: config.maxPromptLength,
-          },
-        ];
-      } catch {
-        return [];
-      }
-    });
+    try {
+      const modelPrompt = resolveMotionPrompt(
+        {
+          motionPrompt: mp,
+          characterTags,
+          description: sceneDescription,
+        },
+        modelKey
+      );
+      if (!modelPrompt) return null;
+      const request = buildMotionRequest(
+        {
+          prompt: modelPrompt,
+          imageUrl: absolutizeUrl(shot.image?.url ?? ''),
+          duration: resolveShotDuration({
+            explicit: undefined,
+            durationMs: shot.durationMs,
+            model: modelKey,
+          }),
+          aspectRatio,
+          generateAudio: videoModelSupportsAudio(modelKey)
+            ? generateAudio
+            : undefined,
+          referenceImages,
+        },
+        modelKey
+      );
+      return {
+        modelName: config.name,
+        endpointId: request.endpointId,
+        prompt: promptFromFalInput(request.input, modelPrompt),
+        json: JSON.stringify(request.input, null, 2),
+        promptLength: modelPrompt.length,
+        maxPromptLength: config.maxPromptLength,
+      };
+    } catch {
+      return null;
+    }
   }, [
     shot,
+    effectiveMotionModel,
     sceneReference,
     sceneDescription,
     mentionCharacters,
@@ -1250,14 +1157,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     absolutizeUrl,
   ]);
 
-  // The exact fal request per image model — same reference resolution the
-  // `/image` trigger uses (buildShotImageReferenceImages) and the same
-  // request assembly the workflow uses (buildReferenceImagePrompt +
-  // buildImageRequest), so the preview shows the real endpoint payload
-  // including inline (Image N) bindings and the ordered image_urls array.
-  const imageRequestPreviews = useMemo((): ModelRequestPreview[] => {
+  // Exact fal request for the *selected* image model — same reference
+  // resolution the `/image` trigger uses and the same request assembly the
+  // workflow uses, so the panel shows the real endpoint payload including
+  // inline (Image N) bindings. Hidden catalog models are skipped unless
+  // they are the current pick (preview turbo).
+  const imageRequestPreview = useMemo((): OptimisedPromptPreview | null => {
     const basePrompt = (editedImagePrompt || imagePrompt || '').trim();
-    if (!basePrompt || !shot) return [];
+    if (!basePrompt || !shot) return null;
+    const modelKey = effectiveImageModel;
+    const config = IMAGE_MODELS[modelKey];
     const referenceImages = buildShotImageReferenceImages({
       scene: sceneReference,
       characters: mentionCharacters ?? [],
@@ -1267,42 +1176,38 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       ...ref,
       referenceImageUrl: absolutizeUrl(ref.referenceImageUrl),
     }));
-    return typedEntries(IMAGE_MODELS).flatMap(([modelKey, config]) => {
-      if ('hidden' in config) return [];
-      try {
-        const { prompt: enhancedPrompt, referenceUrls } =
-          buildReferenceImagePrompt(
-            basePrompt,
-            referenceImages,
-            config.maxPromptLength
-          );
-        const request = buildImageRequest({
-          model: modelKey,
-          prompt: enhancedPrompt,
-          imageSize: aspectRatio
-            ? aspectRatioToImageSize(aspectRatio)
-            : undefined,
-          numImages: 1,
-          referenceImageUrls: referenceUrls,
-        });
-        return [
-          {
-            modelKey,
-            modelName: config.name,
-            endpointId: request.endpointId,
-            json: JSON.stringify(request.input, null, 2),
-            promptLength: enhancedPrompt.length,
-            maxPromptLength: config.maxPromptLength,
-          },
-        ];
-      } catch {
-        return [];
-      }
-    });
+    try {
+      const { prompt: enhancedPrompt, referenceUrls } =
+        buildReferenceImagePrompt(
+          basePrompt,
+          referenceImages,
+          config.maxPromptLength
+        );
+      const request = buildImageRequest({
+        model: modelKey,
+        prompt: enhancedPrompt,
+        imageSize: aspectRatio
+          ? aspectRatioToImageSize(aspectRatio)
+          : undefined,
+        numImages: 1,
+        referenceImageUrls: referenceUrls,
+      });
+      return {
+        modelName: config.name,
+        endpointId: request.endpointId,
+        prompt: promptFromFalInput(request.input, enhancedPrompt),
+        json: JSON.stringify(request.input, null, 2),
+        promptLength: enhancedPrompt.length,
+        maxPromptLength: config.maxPromptLength,
+      };
+    } catch {
+      return null;
+    }
   }, [
     editedImagePrompt,
     imagePrompt,
     shot,
+    effectiveImageModel,
     sceneReference,
     mentionCharacters,
     mentionElements,
@@ -1657,25 +1562,20 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
             </p>
           </div>
 
-          {/* Optimised prompt previews — the exact fal request body per image
-              model, mirroring the /image workflow's reference resolution and
-              request assembly. */}
-          {imageRequestPreviews.length > 0 && (
-            <div className="space-y-2">
-              <span className="text-sm font-medium">Optimised prompts</span>
-              <ModelRequestPreviews
-                idPrefix="image-request"
-                requests={imageRequestPreviews}
-                selectedModel={effectiveImageModel}
-                copiedTab={copiedTab}
-                onCopy={(text, key) => void handleCopy(text, key)}
-                footnote={
-                  !storageDomain
-                    ? 'Relative /r2/ image URLs are made publicly fetchable at submit'
-                    : null
-                }
-              />
-            </div>
+          {/* Optimised prompt — selected image model only, collapsed
+              until the user wants the assembled payload (#1242). */}
+          {imageRequestPreview && (
+            <OptimisedPromptPanel
+              idPrefix="image-request"
+              preview={imageRequestPreview}
+              copiedKey={copiedTab}
+              onCopy={(text, key) => void handleCopy(text, key)}
+              footnote={
+                !storageDomain
+                  ? 'Relative /r2/ image URLs are made publicly fetchable at submit'
+                  : null
+              }
+            />
           )}
 
           {/* Shorten + History buttons */}
@@ -1930,43 +1830,37 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
             </p>
           </div>
 
-          {/* Optimised prompt previews — the exact fal request body per video
-              model (incl. reference bindings) when they can be built, else
-              the assembled prompt text as the fallback. */}
-          {assembledPrompt &&
-            (motionRequestPreviews.length > 0 ||
-              assembledPrompt !== editedMotionPrompt) && (
-              <div className="space-y-2">
-                <span
-                  id="motion-assembled-prompt-heading"
-                  className="text-sm font-medium"
-                >
-                  Optimised prompts
-                </span>
-                {motionRequestPreviews.length > 0 ? (
-                  <ModelRequestPreviews
-                    idPrefix="motion-request"
-                    requests={motionRequestPreviews}
-                    selectedModel={motionModel}
-                    copiedTab={copiedTab}
-                    onCopy={(text, key) => void handleCopy(text, key)}
-                    footnote={
-                      !storageDomain
-                        ? 'Relative /r2/ image URLs are made publicly fetchable at submit'
-                        : null
-                    }
-                  />
-                ) : (
-                  <p
-                    id="motion-assembled-prompt-preview"
-                    aria-labelledby="motion-assembled-prompt-heading"
-                    className="whitespace-pre-wrap rounded-md border bg-muted/50 p-3 text-sm leading-relaxed text-foreground"
-                  >
-                    {assembledPrompt}
-                  </p>
-                )}
-              </div>
-            )}
+          {/* Optimised prompt — selected video model only (#1242). When
+              the request cannot be built (no still yet), fall back to the
+              assembled prompt text if it differs from the editable field. */}
+          {motionRequestPreview ? (
+            <OptimisedPromptPanel
+              idPrefix="motion-request"
+              preview={motionRequestPreview}
+              copiedKey={copiedTab}
+              onCopy={(text, key) => void handleCopy(text, key)}
+              footnote={
+                !storageDomain
+                  ? 'Relative /r2/ image URLs are made publicly fetchable at submit'
+                  : null
+              }
+            />
+          ) : assembledPrompt && assembledPrompt !== editedMotionPrompt ? (
+            <OptimisedPromptPanel
+              idPrefix="motion-assembled"
+              preview={{
+                modelName: IMAGE_TO_VIDEO_MODELS[effectiveMotionModel].name,
+                endpointId: IMAGE_TO_VIDEO_MODELS[effectiveMotionModel].id,
+                prompt: assembledPrompt,
+                json: null,
+                promptLength: assembledPrompt.length,
+                maxPromptLength:
+                  IMAGE_TO_VIDEO_MODELS[effectiveMotionModel].maxPromptLength,
+              }}
+              copiedKey={copiedTab}
+              onCopy={(text, key) => void handleCopy(text, key)}
+            />
+          ) : null}
 
           {/* History button */}
           <Button


### PR DESCRIPTION
Closes #1242

## What
The Image and Video inspector tabs listed every catalog model's fal request in an accordion, so the panel was huge and showed models the user had not picked.

- Collapsed-by-default **Optimised prompt** row for the currently selected model only (name + char count / max; count goes destructive when over the cap).
- Expand to read the assembled prompt the model actually receives (refs, dialogue, audio sections).
- **Prompt / JSON** toggle to copy the exact fal request body. JSON stays unmounted until asked for.
- Image and video builders now assemble the selected model only, instead of iterating the whole catalog.

## Test plan
- [x] `bun run test src/components/scenes/optimised-prompt-panel.test.tsx`
- [x] `bun typecheck`, `bun lint`
- [x] Playwright against a bundled panel: collapsed (no prompt/JSON, no other models) → expand (assembled prompt) → JSON toggle (request body)
- [ ] Manual: open a shot's Image tab and Video tab, confirm only the selected model appears, expand, switch Prompt/JSON, change model and confirm the header updates