### PR TITLE
fix: stop sustained 'Style not found' serverFn errors (#1271)

### DIFF
--- a/src/components/model/add-model-menu.tsx
+++ b/src/components/model/add-model-menu.tsx
@@ -6,7 +6,7 @@ import {
 import { useScenesBySequence } from '@/hooks/use-scenes';
 import { useAddModelToSequence, useSequence } from '@/hooks/use-sequences';
 import { useShotsBySequence } from '@/hooks/use-shots';
-import { useStyle } from '@/hooks/use-styles';
+import { useSequenceStyle } from '@/hooks/use-styles';
 import {
   AUDIO_MODELS,
   IMAGE_MODELS,
@@ -56,7 +56,7 @@ export const AddModelMenuSection = ({
   const { data: shots } = useShotsBySequence(sequenceId);
   const { data: sceneRows } = useScenesBySequence(sequenceId);
   const { data: sequence } = useSequence(sequenceId);
-  const { data: style } = useStyle(sequence?.styleId ?? '');
+  const { data: style } = useSequenceStyle(sequenceId);
   const aspectRatio = sequence?.aspectRatio ?? DEFAULT_ASPECT_RATIO;
   // Style-category gating (mirrors motion-model-selector): a model declaring a
   // `requiredStyleCategory` (none currently declare one) is only offered when

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -45,7 +45,7 @@ import {
   useShotsBySequence,
   useUndiscardVariant,
 } from '@/hooks/use-shots';
-import { useStyle } from '@/hooks/use-styles';
+import { useSequenceStyle } from '@/hooks/use-styles';
 import {
   DEFAULT_IMAGE_MODEL,
   DEFAULT_MUSIC_MODEL,
@@ -271,7 +271,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
   });
   const aspectRatio = sequence?.aspectRatio || DEFAULT_ASPECT_RATIO;
   const isProcessing = sequence?.status === 'processing';
-  const { data: style } = useStyle(sequence?.styleId ?? '');
+  const { data: style } = useSequenceStyle(sequenceId);
   const styleCategory = style?.category ?? undefined;
   const sequenceMusicModel = safeAudioModel(
     sequence?.musicModel,

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -397,9 +397,22 @@ export const ScriptView: FC<{
     effectiveStyleId != null &&
     effectiveStyleId !== AUTO_STYLE_ID &&
     !styles.some((s) => s.id === effectiveStyleId);
-  const { data: boundStyle } = useStyle(
+  const { data: boundStyle, isSuccess: boundStyleResolved } = useStyle(
     needsBoundStyleLookup ? effectiveStyleId : ''
   );
+  // A persisted draft can carry an id nothing resolves any more (a deleted or
+  // de-listed style, or one picked under another account in this browser).
+  // Fall back to Automatic instead of generating against a dead id (#1271).
+  useEffect(() => {
+    if (
+      styleId &&
+      needsBoundStyleLookup &&
+      boundStyleResolved &&
+      boundStyle === null
+    ) {
+      setContentState((s) => ({ ...s, styleId: AUTO_STYLE_ID }));
+    }
+  }, [styleId, needsBoundStyleLookup, boundStyleResolved, boundStyle]);
   const autoStyleSelected =
     effectiveStyleId === AUTO_STYLE_ID ||
     (boundStyle?.sequenceId != null && boundStyle.id === effectiveStyleId);

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -397,22 +397,9 @@ export const ScriptView: FC<{
     effectiveStyleId != null &&
     effectiveStyleId !== AUTO_STYLE_ID &&
     !styles.some((s) => s.id === effectiveStyleId);
-  const { data: boundStyle, isSuccess: boundStyleResolved } = useStyle(
+  const { data: boundStyle } = useStyle(
     needsBoundStyleLookup ? effectiveStyleId : ''
   );
-  // A persisted draft can carry an id nothing resolves any more (a deleted or
-  // de-listed style, or one picked under another account in this browser).
-  // Fall back to Automatic instead of generating against a dead id (#1271).
-  useEffect(() => {
-    if (
-      styleId &&
-      needsBoundStyleLookup &&
-      boundStyleResolved &&
-      boundStyle === null
-    ) {
-      setContentState((s) => ({ ...s, styleId: AUTO_STYLE_ID }));
-    }
-  }, [styleId, needsBoundStyleLookup, boundStyleResolved, boundStyle]);
   const autoStyleSelected =
     effectiveStyleId === AUTO_STYLE_ID ||
     (boundStyle?.sequenceId != null && boundStyle.id === effectiveStyleId);

--- a/src/components/style/style-badge.tsx
+++ b/src/components/style/style-badge.tsx
@@ -10,7 +10,7 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { StyleDetailDialog } from '@/components/style/style-detail-dialog';
 import { PromoteStyleDialog } from '@/components/style/promote-style-dialog';
-import { useStyle, useStyles } from '@/hooks/use-styles';
+import { useSequenceStyle, useStyle, useStyles } from '@/hooks/use-styles';
 import { cn } from '@/lib/utils';
 import { ChevronDown, Info, Library, Wand2 } from 'lucide-react';
 
@@ -66,9 +66,14 @@ export const StyleBadge: React.FC<StyleBadgeProps> = ({
 }) => {
   const { data: styles } = useStyles();
   const listed = styleId ? styles?.find((s) => s.id === styleId) : undefined;
-  const { data: fetched } = useStyle(
-    styleId && styles && !listed ? styleId : ''
+  // Off-list style (an automatic one): resolve through the sequence when we
+  // have it so an admin's view of another team's sequence still gets a name.
+  const needsLookup = !!styleId && !!styles && !listed;
+  const { data: bySequence } = useSequenceStyle(
+    needsLookup && sequenceId ? sequenceId : ''
   );
+  const { data: byId } = useStyle(needsLookup && !sequenceId ? styleId : '');
+  const fetched = bySequence ?? byId;
   const [detailOpen, setDetailOpen] = useState(false);
   const [promoteOpen, setPromoteOpen] = useState(false);
 

--- a/src/functions/styles.ts
+++ b/src/functions/styles.ts
@@ -14,7 +14,7 @@ import {
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
-import { authWithTeamMiddleware } from './middleware';
+import { authWithTeamMiddleware, sequenceAccessMiddleware } from './middleware';
 export { getPublicStylesFn } from './public-styles';
 
 // ============================================================================
@@ -58,6 +58,18 @@ export const getStyleFn = createServerFn({ method: 'GET' })
   .validator(zodValidator(getStyleInputSchema))
   .handler(async ({ data, context }): Promise<Style | null> => {
     return context.scopedDb.styles.getById(data.styleId);
+  });
+
+/**
+ * The style a sequence was generated with, resolved in the sequence's own
+ * team scope — so an admin reviewing another team's sequence still sees its
+ * automatic style, which `getStyleFn` (viewer's team) hides (#1271). The id
+ * comes from the sequence row, never from the client.
+ */
+export const getSequenceStyleFn = createServerFn({ method: 'GET' })
+  .middleware([sequenceAccessMiddleware])
+  .handler(async ({ context }): Promise<Style | null> => {
+    return context.scopedDb.styles.getById(context.sequence.styleId);
   });
 
 // ============================================================================

--- a/src/functions/styles.ts
+++ b/src/functions/styles.ts
@@ -47,21 +47,17 @@ const getStyleInputSchema = z.object({
 });
 
 /**
- * Get a single style by ID
- * @returns The style
+ * Get a single style by ID.
+ * @returns The style, or `null` when it is not visible to this team — a
+ * deleted / de-listed style still referenced by a persisted composer draft,
+ * or another team's automatic style (#1271). That is an outcome, not a
+ * failure: a throw here was retried by the query client and logged at error.
  */
 export const getStyleFn = createServerFn({ method: 'GET' })
   .middleware([authWithTeamMiddleware])
   .validator(zodValidator(getStyleInputSchema))
-  .handler(async ({ data, context }) => {
-    // Style lookup doesn't require team scoping (styles can be public)
-    const style = await context.scopedDb.styles.getById(data.styleId);
-
-    if (!style) {
-      throw new Error('Style not found');
-    }
-
-    return style;
+  .handler(async ({ data, context }): Promise<Style | null> => {
+    return context.scopedDb.styles.getById(data.styleId);
   });
 
 // ============================================================================
@@ -100,7 +96,7 @@ export const updateStyleFn = createServerFn({ method: 'POST' })
     const style = await context.scopedDb.styles.update(styleId, updateData);
 
     if (!style) {
-      throw new Error(
+      throw new NotFoundError(
         'Style not found or you do not have permission to update it'
       );
     }
@@ -127,7 +123,7 @@ export const deleteStyleFn = createServerFn({ method: 'POST' })
     const style = await context.scopedDb.styles.getById(data.styleId);
 
     if (!style) {
-      throw new Error('Style not found');
+      throw new NotFoundError('Style not found');
     }
 
     await requireTeamAdminAccess(context.user.id, style.teamId);

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -45,9 +45,10 @@ export function useStyles(teamId?: string, enabled = true) {
   });
 }
 
-// Hook for getting single style
+// Hook for getting single style. `null` when the id resolves to nothing the
+// team can see (see getStyleFn) — callers render as if there were no style.
 export function useStyle(id: string) {
-  return useQuery<Style>({
+  return useQuery<Style | null>({
     queryKey: styleKeys.detail(id),
     queryFn: async () => {
       return getStyleFn({ data: { styleId: id } });

--- a/src/hooks/use-styles.ts
+++ b/src/hooks/use-styles.ts
@@ -4,6 +4,7 @@ import {
 } from '@/functions/ai';
 import {
   getPublicStylesFn,
+  getSequenceStyleFn,
   getStyleFn,
   getStylesFn,
   promoteSequenceStyleFn,
@@ -23,6 +24,8 @@ export const styleKeys = {
   public: () => publicStylesQueryKey,
   details: () => [...styleKeys.all, 'detail'] as const,
   detail: (id: string) => [...styleKeys.details(), id] as const,
+  forSequence: (sequenceId: string) =>
+    [...styleKeys.all, 'sequence', sequenceId] as const,
   // Recommendations are keyed by a hash of the (trimmed) script, so the same
   // script never re-spends an LLM call and enhancing — which changes the
   // script — naturally lands on a fresh key.
@@ -55,6 +58,21 @@ export function useStyle(id: string) {
     },
     staleTime: 10 * 60 * 1000,
     enabled: !!id,
+  });
+}
+
+/**
+ * The style a sequence was generated with, resolved in the sequence's team
+ * scope (see getSequenceStyleFn). Prefer this over `useStyle(sequence.styleId)`
+ * whenever a sequence is in hand — it also works for admins viewing another
+ * team's sequence. `null` when the row is gone.
+ */
+export function useSequenceStyle(sequenceId: string) {
+  return useQuery<Style | null>({
+    queryKey: styleKeys.forSequence(sequenceId),
+    queryFn: () => getSequenceStyleFn({ data: { sequenceId } }),
+    staleTime: 10 * 60 * 1000,
+    enabled: !!sequenceId,
   });
 }
 

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -442,6 +442,11 @@ export function updateQueryCacheFromEvent(
           `style:${styleId}`
         );
       }
+      debouncedInvalidate(
+        queryClient,
+        styleKeys.forSequence(sequenceId),
+        `style:sequence:${sequenceId}`
+      );
       // `sequence.styleConfig` flipping non-null is what ends the pending state.
       debouncedInvalidate(
         queryClient,


### PR DESCRIPTION
Closes #1271

## Cause
Prod logged ~100 `getStyleFn failed: UNKNOWN "Style not found"` errors over the last week. Prod D1 is consistent (0 sequences with a missing style row, 0 cross-team bound styles). Cross-referencing the request payloads (style ids) with PostHog pageviews: every failing id is an **automatic (sequence-bound) style on another team's sequence opened by a system admin** (`tom@openstory.so`). `sequenceAccessMiddleware` loads the sequence in the owning team's scope for admins, but `getStyleFn` only used `authWithTeamMiddleware` (the viewer's team), and since the #1213 hardening (2026-08-20) other teams' bound rows are hidden there. Three components × 3 query retries per page view = the bursts. A persisted composer draft holding a deleted/de-listed style id hits the same throw.

## Fix
- `getStyleFn` returns `null` when the style isn't visible — an outcome, not a failure. Every `useStyle` caller already renders as if there were no style.
- **`getSequenceStyleFn`** (`sequenceAccessMiddleware`): resolves `sequence.styleId` in the sequence's own team scope, so admins see the automatic style's name. `scenes-view`, `add-model-menu`, and `StyleBadge` (when it has a `sequenceId`) use it via `useSequenceStyle`; `style:ready` invalidates the new key. The composer keeps `getStyleFn` (no sequence exists yet).
- `updateStyleFn` / `deleteStyleFn` misses throw `NotFoundError` (logged at `warn` like the rest of the app).

## Verification
`bun typecheck`, `bun lint`, `bun run test src/functions src/lib/realtime src/lib/db/scoped/styles*.test.ts` — all pass.
