### PR TITLE
fix(staleness): name what changed in the Update all dialog

### DIFF
--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1363,6 +1363,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           isRegenerating={isUpdatingAll || !shotHasStale}
           onRegenerateDepth={shotHasStale ? handleUpdateAll : undefined}
           staleness={staleness}
+          updateAllScope={
+            shot ? { sequenceId, shotId: shot.id } : { sequenceId }
+          }
         />
       )}
       {shotStaleUnknown && !shotHasStale && !shotHasUpdating && (
@@ -1380,6 +1383,8 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       {!shot && scopeShots && onSelectShot && (
         <SceneStaleShots
           shots={scopeShots}
+          sequenceId={sequenceId}
+          sceneId={scriptSceneId}
           staleness={scopeStaleness}
           stalenessFailed={scopeStalenessFailed}
           onSelectShot={onSelectShot}

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1362,6 +1362,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           // would just no-op against the dedup.
           isRegenerating={isUpdatingAll || !shotHasStale}
           onRegenerateDepth={shotHasStale ? handleUpdateAll : undefined}
+          staleness={staleness}
         />
       )}
       {shotStaleUnknown && !shotHasStale && !shotHasUpdating && (

--- a/src/components/scenes/scene-stale-shots.tsx
+++ b/src/components/scenes/scene-stale-shots.tsx
@@ -153,6 +153,7 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
           <UpdateAllDialog
             open={updateAllOpen}
             onOpenChange={setUpdateAllOpen}
+            staleShots={staleShots.flatMap((s) => staleness?.[s.id] ?? [])}
             onConfirm={(depth: UpdateStaleDepth) => {
               setUpdateAllOpen(false);
               onUpdateAll(depth);

--- a/src/components/scenes/scene-stale-shots.tsx
+++ b/src/components/scenes/scene-stale-shots.tsx
@@ -13,6 +13,9 @@ import { useState } from 'react';
 type SceneStaleShotsProps = {
   /** The in-scope shots (a scene's, or the whole sequence's), in order. */
   shots: ShotView[];
+  /** Dry-run preview scope for the depth dialog (#1194). */
+  sequenceId: string;
+  sceneId?: string;
   /** Batched staleness for those shots, keyed by shot id (#1077). */
   staleness: Record<string, ShotStaleness> | undefined;
   /**
@@ -39,6 +42,8 @@ type SceneStaleShotsProps = {
  */
 export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
   shots,
+  sequenceId,
+  sceneId,
   staleness,
   stalenessFailed = false,
   onSelectShot,
@@ -154,6 +159,8 @@ export const SceneStaleShots: React.FC<SceneStaleShotsProps> = ({
             open={updateAllOpen}
             onOpenChange={setUpdateAllOpen}
             staleShots={staleShots.flatMap((s) => staleness?.[s.id] ?? [])}
+            scope={{ sequenceId, sceneId }}
+            shotNumberById={numberByShotId}
             onConfirm={(depth: UpdateStaleDepth) => {
               setUpdateAllOpen(false);
               onUpdateAll(depth);

--- a/src/components/staleness/staleness-indicator.tsx
+++ b/src/components/staleness/staleness-indicator.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { UpdateAllDialog } from '@/components/staleness/update-all-dialog';
+import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
 import { cn } from '@/lib/utils';
 
@@ -77,6 +78,8 @@ type StalenessIndicatorProps = StalenessIndicatorBaseProps &
         artifact?: StalenessArtifact;
         onRegenerate?: () => void;
         onRegenerateDepth?: (depth: UpdateStaleDepth) => void;
+        /** The shot's staleness — explains "what changed" in the depth dialog (#1194). */
+        staleness?: ShotStaleness;
         /** Defaults to "Out of date since your last edit". */
         message?: string;
         /** Defaults to "Update all". */
@@ -209,6 +212,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
             <UpdateAllDialog
               open={updateAllOpen}
               onOpenChange={setUpdateAllOpen}
+              staleShots={props.staleness ? [props.staleness] : []}
               onConfirm={(depth: UpdateStaleDepth) => {
                 setUpdateAllOpen(false);
                 props.onRegenerateDepth?.(depth);

--- a/src/components/staleness/staleness-indicator.tsx
+++ b/src/components/staleness/staleness-indicator.tsx
@@ -80,6 +80,12 @@ type StalenessIndicatorProps = StalenessIndicatorBaseProps &
         onRegenerateDepth?: (depth: UpdateStaleDepth) => void;
         /** The shot's staleness — explains "what changed" in the depth dialog (#1194). */
         staleness?: ShotStaleness;
+        /** Dry-run preview scope for the depth dialog (#1194). Required with `onRegenerateDepth`. */
+        updateAllScope?: {
+          sequenceId: string;
+          sceneId?: string;
+          shotId?: string;
+        };
         /** Defaults to "Out of date since your last edit". */
         message?: string;
         /** Defaults to "Update all". */
@@ -213,6 +219,7 @@ export const StalenessIndicator: React.FC<StalenessIndicatorProps> = (
               open={updateAllOpen}
               onOpenChange={setUpdateAllOpen}
               staleShots={props.staleness ? [props.staleness] : []}
+              scope={props.updateAllScope ?? { sequenceId: '' }}
               onConfirm={(depth: UpdateStaleDepth) => {
                 setUpdateAllOpen(false);
                 props.onRegenerateDepth?.(depth);

--- a/src/components/staleness/update-all-dialog.test.ts
+++ b/src/components/staleness/update-all-dialog.test.ts
@@ -1,6 +1,6 @@
 import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { describe, expect, it } from 'vitest';
-import { describeCauses, describeLevel, shotsLabel } from './update-all-dialog';
+import { describeCauses, previewLevels, shotsLabel } from './update-all-dialog';
 
 const shot = (causes: string[]): ShotStaleness => ({
   thumbnail: 'stale',
@@ -38,7 +38,7 @@ describe('shotsLabel', () => {
   });
 });
 
-describe('describeLevel', () => {
+describe('previewLevels', () => {
   const numbers = new Map([
     ['a', 2],
     ['b', 3],
@@ -50,20 +50,16 @@ describe('describeLevel', () => {
     videoShotIds: [],
     musicPrompt: true,
     musicTrack: false,
-    costByDepth: { prompts: null, images: null, video: null, music: null },
+    costByLevel: { prompts: null, images: null, video: null, music: null },
   };
-  it('names each level concretely', () => {
-    expect(describeLevel('prompts', preview, numbers, false)).toBe(
-      'Image prompts for shots 2 & 3 · Motion prompts for shot 3'
-    );
-    expect(describeLevel('images', preview, numbers, false)).toBe(
-      '+ Images for shots 2 & 3'
-    );
-    expect(describeLevel('video', preview, numbers, false)).toBe(
-      '+ No videos affected'
-    );
-    expect(describeLevel('music', preview, numbers, false)).toBe(
-      '+ Music prompt'
-    );
+  it('lists only levels with work, concretely, in cascade order', () => {
+    expect(previewLevels(preview, numbers, false)).toEqual([
+      {
+        depth: 'prompts',
+        label: 'Image prompts for shots 2 & 3 · Motion prompts for shot 3',
+      },
+      { depth: 'images', label: 'Images for shots 2 & 3' },
+      { depth: 'music', label: 'Music prompt' },
+    ]);
   });
 });

--- a/src/components/staleness/update-all-dialog.test.ts
+++ b/src/components/staleness/update-all-dialog.test.ts
@@ -1,0 +1,29 @@
+import type { ShotStaleness } from '@/hooks/use-shot-staleness';
+import { describe, expect, it } from 'vitest';
+import { describeStaleShots } from './update-all-dialog';
+
+const shot = (o: Partial<ShotStaleness>): ShotStaleness => ({
+  thumbnail: 'fresh',
+  visualPrompt: 'fresh',
+  motionPrompt: 'fresh',
+  ...o,
+});
+
+describe('describeStaleShots', () => {
+  it('names each stale artifact once across shots', () => {
+    expect(
+      describeStaleShots([
+        shot({ visualPrompt: 'stale', thumbnail: 'stale' }),
+        shot({ motionPrompt: 'stale' }),
+        shot({ visualPrompt: 'stale' }),
+      ])
+    ).toBe(
+      '3 shots have an out-of-date visual prompt, motion prompt and image.'
+    );
+  });
+  it('singular shot', () => {
+    expect(describeStaleShots([shot({ thumbnail: 'stale' })])).toBe(
+      'This shot has an out-of-date image.'
+    );
+  });
+});

--- a/src/components/staleness/update-all-dialog.test.ts
+++ b/src/components/staleness/update-all-dialog.test.ts
@@ -1,29 +1,21 @@
 import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { describe, expect, it } from 'vitest';
-import { describeStaleShots } from './update-all-dialog';
+import { describeCauses } from './update-all-dialog';
 
-const shot = (o: Partial<ShotStaleness>): ShotStaleness => ({
-  thumbnail: 'fresh',
+const shot = (causes: string[]): ShotStaleness => ({
+  thumbnail: 'stale',
   visualPrompt: 'fresh',
   motionPrompt: 'fresh',
-  ...o,
+  causes,
 });
 
-describe('describeStaleShots', () => {
-  it('names each stale artifact once across shots', () => {
+describe('describeCauses', () => {
+  it('dedupes causes across shots', () => {
     expect(
-      describeStaleShots([
-        shot({ visualPrompt: 'stale', thumbnail: 'stale' }),
-        shot({ motionPrompt: 'stale' }),
-        shot({ visualPrompt: 'stale' }),
-      ])
-    ).toBe(
-      '3 shots have an out-of-date visual prompt, motion prompt and image.'
-    );
+      describeCauses([shot(['Script', 'Character "Woman"']), shot(['Script'])])
+    ).toBe('Changed: Script, Character "Woman"');
   });
-  it('singular shot', () => {
-    expect(describeStaleShots([shot({ thumbnail: 'stale' })])).toBe(
-      'This shot has an out-of-date image.'
-    );
+  it('null when nothing could be named', () => {
+    expect(describeCauses([shot([])])).toBeNull();
   });
 });

--- a/src/components/staleness/update-all-dialog.test.ts
+++ b/src/components/staleness/update-all-dialog.test.ts
@@ -1,6 +1,6 @@
 import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { describe, expect, it } from 'vitest';
-import { describeCauses } from './update-all-dialog';
+import { describeCauses, describeLevel, shotsLabel } from './update-all-dialog';
 
 const shot = (causes: string[]): ShotStaleness => ({
   thumbnail: 'stale',
@@ -17,5 +17,53 @@ describe('describeCauses', () => {
   });
   it('null when nothing could be named', () => {
     expect(describeCauses([shot([])])).toBeNull();
+  });
+});
+
+describe('shotsLabel', () => {
+  const numbers = new Map([
+    ['a', 2],
+    ['b', 3],
+    ['c', 4],
+  ]);
+  it('lists shot numbers', () => {
+    expect(shotsLabel(['c', 'a', 'b'], numbers, false)).toBe('shots 2, 3 & 4');
+    expect(shotsLabel(['a'], numbers, false)).toBe('shot 2');
+  });
+  it('shot scope reads "this shot"', () => {
+    expect(shotsLabel(['a'], numbers, true)).toBe('this shot');
+  });
+  it('falls back to a count without numbering', () => {
+    expect(shotsLabel(['x', 'y'], undefined, false)).toBe('2 shots');
+  });
+});
+
+describe('describeLevel', () => {
+  const numbers = new Map([
+    ['a', 2],
+    ['b', 3],
+  ]);
+  const preview = {
+    visualPromptShotIds: ['a', 'b'],
+    motionPromptShotIds: ['b'],
+    imageShotIds: ['a', 'b'],
+    videoShotIds: [],
+    musicPrompt: true,
+    musicTrack: false,
+    costByDepth: { prompts: null, images: null, video: null, music: null },
+  };
+  it('names each level concretely', () => {
+    expect(describeLevel('prompts', preview, numbers, false)).toBe(
+      'Image prompts for shots 2 & 3 · Motion prompts for shot 3'
+    );
+    expect(describeLevel('images', preview, numbers, false)).toBe(
+      '+ Images for shots 2 & 3'
+    );
+    expect(describeLevel('video', preview, numbers, false)).toBe(
+      '+ No videos affected'
+    );
+    expect(describeLevel('music', preview, numbers, false)).toBe(
+      '+ Music prompt'
+    );
   });
 });

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -14,7 +14,7 @@ import {
   UPDATE_STALE_DEPTHS,
   type UpdateStaleDepth,
 } from '@/lib/shots/update-stale-depth';
-import type { ShotArtifact, ShotStaleness } from '@/hooks/use-shot-staleness';
+import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 
@@ -23,46 +23,21 @@ type UpdateAllDialogProps = {
   onOpenChange: (open: boolean) => void;
   /** Confirm with the chosen cascade depth; the dialog closes itself. */
   onConfirm: (depth: UpdateStaleDepth) => void;
-  /**
-   * Staleness of each out-of-date shot in scope (#1194) — drives the "what
-   * changed" summary so the depth question has a reason attached.
-   */
+  /** Staleness of each out-of-date shot in scope — supplies the causes (#1194). */
   staleShots: ShotStaleness[];
 };
 
-const ARTIFACT_LABELS: [ShotArtifact, string][] = [
-  ['visualPrompt', 'visual prompt'],
-  ['motionPrompt', 'motion prompt'],
-  ['thumbnail', 'image'],
-];
-
-/**
- * "3 shots have an out-of-date visual prompt, motion prompt and image".
- * Staleness is hash-based — we know WHICH artifacts diverged from their
- * inputs, not which edit did it — so this names the artifacts and the input
- * surface (script, style, characters, locations, shot settings) instead of
- * guessing at the edit.
- */
-export const describeStaleShots = (staleShots: ShotStaleness[]): string => {
-  const parts = ARTIFACT_LABELS.filter(([a]) =>
-    staleShots.some((s) => s[a] === 'stale')
-  ).map(([, label]) => label);
-  const list =
-    parts.length > 1
-      ? `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
-      : (parts[0] ?? 'artifacts');
-  const n = staleShots.length;
-  return n === 1
-    ? `This shot has an out-of-date ${list}.`
-    : `${n} shots have an out-of-date ${list}.`;
+/** "Changed: Script, Character "Woman"" — deduped across shots, or null. */
+export const describeCauses = (staleShots: ShotStaleness[]): string | null => {
+  const causes = [...new Set(staleShots.flatMap((s) => s.causes))];
+  return causes.length > 0 ? `Changed: ${causes.join(', ')}` : null;
 };
 
 /**
- * "Update all" depth confirmation (#1085). One dialog per trigger site
- * (shot status line, scene/sequence summary): pick how deep the update
- * cascades — prompts → images → videos → music — then confirm. A dialog
- * rather than a menu so each level's cost consequence is readable before
- * anything is billed. Native radios for keyboard/AT semantics.
+ * "Update all" depth confirmation (#1085). Leads with WHAT changed (#1194),
+ * then asks how deep the update cascades — prompts → images → videos → music.
+ * A dialog rather than a menu so each level's cost consequence is readable
+ * before anything is billed. Native radios for keyboard/AT semantics.
  */
 export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   open,
@@ -79,18 +54,12 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Update out-of-date items</AlertDialogTitle>
-          <AlertDialogDescription className="flex flex-col gap-2">
-            <span>
-              {describeStaleShots(staleShots)} Something they were generated
-              from — the script, style, characters, locations or shot settings —
-              has changed since, so they no longer match your current project.
+          <AlertDialogDescription className="flex flex-col gap-1">
+            <span className="text-foreground">
+              {describeCauses(staleShots) ??
+                'Inputs changed since these were generated.'}
             </span>
-            <span>
-              Regenerating costs credits, and each level depends on the one
-              before it, so choose how far the update goes. Only items that are
-              already out of date (or become out of date from this update) are
-              regenerated — nothing is created for the first time.
-            </span>
+            <span>Regenerate:</span>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <fieldset className="flex flex-col gap-2">

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -8,15 +8,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { getUpdateStalePreviewFn } from '@/functions/shots';
+import type { ShotStaleness } from '@/hooks/use-shot-staleness';
+import { useShowCosts } from '@/hooks/use-show-costs';
+import { microsToDisplayUsd, type Microdollars } from '@/lib/billing/money';
+import type { UpdateStalePreview } from '@/lib/shots/update-stale-preview';
 import {
-  UPDATE_STALE_DEPTH_DESCRIPTIONS,
   UPDATE_STALE_DEPTH_LABELS,
   UPDATE_STALE_DEPTHS,
   type UpdateStaleDepth,
 } from '@/lib/shots/update-stale-depth';
-import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { cn } from '@/lib/utils';
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
+
+type UpdateAllScope = {
+  sequenceId: string;
+  sceneId?: string;
+  shotId?: string;
+};
 
 type UpdateAllDialogProps = {
   open: boolean;
@@ -25,6 +35,10 @@ type UpdateAllDialogProps = {
   onConfirm: (depth: UpdateStaleDepth) => void;
   /** Staleness of each out-of-date shot in scope — supplies the causes (#1194). */
   staleShots: ShotStaleness[];
+  /** What the dry-run preview plans over (shot / scene / sequence). */
+  scope: UpdateAllScope;
+  /** In-scope display numbers, for "shots 2, 3 & 4" labels. */
+  shotNumberById?: ReadonlyMap<string, number>;
 };
 
 /** "Changed: Script, Character "Woman"" — deduped across shots, or null. */
@@ -33,21 +47,93 @@ export const describeCauses = (staleShots: ShotStaleness[]): string | null => {
   return causes.length > 0 ? `Changed: ${causes.join(', ')}` : null;
 };
 
+/** "shot 2" / "shots 2, 3 & 4" / "this shot" at shot scope. */
+export const shotsLabel = (
+  shotIds: string[],
+  numberById: ReadonlyMap<string, number> | undefined,
+  singleShotScope: boolean
+): string => {
+  if (singleShotScope) return 'this shot';
+  const numbers = shotIds
+    .map((id) => numberById?.get(id))
+    .filter((n): n is number => n != null)
+    .sort((a, b) => a - b);
+  if (numbers.length === 0) return `${shotIds.length} shots`;
+  if (numbers.length === 1) return `shot ${numbers[0]}`;
+  return `shots ${numbers.slice(0, -1).join(', ')} & ${numbers[numbers.length - 1]}`;
+};
+
 /**
- * "Update all" depth confirmation (#1085). Leads with WHAT changed (#1194),
- * then asks how deep the update cascades — prompts → images → videos → music.
- * A dialog rather than a menu so each level's cost consequence is readable
- * before anything is billed. Native radios for keyboard/AT semantics.
+ * What each depth level actually does, from the dry-run preview — only the
+ * level's own additions (levels are cumulative and read top-down).
+ */
+export const describeLevel = (
+  depth: UpdateStaleDepth,
+  preview: UpdateStalePreview,
+  numberById: ReadonlyMap<string, number> | undefined,
+  singleShotScope: boolean
+): string => {
+  const label = (ids: string[]) => shotsLabel(ids, numberById, singleShotScope);
+  switch (depth) {
+    case 'prompts': {
+      const parts: string[] = [];
+      if (preview.visualPromptShotIds.length > 0)
+        parts.push(`Image prompts for ${label(preview.visualPromptShotIds)}`);
+      if (preview.motionPromptShotIds.length > 0)
+        parts.push(`Motion prompts for ${label(preview.motionPromptShotIds)}`);
+      return parts.length > 0 ? parts.join(' · ') : 'No prompts out of date';
+    }
+    case 'images':
+      return preview.imageShotIds.length > 0
+        ? `+ Images for ${label(preview.imageShotIds)}`
+        : '+ No images affected';
+    case 'video':
+      return preview.videoShotIds.length > 0
+        ? `+ Videos for ${label(preview.videoShotIds)}`
+        : '+ No videos affected';
+    case 'music':
+      return preview.musicTrack
+        ? '+ Music prompt and track'
+        : preview.musicPrompt
+          ? '+ Music prompt'
+          : '+ No music changes';
+  }
+};
+
+const costLabel = (cost: Microdollars | null | undefined): string | null =>
+  cost == null ? null : `~${microsToDisplayUsd(cost)}`;
+
+/**
+ * "Update all" depth confirmation (#1085). Leads with WHAT changed, then the
+ * computed cascade — which artifacts on which shots regenerate at each depth,
+ * with the cumulative cost estimate — from a server dry-run of the same plan
+ * the workflow freezes (#1194). Native radios for keyboard/AT semantics.
  */
 export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   open,
   onOpenChange,
   onConfirm,
   staleShots,
+  scope,
+  shotNumberById,
 }) => {
   // 'images' is the middle-ground default — the closest match to what
   // "Update all" did before depths existed.
   const [depth, setDepth] = useState<UpdateStaleDepth>('images');
+  const { showCosts } = useShowCosts();
+  const singleShotScope = scope.shotId != null;
+
+  const { data: preview } = useQuery({
+    queryKey: [
+      'update-stale-preview',
+      scope.sequenceId,
+      scope.sceneId,
+      scope.shotId,
+    ],
+    queryFn: () => getUpdateStalePreviewFn({ data: scope }),
+    enabled: open && scope.sequenceId !== '',
+    staleTime: 30_000,
+  });
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
@@ -64,43 +150,64 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
         </AlertDialogHeader>
         <fieldset className="flex flex-col gap-2">
           <legend className="sr-only">Update depth</legend>
-          {UPDATE_STALE_DEPTHS.map((option) => (
-            <label
-              key={option}
-              htmlFor={`update-all-depth-${option}`}
-              className={cn(
-                'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
-                'has-focus-visible:ring-[3px] has-focus-visible:ring-ring/50',
-                depth === option
-                  ? 'border-primary/40 bg-primary/5'
-                  : 'hover:bg-muted/50'
-              )}
-            >
-              <input
-                id={`update-all-depth-${option}`}
-                type="radio"
-                name="update-all-depth"
-                value={option}
-                checked={depth === option}
-                onChange={() => setDepth(option)}
-                aria-label={UPDATE_STALE_DEPTH_LABELS[option]}
-                className="mt-1 accent-primary"
-              />
-              <span className="flex min-w-0 flex-col gap-0.5">
-                <span className="text-sm font-medium">
-                  {UPDATE_STALE_DEPTH_LABELS[option]}
+          {UPDATE_STALE_DEPTHS.map((option) => {
+            const cost = showCosts
+              ? costLabel(preview?.costByDepth[option])
+              : null;
+            return (
+              <label
+                key={option}
+                htmlFor={`update-all-depth-${option}`}
+                className={cn(
+                  'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
+                  'has-focus-visible:ring-[3px] has-focus-visible:ring-ring/50',
+                  depth === option
+                    ? 'border-primary/40 bg-primary/5'
+                    : 'hover:bg-muted/50'
+                )}
+              >
+                <input
+                  id={`update-all-depth-${option}`}
+                  type="radio"
+                  name="update-all-depth"
+                  value={option}
+                  checked={depth === option}
+                  onChange={() => setDepth(option)}
+                  aria-label={UPDATE_STALE_DEPTH_LABELS[option]}
+                  className="mt-1 accent-primary"
+                />
+                <span className="flex min-w-0 grow flex-col gap-0.5">
+                  <span className="flex items-baseline justify-between gap-2">
+                    <span className="text-sm font-medium">
+                      {UPDATE_STALE_DEPTH_LABELS[option]}
+                    </span>
+                    {cost && (
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {cost}
+                      </span>
+                    )}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {preview
+                      ? describeLevel(
+                          option,
+                          preview,
+                          shotNumberById,
+                          singleShotScope
+                        )
+                      : '…'}
+                  </span>
                 </span>
-                <span className="text-xs text-muted-foreground">
-                  {UPDATE_STALE_DEPTH_DESCRIPTIONS[option]}
-                </span>
-              </span>
-            </label>
-          ))}
+              </label>
+            );
+          })}
         </fieldset>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction onClick={() => onConfirm(depth)}>
-            Update
+            {showCosts && preview?.costByDepth[depth] != null
+              ? `Update · ~${microsToDisplayUsd(preview.costByDepth[depth])}`
+              : 'Update'}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -132,7 +132,7 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   const { showCosts } = useShowCosts();
   const singleShotScope = scope.shotId != null;
 
-  const { data: preview } = useQuery({
+  const { data: preview, isError } = useQuery({
     queryKey: [
       'update-stale-preview',
       scope.sequenceId,
@@ -152,7 +152,11 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
     depth == null
       ? []
       : (levels?.filter((l) => RANK[l.depth] <= RANK[depth]) ?? []);
-  const selectedDepth = available[available.length - 1]?.depth ?? null;
+  // Preview failed: fall back to the pre-preview behaviour — a plain confirm
+  // at the old default depth — rather than blocking the update on a preview.
+  const selectedDepth =
+    available[available.length - 1]?.depth ??
+    (isError && depth != null ? 'images' : null);
   const checked = (d: UpdateStaleDepth) =>
     selectedDepth != null && RANK[d] <= RANK[selectedDepth];
   const total = levels
@@ -189,7 +193,12 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
         </AlertDialogHeader>
         <fieldset className="flex flex-col gap-2">
           <legend className="sr-only">What to regenerate</legend>
-          {levels == null ? (
+          {isError ? (
+            <span className="text-xs text-muted-foreground">
+              Couldn’t compute the plan — Update regenerates out-of-date prompts
+              and images.
+            </span>
+          ) : levels == null ? (
             <span className="text-xs text-muted-foreground">…</span>
           ) : levels.length === 0 ? (
             <span className="text-xs text-muted-foreground">

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -14,6 +14,7 @@ import {
   UPDATE_STALE_DEPTHS,
   type UpdateStaleDepth,
 } from '@/lib/shots/update-stale-depth';
+import type { ShotArtifact, ShotStaleness } from '@/hooks/use-shot-staleness';
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 
@@ -22,6 +23,38 @@ type UpdateAllDialogProps = {
   onOpenChange: (open: boolean) => void;
   /** Confirm with the chosen cascade depth; the dialog closes itself. */
   onConfirm: (depth: UpdateStaleDepth) => void;
+  /**
+   * Staleness of each out-of-date shot in scope (#1194) — drives the "what
+   * changed" summary so the depth question has a reason attached.
+   */
+  staleShots: ShotStaleness[];
+};
+
+const ARTIFACT_LABELS: [ShotArtifact, string][] = [
+  ['visualPrompt', 'visual prompt'],
+  ['motionPrompt', 'motion prompt'],
+  ['thumbnail', 'image'],
+];
+
+/**
+ * "3 shots have an out-of-date visual prompt, motion prompt and image".
+ * Staleness is hash-based — we know WHICH artifacts diverged from their
+ * inputs, not which edit did it — so this names the artifacts and the input
+ * surface (script, style, characters, locations, shot settings) instead of
+ * guessing at the edit.
+ */
+export const describeStaleShots = (staleShots: ShotStaleness[]): string => {
+  const parts = ARTIFACT_LABELS.filter(([a]) =>
+    staleShots.some((s) => s[a] === 'stale')
+  ).map(([, label]) => label);
+  const list =
+    parts.length > 1
+      ? `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`
+      : (parts[0] ?? 'artifacts');
+  const n = staleShots.length;
+  return n === 1
+    ? `This shot has an out-of-date ${list}.`
+    : `${n} shots have an out-of-date ${list}.`;
 };
 
 /**
@@ -35,6 +68,7 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   open,
   onOpenChange,
   onConfirm,
+  staleShots,
 }) => {
   // 'images' is the middle-ground default — the closest match to what
   // "Update all" did before depths existed.
@@ -45,10 +79,18 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Update out-of-date items</AlertDialogTitle>
-          <AlertDialogDescription>
-            Choose how deep the update goes. Only items that are already out of
-            date (or become out of date from this update) are regenerated —
-            nothing is ever created for the first time.
+          <AlertDialogDescription className="flex flex-col gap-2">
+            <span>
+              {describeStaleShots(staleShots)} Something they were generated
+              from — the script, style, characters, locations or shot settings —
+              has changed since, so they no longer match your current project.
+            </span>
+            <span>
+              Regenerating costs credits, and each level depends on the one
+              before it, so choose how far the update goes. Only items that are
+              already out of date (or become out of date from this update) are
+              regenerated — nothing is created for the first time.
+            </span>
           </AlertDialogDescription>
         </AlertDialogHeader>
         <fieldset className="flex flex-col gap-2">

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -11,11 +11,15 @@ import {
 import { getUpdateStalePreviewFn } from '@/functions/shots';
 import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { useShowCosts } from '@/hooks/use-show-costs';
-import { microsToDisplayUsd, type Microdollars } from '@/lib/billing/money';
+import {
+  addMicros,
+  microsToDisplayUsd,
+  ZERO_MICROS,
+  type Microdollars,
+} from '@/lib/billing/money';
 import type { UpdateStalePreview } from '@/lib/shots/update-stale-preview';
 import {
   UPDATE_STALE_DEPTH_LABELS,
-  UPDATE_STALE_DEPTHS,
   type UpdateStaleDepth,
 } from '@/lib/shots/update-stale-depth';
 import { cn } from '@/lib/utils';
@@ -63,51 +67,56 @@ export const shotsLabel = (
   return `shots ${numbers.slice(0, -1).join(', ')} & ${numbers[numbers.length - 1]}`;
 };
 
-/**
- * What each depth level actually does, from the dry-run preview — only the
- * level's own additions (levels are cumulative and read top-down).
- */
-export const describeLevel = (
-  depth: UpdateStaleDepth,
+/** Levels with something to do, in cascade order, with their own additions. */
+export const previewLevels = (
   preview: UpdateStalePreview,
   numberById: ReadonlyMap<string, number> | undefined,
   singleShotScope: boolean
-): string => {
+): Array<{ depth: UpdateStaleDepth; label: string }> => {
   const label = (ids: string[]) => shotsLabel(ids, numberById, singleShotScope);
-  switch (depth) {
-    case 'prompts': {
-      const parts: string[] = [];
-      if (preview.visualPromptShotIds.length > 0)
-        parts.push(`Image prompts for ${label(preview.visualPromptShotIds)}`);
-      if (preview.motionPromptShotIds.length > 0)
-        parts.push(`Motion prompts for ${label(preview.motionPromptShotIds)}`);
-      return parts.length > 0 ? parts.join(' · ') : 'No prompts out of date';
-    }
-    case 'images':
-      return preview.imageShotIds.length > 0
-        ? `+ Images for ${label(preview.imageShotIds)}`
-        : '+ No images affected';
-    case 'video':
-      return preview.videoShotIds.length > 0
-        ? `+ Videos for ${label(preview.videoShotIds)}`
-        : '+ No videos affected';
-    case 'music':
-      return preview.musicTrack
-        ? '+ Music prompt and track'
-        : preview.musicPrompt
-          ? '+ Music prompt'
-          : '+ No music changes';
-  }
+  const levels: Array<{ depth: UpdateStaleDepth; label: string }> = [];
+  const prompts: string[] = [];
+  if (preview.visualPromptShotIds.length > 0)
+    prompts.push(`Image prompts for ${label(preview.visualPromptShotIds)}`);
+  if (preview.motionPromptShotIds.length > 0)
+    prompts.push(`Motion prompts for ${label(preview.motionPromptShotIds)}`);
+  if (prompts.length > 0)
+    levels.push({ depth: 'prompts', label: prompts.join(' · ') });
+  if (preview.imageShotIds.length > 0)
+    levels.push({
+      depth: 'images',
+      label: `Images for ${label(preview.imageShotIds)}`,
+    });
+  if (preview.videoShotIds.length > 0)
+    levels.push({
+      depth: 'video',
+      label: `Videos for ${label(preview.videoShotIds)}`,
+    });
+  if (preview.musicTrack || preview.musicPrompt)
+    levels.push({
+      depth: 'music',
+      label: preview.musicTrack ? 'Music prompt and track' : 'Music prompt',
+    });
+  return levels;
 };
 
 const costLabel = (cost: Microdollars | null | undefined): string | null =>
   cost == null ? null : `~${microsToDisplayUsd(cost)}`;
 
+const RANK: Record<UpdateStaleDepth, number> = {
+  prompts: 0,
+  images: 1,
+  video: 2,
+  music: 3,
+};
+
 /**
- * "Update all" depth confirmation (#1085). Leads with WHAT changed, then the
- * computed cascade — which artifacts on which shots regenerate at each depth,
- * with the cumulative cost estimate — from a server dry-run of the same plan
- * the workflow freezes (#1194). Native radios for keyboard/AT semantics.
+ * "Update all" confirmation (#1085/#1194). Leads with WHAT changed, then the
+ * computed cascade from a server dry-run of the same plan the workflow
+ * freezes: one checkbox per level that has work, with its shots and cost.
+ * Levels cascade (images need prompts, videos need images), so ticking a
+ * level locks every shallower one on. Only the deepest tick is sent — the
+ * run's `depth`. Native inputs for keyboard/AT semantics.
  */
 export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   open,
@@ -119,7 +128,7 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
 }) => {
   // 'images' is the middle-ground default — the closest match to what
   // "Update all" did before depths existed.
-  const [depth, setDepth] = useState<UpdateStaleDepth>('images');
+  const [depth, setDepth] = useState<UpdateStaleDepth | null>('images');
   const { showCosts } = useShowCosts();
   const singleShotScope = scope.shotId != null;
 
@@ -135,6 +144,36 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
     staleTime: 30_000,
   });
 
+  const levels = preview
+    ? previewLevels(preview, shotNumberById, singleShotScope)
+    : null;
+  // Snap the default to a level that exists: the deepest at or above it.
+  const available =
+    depth == null
+      ? []
+      : (levels?.filter((l) => RANK[l.depth] <= RANK[depth]) ?? []);
+  const selectedDepth = available[available.length - 1]?.depth ?? null;
+  const checked = (d: UpdateStaleDepth) =>
+    selectedDepth != null && RANK[d] <= RANK[selectedDepth];
+  const total = levels
+    ? levels
+        .filter((l) => checked(l.depth))
+        .reduce<Microdollars | null>((acc, l) => {
+          const c = preview?.costByLevel[l.depth] ?? null;
+          return acc == null || c == null ? null : addMicros(acc, c);
+        }, ZERO_MICROS)
+    : null;
+
+  const toggle = (d: UpdateStaleDepth, on: boolean) => {
+    if (on) {
+      setDepth(d);
+      return;
+    }
+    // Unticking a level drops it and everything deeper.
+    const shallower = levels?.filter((l) => RANK[l.depth] < RANK[d]) ?? [];
+    setDepth(shallower[shallower.length - 1]?.depth ?? null);
+  };
+
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
@@ -149,64 +188,73 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
           </AlertDialogDescription>
         </AlertDialogHeader>
         <fieldset className="flex flex-col gap-2">
-          <legend className="sr-only">Update depth</legend>
-          {UPDATE_STALE_DEPTHS.map((option) => {
-            const cost = showCosts
-              ? costLabel(preview?.costByDepth[option])
-              : null;
-            return (
-              <label
-                key={option}
-                htmlFor={`update-all-depth-${option}`}
-                className={cn(
-                  'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
-                  'has-focus-visible:ring-[3px] has-focus-visible:ring-ring/50',
-                  depth === option
-                    ? 'border-primary/40 bg-primary/5'
-                    : 'hover:bg-muted/50'
-                )}
-              >
-                <input
-                  id={`update-all-depth-${option}`}
-                  type="radio"
-                  name="update-all-depth"
-                  value={option}
-                  checked={depth === option}
-                  onChange={() => setDepth(option)}
-                  aria-label={UPDATE_STALE_DEPTH_LABELS[option]}
-                  className="mt-1 accent-primary"
-                />
-                <span className="flex min-w-0 grow flex-col gap-0.5">
-                  <span className="flex items-baseline justify-between gap-2">
-                    <span className="text-sm font-medium">
-                      {UPDATE_STALE_DEPTH_LABELS[option]}
+          <legend className="sr-only">What to regenerate</legend>
+          {levels == null ? (
+            <span className="text-xs text-muted-foreground">…</span>
+          ) : levels.length === 0 ? (
+            <span className="text-xs text-muted-foreground">
+              Nothing to regenerate.
+            </span>
+          ) : (
+            levels.map((level, index) => {
+              const isChecked = checked(level.depth);
+              // Shallower levels are prerequisites of a deeper tick.
+              const locked =
+                selectedDepth != null &&
+                RANK[level.depth] < RANK[selectedDepth];
+              const cost = showCosts
+                ? costLabel(preview?.costByLevel[level.depth])
+                : null;
+              return (
+                <label
+                  key={level.depth}
+                  htmlFor={`update-all-level-${level.depth}`}
+                  className={cn(
+                    'flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors',
+                    'has-focus-visible:ring-[3px] has-focus-visible:ring-ring/50',
+                    isChecked
+                      ? 'border-primary/40 bg-primary/5'
+                      : 'hover:bg-muted/50',
+                    locked && 'cursor-default'
+                  )}
+                >
+                  <input
+                    id={`update-all-level-${level.depth}`}
+                    type="checkbox"
+                    checked={isChecked}
+                    disabled={locked}
+                    onChange={(e) =>
+                      toggle(level.depth, e.currentTarget.checked)
+                    }
+                    aria-label={UPDATE_STALE_DEPTH_LABELS[level.depth]}
+                    className="mt-0.5 accent-primary"
+                  />
+                  <span className="flex min-w-0 grow items-baseline justify-between gap-2">
+                    <span className="text-sm">
+                      {index > 0 && (
+                        <span className="text-muted-foreground">+ </span>
+                      )}
+                      {level.label}
                     </span>
                     {cost && (
-                      <span className="text-xs tabular-nums text-muted-foreground">
+                      <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                         {cost}
                       </span>
                     )}
                   </span>
-                  <span className="text-xs text-muted-foreground">
-                    {preview
-                      ? describeLevel(
-                          option,
-                          preview,
-                          shotNumberById,
-                          singleShotScope
-                        )
-                      : '…'}
-                  </span>
-                </span>
-              </label>
-            );
-          })}
+                </label>
+              );
+            })
+          )}
         </fieldset>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={() => onConfirm(depth)}>
-            {showCosts && preview?.costByDepth[depth] != null
-              ? `Update · ~${microsToDisplayUsd(preview.costByDepth[depth])}`
+          <AlertDialogAction
+            disabled={selectedDepth == null}
+            onClick={() => selectedDepth && onConfirm(selectedDepth)}
+          >
+            {showCosts && selectedDepth != null && total != null
+              ? `Update · ~${microsToDisplayUsd(total)}`
               : 'Update'}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -17,6 +17,10 @@ import {
 } from '@/lib/shots/update-stale-depth';
 import { computePlan } from '@/lib/shots/update-stale-plan';
 import {
+  buildUpdateStalePreview,
+  type UpdateStalePreview,
+} from '@/lib/shots/update-stale-preview';
+import {
   toShotView,
   shotViewMissingFrame,
   pendingUpscaleUrlFromVersion,
@@ -868,4 +872,37 @@ export const getShotDownloadUrlFn = createServerFn({ method: 'GET' })
     const downloadUrl = await getVideoDownloadUrl(storagePath, filename, 3600);
 
     return { downloadUrl, filename };
+  });
+
+/**
+ * Dry-run "Update all" preview (#1194): the concrete cascade — which
+ * artifacts on which shots regenerate at each depth — plus cumulative cost
+ * estimates. Same `computePlan` the enqueue path freezes, at max depth, with
+ * no claims and no workflow: nothing is billed by looking.
+ */
+export const getUpdateStalePreviewFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .validator(
+    zodValidator(
+      z.object({
+        sequenceId: ulidSchema,
+        sceneId: ulidSchema.optional(),
+        shotId: ulidSchema.optional(),
+      })
+    )
+  )
+  .handler(async ({ data, context }): Promise<UpdateStalePreview> => {
+    const { sequence, scopedDb } = context;
+    const plan = await computePlan({
+      scopedDb,
+      sequenceId: sequence.id,
+      sceneId: data.sceneId,
+      shotId: data.shotId,
+      depth: 'music',
+    });
+    return buildUpdateStalePreview(
+      plan,
+      await getEffectiveFalPricing(),
+      sequence.musicModel
+    );
   });

--- a/src/functions/shots.ts
+++ b/src/functions/shots.ts
@@ -585,7 +585,8 @@ const toWireStaleness = ({
   thumbnail,
   visualPrompt,
   motionPrompt,
-}: ShotStalenessResult) => ({ thumbnail, visualPrompt, motionPrompt });
+  causes,
+}: ShotStalenessResult) => ({ thumbnail, visualPrompt, motionPrompt, causes });
 
 /**
  * Batched `getShotStalenessFn` (#1077): staleness for every shot in one scene

--- a/src/hooks/use-shot-staleness.ts
+++ b/src/hooks/use-shot-staleness.ts
@@ -27,7 +27,10 @@ export type ShotArtifact = (typeof SHOT_ARTIFACTS)[number];
  * Client-facing staleness (wire shape). Server `ShotStalenessResult` also
  * carries `liveHashes` for enqueue paths; those never cross the wire.
  */
-export type ShotStaleness = Record<ShotArtifact, ArtifactStaleness>;
+export type ShotStaleness = Record<ShotArtifact, ArtifactStaleness> & {
+  /** Inputs edited since the stale artifacts were generated (#1194). */
+  causes: string[];
+};
 
 /** Which of the shot's artifacts are out of date, if any. */
 const staleArtifacts = (staleness: ShotStaleness | undefined): ShotArtifact[] =>

--- a/src/lib/db/scoped/sequence-events.ts
+++ b/src/lib/db/scoped/sequence-events.ts
@@ -112,3 +112,18 @@ export function createSequenceEventsMethods(db: Database) {
     },
   };
 }
+
+/**
+ * Event appended by `scopedDb.sequences.update` when a hash-bearing sequence
+ * setting changes (#1194). Style / aspect ratio / model switches leave no
+ * timestamp on any row (style is a snapshot), so this is the only way to date
+ * them for `findStalenessCauses`.
+ */
+export const SETTINGS_CHANGED_EVENT = 'sequence.settings-changed';
+
+export const SETTINGS_CHANGED_LABELS: Record<string, string> = {
+  styleId: 'Style',
+  aspectRatio: 'Aspect ratio',
+  imageModel: 'Image model',
+  analysisModel: 'Script model',
+};

--- a/src/lib/db/scoped/sequences.ts
+++ b/src/lib/db/scoped/sequences.ts
@@ -30,6 +30,11 @@ import { parseStyleConfig } from '@/lib/style/style-config';
 import type { ShotReadiness, ShotView } from '@/lib/shots/shot-view';
 import { getLatestPreviewByFrameIds } from './frame-variants';
 import { getPrimaryVideoByShotIds } from './video-variants';
+import {
+  buildEventInsert,
+  SETTINGS_CHANGED_EVENT,
+  SETTINGS_CHANGED_LABELS,
+} from './sequence-events';
 import { ValidationError } from '@/lib/errors';
 import { and, asc, desc, eq, inArray, isNull, lt, not, or } from 'drizzle-orm';
 
@@ -403,6 +408,22 @@ export function createSequencesMethods(
       // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard: DB query may return undefined
       if (!data) {
         throw new ValidationError('Sequence not found');
+      }
+
+      // Date hash-bearing setting changes so staleness can name them (#1194);
+      // style is a snapshot, so no row timestamp says when it moved.
+      const fields = Object.keys(SETTINGS_CHANGED_LABELS).filter(
+        (f) => f in values
+      );
+      if (fields.length > 0) {
+        await buildEventInsert(db, {
+          sequenceId: id,
+          actorId: userId,
+          kind: SETTINGS_CHANGED_EVENT,
+          targetType: 'sequence',
+          targetId: id,
+          data: { fields },
+        });
       }
 
       return data;

--- a/src/lib/shots/shot-staleness.test.ts
+++ b/src/lib/shots/shot-staleness.test.ts
@@ -257,6 +257,7 @@ describe('computeShotStaleness', () => {
       visualPrompt: 'generating',
       motionPrompt: 'generating',
       liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
+      causes: [],
     });
     // Short-circuits before any work: the batch fn runs this for every shot in
     // the sequence, on the poll loop that runs hardest during generation.
@@ -387,5 +388,74 @@ describe('computeShotStaleness', () => {
     });
 
     expect(result.thumbnail).toBe('untracked');
+  });
+});
+
+describe('staleness causes (#1194)', () => {
+  it('names inputs touched after the stale artifact was generated', async () => {
+    buildRegenerateShotSnapshot.mockResolvedValue({
+      snapshotInputHash: 'image-live',
+    });
+    loadNarrowShotPromptContext.mockResolvedValue({});
+    computeVisualPromptInputHash.mockResolvedValue('visual-stored');
+    computeMotionPromptInputHash.mockResolvedValue('motion-stored');
+
+    const generated = new Date('2026-01-01T00:00:00Z');
+    const before = new Date('2025-12-31T00:00:00Z');
+    const afterGen = new Date('2026-01-02T00:00:00Z');
+    const scopedDb = makeScopedDb({ motionSelectedHash: 'motion-stored' });
+    Object.assign(scopedDb, {
+      scenes: { getById: vi.fn().mockResolvedValue({ updatedAt: afterGen }) },
+      sceneScriptVersions: {
+        getSelected: vi.fn().mockResolvedValue({ createdAt: afterGen }),
+      },
+      sequenceEvents: {
+        listByTarget: vi.fn().mockResolvedValue([
+          {
+            kind: 'sequence.settings-changed',
+            createdAt: afterGen,
+            data: { fields: ['styleId'] },
+          },
+          {
+            kind: 'sequence.settings-changed',
+            createdAt: before,
+            data: { fields: ['aspectRatio'] },
+          },
+        ]),
+      },
+    });
+    const still = asStub<FrameVariant>({
+      id: 'fv-1',
+      inputHash: 'image-old',
+      model: null,
+      url: null,
+      generatedAt: generated,
+    });
+
+    const result = await computeShotStaleness({
+      scopedDb,
+      sequence,
+      shot: asStub<Shot>({ id: 'shot-1', sceneId: 'scene-1' }),
+      frame,
+      selectedImage: still,
+      scene,
+      refs: asStub({
+        characters: [
+          { name: 'Woman', updatedAt: afterGen, sheetGeneratedAt: null },
+          { name: 'Man', updatedAt: before, sheetGeneratedAt: before },
+        ],
+        locations: [{ name: 'Bathroom', updatedAt: before }],
+        elements: [{ token: 'BOTTLE', updatedAt: afterGen }],
+        style: null,
+      }),
+    });
+
+    expect(result.thumbnail).toBe('stale');
+    expect(result.causes).toEqual([
+      'Script',
+      'Style',
+      'Character "Woman"',
+      'Element BOTTLE',
+    ]);
   });
 });

--- a/src/lib/shots/shot-staleness.ts
+++ b/src/lib/shots/shot-staleness.ts
@@ -19,6 +19,11 @@ import {
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
 import type { Frame, FrameVariant, Shot } from '@/lib/db/schema';
+import { dbSceneId } from '@/lib/db/schema/scenes';
+import {
+  SETTINGS_CHANGED_EVENT,
+  SETTINGS_CHANGED_LABELS,
+} from '@/lib/db/scoped/sequence-events';
 import type { SequenceStatus } from '@/lib/db/schema/sequences';
 import type { ScopedDb } from '@/lib/db/scoped';
 import { buildRegenerateShotSnapshot } from '@/lib/workflows/regenerate-shots-snapshot';
@@ -64,6 +69,8 @@ export type ShotStalenessResult = {
   visualPrompt: ArtifactStaleness;
   motionPrompt: ArtifactStaleness;
   liveHashes: ShotLiveHashes;
+  /** Inputs edited since the stale artifacts were generated (#1194), as display labels. Empty when fresh or undeterminable. */
+  causes: string[];
 };
 
 /** Every artifact unopinionated — the missing-anchor and no-scene cases. */
@@ -72,6 +79,7 @@ export const UNTRACKED_STALENESS: ShotStalenessResult = {
   visualPrompt: 'untracked',
   motionPrompt: 'untracked',
   liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
+  causes: [],
 };
 
 /** Every artifact deferred — the sequence is mid-run (#1121). */
@@ -80,6 +88,7 @@ const GENERATING_STALENESS: ShotStalenessResult = {
   visualPrompt: 'generating',
   motionPrompt: 'generating',
   liveHashes: { thumbnail: null, visualPrompt: null, motionPrompt: null },
+  causes: [],
 };
 
 /**
@@ -236,6 +245,8 @@ export async function computeShotStaleness(args: {
 
   let visualPrompt: ArtifactStaleness = 'untracked';
   let motionPrompt: ArtifactStaleness = 'untracked';
+  let selectedMotion: { inputHash: string | null; createdAt: Date } | null =
+    null;
 
   // Reference hash resolution: prefer the SELECTED version's `inputHash`, but
   // fall back to the most recent version with a non-null one for prompts whose
@@ -285,9 +296,10 @@ export async function computeShotStaleness(args: {
 
   if (scene) {
     try {
-      let referenceHash =
-        (await scopedDb.shotPromptVersions.getSelectedMotion(shot.id))
-          ?.inputHash ?? null;
+      selectedMotion = await scopedDb.shotPromptVersions.getSelectedMotion(
+        shot.id
+      );
+      let referenceHash = selectedMotion?.inputHash ?? null;
       if (!referenceHash) {
         const fallback =
           await scopedDb.shotPromptVersions.getLatestWithInputHash(
@@ -380,5 +392,123 @@ export async function computeShotStaleness(args: {
     }
   }
 
-  return { thumbnail, visualPrompt, motionPrompt, liveHashes };
+  let causes: string[] = [];
+  if ([thumbnail, visualPrompt, motionPrompt].includes('stale')) {
+    try {
+      const resolvedRefs: ShotStalenessRefs = refs ?? {
+        characters: await scopedDb.characters.listWithSheets(sequence.id),
+        locations: await scopedDb.sequenceLocations.listWithReferences(
+          sequence.id
+        ),
+        elements: await scopedDb.sequenceElements.list(sequence.id),
+        style: sequence.styleId
+          ? await scopedDb.styles.getById(sequence.styleId)
+          : null,
+      };
+      causes = await findStalenessCauses({
+        scopedDb,
+        sequence,
+        shot,
+        refs: resolvedRefs,
+        selectedImage,
+        generatedAt: {
+          thumbnail:
+            thumbnail === 'stale' && selectedImage
+              ? (selectedImage.generatedAt ?? selectedImage.createdAt)
+              : undefined,
+          visualPrompt:
+            visualPrompt === 'stale' ? selectedPrompt?.createdAt : undefined,
+          motionPrompt:
+            motionPrompt === 'stale' ? selectedMotion?.createdAt : undefined,
+        },
+      });
+    } catch (error) {
+      // A hint, never a verdict: an unreadable row just leaves it unnamed.
+      logger.warn(`staleness causes uncomputable for shot ${shot.id}:`, {
+        err: error,
+      });
+    }
+  }
+
+  return { thumbnail, visualPrompt, motionPrompt, liveHashes, causes };
+}
+
+const after = (d: Date | null | undefined, at: number) =>
+  d != null && d.getTime() > at;
+
+/**
+ * Name what moved since the stale artifact was generated (#1194). Hashes only
+ * say THAT inputs diverged, so this is a timestamp heuristic: every input row
+ * touched after `artifactAt` is a candidate. Best-effort — a row saved without
+ * a real change can over-name, and nothing here ever changes a verdict.
+ */
+// ponytail: timestamp heuristic; store per-component hashes on the version rows if over-naming bites.
+async function findStalenessCauses(args: {
+  scopedDb: ScopedDb;
+  sequence: { id: string; styleConfig?: unknown };
+  shot: Shot;
+  refs: ShotStalenessRefs;
+  /** When each stale artifact was generated; absent → that artifact isn't stale. */
+  generatedAt: { thumbnail?: Date; visualPrompt?: Date; motionPrompt?: Date };
+  selectedImage: FrameVariant | null;
+}): Promise<string[]> {
+  const { scopedDb, sequence, shot, refs, generatedAt, selectedImage } = args;
+  const times = [
+    generatedAt.thumbnail,
+    generatedAt.visualPrompt,
+    generatedAt.motionPrompt,
+  ].flatMap((d) => (d ? [d.getTime()] : []));
+  if (times.length === 0) return [];
+  const at = Math.min(...times);
+  const causes: string[] = [];
+
+  if (shot.sceneId) {
+    const sceneId = dbSceneId(shot.sceneId);
+    const [sceneRow, script] = await Promise.all([
+      scopedDb.scenes.getById(sceneId),
+      scopedDb.sceneScriptVersions.getSelected(sceneId),
+    ]);
+    if (after(script?.createdAt, at)) causes.push('Script');
+    else if (after(sceneRow?.updatedAt, at)) causes.push('Scene details');
+  }
+
+  const events = await scopedDb.sequenceEvents.listByTarget(
+    'sequence',
+    sequence.id
+  );
+  const fields = new Set<string>();
+  for (const e of events) {
+    if (e.kind !== SETTINGS_CHANGED_EVENT || !after(e.createdAt, at)) continue;
+    const changed = e.data?.fields;
+    if (Array.isArray(changed)) {
+      for (const f of changed) if (typeof f === 'string') fields.add(f);
+    }
+  }
+  for (const f of fields) causes.push(SETTINGS_CHANGED_LABELS[f] ?? f);
+  // Catalog style edits only flow through when the sequence has no snapshot.
+  if (sequence.styleConfig == null && after(refs.style?.updatedAt, at)) {
+    if (!fields.has('styleId')) causes.push('Style');
+  }
+
+  for (const c of refs.characters) {
+    if (after(c.updatedAt, at) || after(c.sheetGeneratedAt, at)) {
+      causes.push(`Character "${c.name}"`);
+    }
+  }
+  for (const l of refs.locations) {
+    if (after(l.updatedAt, at)) causes.push(`Location "${l.name}"`);
+  }
+  for (const el of refs.elements) {
+    if (after(el.updatedAt, at)) causes.push(`Element ${el.token}`);
+  }
+  if (
+    generatedAt.motionPrompt &&
+    after(
+      selectedImage?.generatedAt ?? selectedImage?.createdAt,
+      generatedAt.motionPrompt.getTime()
+    )
+  ) {
+    causes.push('Image re-rendered');
+  }
+  return causes;
 }

--- a/src/lib/shots/update-stale-depth.ts
+++ b/src/lib/shots/update-stale-depth.ts
@@ -55,12 +55,3 @@ export const UPDATE_STALE_DEPTH_LABELS: Record<UpdateStaleDepth, string> = {
   video: 'Prompts, images + videos',
   music: 'Everything, incl. music',
 };
-
-/** One-line consequence of each level, shown in the confirm dialog. */
-export const UPDATE_STALE_DEPTH_DESCRIPTIONS: Record<UpdateStaleDepth, string> =
-  {
-    prompts: 'Rewrites out-of-date prompts. Nothing is rendered.',
-    images: 'Also re-renders stills affected by prompt changes.',
-    video: 'Also re-renders existing videos whose inputs changed.',
-    music: 'Also refreshes the sequence music prompt and track.',
-  };

--- a/src/lib/shots/update-stale-plan.test.ts
+++ b/src/lib/shots/update-stale-plan.test.ts
@@ -17,6 +17,7 @@ const FRESH: ShotStalenessResult = {
   thumbnail: 'fresh',
   visualPrompt: 'fresh',
   motionPrompt: 'fresh',
+  causes: [],
   liveHashes: {
     thumbnail: 'live-thumb',
     visualPrompt: 'live-visual',

--- a/src/lib/shots/update-stale-preview.test.ts
+++ b/src/lib/shots/update-stale-preview.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from 'vitest';
+import { micros } from '@/lib/billing/money';
+
+const { estimateImageCost, estimateVideoCost, estimateAudioCost } = vi.hoisted(
+  () => ({
+    estimateImageCost: vi.fn(),
+    estimateVideoCost: vi.fn(),
+    estimateAudioCost: vi.fn(),
+  })
+);
+vi.mock('@/lib/billing/cost-estimation', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  estimateImageCost,
+  estimateVideoCost,
+  estimateAudioCost,
+}));
+
+const { buildUpdateStalePreview } = await import('./update-stale-preview');
+
+const target = (o: object) =>
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
+  ({
+    shotId: 's1',
+    regenVisual: false,
+    regenMotion: false,
+    regenImage: false,
+    regenVideo: false,
+    durationMs: 4000,
+    imageModel: 'seedream_v5',
+    ...o,
+  }) as never;
+
+const plan = (targets: unknown[], music: unknown = null) =>
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test stub
+  ({
+    aspectRatio: '16:9',
+    sequence: { videoModel: 'seedance_v2' },
+    targets,
+    music,
+    skipped: [],
+    promptContext: null,
+  }) as never;
+
+describe('buildUpdateStalePreview', () => {
+  it('buckets targets per level and accumulates cost by depth', () => {
+    estimateImageCost.mockReturnValue(micros(40_000)); // $0.04
+    estimateVideoCost.mockReturnValue(micros(500_000)); // $0.50
+    const preview = buildUpdateStalePreview(
+      plan([
+        target({ shotId: 'a', regenVisual: true, regenImage: true }),
+        target({ shotId: 'b', regenMotion: true, regenVideo: true }),
+      ]),
+      {},
+      null
+    );
+    expect(preview.visualPromptShotIds).toEqual(['a']);
+    expect(preview.motionPromptShotIds).toEqual(['b']);
+    expect(preview.imageShotIds).toEqual(['a']);
+    expect(preview.videoShotIds).toEqual(['b']);
+    // 2 LLM calls at $0.02 → $0.04; + image $0.04; + video $0.50
+    expect(preview.costByDepth.prompts).toBe(40_000);
+    expect(preview.costByDepth.images).toBe(80_000);
+    expect(preview.costByDepth.video).toBe(580_000);
+    expect(preview.costByDepth.music).toBe(580_000);
+  });
+
+  it('unknown pricing poisons that depth and deeper, never invents a number', () => {
+    estimateImageCost.mockReturnValue(null);
+    const preview = buildUpdateStalePreview(
+      plan([target({ shotId: 'a', regenImage: true })]),
+      {},
+      null
+    );
+    expect(preview.costByDepth.prompts).toBe(0);
+    expect(preview.costByDepth.images).toBeNull();
+    expect(preview.costByDepth.music).toBeNull();
+  });
+
+  it('prices music prompt and track', () => {
+    estimateAudioCost.mockReturnValue(micros(100_000));
+    const preview = buildUpdateStalePreview(
+      plan([], {
+        regenPrompt: true,
+        regenTrack: true,
+        sceneSummaries: [],
+        analysisModelId: 'x',
+        promptSource: 'regenerated',
+        durationSeconds: 30,
+      }),
+      {},
+      'cassetteai'
+    );
+    expect(preview.musicPrompt).toBe(true);
+    expect(preview.musicTrack).toBe(true);
+    expect(preview.costByDepth.music).toBe(120_000);
+  });
+});

--- a/src/lib/shots/update-stale-preview.test.ts
+++ b/src/lib/shots/update-stale-preview.test.ts
@@ -57,23 +57,24 @@ describe('buildUpdateStalePreview', () => {
     expect(preview.motionPromptShotIds).toEqual(['b']);
     expect(preview.imageShotIds).toEqual(['a']);
     expect(preview.videoShotIds).toEqual(['b']);
-    // 2 LLM calls at $0.02 → $0.04; + image $0.04; + video $0.50
-    expect(preview.costByDepth.prompts).toBe(40_000);
-    expect(preview.costByDepth.images).toBe(80_000);
-    expect(preview.costByDepth.video).toBe(580_000);
-    expect(preview.costByDepth.music).toBe(580_000);
+    // 2 LLM calls at $0.02; image $0.04; video $0.50; no music
+    expect(preview.costByLevel).toEqual({
+      prompts: 40_000,
+      images: 40_000,
+      video: 500_000,
+      music: 0,
+    });
   });
 
-  it('unknown pricing poisons that depth and deeper, never invents a number', () => {
+  it('unknown pricing yields null, never an invented number', () => {
     estimateImageCost.mockReturnValue(null);
     const preview = buildUpdateStalePreview(
       plan([target({ shotId: 'a', regenImage: true })]),
       {},
       null
     );
-    expect(preview.costByDepth.prompts).toBe(0);
-    expect(preview.costByDepth.images).toBeNull();
-    expect(preview.costByDepth.music).toBeNull();
+    expect(preview.costByLevel.prompts).toBe(0);
+    expect(preview.costByLevel.images).toBeNull();
   });
 
   it('prices music prompt and track', () => {
@@ -92,6 +93,6 @@ describe('buildUpdateStalePreview', () => {
     );
     expect(preview.musicPrompt).toBe(true);
     expect(preview.musicTrack).toBe(true);
-    expect(preview.costByDepth.music).toBe(120_000);
+    expect(preview.costByLevel.music).toBe(120_000);
   });
 });

--- a/src/lib/shots/update-stale-preview.ts
+++ b/src/lib/shots/update-stale-preview.ts
@@ -27,10 +27,10 @@ export type UpdateStalePreview = {
   musicPrompt: boolean;
   musicTrack: boolean;
   /**
-   * Cumulative estimated cost at each depth (micros). Null = a component in
-   * that cascade has no pricing signal — never invent a number.
+   * Estimated cost of each level's OWN additions (micros). Null = no pricing
+   * signal for a component — never invent a number.
    */
-  costByDepth: Record<UpdateStaleDepth, Microdollars | null>;
+  costByLevel: Record<UpdateStaleDepth, Microdollars | null>;
 };
 
 /** Fallback clip length for video pricing when the plan carries none. */
@@ -90,10 +90,6 @@ export function buildUpdateStalePreview(
       )
     : ZERO_MICROS;
 
-  const atImages = addMaybe(promptsCost, imagesCost);
-  const atVideo = addMaybe(atImages, videosCost);
-  const atMusic = addMaybe(atVideo, musicCost);
-
   return {
     visualPromptShotIds: visual.map((t) => t.shotId),
     motionPromptShotIds: motion.map((t) => t.shotId),
@@ -101,11 +97,11 @@ export function buildUpdateStalePreview(
     videoShotIds: videos.map((t) => t.shotId),
     musicPrompt: music?.regenPrompt ?? false,
     musicTrack: music?.regenTrack ?? false,
-    costByDepth: {
+    costByLevel: {
       prompts: promptsCost,
-      images: atImages,
-      video: atVideo,
-      music: atMusic,
+      images: imagesCost,
+      video: videosCost,
+      music: musicCost,
     },
   };
 }

--- a/src/lib/shots/update-stale-preview.ts
+++ b/src/lib/shots/update-stale-preview.ts
@@ -1,0 +1,111 @@
+/**
+ * "Update all" dry-run preview (#1194) — turn a max-depth `computePlan` result
+ * into the concrete cascade the dialog shows: which artifacts on which shots
+ * regenerate at each depth, and the cumulative cost estimate. Pure: the plan
+ * is already computed and nothing here writes.
+ */
+
+import {
+  estimateAudioCost,
+  estimateImageCost,
+  estimateLLMCost,
+  estimateVideoCost,
+} from '@/lib/billing/cost-estimation';
+import type { EffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
+
+type FalPricingMap = Record<string, EffectiveFalPricing>;
+import { safeAudioModel, safeImageToVideoModel } from '@/lib/ai/models';
+import { addMicros, ZERO_MICROS, type Microdollars } from '@/lib/billing/money';
+import type { UpdateStalePlan } from '@/lib/shots/update-stale-plan';
+import type { UpdateStaleDepth } from '@/lib/shots/update-stale-depth';
+
+export type UpdateStalePreview = {
+  visualPromptShotIds: string[];
+  motionPromptShotIds: string[];
+  imageShotIds: string[];
+  videoShotIds: string[];
+  musicPrompt: boolean;
+  musicTrack: boolean;
+  /**
+   * Cumulative estimated cost at each depth (micros). Null = a component in
+   * that cascade has no pricing signal — never invent a number.
+   */
+  costByDepth: Record<UpdateStaleDepth, Microdollars | null>;
+};
+
+/** Fallback clip length for video pricing when the plan carries none. */
+const DEFAULT_VIDEO_DURATION_MS = 5_000;
+
+const sum = (parts: Array<Microdollars | null>): Microdollars | null =>
+  parts.reduce<Microdollars | null>(
+    (acc, p) => (acc == null || p == null ? null : addMicros(acc, p)),
+    ZERO_MICROS
+  );
+
+/** Add two possibly-unknown estimates; unknown poisons the total (honesty). */
+const addMaybe = (
+  a: Microdollars | null,
+  b: Microdollars | null
+): Microdollars | null => (a == null || b == null ? null : addMicros(a, b));
+
+export function buildUpdateStalePreview(
+  plan: UpdateStalePlan,
+  pricing: FalPricingMap,
+  musicModel: string | null
+): UpdateStalePreview {
+  const visual = plan.targets.filter((t) => t.regenVisual);
+  const motion = plan.targets.filter((t) => t.regenMotion);
+  const images = plan.targets.filter((t) => t.regenImage);
+  const videos = plan.targets.filter((t) => t.regenVideo);
+  const music = plan.music;
+
+  const promptsCost = estimateLLMCost(visual.length + motion.length);
+  const imagesCost = sum(
+    images.map((t) =>
+      estimateImageCost(t.imageModel, plan.aspectRatio, 1, { pricing })
+    )
+  );
+  const videoModel = safeImageToVideoModel(plan.sequence.videoModel);
+  const videosCost = sum(
+    videos.map((t) =>
+      estimateVideoCost(
+        videoModel,
+        (t.durationMs ?? DEFAULT_VIDEO_DURATION_MS) / 1000,
+        { pricing }
+      )
+    )
+  );
+  const musicCost = music
+    ? addMaybe(
+        music.regenPrompt ? estimateLLMCost(1) : ZERO_MICROS,
+        music.regenTrack
+          ? estimateAudioCost(
+              safeAudioModel(musicModel),
+              music.durationSeconds,
+              {
+                pricing,
+              }
+            )
+          : ZERO_MICROS
+      )
+    : ZERO_MICROS;
+
+  const atImages = addMaybe(promptsCost, imagesCost);
+  const atVideo = addMaybe(atImages, videosCost);
+  const atMusic = addMaybe(atVideo, musicCost);
+
+  return {
+    visualPromptShotIds: visual.map((t) => t.shotId),
+    motionPromptShotIds: motion.map((t) => t.shotId),
+    imageShotIds: images.map((t) => t.shotId),
+    videoShotIds: videos.map((t) => t.shotId),
+    musicPrompt: music?.regenPrompt ?? false,
+    musicTrack: music?.regenTrack ?? false,
+    costByDepth: {
+      prompts: promptsCost,
+      images: atImages,
+      video: atVideo,
+      music: atMusic,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- The "Update all" dialog opened cold — it asked how deep to regenerate without saying *why*. It now leads with the cause: `Changed: Style, Character "Woman"`, then the depth options. No explanatory prose.
- `computeShotStaleness` returns `causes[]`: every input row edited after the stale artifact was generated — script version, scene details, characters (edit or sheet regen), locations, elements, and "Image re-rendered" for a stale motion prompt.
- Style / aspect ratio / model switches leave no row timestamp (style is a snapshot on the sequence), so `sequences.update` now appends a `sequence.settings-changed` event the check reads back.
- Falls back to "Inputs changed since these were generated." when nothing can be named.

Timestamp heuristic, not a diff — a row saved without a real change can be over-named. Upgrade path (per-component hashes on version rows) is marked with a `ponytail:` comment.

Closes #1194

## Test plan
- [x] `bun run test` (2669 pass), `bun lint`, `bun typecheck`
- [x] New unit tests: `findStalenessCauses` via `computeShotStaleness`, `describeCauses`
- [x] Ran locally: sequence-scope and shot-scope Update all both show `Changed: …` above the options

https://claude.ai/code/session_01QfjQvS6DLTf54skwKBAavt