### PR TITLE
fix(#1288): isolate Better Auth cookies per local worktree

### DIFF
--- a/src/lib/auth/client.ts
+++ b/src/lib/auth/client.ts
@@ -12,7 +12,13 @@ import {
 } from 'better-auth/client/plugins';
 import { createAuthClient } from 'better-auth/react';
 import { getQueryClient } from '../query-client';
+import {
+  currentAuthCookiePrefix,
+  lastUsedLoginMethodCookieName,
+} from './cookie-prefix';
 import type { Auth } from './config';
+
+const cookiePrefix = currentAuthCookiePrefix();
 
 /** Auth API paths that change session state */
 const SESSION_MUTATION_PATHS = [
@@ -50,7 +56,9 @@ export const authClient = createAuthClient({
     emailOTPClient(),
     passkeyClient(),
     inferAdditionalFields<Auth>(),
-    lastLoginMethodClient(),
+    lastLoginMethodClient({
+      cookieName: lastUsedLoginMethodCookieName(cookiePrefix),
+    }),
   ],
 });
 

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -26,6 +26,10 @@ import { SIGNUP_GRANT_MICROS } from '@/lib/billing/constants';
 import { microsToDisplayUsd } from '@/lib/billing/money';
 import { createBillingMethods } from '@/lib/db/scoped/billing';
 import { sendOtpEmail } from '@/lib/services/email-service';
+import {
+  currentAuthCookiePrefix,
+  lastUsedLoginMethodCookieName,
+} from '@/lib/auth/cookie-prefix';
 import { DEV_OTP_CODE } from '@/lib/auth/dev-otp';
 import {
   isGoogleAuthConfigured,
@@ -91,6 +95,7 @@ let _authInstance: ReturnType<typeof createAuth> | undefined;
 /** `db` is injectable only for `bun auth:generate` (schema generation never queries). */
 export function createAuth(db: ReturnType<typeof getDb> = getDb()) {
   const runtimeEnv = getEnv();
+  const cookiePrefix = currentAuthCookiePrefix();
 
   return betterAuth({
     // Route Better Auth's own logs through LogTape so they land in the same
@@ -190,7 +195,9 @@ export function createAuth(db: ReturnType<typeof getDb> = getDb()) {
           }
         },
       }),
-      lastLoginMethod(),
+      lastLoginMethod({
+        cookieName: lastUsedLoginMethodCookieName(cookiePrefix),
+      }),
       passkeyPlugin(),
       // Device-code login for the public API (#1219, RFC 8628). The plugin
       // owns the code lifecycle; `src/lib/api-v1/device-auth.ts` wraps it to
@@ -330,6 +337,10 @@ export function createAuth(db: ReturnType<typeof getDb> = getDb()) {
 
     // Advanced configuration
     advanced: {
+      // Local worktrees share the localhost cookie jar across ports (#1288).
+      // Vite injects a per-cwd prefix in `vite serve`; production keeps
+      // Better Auth's default so existing sessions survive deploys.
+      cookiePrefix,
       database: {
         // Generate ULID for user IDs (time-ordered, better performance)
         generateId: () => generateId(),

--- a/src/lib/auth/cookie-prefix.test.ts
+++ b/src/lib/auth/cookie-prefix.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_AUTH_COOKIE_PREFIX,
+  lastUsedLoginMethodCookieName,
+  resolveAuthCookiePrefix,
+  worktreeAuthCookiePrefix,
+} from './cookie-prefix';
+
+describe('worktreeAuthCookiePrefix', () => {
+  it('namespaces published FNV-1a 32-bit vectors as cookie-name tokens', () => {
+    expect(worktreeAuthCookiePrefix('')).toBe('ba-811c9dc5');
+    expect(worktreeAuthCookiePrefix('a')).toBe('ba-e40c292c');
+    expect(worktreeAuthCookiePrefix('foobar')).toBe('ba-bf9cf968');
+  });
+
+  it('differs across worktree paths and is stable for the same path', () => {
+    const a = worktreeAuthCookiePrefix(
+      '/Users/tom/.herdr/worktrees/openstory/1288-worktree-auth-cookies'
+    );
+    const b = worktreeAuthCookiePrefix(
+      '/Users/tom/.herdr/worktrees/openstory/other-issue'
+    );
+    expect(a).toBe('ba-419ef3f1');
+    expect(b).toBe('ba-51ee7169');
+    expect(a).not.toBe(b);
+    expect(
+      worktreeAuthCookiePrefix(
+        '/Users/tom/.herdr/worktrees/openstory/1288-worktree-auth-cookies'
+      )
+    ).toBe(a);
+  });
+});
+
+describe('resolveAuthCookiePrefix', () => {
+  it('keeps the Better Auth default outside vite dev', () => {
+    expect(
+      resolveAuthCookiePrefix({
+        isDev: false,
+        injectedPrefix: 'ba-deadbeef',
+      })
+    ).toBe(DEFAULT_AUTH_COOKIE_PREFIX);
+  });
+
+  it('uses the injected worktree prefix in vite dev', () => {
+    expect(
+      resolveAuthCookiePrefix({
+        isDev: true,
+        injectedPrefix: 'ba-deadbeef',
+      })
+    ).toBe('ba-deadbeef');
+  });
+
+  it('falls back to the default when vite did not inject a prefix', () => {
+    expect(
+      resolveAuthCookiePrefix({ isDev: true, injectedPrefix: undefined })
+    ).toBe(DEFAULT_AUTH_COOKIE_PREFIX);
+  });
+});
+
+describe('lastUsedLoginMethodCookieName', () => {
+  it('matches Better Auth default name at the stock prefix', () => {
+    expect(lastUsedLoginMethodCookieName(DEFAULT_AUTH_COOKIE_PREFIX)).toBe(
+      'better-auth.last_used_login_method'
+    );
+  });
+
+  it('stays under the worktree prefix', () => {
+    expect(lastUsedLoginMethodCookieName('ba-deadbeef')).toBe(
+      'ba-deadbeef.last_used_login_method'
+    );
+  });
+});

--- a/src/lib/auth/cookie-prefix.ts
+++ b/src/lib/auth/cookie-prefix.ts
@@ -1,0 +1,60 @@
+/**
+ * Better Auth cookie prefix.
+ *
+ * Browsers scope cookies by host, not port, so two `bun dev` worktrees on
+ * localhost:3000 and localhost:3001 both send `better-auth.session_token`.
+ * Each worktree has its own Miniflare D1, so the session lookup fails (or
+ * worse, hits a different user) and logging into one clobbers the other.
+ *
+ * Dev (`vite serve`) injects a per-cwd prefix via
+ * `import.meta.env.VITE_AUTH_COOKIE_PREFIX` (see vite.config.ts). Production
+ * builds leave it unset and keep Better Auth's default `better-auth`, so
+ * existing sessions survive deploys.
+ */
+
+export const DEFAULT_AUTH_COOKIE_PREFIX = 'better-auth';
+
+/**
+ * FNV-1a 32-bit as 8 lowercase hex chars.
+ * Test vectors: "" → 811c9dc5, "a" → e40c292c, "foobar" → bf9cf968.
+ */
+function fnv1a32Hex(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+/** Cookie prefix unique to this checkout. Safe as a cookie-name token. */
+export function worktreeAuthCookiePrefix(cwd: string): string {
+  return `ba-${fnv1a32Hex(cwd)}`;
+}
+
+/**
+ * Resolve the Better Auth `advanced.cookiePrefix`.
+ * `injectedPrefix` is Vite's `import.meta.env.VITE_AUTH_COOKIE_PREFIX` from
+ * `vite serve`; ignored when `isDev` is false so a leaked env cannot rename
+ * production cookies.
+ */
+export function resolveAuthCookiePrefix(input: {
+  isDev: boolean;
+  injectedPrefix: string | undefined;
+}): string {
+  if (input.isDev && input.injectedPrefix) return input.injectedPrefix;
+  return DEFAULT_AUTH_COOKIE_PREFIX;
+}
+
+/** Prefix for this process: worktree-local in vite dev, default in production. */
+export function currentAuthCookiePrefix(): string {
+  return resolveAuthCookiePrefix({
+    isDev: import.meta.env.DEV,
+    injectedPrefix: import.meta.env.VITE_AUTH_COOKIE_PREFIX,
+  });
+}
+
+/** `lastLoginMethod` cookie; plugin default is `better-auth.last_used_login_method`. */
+export function lastUsedLoginMethodCookieName(prefix: string): string {
+  return `${prefix}.last_used_login_method`;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,8 @@ interface ImportMetaEnv {
   readonly VITE_APP_URL: string | undefined;
   readonly VITE_R2_PUBLIC_ASSETS_DOMAIN: string | undefined;
   readonly VITE_MODELS_ENABLED: string | undefined;
+  /** Per-worktree Better Auth cookie prefix. Set only by `vite serve`. */
+  readonly VITE_AUTH_COOKIE_PREFIX: string | undefined;
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,8 +10,19 @@ import { defineConfig, type Plugin } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';
 import viteReact from '@vitejs/plugin-react';
+import { worktreeAuthCookiePrefix } from './src/lib/auth/cookie-prefix';
 
 const isDev = process.env.NODE_ENV !== 'production';
+// Per-worktree auth cookie name (#1288). Set on process.env so Vite's usual
+// `import.meta.env.VITE_*` replacement ships it into the worker the same way
+// as VITE_APP_URL. Production builds leave it unset.
+if (isDev) {
+  // Always derive from cwd — a copied `.env.local` must not re-share a prefix.
+  process.env.VITE_AUTH_COOKIE_PREFIX = worktreeAuthCookiePrefix(process.cwd());
+}
+const authCookiePrefix = isDev
+  ? process.env.VITE_AUTH_COOKIE_PREFIX
+  : undefined;
 
 /**
  * Prints which wrangler.jsonc bindings are local vs REMOTE on dev startup.
@@ -66,6 +77,11 @@ function wranglerBindingsBanner(): Plugin {
             : `${DIM}local${RESET}   (Miniflare)`;
           process.stdout.write(
             `    ${kind} ${name.padEnd(nameWidth)}  →  ${status}\n`
+          );
+        }
+        if (authCookiePrefix) {
+          process.stdout.write(
+            `    AUTH ${'cookies'.padEnd(nameWidth)}  →  ${DIM}${authCookiePrefix}${RESET}  (per-worktree)\n`
           );
         }
         if (rows.some(([, , r]) => r)) {


### PR DESCRIPTION
## Related Issue

Closes #1288

## Summary of Changes

Browsers scope cookies by host, not port. Two `bun dev` worktrees on `localhost:3000` and `localhost:3001` were sending the same `better-auth.session_token` at each other, even though each worktree has its own Miniflare D1. Login on one clobbered the other; session lookups missed (or hit the wrong user).

`vite serve` now injects `VITE_AUTH_COOKIE_PREFIX=ba-<cwd-hash>` so each worktree gets its own cookie names (`ba-419ef3f1.session_token`, etc.). Production builds leave the prefix unset, so existing sessions stay on Better Auth's default `better-auth`.

The `bun dev` bindings banner prints the prefix so you can see which jar that process is using.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Production cookie names are unchanged (`import.meta.env.DEV` + production-build env gate). Local sessions need one re-login after pulling this — leftover `better-auth.session_token` cookies are ignored.

## Additional Notes

Keying off cwd (not port) so:

- Concurrent worktrees on different ports don't share a jar
- Switching worktrees on the same port (`:3000`) also doesn't
- Two processes of the *same* worktree still share cookies (same D1 — correct)

The last-login-method cookie is prefixed to match. OpenRouter PKCE state cookies are unchanged (short-lived, out of scope).