### PR TITLE
fix(#1259): region fallback for Anthropic-blocked users, DeepSeek default for China

### DIFF
--- a/src/components/model/model-selector.tsx
+++ b/src/components/model/model-selector.tsx
@@ -1,11 +1,17 @@
 import { BaseModelSelector } from './base-model-selector';
+import { getRequestCountryFn } from '@/functions/ai';
 import {
   isSelectableAnalysisModelId,
   isValidAnalysisModelId,
   SCRIPT_ANALYSIS_MODELS,
   type AnalysisModelId,
 } from '@/lib/ai/models.config';
-import { useMemo } from 'react';
+import {
+  isRegionBlockedModel,
+  resolveModelForCountry,
+} from '@/lib/ai/region-policy';
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
 
 const GROUP_ORDER = ['all'] as const;
 
@@ -22,10 +28,21 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
   disabled = false,
   singleSelect = false,
 }) => {
+  // Region-blocked vendors are hidden from the picker (#1259): a user in an
+  // Anthropic-blocked country shouldn't be offered a model the server would
+  // swap away anyway. While the country is loading, the unfiltered list shows
+  // — the server-side swap in createSequences stays the enforcement.
+  const { data: country } = useQuery({
+    queryKey: ['request-country'],
+    queryFn: () => getRequestCountryFn(),
+    staleTime: Infinity,
+  });
+
   const models = useMemo(
     () =>
       [...SCRIPT_ANALYSIS_MODELS]
         .filter((m) => isSelectableAnalysisModelId(m.id))
+        .filter((m) => !isRegionBlockedModel(m.id, country))
         .sort((a, b) => a.qualityRank - b.qualityRank)
         .map((m) => ({
           id: m.id,
@@ -33,8 +50,22 @@ export const ModelSelector: React.FC<ModelSelectorProps> = ({
           group: 'all',
           badge: m.license,
         })),
-    []
+    [country]
   );
+
+  // Remap an already-selected blocked model (stored default, restored draft)
+  // onto the region fallback so the selection matches what the list shows and
+  // what the server will actually run.
+  useEffect(() => {
+    if (!country) return;
+    const remapped = [
+      ...new Set(selectedModels.map((m) => resolveModelForCountry(m, country))),
+    ];
+    const changed =
+      remapped.length !== selectedModels.length ||
+      remapped.some((m, i) => m !== selectedModels[i]);
+    if (changed) onModelsChange(remapped);
+  }, [country, selectedModels, onModelsChange]);
 
   return (
     <BaseModelSelector

--- a/src/functions/ai.ts
+++ b/src/functions/ai.ts
@@ -76,6 +76,15 @@ function getClientIP(): string {
   );
 }
 
+/**
+ * The request's Cloudflare-detected country (`cf-ipcountry`), for the
+ * region-aware model picker (#1259). `null` in local dev. No auth: it is the
+ * caller's own request metadata and the composer is anonymous-browsable.
+ */
+export const getRequestCountryFn = createServerFn({ method: 'GET' }).handler(
+  async () => getRequest().headers.get('cf-ipcountry')
+);
+
 function enforceRateLimit(limiter: RateLimiter, key: string): void {
   if (limiter.isAllowed(key)) return;
   const remainingMs = limiter.getRemainingTime(key);

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -213,6 +213,11 @@ export function useCreateSequence() {
           });
         });
     },
+    // A silent failure here is what produced 9 identical resubmissions in
+    // #1259 — always tell the user why nothing happened.
+    onError: (error) => {
+      toast.error(error.message || 'Generation failed to start.');
+    },
   });
 }
 

