### PR TITLE
fix(#1269): drops on talent/location/element dropzones no longer also add elements

### DIFF
--- a/e2e/fixtures/add-talent.ts
+++ b/e2e/fixtures/add-talent.ts
@@ -74,6 +74,27 @@ export async function uploadNamedTalentImage(
   await waitForUploadComplete(page);
 }
 
+// Drag-and-drop path (vs. the file chooser above): the dialog is a portal, so
+// the drop also bubbles to the composer's whole-page element dropzone (#1269).
+export async function dropNamedTalentImage(
+  page: Page,
+  filename: string
+): Promise<void> {
+  const dataTransfer = await page.evaluateHandle(
+    ({ b64, name }) => {
+      const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+      const dt = new DataTransfer();
+      dt.items.add(new File([bytes], name, { type: 'image/jpeg' }));
+      return dt;
+    },
+    { b64: TEST_IMAGE_JPEG.toString('base64'), name: filename }
+  );
+  await addTalentDialog(page)
+    .getByText('Drag & drop or paste')
+    .dispatchEvent('drop', { dataTransfer });
+  await waitForUploadComplete(page);
+}
+
 export async function waitForSubjectKind(
   page: Page,
   kind: 'Human' | 'Animated' | 'Other'

--- a/e2e/tests/talent.spec.ts
+++ b/e2e/tests/talent.spec.ts
@@ -15,6 +15,7 @@ import {
   addTalentDialog,
   attestAssetRights,
   attestPortraitRights,
+  dropNamedTalentImage,
   openAddTalentFromLibrary,
   openAddTalentFromSequence,
   submitAddTalent,
@@ -389,7 +390,10 @@ testWithUser.describe('Add Talent from new sequence page', () => {
       const { picker } = await openAddTalentFromSequence(page);
 
       await addTalentDialog(page).getByLabel('Name').fill(uniqueName);
-      await uploadNamedTalentImage(page, 'test-image.jpg');
+      // Drop (not browse) so the same image cannot also land in the composer's
+      // Elements dropzone underneath the dialog (#1269).
+      await dropNamedTalentImage(page, 'test-image.jpg');
+      await expect(page.getByText('Upload reference elements')).toHaveCount(0);
       await waitForSubjectKind(page, 'Human');
       await attestPortraitRights(page);
       await submitAddTalent(page);
@@ -403,6 +407,10 @@ testWithUser.describe('Add Talent from new sequence page', () => {
         picker.getByRole('button', { name: /^Cast 1 role$/i })
       ).toBeVisible();
       await expect(page.getByRole('link', { name: uniqueName })).toHaveCount(0);
+      await expect(
+        // CSS, not role: the picker dialog is still open so `main` is aria-hidden.
+        page.locator('main').locator('button', { hasText: 'Elements' })
+      ).toHaveText('Elements');
 
       await cleanupTalentByName(testUser.teamId, uniqueName);
     }

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -357,9 +357,13 @@ export const ScriptView: FC<{
 
   const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
     if (!allowElementDrop || !hasDraggedImages(e)) return;
-    e.preventDefault();
     dragCounterRef.current = 0;
     setIsDraggingFiles(false);
+    // A nested dropzone (talent/location dialog, element popover) already took
+    // this drop — portals still bubble React events here, so don't add it as
+    // an element too (#1269).
+    if (e.defaultPrevented) return;
+    e.preventDefault();
     const snapshot = snapshotDataTransfer(e.dataTransfer);
     void extractImagesFromSnapshot(snapshot).then(({ files, failedUrls }) => {
       if (files.length > 0) {


### PR DESCRIPTION
Closes #1269

## Problem
`ScriptView` is a whole-page image drop target that routes files into the Elements selector. The talent/location upload dialogs and the elements popover are portals, so React still bubbles their `drop` events up to `ScriptView.handleDrop` — an image dropped on the character-sheet dropzone was uploaded as talent media **and** added as an element.

## Fix
`handleDrop` returns early when `e.defaultPrevented` is already set (every nested dropzone calls `preventDefault()` first). One guard in the shared ancestor covers all nested dropzones rather than `stopPropagation` in each.

## Test
`e2e/tests/talent.spec.ts` "photo create…" now uploads via a real `drop` event (`dropNamedTalentImage`) and asserts the elements popover doesn't open and the Elements button stays empty. Verified it fails without the fix (`Expected: 0, Received: 1`) and passes with it.