### PR TITLE
fix: Generate button no longer sticks on "Analyzing elements…"

### DIFF
--- a/src/components/element/element-selector.test.ts
+++ b/src/components/element/element-selector.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { selectFilesToAccept } from './element-selector';
+import { MAX_SEQUENCE_ELEMENTS } from '@/lib/sequence-elements/limits';
+
+const file = (name: string) => new File([], name);
+const keyByName = (f: File) => f.name;
+
+describe('selectFilesToAccept', () => {
+  it('accepts new files and skips duplicates (existing and within the batch)', () => {
+    const accepted = selectFilesToAccept(
+      [file('a'), file('b'), file('a'), file('c')],
+      new Set(['b']),
+      1,
+      keyByName
+    );
+    expect(accepted.map((e) => e.key)).toEqual(['a', 'c']);
+  });
+
+  it('caps at MAX_SEQUENCE_ELEMENTS counting existing elements', () => {
+    const files = Array.from({ length: MAX_SEQUENCE_ELEMENTS }, (_, i) =>
+      file(`f${i}`)
+    );
+    const accepted = selectFilesToAccept(
+      files,
+      new Set(),
+      MAX_SEQUENCE_ELEMENTS - 2,
+      keyByName
+    );
+    expect(accepted).toHaveLength(2);
+  });
+
+  it('accepts nothing when already at the cap', () => {
+    expect(
+      selectFilesToAccept(
+        [file('a')],
+        new Set(),
+        MAX_SEQUENCE_ELEMENTS,
+        keyByName
+      )
+    ).toEqual([]);
+  });
+});

--- a/src/components/element/element-selector.test.ts
+++ b/src/components/element/element-selector.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it } from 'vitest';
 import { selectFilesToAccept } from './element-selector';
 import { MAX_SEQUENCE_ELEMENTS } from '@/lib/sequence-elements/limits';
+import { getFileKey } from '@/lib/utils/upload';
 