--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -27,8 +27,9 @@ vi.doMock('@tanstack/ai', () => ({
 // Mock create-adapter to avoid real adapter creation. `resolveNativeGrokModel`
 // returns undefined so these tests exercise the OpenRouter request shape;
 // native xAI routing has its own coverage in create-adapter.test.ts.
+const mockCreateAdapter = vi.fn(() => ({ kind: 'text', name: 'mock' }));
 vi.doMock('./create-adapter', () => ({
-  createAdapter: () => ({ kind: 'text', name: 'mock' }),
+  createAdapter: mockCreateAdapter,
   resolveNativeGrokModel: () => undefined,
 }));
 
@@ -66,6 +67,7 @@ const usage = (cost?: number): TokenUsage => ({
 describe('llm-client', () => {
   beforeEach(() => {
     mockChat.mockClear();
+    mockCreateAdapter.mockClear();
     mockAIObservabilityMiddleware.mockClear();
   });
 
@@ -321,6 +323,59 @@ describe('llm-client', () => {
         )
       ).rejects.toThrow(/empty-response/);
       expect(cancelled).toBe(false);
+    });
+
+    it('retries a region-blocked model with the DeepSeek fallback (#1259)', async () => {
+      mockChat
+        .mockReturnValueOnce(
+          (async function* () {
+            yield {
+              type: 'RUN_ERROR',
+              message: 'This model is not available in your region.',
+              model: 'anthropic/claude-opus-5-fast',
+            };
+          })()
+        )
+        .mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'fallback answer' };
+          })()
+        );
+
+      const result = await callLLM({
+        model: 'anthropic/claude-opus-5-fast',
+        messages: [{ role: 'user', content: 'test' }],
+      });
+
+      expect(result).toBe('fallback answer');
+      expect(mockChat).toHaveBeenCalledTimes(2);
+      expect(mockCreateAdapter).toHaveBeenNthCalledWith(
+        2,
+        'deepseek/deepseek-v4-pro-0813',
+        undefined
+      );
+    });
+
+    it('does not retry a region block after content was already yielded', async () => {
+      mockChat.mockReturnValueOnce(
+        (async function* () {
+          yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'partial' };
+          yield {
+            type: 'RUN_ERROR',
+            message: 'This model is not available in your region.',
+          };
+        })()
+      );
+
+      await expect(
+        drain(
+          callLLMStream({
+            model: 'anthropic/claude-opus-5-fast',
+            messages: [{ role: 'user', content: 'test' }],
+          })
+        )
+      ).rejects.toThrow('not available in your region');
+      expect(mockChat).toHaveBeenCalledTimes(1);
     });
 
     it('preserves event.code in stream errors', () => {

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -26,6 +26,10 @@ import {
   grokTextCostFromUsage,
   nativeGrokTextModel,
 } from '@/lib/ai/grok-native';
+import {
+  isRegionBlockedLlmError,
+  regionFallbackModel,
+} from '@/lib/ai/region-policy';
 import { aiDebugLogger } from './ai-debug-logger';
 import {
   createAdapter,
@@ -255,6 +259,7 @@ const STRUCTURED_OUTPUT_MODELS = new Set([
   'anthropic/claude-opus-5-fast',
   'anthropic/claude-opus-4.8',
   'deepseek/deepseek-v3.2',
+  'deepseek/deepseek-v4-pro-0813',
   'z-ai/glm-5.2',
   'google/gemini-3.1-pro-preview',
   'openai/gpt-5.5',
@@ -696,6 +701,16 @@ export function throwNotedRunError(detail: RunErrorDetail | null): void {
   throw new Error(message);
 }
 
+/** Whether any message carries an image content part (drives which region
+ *  fallback model is eligible — DeepSeek is text-only). */
+function messagesHaveImages(messages: ChatMessage[]): boolean {
+  return messages.some(
+    (msg) =>
+      typeof msg.content !== 'string' &&
+      msg.content.some((part) => part.type === 'image')
+  );
+}
+
 export function callLLMStream<T>(
   params: LLMRequestParams<T> & { responseSchema: z.ZodType<T> }
 ): AsyncGenerator<StreamChunk<T>>;
@@ -703,6 +718,34 @@ export function callLLMStream(
   params: LLMRequestParams & { responseSchema?: undefined }
 ): AsyncGenerator<StreamChunk>;
 export async function* callLLMStream<T>(
+  params: LLMRequestParams<T>
+): AsyncGenerator<StreamChunk<T>> {
+  // Region-block fallback (#1259): a geo-blocked model (Anthropic from a
+  // mainland-China colo) fails before its first token, so retrying with a
+  // region-available model is safe — but only when nothing was yielded yet,
+  // so a mid-stream failure can never replay content into the consumer.
+  let yielded = false;
+  try {
+    for await (const chunk of callLLMStreamOnce(params)) {
+      yielded = true;
+      yield chunk;
+    }
+    return;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const fallback =
+      !yielded && isRegionBlockedLlmError(message)
+        ? regionFallbackModel(params.model, messagesHaveImages(params.messages))
+        : null;
+    if (!fallback) throw error;
+    logger.warn(
+      `Model ${params.model} is region-blocked here; retrying with ${fallback}`
+    );
+    yield* callLLMStreamOnce({ ...params, model: fallback });
+  }
+}
+
+async function* callLLMStreamOnce<T>(
   params: LLMRequestParams<T>
 ): AsyncGenerator<StreamChunk<T>> {
   let accumulated = '';

--- a/src/lib/ai/models.config.ts
+++ b/src/lib/ai/models.config.ts
@@ -91,6 +91,17 @@ export const SCRIPT_ANALYSIS_MODELS = [
     description: 'Apache 2.0, 119B MoE, multimodal + agentic coding',
   },
   {
+    id: 'deepseek/deepseek-v4-pro-0813',
+    name: 'DeepSeek V4 Pro',
+    vendor: 'DeepSeek',
+    license: 'open-source' as const,
+    qualityRank: 8,
+    contextWindow: 1_048_576,
+    // Text-only.
+    vision: false,
+    description: 'Open-weights frontier reasoning, 1M context',
+  },
+  {
     id: 'deepseek/deepseek-v3.2',
     name: 'DeepSeek V3.2',
     vendor: 'DeepSeek',
@@ -100,6 +111,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     // Text-only.
     vision: false,
     description: 'MIT license, MMLU 94.2, GPT-5 class reasoning',
+    hidden: true,
   },
   {
     id: 'z-ai/glm-5.2',

--- a/src/lib/ai/openrouter-pricing-data.ts
+++ b/src/lib/ai/openrouter-pricing-data.ts
@@ -58,10 +58,15 @@ export const OPENROUTER_PRICING: Record<string, OpenRouterPricing> = {
     promptPerMillionTokens: 0.15,
     completionPerMillionTokens: 0.6,
   },
+  'deepseek/deepseek-v4-pro-0813': {
+    name: 'DeepSeek: DeepSeek V4 Pro 0813',
+    promptPerMillionTokens: 1.122,
+    completionPerMillionTokens: 3.366,
+  },
   'deepseek/deepseek-v3.2': {
     name: 'DeepSeek: DeepSeek V3.2',
-    promptPerMillionTokens: 0.26899999999999996,
-    completionPerMillionTokens: 0.39999999999999997,
+    promptPerMillionTokens: 0.26,
+    completionPerMillionTokens: 0.38,
   },
   'z-ai/glm-5.2': {
     name: 'Z.ai: GLM 5.2',
@@ -105,4 +110,4 @@ export const OPENROUTER_PRICING: Record<string, OpenRouterPricing> = {
   },
 };
 
-export const OPENROUTER_PRICING_LAST_UPDATED = '2026-08-21T04:57:10.073Z';
+export const OPENROUTER_PRICING_LAST_UPDATED = '2026-08-24T10:59:01.199Z';

--- a/src/lib/ai/region-policy.test.ts
+++ b/src/lib/ai/region-policy.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isRegionBlockedLlmError,
+  REGION_FALLBACK_TEXT_MODEL,
+  REGION_FALLBACK_VISION_MODEL,
+  regionFallbackModel,
+  resolveModelForCountry,
+  withRegionFallback,
+} from './region-policy';
+
+describe('isRegionBlockedLlmError', () => {
+  it('matches the real production error string (#1259)', () => {
+    expect(
+      isRegionBlockedLlmError(
+        'LLM stream error [model=anthropic/claude-opus-5-fast]: This model is not available in your region.'
+      )
+    ).toBe(true);
+  });
+
+  it('does not match other provider errors', () => {
+    expect(isRegionBlockedLlmError('LLM stream error: 401 Unauthorized')).toBe(
+      false
+    );
+    expect(isRegionBlockedLlmError('Provider returned error')).toBe(false);
+  });
+});
+
+describe('regionFallbackModel', () => {
+  it('falls back to DeepSeek for text calls', () => {
+    expect(regionFallbackModel('anthropic/claude-opus-5-fast')).toBe(
+      REGION_FALLBACK_TEXT_MODEL
+    );
+  });
+
+  it('falls back to a vision-capable model for image-bearing calls', () => {
+    expect(regionFallbackModel('anthropic/claude-sonnet-5', true)).toBe(
+      REGION_FALLBACK_VISION_MODEL
+    );
+  });
+
+  it('returns null when the failed model already is the fallback', () => {
+    expect(regionFallbackModel(REGION_FALLBACK_TEXT_MODEL)).toBeNull();
+    expect(regionFallbackModel(REGION_FALLBACK_VISION_MODEL, true)).toBeNull();
+  });
+});
+
+describe('resolveModelForCountry', () => {
+  it('swaps Anthropic models for blocked countries', () => {
+    expect(resolveModelForCountry('anthropic/claude-opus-5', 'CN')).toBe(
+      REGION_FALLBACK_TEXT_MODEL
+    );
+  });
+
+  it('keeps non-Anthropic models even in blocked countries', () => {
+    expect(resolveModelForCountry('x-ai/grok-4.6', 'CN')).toBe('x-ai/grok-4.6');
+  });
+
+  it('passes through outside blocked countries and without a header', () => {
+    expect(resolveModelForCountry('anthropic/claude-opus-5', 'US')).toBe(
+      'anthropic/claude-opus-5'
+    );
+    expect(resolveModelForCountry('anthropic/claude-opus-5', null)).toBe(
+      'anthropic/claude-opus-5'
+    );
+  });
+});
+
+describe('withRegionFallback', () => {
+  it('retries once with the fallback model on a region block', async () => {
+    const run = vi
+      .fn<(model: string) => Promise<string>>()
+      .mockRejectedValueOnce(
+        new Error('This model is not available in your region.')
+      )
+      .mockResolvedValueOnce('ok');
+    await expect(
+      withRegionFallback('anthropic/claude-opus-5', false, run)
+    ).resolves.toBe('ok');
+    expect(run).toHaveBeenNthCalledWith(1, 'anthropic/claude-opus-5');
+    expect(run).toHaveBeenNthCalledWith(2, REGION_FALLBACK_TEXT_MODEL);
+  });
+
+  it('rethrows non-region errors untouched', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('402 out of credits'));
+    await expect(
+      withRegionFallback('anthropic/claude-opus-5', false, run)
+    ).rejects.toThrow('402 out of credits');
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows when the fallback itself is region-blocked', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValue(new Error('not available in your region'));
+    await expect(
+      withRegionFallback(REGION_FALLBACK_TEXT_MODEL, false, run)
+    ).rejects.toThrow('not available in your region');
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/ai/region-policy.test.ts
+++ b/src/lib/ai/region-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   isRegionBlockedLlmError,
+  isRegionBlockedModel,
   REGION_FALLBACK_TEXT_MODEL,
   REGION_FALLBACK_VISION_MODEL,
   regionFallbackModel,
@@ -61,6 +62,17 @@ describe('resolveModelForCountry', () => {
     );
     expect(resolveModelForCountry('anthropic/claude-opus-5', null)).toBe(
       'anthropic/claude-opus-5'
+    );
+  });
+});
+
+describe('isRegionBlockedModel', () => {
+  it('blocks only Anthropic models in blocked countries', () => {
+    expect(isRegionBlockedModel('anthropic/claude-opus-5', 'CN')).toBe(true);
+    expect(isRegionBlockedModel('x-ai/grok-4.6', 'CN')).toBe(false);
+    expect(isRegionBlockedModel('anthropic/claude-opus-5', 'US')).toBe(false);
+    expect(isRegionBlockedModel('anthropic/claude-opus-5', undefined)).toBe(
+      false
     );
   });
 });

--- a/src/lib/ai/region-policy.ts
+++ b/src/lib/ai/region-policy.ts
@@ -83,6 +83,15 @@ export function resolveModelForCountry<M extends string>(
   return model.startsWith('anthropic/') ? REGION_FALLBACK_TEXT_MODEL : model;
 }
 
+/** Whether a model would be swapped away for this country — drives hiding it
+ *  in the model picker so users never select what they can't run. */
+export function isRegionBlockedModel(
+  model: string,
+  country: string | null | undefined
+): boolean {
+  return resolveModelForCountry(model, country) !== model;
+}
+
 /**
  * Run an LLM call; on a region-block error, retry once with the
  * region-available fallback model. Any other error rethrows untouched.

--- a/src/lib/ai/region-policy.ts
+++ b/src/lib/ai/region-policy.ts
@@ -1,0 +1,109 @@
+/**
+ * Anthropic geo-block policy (#1259).
+ *
+ * Server-side LLM calls egress from the Cloudflare colo nearest the user, so
+ * Anthropic's regional block applies to our "server-side" OpenRouter calls
+ * too — a user in mainland China gets "This model is not available in your
+ * region" from every Anthropic-model step and the whole storyboard pipeline
+ * dies. Two layers:
+ *
+ * 1. Request-time (`resolveModelForCountry`): when the request's
+ *    `cf-ipcountry` is a known Anthropic-blocked country, never pick an
+ *    Anthropic model in the first place — DeepSeek becomes the default.
+ * 2. Error-time (`withRegionFallback` / the retry in `callLLMStream`): any
+ *    call that still hits a region block is retried once on a
+ *    region-available model instead of exhausting workflow step retries.
+ */
+
+import type { TextModel } from '@/lib/ai/models';
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'ai', 'region-policy']);
+
+/**
+ * Countries (ISO 3166-1 alpha-2, as Cloudflare's `cf-ipcountry` reports them)
+ * where Anthropic blocks API access. Deliberately only the unambiguous ones —
+ * a wrong entry silently downgrades users who could have had Claude, and the
+ * error-time fallback catches anywhere not listed.
+ */
+const ANTHROPIC_BLOCKED_COUNTRIES = new Set([
+  'CN',
+  'HK',
+  'MO',
+  'RU',
+  'BY',
+  'IR',
+  'KP',
+  'SY',
+  'CU',
+]);
+
+/** Region-available default: DeepSeek is not geo-blocked where Anthropic is. */
+export const REGION_FALLBACK_TEXT_MODEL =
+  'deepseek/deepseek-v4-pro-0813' satisfies TextModel;
+
+/**
+ * DeepSeek is text-only, so image-bearing calls fall back to Mistral instead
+ * (vision + strict structured outputs, not geo-blocked in China).
+ */
+export const REGION_FALLBACK_VISION_MODEL =
+  'mistralai/mistral-small-2603' satisfies TextModel;
+
+/** Matches the provider error a geo-blocked model returns through OpenRouter. */
+export function isRegionBlockedLlmError(message: string): boolean {
+  return /not available in your region|unsupported_country_region/i.test(
+    message
+  );
+}
+
+/**
+ * The model to retry with after a region block, or `null` when the failed
+ * model already IS the fallback (nothing regional left to try).
+ */
+export function regionFallbackModel(
+  model: string,
+  hasImageInput = false
+): TextModel | null {
+  const fallback = hasImageInput
+    ? REGION_FALLBACK_VISION_MODEL
+    : REGION_FALLBACK_TEXT_MODEL;
+  return model === fallback ? null : fallback;
+}
+
+/**
+ * Request-time swap: an Anthropic model requested from an Anthropic-blocked
+ * country becomes the DeepSeek fallback. Anything else passes through.
+ * `country` is the request's `cf-ipcountry` header (absent in local dev).
+ */
+export function resolveModelForCountry<M extends string>(
+  model: M,
+  country: string | null | undefined
+): M | typeof REGION_FALLBACK_TEXT_MODEL {
+  if (!country || !ANTHROPIC_BLOCKED_COUNTRIES.has(country)) return model;
+  return model.startsWith('anthropic/') ? REGION_FALLBACK_TEXT_MODEL : model;
+}
+
+/**
+ * Run an LLM call; on a region-block error, retry once with the
+ * region-available fallback model. Any other error rethrows untouched.
+ */
+export async function withRegionFallback<T>(
+  model: TextModel,
+  hasImageInput: boolean,
+  run: (model: TextModel) => Promise<T>
+): Promise<T> {
+  try {
+    return await run(model);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const fallback = isRegionBlockedLlmError(message)
+      ? regionFallbackModel(model, hasImageInput)
+      : null;
+    if (!fallback) throw error;
+    logger.warn(
+      `Model ${model} is region-blocked here; retrying with ${fallback}`,
+      { err: error }
+    );
+    return run(fallback);
+  }
+}

--- a/src/lib/sequences/create-sequences.ts
+++ b/src/lib/sequences/create-sequences.ts
@@ -21,6 +21,7 @@ import {
   DEFAULT_ANALYSIS_MODEL,
   getAnalysisModelById,
 } from '@/lib/ai/models.config';
+import { resolveModelForCountry } from '@/lib/ai/region-policy';
 import { resolveAudioModels } from '@/lib/ai/resolve-audio-models';
 import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
@@ -45,6 +46,7 @@ import { bumpStylePopularity } from '@/lib/style/bump-style-popularity';
 import { triggerStoryboard } from '@/lib/workflow/launchers';
 import type { StoryboardTriggerInput } from '@/lib/workflow/types';
 import { createServerOnlyFn } from '@tanstack/react-start';
+import { getRequest } from '@tanstack/react-start/server';
 
 export type StyleSource =
   | { kind: 'library' }
@@ -114,7 +116,7 @@ export const createSequences = createServerOnlyFn(
       script,
       styleId,
       aspectRatio,
-      analysisModels,
+      analysisModels: requestedAnalysisModels,
       imageModel: imageModelLegacy,
       imageModels: imageModelsInput,
       videoModel,
@@ -129,6 +131,43 @@ export const createSequences = createServerOnlyFn(
       elementUploads,
       sourceSequenceId,
     } = data;
+
+    // Anthropic geo-blocks some countries and our LLM calls egress from the
+    // Cloudflare colo nearest the user (#1259) — never persist an Anthropic
+    // model for a request from a blocked country. Set-dedup in case several
+    // picks collapse onto the same fallback.
+    const country = getRequest().headers.get('cf-ipcountry');
+    const analysisModels = [
+      ...new Set(
+        requestedAnalysisModels.map((m) => resolveModelForCountry(m, country))
+      ),
+    ];
+
+    // Retry-click guard (#1259): a user who sees no feedback resubmits the
+    // identical script — each click used to spawn a full pipeline. If every
+    // requested model already has a fresh live run of this exact script,
+    // reject with a visible error instead.
+    if (analysisModels.length > 0) {
+      const recent = await context.scopedDb.sequences.listPage({
+        limit: 10,
+        cursor: null,
+      });
+      const liveDuplicates = recent.filter(
+        (s) =>
+          s.status === 'processing' &&
+          s.script === script &&
+          Date.now() - s.createdAt.getTime() < 2 * 60_000
+      );
+      if (
+        analysisModels.every((m) =>
+          liveDuplicates.some((d) => d.analysisModel === m)
+        )
+      ) {
+        throw new ValidationError(
+          'Already generating this script — open the existing sequence.'
+        );
+      }
+    }
 
     // Verify source sequence access (scoped read returns null for other teams)
     if (sourceSequenceId) {
@@ -244,7 +283,8 @@ export const createSequences = createServerOnlyFn(
           deferStyleSnapshot: styleSource.kind === 'pending',
           aspectRatio,
           analysisModel:
-            getAnalysisModelById(modelId)?.id || DEFAULT_ANALYSIS_MODEL,
+            getAnalysisModelById(modelId)?.id ||
+            resolveModelForCountry(DEFAULT_ANALYSIS_MODEL, country),
           imageModel: primaryImageModel,
           videoModel: autoGenerateMotion ? primaryVideoModel : undefined,
           musicModel: persistedMusicModel,

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -27,6 +27,7 @@ import {
   getContextWindow,
   resolveVisionModel,
 } from '@/lib/ai/models.config';
+import { withRegionFallback } from '@/lib/ai/region-policy';
 import { extractStreamingStringField } from '@/lib/ai/stream-extract';
 import type { Microdollars } from '@/lib/billing/money';
 import { deductWorkflowCredits } from '@/lib/billing/workflow-deduction';
@@ -280,110 +281,115 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
       keySource: LlmKeySource;
     }> => {
       const llmKeyInfo = await resolveCallKey(callContext, modelId);
-      const adapter = createAdapter(modelId, llmKeyInfo);
+      // Region-block fallback (#1259): workflows egress from the colo nearest
+      // the user, so an Anthropic model can be geo-blocked even "server-side".
+      // Retry once on a region-available model instead of burning step retries.
+      return withRegionFallback(modelId, hasImageInput, async (model) => {
+        const adapter = createAdapter(model, llmKeyInfo);
 
-      logger.info(`[LLM:${logName}:cf] Starting call`, {
-        model: modelId,
-        requestedModel: config.modelId,
-        keySource: llmKeyInfo.source,
-        keyVia: llmKeyInfo.via,
-        messageCount: messages.length,
-      });
-
-      // Only attach the still when the effective model accepts image input.
-      // resolveVisionModel routes text-only models to DEFAULT_VISION_MODEL, so
-      // reaching here with an image but no vision support means that default is
-      // misconfigured to a text-only model. Warn and drop the image (don't fail
-      // — text-only is a supported mode) rather than send it to a text model.
-      const effectiveSupportsVision = analysisModelSupportsVision(modelId);
-      if (hasImageInput && !effectiveSupportsVision) {
-        logger.warn(
-          `[LLM:${logName}:cf] Dropping vision image(s): effective model ${modelId} (requested ${config.modelId}) is text-only; DEFAULT_VISION_MODEL may be misconfigured — running text-only`
-        );
-      }
-      const visionImageSources = effectiveSupportsVision
-        ? await resolveVisionImageSources(config.visionImageUrls)
-        : undefined;
-      const { systemPrompts, chatMessages } = buildChatMessages(
-        messages,
-        visionImageSources
-      );
-
-      const abortController = new AbortController();
-      const timeout = setTimeout(() => abortController.abort(), 300_000);
-
-      // Always stream structured output so OpenRouter attaches usage.cost
-      // (TanStack/ai#1076). No live channel here — drain for result + usage.
-      const usageCapture = createUsageCapture();
-      try {
-        const commonOptions = {
-          adapter,
-          messages: chatMessages,
-          stream: true as const,
-          abortController,
-          modelOptions: chatModelOptionsForCall(
-            modelId,
-            llmKeyInfo,
-            config.reasoning
-          ),
-          middleware: [
-            ...aiObservabilityMiddleware({
-              observationName: logName,
-              tags: logTags,
-              metadata: logMetadata,
-              sessionId: callContext.sequenceId,
-              // Fall back to the scoped db's user. Callers reliably pass
-              // `scopedDb` (it resolves the LLM key and books the credit
-              // deduction) but often not `userId`, which silently produced
-              // anonymous generations — see the media-side note in
-              // image-generation.ts.
-              userId: callContext.userId ?? callContext.scopedDb?.userId,
-            }),
-            ...usageCapture.middleware,
-          ],
-          debug: false,
-        };
-        const eventStream = chat({
-          ...commonOptions,
-          systemPrompts,
-          outputSchema: config.responseSchema,
+        logger.info(`[LLM:${logName}:cf] Starting call`, {
+          model,
+          requestedModel: config.modelId,
+          keySource: llmKeyInfo.source,
+          keyVia: llmKeyInfo.via,
+          messageCount: messages.length,
         });
 
-        let structuredObject: unknown;
-        let runError = null;
-        for await (const event of eventStream) {
-          usageCapture.noteFromStreamEvent(event);
-          const noted = extractRunError(event);
-          if (noted) {
-            runError ??= noted;
-            continue;
-          }
-          if (
-            event.type === 'CUSTOM' &&
-            event.name === 'structured-output.complete'
-          ) {
-            structuredObject = event.value.object;
-            continue;
-          }
-        }
-        throwNotedRunError(runError);
-
-        if (structuredObject === undefined) {
-          throw new NonRetryableError(
-            `[LLM:${logName}:cf] Call ended without a structured-output.complete event`
+        // Only attach the still when the effective model accepts image input.
+        // resolveVisionModel routes text-only models to DEFAULT_VISION_MODEL, so
+        // reaching here with an image but no vision support means that default is
+        // misconfigured to a text-only model. Warn and drop the image (don't fail
+        // — text-only is a supported mode) rather than send it to a text model.
+        const effectiveSupportsVision = analysisModelSupportsVision(model);
+        if (hasImageInput && !effectiveSupportsVision) {
+          logger.warn(
+            `[LLM:${logName}:cf] Dropping vision image(s): effective model ${model} (requested ${config.modelId}) is text-only; DEFAULT_VISION_MODEL may be misconfigured — running text-only`
           );
         }
-        logger.info(`[LLM:${logName}:cf] Call succeeded`);
-        // Return as JSON string — round-trips through step.do without hitting
-        // CF's Rpc.Serializable constraint on the Zod-inferred shape.
-        return {
-          jsonText: JSON.stringify(structuredObject),
-          costMicros: llmCostFromUsage(usageCapture.get(), modelId),
-          keySource: llmKeyInfo.source,
-        };
-      } finally {
-        clearTimeout(timeout);
-      }
+        const visionImageSources = effectiveSupportsVision
+          ? await resolveVisionImageSources(config.visionImageUrls)
+          : undefined;
+        const { systemPrompts, chatMessages } = buildChatMessages(
+          messages,
+          visionImageSources
+        );
+
+        const abortController = new AbortController();
+        const timeout = setTimeout(() => abortController.abort(), 300_000);
+
+        // Always stream structured output so OpenRouter attaches usage.cost
+        // (TanStack/ai#1076). No live channel here — drain for result + usage.
+        const usageCapture = createUsageCapture();
+        try {
+          const commonOptions = {
+            adapter,
+            messages: chatMessages,
+            stream: true as const,
+            abortController,
+            modelOptions: chatModelOptionsForCall(
+              model,
+              llmKeyInfo,
+              config.reasoning
+            ),
+            middleware: [
+              ...aiObservabilityMiddleware({
+                observationName: logName,
+                tags: logTags,
+                metadata: logMetadata,
+                sessionId: callContext.sequenceId,
+                // Fall back to the scoped db's user. Callers reliably pass
+                // `scopedDb` (it resolves the LLM key and books the credit
+                // deduction) but often not `userId`, which silently produced
+                // anonymous generations — see the media-side note in
+                // image-generation.ts.
+                userId: callContext.userId ?? callContext.scopedDb?.userId,
+              }),
+              ...usageCapture.middleware,
+            ],
+            debug: false,
+          };
+          const eventStream = chat({
+            ...commonOptions,
+            systemPrompts,
+            outputSchema: config.responseSchema,
+          });
+
+          let structuredObject: unknown;
+          let runError = null;
+          for await (const event of eventStream) {
+            usageCapture.noteFromStreamEvent(event);
+            const noted = extractRunError(event);
+            if (noted) {
+              runError ??= noted;
+              continue;
+            }
+            if (
+              event.type === 'CUSTOM' &&
+              event.name === 'structured-output.complete'
+            ) {
+              structuredObject = event.value.object;
+              continue;
+            }
+          }
+          throwNotedRunError(runError);
+
+          if (structuredObject === undefined) {
+            throw new NonRetryableError(
+              `[LLM:${logName}:cf] Call ended without a structured-output.complete event`
+            );
+          }
+          logger.info(`[LLM:${logName}:cf] Call succeeded`);
+          // Return as JSON string — round-trips through step.do without hitting
+          // CF's Rpc.Serializable constraint on the Zod-inferred shape.
+          return {
+            jsonText: JSON.stringify(structuredObject),
+            costMicros: llmCostFromUsage(usageCapture.get(), model),
+            keySource: llmKeyInfo.source,
+          };
+        } finally {
+          clearTimeout(timeout);
+        }
+      });
     }
   );
 
@@ -460,133 +466,141 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
       keySource: LlmKeySource;
     }> => {
       const llmKeyInfo = await resolveCallKey(callContext, modelId);
-      const adapter = createAdapter(modelId, llmKeyInfo);
+      // Region-block fallback (#1259) — see durableLLMCallCf. A geo-blocked
+      // model errors before its first token, so the realtime channel has seen
+      // nothing when the retry restarts the stream.
+      return withRegionFallback(modelId, hasImageInput, async (model) => {
+        const adapter = createAdapter(model, llmKeyInfo);
 
-      logger.info(`[LLM:${logName}:cf] Starting streaming call`, {
-        model: modelId,
-        requestedModel: config.modelId,
-        keySource: llmKeyInfo.source,
-        keyVia: llmKeyInfo.via,
-        messageCount: messages.length,
-        shotId,
-        promptType,
-      });
+        logger.info(`[LLM:${logName}:cf] Starting streaming call`, {
+          model,
+          requestedModel: config.modelId,
+          keySource: llmKeyInfo.source,
+          keyVia: llmKeyInfo.via,
+          messageCount: messages.length,
+          shotId,
+          promptType,
+        });
 
-      // Only attach the still when the effective model accepts image input;
-      // warn (don't fail) when an image is dropped — see durableLLMCallCf.
-      const effectiveSupportsVision = analysisModelSupportsVision(modelId);
-      if (hasImageInput && !effectiveSupportsVision) {
-        logger.warn(
-          `[LLM:${logName}:cf] Dropping vision image(s): effective model ${modelId} (requested ${config.modelId}) is text-only with no vision companion; running text-only`
-        );
-      }
-      const visionImageSources = effectiveSupportsVision
-        ? await resolveVisionImageSources(config.visionImageUrls)
-        : undefined;
-      const { systemPrompts, chatMessages } = buildChatMessages(
-        messages,
-        visionImageSources
-      );
-
-      const abortController = new AbortController();
-      const timeout = setTimeout(() => abortController.abort(), 300_000);
-
-      const channel = getShotPromptChannel(shotId);
-      let accumulated = '';
-      let lastExtracted = '';
-      let pendingDelta = '';
-      let lastEmitAt = 0;
-      const usageCapture = createUsageCapture();
-
-      const flushDelta = async () => {
-        if (!pendingDelta) return;
-        const delta = pendingDelta;
-        pendingDelta = '';
-        lastEmitAt = Date.now();
-        await channel.emit('shotPrompt.streaming', { promptType, delta });
-      };
-
-      const commonOptions = {
-        adapter,
-        messages: chatMessages,
-        stream: true as const,
-        abortController,
-        modelOptions: chatModelOptionsForCall(
-          modelId,
-          llmKeyInfo,
-          config.reasoning
-        ),
-        middleware: [
-          ...aiObservabilityMiddleware({
-            observationName: logName,
-            tags: logTags,
-            metadata: logMetadata,
-            sessionId: callContext.sequenceId,
-            // Same scopedDb fallback as the non-streaming path above.
-            userId: callContext.userId ?? callContext.scopedDb?.userId,
-          }),
-          ...usageCapture.middleware,
-        ],
-        debug: false,
-      };
-      const eventStream = chat({
-        ...commonOptions,
-        systemPrompts,
-        outputSchema: config.responseSchema,
-      });
-      // The orchestrator-validated result from the terminal
-      // `structured-output.complete` event. Preferred over the
-      // hand-accumulated text: it's what the library validated, and it
-      // survives any delta-assembly drift.
-      let structuredJson: string | null = null;
-      let runError = null;
-      try {
-        for await (const event of eventStream) {
-          usageCapture.noteFromStreamEvent(event);
-          const noted = extractRunError(event);
-          if (noted) {
-            runError ??= noted;
-            continue;
-          }
-          if (
-            event.type === 'TEXT_MESSAGE_CONTENT' &&
-            typeof event.delta === 'string'
-          ) {
-            accumulated += event.delta;
-            const next = extractStreamingStringField(accumulated, 'fullPrompt');
-            if (next.length > lastExtracted.length) {
-              pendingDelta += next.slice(lastExtracted.length);
-              lastExtracted = next;
-            }
-            if (pendingDelta && Date.now() - lastEmitAt >= flushIntervalMs) {
-              await flushDelta();
-            }
-            continue;
-          }
-          if (
-            event.type === 'CUSTOM' &&
-            event.name === 'structured-output.complete'
-          ) {
-            structuredJson = JSON.stringify(event.value.object);
-            continue;
-          }
-        }
-        throwNotedRunError(runError);
-        await flushDelta();
-        if (structuredJson === null) {
-          throw new NonRetryableError(
-            `[LLM:${logName}:cf] Stream ended without a structured-output.complete event`
+        // Only attach the still when the effective model accepts image input;
+        // warn (don't fail) when an image is dropped — see durableLLMCallCf.
+        const effectiveSupportsVision = analysisModelSupportsVision(model);
+        if (hasImageInput && !effectiveSupportsVision) {
+          logger.warn(
+            `[LLM:${logName}:cf] Dropping vision image(s): effective model ${model} (requested ${config.modelId}) is text-only with no vision companion; running text-only`
           );
         }
-        logger.info(`[LLM:${logName}:cf] Streaming call succeeded`);
-        return {
-          jsonText: structuredJson,
-          costMicros: llmCostFromUsage(usageCapture.get(), modelId),
-          keySource: llmKeyInfo.source,
+        const visionImageSources = effectiveSupportsVision
+          ? await resolveVisionImageSources(config.visionImageUrls)
+          : undefined;
+        const { systemPrompts, chatMessages } = buildChatMessages(
+          messages,
+          visionImageSources
+        );
+
+        const abortController = new AbortController();
+        const timeout = setTimeout(() => abortController.abort(), 300_000);
+
+        const channel = getShotPromptChannel(shotId);
+        let accumulated = '';
+        let lastExtracted = '';
+        let pendingDelta = '';
+        let lastEmitAt = 0;
+        const usageCapture = createUsageCapture();
+
+        const flushDelta = async () => {
+          if (!pendingDelta) return;
+          const delta = pendingDelta;
+          pendingDelta = '';
+          lastEmitAt = Date.now();
+          await channel.emit('shotPrompt.streaming', { promptType, delta });
         };
-      } finally {
-        clearTimeout(timeout);
-      }
+
+        const commonOptions = {
+          adapter,
+          messages: chatMessages,
+          stream: true as const,
+          abortController,
+          modelOptions: chatModelOptionsForCall(
+            model,
+            llmKeyInfo,
+            config.reasoning
+          ),
+          middleware: [
+            ...aiObservabilityMiddleware({
+              observationName: logName,
+              tags: logTags,
+              metadata: logMetadata,
+              sessionId: callContext.sequenceId,
+              // Same scopedDb fallback as the non-streaming path above.
+              userId: callContext.userId ?? callContext.scopedDb?.userId,
+            }),
+            ...usageCapture.middleware,
+          ],
+          debug: false,
+        };
+        const eventStream = chat({
+          ...commonOptions,
+          systemPrompts,
+          outputSchema: config.responseSchema,
+        });
+        // The orchestrator-validated result from the terminal
+        // `structured-output.complete` event. Preferred over the
+        // hand-accumulated text: it's what the library validated, and it
+        // survives any delta-assembly drift.
+        let structuredJson: string | null = null;
+        let runError = null;
+        try {
+          for await (const event of eventStream) {
+            usageCapture.noteFromStreamEvent(event);
+            const noted = extractRunError(event);
+            if (noted) {
+              runError ??= noted;
+              continue;
+            }
+            if (
+              event.type === 'TEXT_MESSAGE_CONTENT' &&
+              typeof event.delta === 'string'
+            ) {
+              accumulated += event.delta;
+              const next = extractStreamingStringField(
+                accumulated,
+                'fullPrompt'
+              );
+              if (next.length > lastExtracted.length) {
+                pendingDelta += next.slice(lastExtracted.length);
+                lastExtracted = next;
+              }
+              if (pendingDelta && Date.now() - lastEmitAt >= flushIntervalMs) {
+                await flushDelta();
+              }
+              continue;
+            }
+            if (
+              event.type === 'CUSTOM' &&
+              event.name === 'structured-output.complete'
+            ) {
+              structuredJson = JSON.stringify(event.value.object);
+              continue;
+            }
+          }
+          throwNotedRunError(runError);
+          await flushDelta();
+          if (structuredJson === null) {
+            throw new NonRetryableError(
+              `[LLM:${logName}:cf] Stream ended without a structured-output.complete event`
+            );
+          }
+          logger.info(`[LLM:${logName}:cf] Streaming call succeeded`);
+          return {
+            jsonText: structuredJson,
+            costMicros: llmCostFromUsage(usageCapture.get(), model),
+            keySource: llmKeyInfo.source,
+          };
+        } finally {
+          clearTimeout(timeout);
+        }
+      });
     }
   );
 


### PR DESCRIPTION
Closes #1259.

## What

A signup from mainland China had every storyboard run die on \`This model is not available in your region\` — our LLM calls egress from the Cloudflare colo nearest the user, so Anthropic's geo-block applies even to "server-side" calls. No fallback existed, the composer showed nothing, and the user resubmitted the identical script 9 times.

## Changes

**Region policy (new \`src/lib/ai/region-policy.ts\`)**
- Request-time: \`resolveModelForCountry\` swaps any \`anthropic/*\` model to DeepSeek when the request's \`cf-ipcountry\` is a known Anthropic-blocked country (CN/HK/MO/RU/BY/IR/KP/SY/CU). Applied in \`createSequences\`, so a China-region sequence never persists an Anthropic analysis model.
- Error-time: any LLM call that still hits a region block retries once on a region-available model — DeepSeek for text, Mistral Small 4 for vision-bearing calls. Wired into \`callLLMStream\` (guarded so a retry can never replay already-yielded content) and both durable workflow helpers (\`withRegionFallback\`), so steps recover instead of exhausting retries. This also covers the hardcoded \`SCENE_SPLIT_MODEL\` boundary pass, which has no request context to swap proactively.

**DeepSeek bumped to latest**
- \`deepseek/deepseek-v3.2\` → \`deepseek/deepseek-v4-pro-0813\` (1M context, structured outputs, newest on OpenRouter as of 2026-08-24). v3.2 stays in the registry \`hidden\` for existing sequences; pricing data regenerated via \`bun scripts/update-openrouter-pricing.ts\`.

**Composer feedback + dedup**
- \`useCreateSequence\` now toasts on failure (it was fully silent).
- \`createSequences\` rejects a resubmit when every requested analysis model already has a live (<2 min, \`processing\`) run of the exact same script for the team — retry-clicking can no longer spawn N identical pipelines. (The Generate button was already disabled while pending; per-sequence runs were already mutexed by #839 — the gap was N fresh sequences.)

## Notes / deliberate scope cuts

- Anthropic can still be *attempted* once from a blocked region on paths with no request context (workflow-internal \`SCENE_SPLIT_MODEL\`, \`RECOMMENDED_MODELS\` server fns) — the attempt fails at Anthropic's edge and immediately falls back, so no user-visible failure and no Anthropic output is ever served there. Threading country through workflow payloads wasn't worth the churn.
- PostHog \`$exception\` blindness to workflow failures (issue evidence #3) not addressed here.

## Tests

- New \`region-policy.test.ts\` (error matching, fallback picks, country swap, retry semantics).
- \`llm-client.test.ts\`: fallback retry uses DeepSeek adapter; mid-stream region error does not retry.
- Full unit suite (2,685), typecheck, lint, knip all green.