### PR TITLE
fix: auto-style enum rejection no longer fails the run as "split script failed"

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -60,6 +60,7 @@ import { useSequenceLocations } from '@/hooks/use-sequence-locations';
 import { useCreateSequence } from '@/hooks/use-sequences';
 import { useRecommendedStyles, useStyle, useStyles } from '@/hooks/use-styles';
 import { AUTO_STYLE_ID } from '@/lib/style/auto-style';
+import { errorMessage } from '@/lib/errors';
 import { toEnhanceInputs } from '@/lib/ai/enhance-inputs';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -1025,10 +1026,7 @@ export const ScriptView: FC<{
       });
     } catch (error) {
       if (!abortController.signal.aborted) {
-        setEnhance(
-          'error',
-          error instanceof Error ? error.message : 'Failed to enhance script'
-        );
+        setEnhance('error', errorMessage(error, 'Failed to enhance script'));
         setScript(previousScriptRef.current);
       }
     } finally {

--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -675,11 +675,12 @@ describe('llm-client', () => {
         );
 
         expect(mockChat.mock.calls[0]?.[0]?.modelOptions.provider).toEqual({
+          requireParameters: true,
           ignore: ['azure'],
         });
       });
 
-      it('leaves non-Anthropic models unrestricted', async () => {
+      it('only requires parameter support for non-Anthropic models', async () => {
         mockChat.mockReturnValue(textStream());
 
         await drain(
@@ -689,12 +690,12 @@ describe('llm-client', () => {
           })
         );
 
-        expect(
-          mockChat.mock.calls[0]?.[0]?.modelOptions.provider
-        ).toBeUndefined();
+        expect(mockChat.mock.calls[0]?.[0]?.modelOptions.provider).toEqual({
+          requireParameters: true,
+        });
       });
 
-      it('caller-supplied provider preferences win', async () => {
+      it('caller-supplied provider preferences layer on top', async () => {
         mockChat.mockReturnValue(textStream());
 
         await drain(
@@ -706,6 +707,8 @@ describe('llm-client', () => {
         );
 
         expect(mockChat.mock.calls[0]?.[0]?.modelOptions.provider).toEqual({
+          requireParameters: true,
+          ignore: ['azure'],
           only: ['anthropic'],
         });
       });

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -379,15 +379,21 @@ function toGrokReasoningEffort(
 // chat(). The public LLMRequestParams surface keeps its OpenAI-style
 // snake_case names; this is the single mapping point.
 function buildModelOptions(params: LLMRequestParams) {
-  // Azure-hosted Claude compiles strict structured-output schemas against a
-  // much smaller grammar budget than Anthropic's own endpoint and rejects our
-  // analysis schemas ("The compiled grammar is too large"). Keep Anthropic
-  // models off Azure; an explicit caller-supplied preference still wins.
-  const provider =
-    params.provider ??
-    (params.model.startsWith('anthropic/') ? { ignore: ['azure'] } : undefined);
+  // `requireParameters`: only route to upstreams that support every parameter
+  // we send. Without it OpenRouter treats `response_format` as a soft
+  // preference — Google Vertex advertises `response_format` but not
+  // `structured_outputs`, so a Claude call landing there returned free-form
+  // JSON with no error (#1285). Azure-hosted Claude compiles strict schemas
+  // against a much smaller grammar budget and rejects ours ("The compiled
+  // grammar is too large"), so Anthropic models stay off Azure. Caller-supplied
+  // preferences layer on top.
+  const provider: ProviderPreferences = {
+    requireParameters: true,
+    ...(params.model.startsWith('anthropic/') && { ignore: ['azure'] }),
+    ...params.provider,
+  };
   return {
-    ...(provider && { provider }),
+    provider,
     ...(params.reasoning && { reasoning: params.reasoning }),
     maxCompletionTokens: params.max_tokens,
     temperature: params.temperature,

--- a/src/lib/errors.test.ts
+++ b/src/lib/errors.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { describe, expect, it } from 'vitest';
 // Static, not a dynamic import inside the test: pulling in the whole start
 // instance takes seconds under full-suite load and would blow the timeout.
@@ -274,5 +275,29 @@ describe('errorCode / isInsufficientCreditsError', () => {
     expect(errorMessage(new Error(ours.message))).toBe(
       'Insufficient credits for image'
     );
+  });
+});
+
+describe('errorMessage', () => {
+  // A raw Zod issue array reached users as `status_error` and the enhance
+  // banner (#1285) — both live ZodErrors and ones flattened to `message` by
+  // the server-fn boundary collapse to one line.
+  it('collapses Zod issues to one path: message line', () => {
+    const live = z
+      .object({ category: z.enum(['film', 'tech']), name: z.string().min(1) })
+      .safeParse({ category: 'documentary', name: '' }).error;
+    expect(live).toBeDefined();
+    expect(errorMessage(live)).toBe(
+      'category: Invalid option: expected one of "film"|"tech"; name: Too small: expected string to have >=1 characters'
+    );
+    expect(errorMessage(new Error(live?.message ?? ''))).toBe(
+      errorMessage(live)
+    );
+  });
+
+  it('leaves non-Zod messages alone, even bracketed ones', () => {
+    expect(errorMessage(new Error('[LLM] timed out'))).toBe('[LLM] timed out');
+    expect(errorMessage(new Error('[1, 2]'))).toBe('[1, 2]');
+    expect(errorMessage('nope', 'fallback')).toBe('fallback');
   });
 });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -165,13 +165,36 @@ export function isInsufficientCreditsError(error: unknown): boolean {
   return errorCode(error) === 'INSUFFICIENT_CREDITS';
 }
 
-/** Display text for an arbitrary thrown value. */
+/**
+ * Display text for an arbitrary thrown value. A Zod failure — a live
+ * `ZodError`, or one that crossed the server-fn boundary as its JSON `message`
+ * (#1285) — collapses to one `path: message` line per issue instead of the raw
+ * issue array.
+ */
 export function errorMessage(
   error: unknown,
   fallback = 'Unknown error'
 ): string {
   if (!(error instanceof Error)) return fallback;
-  return error.message;
+  return zodIssuesLine(error.message) ?? error.message;
+}
+
+function zodIssuesLine(message: string): string | null {
+  if (!message.startsWith('[')) return null;
+  let issues: unknown;
+  try {
+    issues = JSON.parse(message);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(issues) || issues.length === 0) return null;
+  const lines: string[] = [];
+  for (const issue of issues) {
+    if (!isRecord(issue) || typeof issue.message !== 'string') return null;
+    const path = Array.isArray(issue.path) ? issue.path.join('.') : '';
+    lines.push(path ? `${path}: ${issue.message}` : issue.message);
+  }
+  return lines.join('; ');
 }
 
 /**

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -1004,8 +1004,8 @@ Rules:
 5. \`colorPalette\`: 3–6 hex colors (e.g. "#0a0a14"), dominant first.
 6. \`references\`: 2–5 descriptive aesthetic phrases (e.g. "rain-slicked neon-noir cityscapes"), not film titles.
 7. \`name\`: a short, evocative style name of 2–4 words (e.g. "Rain-slick Neon Noir"). \`description\`: one sentence a user would read on a style card.
-8. \`category\`: the single best-fitting catalog category. \`tags\`: 3–6 lowercase keywords.
-9. \`energy\`: integer 1 (stillness) to 5 (kinetic chaos). \`pace\`: the cutting rhythm.`,
+8. \`category\`: the single best-fitting catalog category — exactly one of: {{categories}}. \`tags\`: 3–6 lowercase keywords.
+9. \`energy\`: integer 1 (stillness) to 5 (kinetic chaos). \`pace\`: the cutting rhythm — exactly one of: {{paces}}.`,
     },
     {
       role: 'user',

--- a/src/lib/style/auto-style.test.ts
+++ b/src/lib/style/auto-style.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   AUTO_STYLE_PLACEHOLDER_NAME,
+  DEFAULT_AUTO_STYLE_CATEGORY,
   type AutoStyleResponse,
   autoStyleDraftFromResponse,
   placeholderAutoStyleDraft,
@@ -86,5 +87,22 @@ describe('placeholderAutoStyleDraft', () => {
     const draft = placeholderAutoStyleDraft();
     expect(draft.name).toBe(AUTO_STYLE_PLACEHOLDER_NAME);
     expect(() => StyleConfigSchema.parse(draft.config)).not.toThrow();
+  });
+});
+
+describe('autoStyleDraftFromResponse vocabulary guesses (#1285)', () => {
+  it('coerces category and pace to the closed vocabulary instead of failing the run', () => {
+    expect(
+      autoStyleDraftFromResponse({ ...RESPONSE, category: ' Commercial ' })
+        .category
+    ).toBe('commercial');
+    const offList = autoStyleDraftFromResponse({
+      ...RESPONSE,
+      category: 'documentary',
+      pace: 'rapid',
+    });
+    expect(offList.category).toBe(DEFAULT_AUTO_STYLE_CATEGORY);
+    expect(offList.config.motion.pace).toBeUndefined();
+    expect(StyleConfigSchema.safeParse(offList.config).success).toBe(true);
   });
 });

--- a/src/lib/style/auto-style.test.ts
+++ b/src/lib/style/auto-style.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 import {
   AUTO_STYLE_PLACEHOLDER_NAME,
   DEFAULT_AUTO_STYLE_CATEGORY,
+  STYLE_CATEGORIES,
+  autoStyleResponseSchema,
   type AutoStyleResponse,
   autoStyleDraftFromResponse,
   placeholderAutoStyleDraft,
@@ -90,19 +93,25 @@ describe('placeholderAutoStyleDraft', () => {
   });
 });
 
-describe('autoStyleDraftFromResponse vocabulary guesses (#1285)', () => {
-  it('coerces category and pace to the closed vocabulary instead of failing the run', () => {
-    expect(
-      autoStyleDraftFromResponse({ ...RESPONSE, category: ' Commercial ' })
-        .category
-    ).toBe('commercial');
-    const offList = autoStyleDraftFromResponse({
+describe('autoStyleResponseSchema vocabulary guesses (#1285)', () => {
+  it('defaults an off-vocabulary category/pace instead of failing the parse', () => {
+    const parsed = autoStyleResponseSchema.parse({
       ...RESPONSE,
-      category: 'documentary',
+      category: 'Documentary',
       pace: 'rapid',
     });
-    expect(offList.category).toBe(DEFAULT_AUTO_STYLE_CATEGORY);
-    expect(offList.config.motion.pace).toBeUndefined();
-    expect(StyleConfigSchema.safeParse(offList.config).success).toBe(true);
+    expect(parsed.category).toBe(DEFAULT_AUTO_STYLE_CATEGORY);
+    expect(parsed.pace).toBe('measured');
+    expect(autoStyleResponseSchema.parse(RESPONSE).category).toBe('film');
+    const draft = autoStyleDraftFromResponse(parsed);
+    expect(StyleConfigSchema.safeParse(draft.config).success).toBe(true);
+  });
+
+  it('still sends the enum to the provider', () => {
+    const json = z.toJSONSchema(autoStyleResponseSchema);
+    expect(json.properties?.category).toMatchObject({
+      enum: [...STYLE_CATEGORIES],
+      default: DEFAULT_AUTO_STYLE_CATEGORY,
+    });
   });
 });

--- a/src/lib/style/auto-style.ts
+++ b/src/lib/style/auto-style.ts
@@ -17,7 +17,7 @@ export const AUTO_STYLE_ID = 'auto';
 
 export const AUTO_STYLE_PLACEHOLDER_NAME = 'Automatic style';
 
-const STYLE_CATEGORIES = [
+export const STYLE_CATEGORIES = [
   'film',
   'commercial',
   'ecommerce',
@@ -46,12 +46,14 @@ const AUTO_STYLE_PLACEHOLDER_CONFIG: StyleConfig = {
  * rejects string/array length bounds and integer min/max (see
  * `sceneDurationResponseSchema`). Bounds are applied in
  * {@link autoStyleDraftFromResponse}, which re-validates against the real
- * `StyleConfigSchema`.
+ * `StyleConfigSchema`. `category`/`pace` are open strings too: this is a
+ * guess, and an out-of-vocabulary word must never fail the run (#1285) — the
+ * prompt lists the vocabulary and the draft coerces to it.
  */
 export const autoStyleResponseSchema = z.object({
   name: z.string(),
   description: z.string(),
-  category: z.enum(STYLE_CATEGORIES),
+  category: z.string(),
   tags: z.array(z.string()),
   mood: z.string(),
   artStyle: z.string(),
@@ -61,7 +63,7 @@ export const autoStyleResponseSchema = z.object({
   colorGrading: z.string(),
   camera: z.string(),
   shots: z.string(),
-  pace: z.enum(STYLE_PACE_VALUES),
+  pace: z.string(),
   /** 1 = stillness, 5 = kinetic chaos. */
   energy: z.number(),
   references: z.array(z.string()),
@@ -89,6 +91,18 @@ export function placeholderAutoStyleDraft(): AutoStyleDraft {
 }
 
 const MAX_NAME_LENGTH = 60;
+
+/** Where a category guess lands when the model coins its own word. */
+export const DEFAULT_AUTO_STYLE_CATEGORY = 'film';
+
+/** Case-insensitive match against a closed vocabulary; `undefined` when off-list. */
+function pickEnum<const T extends readonly string[]>(
+  values: T,
+  raw: string
+): T[number] | undefined {
+  const needle = raw.trim().toLowerCase();
+  return values.find((v) => v === needle);
+}
 
 function clampProse(value: string): string {
   return value.trim().slice(0, 1000);
@@ -126,7 +140,7 @@ export function autoStyleDraftFromResponse(
     motion: {
       camera: clampProse(response.camera),
       shots: response.shots.trim() ? clampProse(response.shots) : undefined,
-      pace: response.pace,
+      pace: pickEnum(STYLE_PACE_VALUES, response.pace),
       energy: Math.min(5, Math.max(1, Math.round(response.energy))),
     },
     references: nonEmpty(response.references, 50),
@@ -135,7 +149,9 @@ export function autoStyleDraftFromResponse(
     name,
     description: response.description.trim() || null,
     config,
-    category: response.category,
+    category:
+      pickEnum(STYLE_CATEGORIES, response.category) ??
+      DEFAULT_AUTO_STYLE_CATEGORY,
     tags: nonEmpty(response.tags, 10),
   };
 }

--- a/src/lib/style/auto-style.ts
+++ b/src/lib/style/auto-style.ts
@@ -46,14 +46,20 @@ const AUTO_STYLE_PLACEHOLDER_CONFIG: StyleConfig = {
  * rejects string/array length bounds and integer min/max (see
  * `sceneDurationResponseSchema`). Bounds are applied in
  * {@link autoStyleDraftFromResponse}, which re-validates against the real
- * `StyleConfigSchema`. `category`/`pace` are open strings too: this is a
- * guess, and an out-of-vocabulary word must never fail the run (#1285) — the
- * prompt lists the vocabulary and the draft coerces to it.
+ * `StyleConfigSchema`.
+ *
+ * `category`/`pace` keep their `enum` (a hard constraint on strict routes —
+ * Anthropic supports `enum` + `default`) but `.catch()` to a default: this is
+ * a guess, and an off-vocabulary word from a non-enforcing route must never
+ * fail the run (#1285). The prompt lists both vocabularies as well.
  */
+/** Where a category guess lands when the model coins its own word. */
+export const DEFAULT_AUTO_STYLE_CATEGORY = 'film';
+
 export const autoStyleResponseSchema = z.object({
   name: z.string(),
   description: z.string(),
-  category: z.string(),
+  category: z.enum(STYLE_CATEGORIES).catch(DEFAULT_AUTO_STYLE_CATEGORY),
   tags: z.array(z.string()),
   mood: z.string(),
   artStyle: z.string(),
@@ -63,7 +69,7 @@ export const autoStyleResponseSchema = z.object({
   colorGrading: z.string(),
   camera: z.string(),
   shots: z.string(),
-  pace: z.string(),
+  pace: z.enum(STYLE_PACE_VALUES).catch('measured'),
   /** 1 = stillness, 5 = kinetic chaos. */
   energy: z.number(),
   references: z.array(z.string()),
@@ -91,18 +97,6 @@ export function placeholderAutoStyleDraft(): AutoStyleDraft {
 }
 
 const MAX_NAME_LENGTH = 60;
-
-/** Where a category guess lands when the model coins its own word. */
-export const DEFAULT_AUTO_STYLE_CATEGORY = 'film';
-
-/** Case-insensitive match against a closed vocabulary; `undefined` when off-list. */
-function pickEnum<const T extends readonly string[]>(
-  values: T,
-  raw: string
-): T[number] | undefined {
-  const needle = raw.trim().toLowerCase();
-  return values.find((v) => v === needle);
-}
 
 function clampProse(value: string): string {
   return value.trim().slice(0, 1000);
@@ -140,7 +134,7 @@ export function autoStyleDraftFromResponse(
     motion: {
       camera: clampProse(response.camera),
       shots: response.shots.trim() ? clampProse(response.shots) : undefined,
-      pace: pickEnum(STYLE_PACE_VALUES, response.pace),
+      pace: response.pace,
       energy: Math.min(5, Math.max(1, Math.round(response.energy))),
     },
     references: nonEmpty(response.references, 50),
@@ -149,9 +143,7 @@ export function autoStyleDraftFromResponse(
     name,
     description: response.description.trim() || null,
     config,
-    category:
-      pickEnum(STYLE_CATEGORIES, response.category) ??
-      DEFAULT_AUTO_STYLE_CATEGORY,
+    category: response.category,
     tags: nonEmpty(response.tags, 10),
   };
 }

--- a/src/lib/workflow/sanitize-fail-response.test.ts
+++ b/src/lib/workflow/sanitize-fail-response.test.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { describe, expect, test } from 'vitest';
 import { isLlmAuthError, sanitizeFailResponse } from './sanitize-fail-response';
 
@@ -102,5 +103,14 @@ describe('isLlmAuthError', () => {
     expect(isLlmAuthError('Request timed out')).toBe(false);
     expect(isLlmAuthError('500 Internal Server Error')).toBe(false);
     expect(isLlmAuthError('Rate limit exceeded')).toBe(false);
+  });
+});
+
+describe('sanitizeFailResponse with a ZodError', () => {
+  test('stores one line, not the raw issue array (#1285)', () => {
+    const error = z.enum(['film', 'tech']).safeParse('documentary').error;
+    expect(sanitizeFailResponse(error)).toBe(
+      'Invalid option: expected one of "film"|"tech"'
+    );
   });
 });

--- a/src/lib/workflow/sanitize-fail-response.ts
+++ b/src/lib/workflow/sanitize-fail-response.ts
@@ -1,3 +1,5 @@
+import { errorMessage } from '@/lib/errors';
+
 const MAX_MESSAGE_LENGTH = 500;
 
 /** Known Cloudflare error codes mapped to human-readable messages */
@@ -46,7 +48,7 @@ export function sanitizeFailResponse(failResponse: unknown): string {
 function extractRawMessage(value: unknown): string {
   if (typeof value === 'string') return value;
   if (value == null) return '';
-  if (value instanceof Error) return value.message || value.toString();
+  if (value instanceof Error) return errorMessage(value) || value.toString();
   if (typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
   }

--- a/src/lib/workflows/auto-style-step.test.ts
+++ b/src/lib/workflows/auto-style-step.test.ts
@@ -94,8 +94,29 @@ describe('deriveAutoStyle', () => {
       name: 'automatic-style',
       promptName: 'phase/automatic-style-chat',
       modelId: 'anthropic/claude-sonnet-5',
-      promptVariables: { script: 'INT. HALLWAY — NIGHT' },
+      promptVariables: {
+        script: 'INT. HALLWAY — NIGHT',
+        categories: expect.stringContaining('film, commercial'),
+        paces: expect.stringContaining('slow, measured'),
+      },
     });
+  });
+
+  it('saves an off-vocabulary category guess as film instead of failing the run (#1285)', async () => {
+    durableLLMCallCf.mockResolvedValueOnce({
+      ...RESPONSE,
+      category: 'documentary',
+    });
+    emit.mockReset();
+    const { scopedDb, setGeneratedForSequence } = makeScopedDb(true);
+
+    await deriveAutoStyle(step, { scopedDb, ...PARAMS });
+
+    expect(setGeneratedForSequence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draft: expect.objectContaining({ category: 'film' }),
+      })
+    );
   });
 
   it('refuses to touch a row that is no longer bound to the sequence', async () => {

--- a/src/lib/workflows/auto-style-step.test.ts
+++ b/src/lib/workflows/auto-style-step.test.ts
@@ -7,6 +7,7 @@ import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import type { AutoStyleResponse } from '@/lib/style/auto-style';
 import type { WorkflowStep } from 'cloudflare:workers';
 import { describe, expect, it, vi } from 'vitest';
+import type { z } from 'zod';
 
 const durableLLMCallCf = vi.fn();
 vi.doMock('@/lib/workflows/llm-call-helper', () => ({ durableLLMCallCf }));
@@ -103,10 +104,11 @@ describe('deriveAutoStyle', () => {
   });
 
   it('saves an off-vocabulary category guess as film instead of failing the run (#1285)', async () => {
-    durableLLMCallCf.mockResolvedValueOnce({
-      ...RESPONSE,
-      category: 'documentary',
-    });
+    // durableLLMCallCf parses through `responseSchema` — mirror that here.
+    durableLLMCallCf.mockImplementationOnce(
+      async (_step: unknown, cfg: { responseSchema: z.ZodType }) =>
+        cfg.responseSchema.parse({ ...RESPONSE, category: 'documentary' })
+    );
     emit.mockReset();
     const { scopedDb, setGeneratedForSequence } = makeScopedDb(true);
 

--- a/src/lib/workflows/auto-style-step.ts
+++ b/src/lib/workflows/auto-style-step.ts
@@ -67,13 +67,6 @@ export async function deriveAutoStyle(
       `Automatic style for sequence ${sequenceId} was unsalvageable: ${error instanceof Error ? error.message : String(error)}`
     );
   }
-  if (draft.category !== response.category.trim().toLowerCase()) {
-    logger.warn('[AutoStyle:cf] category guess off-vocabulary; defaulted', {
-      sequenceId,
-      guessed: response.category,
-      category: draft.category,
-    });
-  }
 
   await step.do('save-automatic-style', async () => {
     const bound = await scopedDb.styles.setGeneratedForSequence({

--- a/src/lib/workflows/auto-style-step.ts
+++ b/src/lib/workflows/auto-style-step.ts
@@ -12,9 +12,10 @@ import { getGenerationChannel } from '@/lib/realtime';
 import {
   autoStyleDraftFromResponse,
   autoStyleResponseSchema,
+  STYLE_CATEGORIES,
   type AutoStyleDraft,
 } from '@/lib/style/auto-style';
-import type { StyleConfig } from '@/lib/style/style-config';
+import { STYLE_PACE_VALUES, type StyleConfig } from '@/lib/style/style-config';
 import { durableLLMCallCf } from '@/lib/workflows/llm-call-helper';
 import type { WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
@@ -44,6 +45,8 @@ export async function deriveAutoStyle(
       promptVariables: {
         script: params.script,
         aspectRatio: params.aspectRatio,
+        categories: STYLE_CATEGORIES.join(', '),
+        paces: STYLE_PACE_VALUES.join(', '),
       },
       modelId: params.analysisModelId,
       responseSchema: autoStyleResponseSchema,
@@ -63,6 +66,13 @@ export async function deriveAutoStyle(
     throw new NonRetryableError(
       `Automatic style for sequence ${sequenceId} was unsalvageable: ${error instanceof Error ? error.message : String(error)}`
     );
+  }
+  if (draft.category !== response.category.trim().toLowerCase()) {
+    logger.warn('[AutoStyle:cf] category guess off-vocabulary; defaulted', {
+      sequenceId,
+      guessed: response.category,
+      category: draft.category,
+    });
   }
 
   await step.do('save-automatic-style', async () => {


### PR DESCRIPTION
Closes #1285

## Cause
The failing run (2026-08-25 00:50 UTC) was `anthropic/claude-opus-5` via OpenRouter. We sent the schema correctly — `response_format: json_schema`, `strict: true`, `enum` intact — but OpenRouter routed the call to **Google Vertex**, which advertises `response_format` but not `structured_outputs`: it accepted the parameter, enforced nothing, and returned free-form JSON (`"category":"Documentary"`, plus a `look` key that isn't in our schema) with no error. Our provider preference was only `{ ignore: ['azure'] }`, with OpenRouter's `require_parameters` at its default `false` ("soft preference").

`durableLLMCallCf` then parsed that answer *outside* `step.do` (`llm-call-helper.ts:417`), the `z.enum` threw, and the whole analyze-script run failed with the raw Zod issue array as `status_error`.

## Fix
- **Route only to enforcing upstreams.** `buildModelOptions` now always sets `requireParameters: true` (caller prefs layer on top). Applies to every structured-output call in the app, not just auto-style.
- **A guess still can't fail the run.** `category`/`pace` keep `z.enum` (a hard constraint on strict routes — Anthropic supports `enum` + `default`) with a static `.catch()` (`'film'` / `'measured'`), so an off-vocabulary word from any route parses instead of throwing. The prompt lists both vocabularies too.
- **One-line Zod errors.** `errorMessage()` collapses a Zod issue array (live `ZodError`, or one flattened to `message` by the server-fn boundary) to `path: message; …`. `sanitizeFailResponse` (→ `status_error`) and the enhance banner in `script-view.tsx` route through it.

## Tests
- `llm-client.test.ts`: `requireParameters` on every route; Anthropic keeps `ignore: ['azure']`; caller prefs merge
- `auto-style.test.ts`: off-list category/pace parse to defaults; JSON schema still carries the `enum`
- `auto-style-step.test.ts`: prompt variables carry the vocabulary; an off-list answer saves as `film`
- `errors.test.ts` / `sanitize-fail-response.test.ts`: Zod → one line; bracketed non-Zod messages untouched