-const file = (name: string) => new File([], name);
-const keyByName = (f: File) => f.name;
+// Pinned lastModified so keys (`name-lastModified`) are deterministic.
+const file = (name: string) => new File([], name, { lastModified: 1 });
 
 describe('selectFilesToAccept', () => {
   it('accepts new files and skips duplicates (existing and within the batch)', () => {
     const accepted = selectFilesToAccept(
       [file('a'), file('b'), file('a'), file('c')],
-      new Set(['b']),
-      1,
-      keyByName
+      new Set([getFileKey(file('b'))]),
+      1
     );
-    expect(accepted.map((e) => e.key)).toEqual(['a', 'c']);
+    expect(accepted.map((e) => e.key)).toEqual([
+      getFileKey(file('a')),
+      getFileKey(file('c')),
+    ]);
   });
 
   it('caps at MAX_SEQUENCE_ELEMENTS counting existing elements', () => {
@@ -23,20 +26,17 @@ describe('selectFilesToAccept', () => {
     const accepted = selectFilesToAccept(
       files,
       new Set(),
-      MAX_SEQUENCE_ELEMENTS - 2,
-      keyByName
+      MAX_SEQUENCE_ELEMENTS - 2
     );
     expect(accepted).toHaveLength(2);
   });
 
-  it('accepts nothing when already at the cap', () => {
+  it('accepts nothing at or over the cap', () => {
     expect(
-      selectFilesToAccept(
-        [file('a')],
-        new Set(),
-        MAX_SEQUENCE_ELEMENTS,
-        keyByName
-      )
+      selectFilesToAccept([file('a')], new Set(), MAX_SEQUENCE_ELEMENTS)
+    ).toEqual([]);
+    expect(
+      selectFilesToAccept([file('a')], new Set(), MAX_SEQUENCE_ELEMENTS + 1)
     ).toEqual([]);
   });
 });

--- a/src/components/element/element-selector.tsx
+++ b/src/components/element/element-selector.tsx
@@ -105,6 +105,35 @@ type LocalEntry = {
   errorMessage?: string;
 };
 
+/**
+ * Pick which incoming files to accept: image-cap and duplicate-key filtering,
+ * pure so `processFiles` can run it before touching state. It must NOT run
+ * inside the setEntries updater — updaters aren't guaranteed to run before the
+ * code that follows the setState call, and an `accepted` list built inside one
+ * can still be empty when the uploads are started from it, stranding entries
+ * in `uploading` forever and locking the Generate button on
+ * "Analyzing elements…" (#1231).
+ */
+export function selectFilesToAccept(
+  files: File[],
+  existingKeys: ReadonlySet<string>,
+  existingCount: number,
+  getKey: (file: File) => string = getFileKey
+): { key: string; file: File }[] {
+  const accepted: { key: string; file: File }[] = [];
+  const seen = new Set(existingKeys);
+  let remaining = MAX_SEQUENCE_ELEMENTS - existingCount;
+  for (const file of files) {
+    if (remaining <= 0) break;
+    const key = getKey(file);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    accepted.push({ key, file });
+    remaining--;
+  }
+  return accepted;
+}
+
 type DisplayItem = {
   key: string;
   imageUrl: string;
@@ -236,24 +265,36 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
       // prompt instead (covers browse, drop, paste, and external drops).
       if (!requireAuth()) return;
 
-      const accepted: { key: string; file: File }[] = [];
+      // Accept files BEFORE touching state (see selectFilesToAccept). The ref
+      // mirror is the synchronous source of truth for keys/counts; the state
+      // updater below stays pure and merges the same entries.
+      const currentEntries = entriesRef.current;
+      const existingCount = isPersisted
+        ? persistedElements.length + currentEntries.size
+        : draftElementsRef.current.length + currentEntries.size;
+      const accepted = selectFilesToAccept(
+        images,
+        new Set(currentEntries.keys()),
+        existingCount
+      );
+      if (accepted.length === 0) return;
+
+      const seeded = new Map(currentEntries);
+      for (const { key, file } of accepted) {
+        seeded.set(key, {
+          file,
+          previewUrl: URL.createObjectURL(file),
+          status: 'uploading',
+        });
+      }
+      // Sync the mirror now so a second processFiles call in the same tick
+      // sees these keys (state only catches up on the next render).
+      entriesRef.current = seeded;
       setEntries((prev) => {
         const next = new Map(prev);
-        const existingCount = isPersisted
-          ? persistedElements.length + next.size
-          : draftElementsRef.current.length + next.size;
-        let remaining = MAX_SEQUENCE_ELEMENTS - existingCount;
-        for (const file of images) {
-          if (remaining <= 0) break;
-          const key = getFileKey(file);
-          if (next.has(key)) continue;
-          next.set(key, {
-            file,
-            previewUrl: URL.createObjectURL(file),
-            status: 'uploading',
-          });
-          accepted.push({ key, file });
-          remaining--;
+        for (const { key } of accepted) {
+          const entry = seeded.get(key);
+          if (entry && !next.has(key)) next.set(key, entry);
         }
         return next;
       });

--- a/src/components/element/element-selector.tsx
+++ b/src/components/element/element-selector.tsx
@@ -106,26 +106,25 @@ type LocalEntry = {
 };
 
 /**
- * Pick which incoming files to accept: image-cap and duplicate-key filtering,
- * pure so `processFiles` can run it before touching state. It must NOT run
- * inside the setEntries updater — updaters aren't guaranteed to run before the
- * code that follows the setState call, and an `accepted` list built inside one
- * can still be empty when the uploads are started from it, stranding entries
- * in `uploading` forever and locking the Generate button on
+ * Pick which incoming files to accept: element-count cap and duplicate-key
+ * filtering, pure so `processFiles` can run it before touching state. It must
+ * NOT run inside the setEntries updater — updaters aren't guaranteed to run
+ * before the code that follows the setState call, and an `accepted` list built
+ * inside one can still be empty when the uploads are started from it,
+ * stranding entries in `uploading` forever and locking the Generate button on
  * "Analyzing elements…" (#1231).
  */
 export function selectFilesToAccept(
   files: File[],
   existingKeys: ReadonlySet<string>,
-  existingCount: number,
-  getKey: (file: File) => string = getFileKey
+  existingCount: number
 ): { key: string; file: File }[] {
   const accepted: { key: string; file: File }[] = [];
   const seen = new Set(existingKeys);
   let remaining = MAX_SEQUENCE_ELEMENTS - existingCount;
   for (const file of files) {
     if (remaining <= 0) break;
-    const key = getKey(file);
+    const key = getFileKey(file);
     if (seen.has(key)) continue;
     seen.add(key);
     accepted.push({ key, file });
@@ -205,8 +204,14 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
     onElementBusyChange?.(isBusy);
   }, [isBusy, onElementBusyChange]);
 
+  // Reconciled after commit (not during render): a discarded or lower-priority
+  // render pass can carry an `entries` value that predates keys `processFiles`
+  // just pushed into the mirror, and a render-phase write would clobber them —
+  // resurrecting the stuck-upload bug this mirror exists to prevent (#1231).
   const entriesRef = useRef(entries);
-  entriesRef.current = entries;
+  useEffect(() => {
+    entriesRef.current = entries;
+  });
 
   // Persisted mode: once an upload's element row lands in the query data,
   // drop the transient local entry (its tile is superseded by the real one).
@@ -266,8 +271,8 @@ export const ElementSelector: React.FC<ElementSelectorProps> = (props) => {
       if (!requireAuth()) return;
 
       // Accept files BEFORE touching state (see selectFilesToAccept). The ref
-      // mirror is the synchronous source of truth for keys/counts; the state
-      // updater below stays pure and merges the same entries.
+      // mirror is what this function reads synchronously for keys/counts; the
+      // state updater below stays pure and merges the same entries.
       const currentEntries = entriesRef.current;
       const existingCount = isPersisted
         ? persistedElements.length + currentEntries.size


### PR DESCRIPTION
Fixes #1231

## Root cause

In `ElementSelector.processFiles`, the `accepted` list of files to upload was built **inside** the `setEntries` state updater. React only runs updater functions synchronously via the eager-evaluation fast path, which is skipped whenever the component's fiber already has a pending update — e.g. a status change from an earlier upload/vision-analysis settling (a window of several seconds per element). When skipped, the updater runs later during render, so `accepted` was still **empty** at `await Promise.all(accepted.map(...))`:

- entries were seeded into the map in `uploading` state,
- but no upload was ever started for them,
- so nothing ever settled them → `isBusy` stayed `true` forever → the Generate button stayed disabled on "Analyzing elements…".

The stuck entries don't count toward the badge and live inside the closed popover, so there was no visible reason for the disabled button — matching the report. Forcing the click worked because the phantom entries never touched the canonical `draftElements` list.

## Fix

- Accept/dedupe/cap now runs synchronously **before** any state call, via a pure `selectFilesToAccept` helper, reading the ref mirror of entries (same pattern as the existing `draftElementsRef`). The mirror is updated synchronously so a second `processFiles` call in the same tick sees the new keys.
- The `setEntries` updater is now pure (merge only, no side effects), as React requires.

## Testing

- New unit test for `selectFilesToAccept` (dedupe within batch + against existing keys, element cap).
- `bun run test`: 2669 passed. `bun lint` / `bun typecheck` clean.

https://claude.ai/code/session_012zxjAc7KsuiDn7F2uxqFyV