### PR TITLE
fix(ui): stop the prompt editors from swallowing desktop wheel scroll

### DIFF
--- a/src/components/script/script-editor.tsx
+++ b/src/components/script/script-editor.tsx
@@ -75,8 +75,11 @@ export const ScriptEditor: React.FC<ScriptEditorProps> = ({
           placeholder={placeholder}
           disabled={disabled}
           aria-invalid={hasError}
+          // This is the one height-bounded editor, so it owns the scrolling.
+          // overscroll-contain: hitting its scroll bounds must not chain the
+          // touch gesture into scrolling the page underneath.
           className={cn(
-            'min-h-[2lh] md:min-h-[4lh] flex-1 bg-transparent dark:bg-transparent border-none shadow-none focus-within:ring-0 focus-within:border-input pb-10',
+            'min-h-[2lh] md:min-h-[4lh] flex-1 overflow-y-auto overscroll-contain bg-transparent dark:bg-transparent border-none shadow-none focus-within:ring-0 focus-within:border-input pb-10',
             hasError && 'border-destructive focus-within:ring-destructive/20'
           )}
           data-testid="script-editor-textarea"

--- a/src/components/text-editor/markdown-editor-placeholder.test.tsx
+++ b/src/components/text-editor/markdown-editor-placeholder.test.tsx
@@ -26,3 +26,17 @@ describe('MarkdownEditor empty placeholder', () => {
     expect(html).not.toContain('A one-liner is enough');
   });
 });
+
+describe('MarkdownEditor scrolling', () => {
+  // #1281: a scroll container with overscroll-contain stops Chrome's wheel
+  // chaining even when it has nothing to scroll, which froze the panel behind
+  // every grow-with-content prompt editor. Only a height-bounded caller may
+  // opt the editor into scrolling.
+  it('is not a scroll container by default', () => {
+    const html = renderToStaticMarkup(
+      <MarkdownEditor value="" onValueChange={() => undefined} />
+    );
+    expect(html).not.toContain('overflow-y-auto');
+    expect(html).not.toContain('overscroll-contain');
+  });
+});

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -346,9 +346,12 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         containerBaseClasses,
         'relative',
         disabled && disabledClasses,
-        // overscroll-contain: hitting the editor's scroll bounds must not
-        // chain the touch gesture into scrolling the page underneath.
-        'overflow-y-auto overscroll-contain',
+        // No overflow rule here: the editor grows with its content. A caller
+        // that bounds its height (the composer's ScriptEditor) makes it the
+        // scroller. Chrome stops wheel chaining at a scroll container with
+        // overscroll-contain even when it has nothing to scroll, so an
+        // unconditional `overflow-y-auto overscroll-contain` froze the panel
+        // behind every prompt editor on desktop (#1281).
         className
       )}
       aria-invalid={ariaInvalid}


### PR DESCRIPTION
Closes #1281

## Root cause
`MarkdownEditor` was unconditionally an `overflow-y-auto` scroll container, and the mobile fix (a0c519df) added `overscroll-contain` to it. Chrome stops wheel chaining at a contained scroll container **even when it has nothing to scroll**, so the panel behind every grow-with-content editor — image prompt, video prompt, scene script — stopped responding to the wheel on desktop.

Reproduced with Playwright's native wheel on a minimal page (parent scroller + non-overflowing child):

| child CSS | Chromium panel.scrollTop | WebKit |
|---|---|---|
| (none) | 100 | 100 |
| `overflow-y:auto` | 100 | 100 |
| `overflow-y:auto; overscroll-behavior:contain` | **0** | 100 |
| `overscroll-behavior:contain` | 100 | 100 |

## Fix
Only the composer's `ScriptEditor` bounds the editor's height, so it now opts into `overflow-y-auto overscroll-contain` itself (mobile fix preserved there). The default editor is no longer a scroll container, so wheel input chains to the panel as before.

Other `overscroll-contain` sites (composer `CardContent`, style dialog list) sit where the page behind can't scroll anyway, so they're left alone.

## Test
Adds a unit assertion that the default `MarkdownEditor` renders without `overflow-y-auto`/`overscroll-contain`.