### PR TITLE
fix(#1293): content-checker failures render as a warning; soften prompts on every image path

### DIFF
--- a/src/components/sequence/failure-summary-banner.tsx
+++ b/src/components/sequence/failure-summary-banner.tsx
@@ -39,10 +39,10 @@ export const FailureSummaryBanner: React.FC<FailureSummaryBannerProps> = ({
         <AlertCircle className="h-4 w-4" />
       )}
       <AlertTitle>
-        {summary.requiresFullRetry
-          ? 'Generation failed'
-          : isWarning
-            ? 'Content checker'
+        {isWarning
+          ? 'Content checker'
+          : summary.requiresFullRetry
+            ? 'Generation failed'
             : summary.headline}
       </AlertTitle>
       <AlertDescription>

--- a/src/lib/ai/content-rejection.test.ts
+++ b/src/lib/ai/content-rejection.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   CONTENT_REJECTION_PATTERNS,
+  contentRejectionSubjects,
+  contentRejectionSummary,
   isContentRejectionError,
 } from './content-rejection';
 
@@ -77,5 +79,41 @@ describe('isContentRejectionError', () => {
 
   it('exposes a non-empty pattern list', () => {
     expect(CONTENT_REJECTION_PATTERNS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('contentRejectionSummary / contentRejectionSubjects', () => {
+  it('collapses content-only failures to the names and reads them back (#1293)', () => {
+    const summary = contentRejectionSummary([
+      { name: 'Ron Weasley', reason: 'material flagged by a content checker.' },
+      {
+        name: 'Harry Potter',
+        reason: 'Character sheet rejected by content filter after 3 attempts',
+      },
+    ]);
+    expect(summary).toBe(
+      'Blocked by the content checker: Ron Weasley, Harry Potter'
+    );
+    expect(isContentRejectionError(summary)).toBe(true);
+    // Parents only prefix; the tail survives a 500-char truncation ellipsis.
+    expect(
+      contentRejectionSubjects(
+        `Child workflow analyze-script:1 failed: Character sheet generation failed: Child workflow character-bible:1 failed: ${summary}…`
+      )
+    ).toEqual(['Ron Weasley', 'Harry Potter']);
+  });
+
+  it('is null when any failure is not a content rejection', () => {
+    expect(
+      contentRejectionSummary([
+        {
+          name: 'Ron Weasley',
+          reason: 'material flagged by a content checker.',
+        },
+        { name: 'Harry Potter', reason: 'ECONNRESET' },
+      ])
+    ).toBeNull();
+    expect(contentRejectionSummary([])).toBeNull();
+    expect(contentRejectionSubjects('Generation failed')).toEqual([]);
   });
 });

--- a/src/lib/ai/content-rejection.ts
+++ b/src/lib/ai/content-rejection.ts
@@ -93,3 +93,35 @@ export const CONTENT_REJECTION_USER_TITLE = 'Blocked by the content checker';
 /** What the user can do next. */
 export const CONTENT_REJECTION_USER_HINT =
   'Edit the script or the visual prompt, or retry.';
+
+/**
+ * Bible-level failure message when EVERY child failed a content check:
+ * `Blocked by the content checker: Ron Weasley, Harry Potter`. Parent
+ * workflows only prefix, so the names survive to `sequence.statusError` and
+ * {@link contentRejectionSubjects} reads them back. `null` when any failure
+ * was something else — the caller keeps its verbose message.
+ */
+export function contentRejectionSummary(
+  failures: ReadonlyArray<{ name: string; reason: string }>
+): string | null {
+  if (
+    failures.length === 0 ||
+    !failures.every((f) => isContentRejectionError(f.reason))
+  ) {
+    return null;
+  }
+  return `${CONTENT_REJECTION_USER_TITLE}: ${failures.map((f) => f.name).join(', ')}`;
+}
+
+/** Names appended by {@link contentRejectionSummary}, or `[]`. */
+export function contentRejectionSubjects(error: string): string[] {
+  const marker = `${CONTENT_REJECTION_USER_TITLE}: `;
+  const start = error.lastIndexOf(marker);
+  if (start < 0) return [];
+  return error
+    .slice(start + marker.length)
+    .replace(/…$/, '')
+    .split(', ')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/src/lib/ai/response-schema-budget.test.ts
+++ b/src/lib/ai/response-schema-budget.test.ts
@@ -20,7 +20,7 @@ import type { z } from 'zod';
 import { elementVisionResponseSchema } from './element-vision';
 import { talentMediaAnalysisSchema } from './talent-vision';
 import { autoStyleResponseSchema } from '@/lib/style/auto-style';
-import { softenImagePromptResponseSchema } from '@/lib/workflows/soften-image-prompt';
+import { softenImagePromptResponseSchema } from '@/lib/workflows/content-soften';
 import {
   ANTHROPIC_GRAMMAR_BUDGET_BYTES,
   structuredOutputSchemaBytes,

--- a/src/lib/failures/failure-analysis.test.ts
+++ b/src/lib/failures/failure-analysis.test.ts
@@ -167,6 +167,21 @@ describe('analyzeFailures', () => {
     expect(result.headline).toContain('full retry required');
   });
 
+  test('content-checker sequence error (no shots) is a warning, not a hard error', () => {
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError: 'Blocked by the content checker',
+    });
+
+    const result = analyzeFailures([], sequence, SCENES);
+
+    expect(result.requiresFullRetry).toBe(true);
+    expect(result.tone).toBe('warning');
+    expect(result.headline).toBe(
+      "Didn't pass the content checker \u2014 regenerate to retry"
+    );
+  });
+
   test('content-checker image failures are a warning, not a hard error', () => {
     const shots = [
       makeShot({

--- a/src/lib/failures/failure-analysis.test.ts
+++ b/src/lib/failures/failure-analysis.test.ts
@@ -178,7 +178,22 @@ describe('analyzeFailures', () => {
     expect(result.requiresFullRetry).toBe(true);
     expect(result.tone).toBe('warning');
     expect(result.headline).toBe(
-      "Didn't pass the content checker \u2014 regenerate to retry"
+      "Script didn't pass the content checker \u2014 regenerate to retry"
+    );
+  });
+
+  test('names the blocked characters from a bible-level content rejection', () => {
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError:
+        'Child workflow analyze-script:1 failed: Character sheet generation failed: Child workflow character-bible:1 failed: Blocked by the content checker: Ron Weasley, Hermione Granger, Harry Potter',
+    });
+
+    const result = analyzeFailures([], sequence, SCENES);
+
+    expect(result.tone).toBe('warning');
+    expect(result.headline).toBe(
+      "Ron Weasley, Hermione Granger and Harry Potter didn't pass the content checker \u2014 regenerate to retry"
     );
   });
 

--- a/src/lib/failures/failure-analysis.ts
+++ b/src/lib/failures/failure-analysis.ts
@@ -66,15 +66,30 @@ function groupIsContentOnly(group: FailureGroup): boolean {
   return !!group.error && isContentRejectionError(group.error);
 }
 
+/** A sequence-level error is only a warning when it is a content rejection. */
+function toneOf(error: string | null | undefined): FailureSummary['tone'] {
+  return error && isContentRejectionError(error) ? 'warning' : 'error';
+}
+
+const FULL_RETRY_HEADLINE = 'Generation failed \u2014 full retry required';
+const CONTENT_FULL_RETRY_HEADLINE =
+  "Didn't pass the content checker \u2014 regenerate to retry";
+
+function fullRetryHeadline(error: string | null | undefined): string {
+  return toneOf(error) === 'warning'
+    ? CONTENT_FULL_RETRY_HEADLINE
+    : FULL_RETRY_HEADLINE;
+}
+
 function buildHeadline(
   groups: FailureGroup[],
   requiresFullRetry: boolean,
+  error: string | null | undefined,
   clipsReady: number,
   clipsTotal: number
 ): string {
   if (groups.length === 0) {
-    if (requiresFullRetry)
-      return 'Generation failed \u2014 full retry required';
+    if (requiresFullRetry) return fullRetryHeadline(error);
     return 'No failures detected';
   }
 
@@ -86,7 +101,7 @@ function buildHeadline(
       const names = promptGroups.map((g) => g.label).join(' and ');
       return `${names} \u2014 full retry required`;
     }
-    return 'Generation failed \u2014 full retry required';
+    return fullRetryHeadline(error);
   }
 
   const parts: string[] = [];
@@ -144,12 +159,12 @@ export function analyzeFailures(
   if (shots.length === 0 && sequence.status === 'failed') {
     return {
       requiresFullRetry: true,
-      headline: 'Generation failed \u2014 full retry required',
+      headline: fullRetryHeadline(sequence.statusError),
       groups: [],
       totalFailures: 1,
       hasFailed: true,
       error: sequence.statusError,
-      tone: 'error',
+      tone: toneOf(sequence.statusError),
     };
   }
 
@@ -260,12 +275,12 @@ export function analyzeFailures(
   ) {
     return {
       requiresFullRetry: true,
-      headline: 'Generation failed \u2014 full retry required',
+      headline: fullRetryHeadline(sequence.statusError),
       groups: [],
       totalFailures: 1,
       hasFailed: true,
       error: sequence.statusError,
-      tone: 'error',
+      tone: toneOf(sequence.statusError),
     };
   }
 
@@ -286,6 +301,7 @@ export function analyzeFailures(
     headline: buildHeadline(
       groups,
       requiresFullRetry,
+      sequence.statusError,
       clipsReady,
       shots.length
     ),
@@ -295,7 +311,7 @@ export function analyzeFailures(
     error: sequence.statusError,
     tone:
       requiresFullRetry || groups.length === 0
-        ? 'error'
+        ? toneOf(sequence.statusError)
         : groups.every(groupIsContentOnly)
           ? 'warning'
           : 'error',

--- a/src/lib/failures/failure-analysis.ts
+++ b/src/lib/failures/failure-analysis.ts
@@ -3,7 +3,10 @@
  * Analyzes shots + sequence to determine what failed and whether smart retry is possible.
  */
 
-import { isContentRejectionError } from '@/lib/ai/content-rejection';
+import {
+  contentRejectionSubjects,
+  isContentRejectionError,
+} from '@/lib/ai/content-rejection';
 import type { SceneRow } from '@/lib/db/schema/scenes';
 import type { Shot } from '@/lib/db/schema/shots';
 import type { Sequence } from '@/lib/db/schema/sequences';
@@ -72,13 +75,17 @@ function toneOf(error: string | null | undefined): FailureSummary['tone'] {
 }
 
 const FULL_RETRY_HEADLINE = 'Generation failed \u2014 full retry required';
-const CONTENT_FULL_RETRY_HEADLINE =
-  "Didn't pass the content checker \u2014 regenerate to retry";
+
+/** "A", "A and B", "A, B and C". */
+function listNames(names: string[]): string {
+  if (names.length <= 1) return names.join('');
+  return `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
+}
 
 function fullRetryHeadline(error: string | null | undefined): string {
-  return toneOf(error) === 'warning'
-    ? CONTENT_FULL_RETRY_HEADLINE
-    : FULL_RETRY_HEADLINE;
+  if (toneOf(error) !== 'warning') return FULL_RETRY_HEADLINE;
+  const subjects = contentRejectionSubjects(error ?? '');
+  return `${subjects.length > 0 ? listNames(subjects) : 'Script'} didn't pass the content checker \u2014 regenerate to retry`;
 }
 
 function buildHeadline(

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -1027,14 +1027,14 @@ Rules:
       content: `You rewrite a cinematic still-image prompt that an image model rejected, so a retry can succeed. Read <REJECTION> and pick the rewrite that matches it.
 
 Two rejection classes:
-- POLICY — content checker / NSFW / unsafe / sensitive / flagged. Soften graphic violence, gore, sexual/nude wording, self-harm, real-person likeness instructions, and explicit crime into cinematic implication (aftermath, tension, silhouette, tasteful coverage).
+- POLICY — content checker / NSFW / unsafe / sensitive / flagged. Soften graphic violence, gore, sexual/nude wording, self-harm, real-person likeness instructions, and explicit crime into cinematic implication (aftermath, tension, silhouette, tasteful coverage). A name that identifies a real person or a well-known franchise / trademarked character (film, book, game, comic) trips likeness and IP checks on its own: drop the name and describe the look generically (age, build, hair, wardrobe, demeanour) — never name the franchise.
 - UNEXPECTED OUTPUT — "did not generate the expected output", "could not generate images", "unexpected result". The model often rejects its own sample because the prompt's grammar is broken or it stacks unusual word combinations. Rewrite into plain, grammatical cinematic English: short clauses, common collocations, no jammed modifiers or contradictory descriptors. Do not invent safer-sounding plot; the scene stays the same.
 
 ### CRITICAL OUTPUT RULES
 1. You will be called via a structured output tool. Follow the provided schema exactly.
 2. Return one rewritten prompt in \`prompt\`. Natural language only — no headers, bullets, or quotation marks wrapping the whole prompt.
 3. Keep the same scene: subjects, setting, camera, lighting, wardrobe, and style. Do not add new characters, props, locations, text, logos, or plot.
-4. Keep CHARACTER NAMES IN CAPS and UPPERCASE element tokens (e.g. BONDI_SCREEN) verbatim. Do not describe a referenced element's internal visual identity.
+4. Keep CHARACTER NAMES IN CAPS and UPPERCASE element tokens (e.g. BONDI_SCREEN) verbatim — they label reference images, not likenesses. A mixed-case \`Name:\` line in a sheet prompt is not a token and may be rewritten per the POLICY rule. Do not describe a referenced element's internal visual identity.
 5. If the rejection is ambiguous, do both: clean the grammar AND soften any policy-risky wording.
 6. Never return the original unchanged.`,
     },

--- a/src/lib/workflows/character-bible-workflow.ts
+++ b/src/lib/workflows/character-bible-workflow.ts
@@ -23,6 +23,7 @@ import type { CharacterMinimal, NewCharacter } from '@/lib/db/schema';
 import { buildCastingAttributes } from '@/lib/prompts/character-prompt';
 import { shouldReuseTalentSheet } from '@/lib/talent/reuse-talent-sheet';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
+import { contentRejectionSummary } from '@/lib/ai/content-rejection';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
@@ -190,7 +191,7 @@ export class CharacterBibleWorkflow extends OpenStoryWorkflowEntrypoint<Characte
     const settled = await Promise.allSettled(spawnPromises);
 
     const seqCharacters: CharacterMinimal[] = [];
-    const failures: string[] = [];
+    const failures: { name: string; reason: string }[] = [];
     for (const [index, outcome] of settled.entries()) {
       if (outcome.status === 'rejected') {
         // A reference sheet is what anchors a character's identity across cuts
@@ -216,7 +217,7 @@ export class CharacterBibleWorkflow extends OpenStoryWorkflowEntrypoint<Characte
             err: outcome.reason,
           }
         );
-        failures.push(`${name} (${reason})`);
+        failures.push({ name, reason });
         continue;
       }
 
@@ -242,9 +243,12 @@ export class CharacterBibleWorkflow extends OpenStoryWorkflowEntrypoint<Characte
       // (#939). This rejection propagates up through `spawnAndAwaitChild` to
       // analyze-script's `charSettled.status === 'rejected'` branch, which marks
       // the sequence `failed` with this message and emits `generation.failed`.
+      // Content-only failures collapse to the names so the banner can list
+      // who was blocked (#1293).
       throw new Error(
-        `Character sheet generation failed for ${failures.length} of ${settled.length} character(s); ` +
-          `stopping rather than rendering an unanchored sequence: ${failures.join('; ')}`
+        contentRejectionSummary(failures) ??
+          `Character sheet generation failed for ${failures.length} of ${settled.length} character(s); ` +
+            `stopping rather than rendering an unanchored sequence: ${failures.map((f) => `${f.name} (${f.reason})`).join('; ')}`
       );
     }
 

--- a/src/lib/workflows/character-sheet-workflow.ts
+++ b/src/lib/workflows/character-sheet-workflow.ts
@@ -16,10 +16,8 @@
 
 import {
   CONTENT_REJECTION_EVENT,
-  CONTENT_REJECTION_RETRY_EVENT,
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
-import { extractFalErrorMessage } from '@/lib/ai/fal-error';
 import { DEFAULT_IMAGE_MODEL } from '@/lib/ai/models';
 import {
   deductWorkflowCredits,
@@ -28,11 +26,7 @@ import {
 } from '@/lib/billing/workflow-deduction';
 import { generateId } from '@/lib/db/id';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
-import {
-  generateImageWithProvider,
-  type ImageGenerationParams,
-  type ImageGenerationResult,
-} from '@/lib/image/image-generation';
+import type { ImageGenerationParams } from '@/lib/image/image-generation';
 import { buildCharacterSheetPrompt } from '@/lib/prompts/character-prompt';
 import { recordProvenance } from '@/lib/compliance/provenance';
 import { getGenerationChannel } from '@/lib/realtime';
@@ -40,6 +34,7 @@ import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
 import { copyStoredImage } from '@/lib/storage/copy-stored-image';
 import { uploadResponse } from '@/lib/storage/upload-response';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { generateImageSoftening } from '@/lib/workflows/content-soften';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
   CharacterSheetWorkflowInput,
@@ -53,21 +48,10 @@ import {
   computeCharacterSheetHashCurrent,
   computeCharacterSheetHashFromDto,
 } from '@/lib/workflows/sheet-snapshots';
-import { NonRetryableError } from 'cloudflare:workflows';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'character-sheet']);
-
-/**
- * Total sheet generation attempts on a content-flag rejection (#881/#939): the
- * initial attempt plus 2 reseeded re-rolls. `generateImageWithProvider` is
- * called without a fixed seed, so each attempt is naturally reseeded; the
- * stochastic content-checker hits clear on a re-roll, while deterministic ones
- * exhaust this budget and fail hard (a character with no reference sheet can't
- * anchor identity across cuts, so we stop rather than continue unanchored).
- */
-const MAX_SHEET_ATTEMPTS = 3;
 
 async function persistReusedTalentSheet(params: {
   event: Readonly<WorkflowEvent<CharacterSheetWorkflowInput>>;
@@ -240,7 +224,7 @@ export class CharacterSheetWorkflow extends OpenStoryWorkflowEntrypoint<Characte
     }
 
     // Step 1: Validate and build prompt
-    const generationParams: ImageGenerationParams = await step.do(
+    const builtParams: ImageGenerationParams = await step.do(
       'build-prompt',
       async () => {
         // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
@@ -283,86 +267,26 @@ export class CharacterSheetWorkflow extends OpenStoryWorkflowEntrypoint<Characte
       }
     );
 
-    // Step 2: Generate the character sheet image with a bounded same-model
-    // reseed retry on content-flag rejections (#881/#939). A content rejection
-    // is caught INSIDE the step and surfaced as a sentinel so CF's per-step
-    // retry doesn't burn its budget re-rolling it — the loop owns that re-roll;
-    // genuine transient errors still throw and lean on CF's per-step retries.
-    // The sheet anchors a character's identity across cuts (#801), so an
-    // exhausted budget is a HARD failure: we throw rather than persist a null
-    // sheet and let the sequence render an unanchored character (#939).
-    let imageResult: ImageGenerationResult | null = null;
-    let lastRejection: string | null = null;
-    for (let attempt = 0; attempt < MAX_SHEET_ATTEMPTS; attempt++) {
-      const tag = attempt === 0 ? '' : `-retry-${attempt}`;
-      const outcome = await step.do(
-        `generate-sheet-image${tag}`,
-        async (): Promise<
-          | { ok: true; result: ImageGenerationResult }
-          | { ok: false; rejection: string }
-        > => {
-          logger.info(
-            `[CharacterSheetWorkflow:cf] Generating sheet for ${input.characterName} with model ${generationParams.model} (attempt ${attempt + 1}/${MAX_SHEET_ATTEMPTS})`
-          );
-          try {
-            const result = await generateImageWithProvider(generationParams, {
-              scopedDb: scopedDb.credentials,
-            });
-            return { ok: true, result };
-          } catch (error) {
-            if (isContentRejectionError(error)) {
-              return { ok: false, rejection: extractFalErrorMessage(error) };
-            }
-            // Not a content flag → transient. Let CF retry the step.
-            throw error;
-          }
-        }
-      );
-
-      if (outcome.ok) {
-        imageResult = outcome.result;
-        if (attempt > 0) {
-          logger.info(
-            `[CharacterSheetWorkflow:cf] content-flag retry rescued sheet for character ${input.characterDbId} on attempt ${attempt + 1}`,
-            {
-              event: CONTENT_REJECTION_RETRY_EVENT,
-              outcome: 'rescued',
-              kind: 'character-sheet',
-              model: generationParams.model,
-              attempts: attempt + 1,
-              characterDbId: input.characterDbId,
-              sequenceId: input.sequenceId,
-            }
-          );
-        }
-        break;
-      }
-
-      lastRejection = outcome.rejection;
-      logger.warn(
-        `[CharacterSheetWorkflow:cf] content-flag rejection on sheet attempt ${attempt + 1}/${MAX_SHEET_ATTEMPTS} for character ${input.characterDbId}: ${outcome.rejection}`
-      );
-    }
-
-    if (!imageResult) {
-      logger.error(
-        `[CharacterSheetWorkflow:cf] content-flag retry exhausted for character ${input.characterDbId} after ${MAX_SHEET_ATTEMPTS} attempts`,
-        {
-          event: CONTENT_REJECTION_RETRY_EVENT,
-          outcome: 'exhausted',
-          kind: 'character-sheet',
-          model: generationParams.model,
-          attempts: MAX_SHEET_ATTEMPTS,
-          characterDbId: input.characterDbId,
-          sequenceId: input.sequenceId,
-          rejection: lastRejection,
-        }
-      );
-      throw new NonRetryableError(
-        `Character sheet rejected by content filter after ${MAX_SHEET_ATTEMPTS} attempts: ${lastRejection ?? 'unknown rejection'}`,
-        'ContentRejectionExhausted'
-      );
-    }
+    // Step 2: Generate the sheet — same-model reseeds on a content flag
+    // (#881/#939), then one softened prompt (#1293). The sheet anchors a
+    // character's identity across cuts (#801), so exhaustion is a HARD
+    // failure: throw rather than persist a null sheet and render the
+    // character unanchored (#939).
+    const generation = await generateImageSoftening({
+      step,
+      scopedDb,
+      workflowRunId,
+      userId: input.userId,
+      sequenceId: input.sequenceId,
+      kind: 'character-sheet',
+      logTag: '[CharacterSheetWorkflow:cf]',
+      subject: `sheet for ${input.characterName}`,
+      stepName: 'generate-sheet-image',
+      params: builtParams,
+      meta: { characterDbId: input.characterDbId },
+    });
+    const imageResult = generation.result;
+    const generationParams = generation.params;
 
     // Before the deduction guard — see recordFalUsageStep (#1069).
     const falUsage = await recordFalUsageStep(

--- a/src/lib/workflows/content-soften.test.ts
+++ b/src/lib/workflows/content-soften.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared content-rejection reseeds + one softened prompt retry (#1293).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
+import type { ImageGenerationParams } from '@/lib/image/build-image-request';
+import type { ImageGenerationResult } from '@/lib/image/image-generation';
+import type { WorkflowStep } from 'cloudflare:workers';
+
+const generateImageWithProvider = vi.fn();
+vi.doMock('@/lib/image/image-generation', async () => {
+  const real = await vi.importActual<
+    typeof import('@/lib/image/image-generation')
+  >('@/lib/image/image-generation');
+  return { ...real, generateImageWithProvider };
+});
+
+const durableLLMCallCf = vi.fn();
+vi.doMock('@/lib/workflows/llm-call-helper', () => ({ durableLLMCallCf }));
+
+const { generateImageSoftening, MAX_CONTENT_ATTEMPTS } =
+  await import('./content-soften');
+const { NonRetryableError } = await import('cloudflare:workflows');
+
+const stepNames: string[] = [];
+// oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- helper only uses `do`
+const step = {
+  do: async <T>(name: string, fn: () => Promise<T>) => {
+    stepNames.push(name);
+    return fn();
+  },
+} as unknown as WorkflowStep;
+
+// oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- only `credentials` is read
+const scopedDb = { credentials: {} } as unknown as WorkflowScopedDb;
+
+const PARAMS: ImageGenerationParams = {
+  model: 'nano_banana_2',
+  prompt: 'Name: Harry Potter\nA boy wizard in school robes',
+  imageSize: 'landscape_16_9',
+  numImages: 1,
+};
+
+function okResult(prompt: string): ImageGenerationResult {
+  return {
+    imageUrls: ['https://cdn/img.jpg'],
+    parameters: { ...PARAMS, prompt },
+    generatedAt: '2026-08-25T00:00:00.000Z',
+    processingTimeMs: 12,
+    via: 'fal',
+    metadata: {
+      prompt,
+      model: PARAMS.model,
+      endpointId: 'fal-ai/nano-banana-2',
+      dimensions: [],
+      file_sizes: [],
+      usedOwnKey: false,
+    },
+  };
+}
+
+const contentError = () => new Error('material flagged by a content checker.');
+
+function run(
+  overrides: Partial<Parameters<typeof generateImageSoftening>[0]> = {}
+) {
+  return generateImageSoftening({
+    step,
+    scopedDb,
+    workflowRunId: 'wf-1',
+    userId: 'u1',
+    sequenceId: 'seq_1',
+    kind: 'character-sheet',
+    logTag: '[Test]',
+    subject: 'sheet for Harry Potter',
+    stepName: 'generate-sheet-image',
+    params: PARAMS,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  generateImageWithProvider.mockReset();
+  durableLLMCallCf.mockReset();
+  stepNames.length = 0;
+});
+
+describe('generateImageSoftening', () => {
+  it('reseeds, then softens once and renders the rewritten prompt', async () => {
+    generateImageWithProvider
+      .mockRejectedValueOnce(contentError())
+      .mockRejectedValueOnce(contentError())
+      .mockRejectedValueOnce(contentError())
+      .mockImplementationOnce(async (p: ImageGenerationParams) =>
+        okResult(p.prompt)
+      );
+    durableLLMCallCf.mockResolvedValue({
+      prompt: 'Name: a boy wizard\nA boy wizard in school robes',
+    });
+
+    const out = await run();
+
+    expect(generateImageWithProvider).toHaveBeenCalledTimes(
+      MAX_CONTENT_ATTEMPTS + 1
+    );
+    expect(out.softened).toBe(true);
+    expect(out.params.prompt).toBe(
+      'Name: a boy wizard\nA boy wizard in school robes'
+    );
+    expect(durableLLMCallCf).toHaveBeenCalledTimes(1);
+    expect(durableLLMCallCf.mock.calls[0]?.[1]).toMatchObject({
+      name: 'soften-generate-sheet-image',
+      promptVariables: { prompt: PARAMS.prompt },
+    });
+    expect(stepNames).toEqual([
+      'generate-sheet-image',
+      'generate-sheet-image-retry-1',
+      'generate-sheet-image-retry-2',
+      'generate-sheet-image-softened',
+    ]);
+  });
+
+  it('fails hard with the real rejection when the softened prompt is also flagged', async () => {
+    generateImageWithProvider.mockRejectedValue(contentError());
+    durableLLMCallCf.mockResolvedValue({ prompt: 'A boy wizard' });
+
+    await expect(run()).rejects.toThrow(NonRetryableError);
+    await expect(run()).rejects.toThrow(/softened prompt.*content checker/);
+  });
+
+  it('rethrows transient errors so Cloudflare retries the step, without softening', async () => {
+    generateImageWithProvider.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    await expect(run()).rejects.toThrow('ECONNRESET');
+    expect(durableLLMCallCf).not.toHaveBeenCalled();
+  });
+
+  it('uses `rebuild` so the softened prompt keeps its reference legend', async () => {
+    generateImageWithProvider
+      .mockRejectedValueOnce(contentError())
+      .mockRejectedValueOnce(contentError())
+      .mockRejectedValueOnce(contentError())
+      .mockImplementationOnce(async (p: ImageGenerationParams) =>
+        okResult(p.prompt)
+      );
+    durableLLMCallCf.mockResolvedValue({ prompt: 'softened' });
+
+    const out = await run({
+      prompt: 'authored',
+      rebuild: (p) => ({ ...PARAMS, prompt: `${p} | Image 1: HARRY` }),
+    });
+
+    expect(durableLLMCallCf.mock.calls[0]?.[1]).toMatchObject({
+      promptVariables: { prompt: 'authored' },
+    });
+    expect(out.params.prompt).toBe('softened | Image 1: HARRY');
+  });
+});

--- a/src/lib/workflows/content-soften.ts
+++ b/src/lib/workflows/content-soften.ts
@@ -1,0 +1,265 @@
+/**
+ * Content-rejection handling shared by every image render that is not a
+ * shot still (#1293): character / location / element sheets, library talent
+ * and location sheets, variant grids.
+ *
+ * Same-prompt reseeds first (#881) — stochastic checker hits often clear on a
+ * fresh seed. When they don't, rewrite the prompt with an LLM (policy soften
+ * and/or plainer grammar, #1272) and generate once more. One soften pass
+ * bounds the loop; a second content hit fails the run with the real
+ * rejection so the parent can name it. Transient errors throw so Cloudflare
+ * retries the named generate step.
+ *
+ * Shot stills use `generateImageWithContentRetry` (adds the Grok fallback and
+ * prompt-version persistence); both paths share `softenRejectedImagePrompt`.
+ */
+
+import { z } from 'zod';
+import {
+  CONTENT_REJECTION_RETRY_EVENT,
+  CONTENT_REJECTION_SOFTEN_EVENT,
+  isContentRejectionError,
+} from '@/lib/ai/content-rejection';
+import { extractFalErrorMessage } from '@/lib/ai/fal-error';
+import {
+  DEFAULT_ANALYSIS_MODEL,
+  type AnalysisModelId,
+} from '@/lib/ai/models.config';
+import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
+import {
+  generateImageWithProvider,
+  type ImageGenerationParams,
+  type ImageGenerationResult,
+} from '@/lib/image/image-generation';
+import { getLogger } from '@/lib/observability/logger';
+import { durableLLMCallCf } from '@/lib/workflows/llm-call-helper';
+import type { WorkflowStep } from 'cloudflare:workers';
+import { NonRetryableError } from 'cloudflare:workflows';
+
+const logger = getLogger(['openstory', 'workflow', 'content-soften']);
+
+/** Same-prompt reseeds before the prompt is rewritten (#881). */
+export const MAX_CONTENT_ATTEMPTS = 3;
+
+/** Plain `z.string()` — no min/max (Bedrock rejects integer bounds). */
+export const softenImagePromptResponseSchema = z.object({
+  prompt: z.string(),
+});
+
+export async function softenRejectedImagePrompt(
+  step: WorkflowStep,
+  args: {
+    scopedDb: WorkflowScopedDb;
+    workflowRunId: string;
+    sequenceId?: string;
+    userId: string;
+    prompt: string;
+    rejection: string;
+    analysisModelId: AnalysisModelId;
+    shotId?: string;
+    model: string;
+    /** Durable step name — must be unique per call within a run. */
+    name?: string;
+  }
+): Promise<string> {
+  const response = await durableLLMCallCf(
+    step,
+    {
+      name: args.name ?? 'soften-image-prompt',
+      phase: { number: 4, name: 'Softening image prompt…' },
+      promptName: 'phase/soften-image-prompt-chat',
+      promptVariables: {
+        prompt: args.prompt,
+        rejection: args.rejection,
+      },
+      modelId: args.analysisModelId,
+      responseSchema: softenImagePromptResponseSchema,
+      additionalMetadata: {
+        shotId: args.shotId,
+        model: args.model,
+      },
+    },
+    {
+      sequenceId: args.sequenceId,
+      userId: args.userId,
+      workflowRunId: args.workflowRunId,
+      scopedDb: args.scopedDb,
+    }
+  );
+
+  const softened = response.prompt.trim();
+  if (!softened) {
+    throw new Error('Softened prompt was empty');
+  }
+  if (softened === args.prompt.trim()) {
+    throw new Error('Softened prompt was unchanged');
+  }
+  return softened;
+}
+
+export type GenerateImageSofteningArgs = {
+  step: WorkflowStep;
+  scopedDb: WorkflowScopedDb;
+  workflowRunId: string;
+  userId: string;
+  sequenceId?: string;
+  analysisModelId?: AnalysisModelId;
+  /** Structured-log `kind`, e.g. `'character-sheet'`. */
+  kind: string;
+  /** Log prefix, e.g. `'[CharacterSheetWorkflow:cf]'`. */
+  logTag: string;
+  /** Log subject, e.g. `'character Ron Weasley'`. */
+  subject: string;
+  /**
+   * Durable step name of the first attempt — keep the caller's historical
+   * name so in-flight runs replay. Retries and the softened attempt suffix it.
+   */
+  stepName: string;
+  params: ImageGenerationParams;
+  /** Authored prompt to soften. Defaults to `params.prompt`. */
+  prompt?: string;
+  /** Params for the softened prompt. Defaults to swapping `params.prompt`. */
+  rebuild?: (prompt: string) => ImageGenerationParams;
+  /** Ids for structured logs. */
+  meta?: Record<string, unknown>;
+};
+
+export type GenerateImageSofteningResult = {
+  result: ImageGenerationResult;
+  /** Params actually rendered — softened when `softened` is true. */
+  params: ImageGenerationParams;
+  softened: boolean;
+};
+
+type Outcome =
+  | { ok: true; result: ImageGenerationResult }
+  | { ok: false; rejection: string };
+
+export async function generateImageSoftening(
+  args: GenerateImageSofteningArgs
+): Promise<GenerateImageSofteningResult> {
+  const { step, scopedDb, logTag, subject, stepName } = args;
+  const meta = { kind: args.kind, sequenceId: args.sequenceId, ...args.meta };
+  const maxAttempts = MAX_CONTENT_ATTEMPTS + 1;
+
+  const generateOnce = (
+    name: string,
+    params: ImageGenerationParams,
+    attempt: number
+  ) =>
+    step.do(name, async (): Promise<Outcome> => {
+      logger.info(
+        `${logTag} Generating ${subject} with model ${params.model} (attempt ${attempt}/${maxAttempts})`
+      );
+      try {
+        const result = await generateImageWithProvider(params, {
+          scopedDb: scopedDb.credentials,
+        });
+        return { ok: true, result };
+      } catch (error) {
+        if (isContentRejectionError(error)) {
+          return { ok: false, rejection: extractFalErrorMessage(error) };
+        }
+        throw error;
+      }
+    });
+
+  let lastRejection: string | null = null;
+  for (let attempt = 0; attempt < MAX_CONTENT_ATTEMPTS; attempt++) {
+    const tag = attempt === 0 ? '' : `-retry-${attempt}`;
+    const outcome = await generateOnce(
+      `${stepName}${tag}`,
+      args.params,
+      attempt + 1
+    );
+    if (outcome.ok) {
+      if (attempt > 0) {
+        logger.info(
+          `${logTag} content-flag retry rescued ${subject} on attempt ${attempt + 1}`,
+          {
+            event: CONTENT_REJECTION_RETRY_EVENT,
+            outcome: 'rescued',
+            model: args.params.model,
+            attempts: attempt + 1,
+            ...meta,
+          }
+        );
+      }
+      return { result: outcome.result, params: args.params, softened: false };
+    }
+    lastRejection = outcome.rejection;
+    logger.warn(
+      `${logTag} content-flag rejection on attempt ${attempt + 1}/${MAX_CONTENT_ATTEMPTS} for ${subject}: ${outcome.rejection}`
+    );
+  }
+
+  const rejection = lastRejection ?? 'unknown rejection';
+  logger.warn(
+    `${logTag} same-prompt reseeds exhausted; softening prompt for ${subject}`,
+    {
+      event: CONTENT_REJECTION_SOFTEN_EVENT,
+      model: args.params.model,
+      rejection,
+      ...meta,
+    }
+  );
+
+  const prompt = args.prompt ?? args.params.prompt;
+  let softened: string;
+  try {
+    softened = await softenRejectedImagePrompt(step, {
+      scopedDb,
+      workflowRunId: args.workflowRunId,
+      sequenceId: args.sequenceId,
+      userId: args.userId,
+      prompt,
+      rejection,
+      analysisModelId: args.analysisModelId ?? DEFAULT_ANALYSIS_MODEL,
+      model: args.params.model,
+      name: `soften-${stepName}`,
+    });
+  } catch (error) {
+    logger.warn(`${logTag} failed to soften prompt for ${subject}`, {
+      err: error,
+      rejection,
+    });
+    throw new NonRetryableError(
+      `Image rejected by content filter after ${MAX_CONTENT_ATTEMPTS} attempts: ${rejection}`,
+      'ContentRejectionExhausted'
+    );
+  }
+
+  const params = args.rebuild
+    ? args.rebuild(softened)
+    : { ...args.params, prompt: softened };
+  const outcome = await generateOnce(
+    `${stepName}-softened`,
+    params,
+    maxAttempts
+  );
+  if (outcome.ok) {
+    logger.info(`${logTag} softened prompt rescued ${subject}`, {
+      event: CONTENT_REJECTION_SOFTEN_EVENT,
+      outcome: 'rescued',
+      model: params.model,
+      ...meta,
+    });
+    return { result: outcome.result, params, softened: true };
+  }
+
+  logger.error(
+    `${logTag} content-flag retry exhausted for ${subject} after soften`,
+    {
+      event: CONTENT_REJECTION_RETRY_EVENT,
+      outcome: 'exhausted',
+      model: params.model,
+      attempts: maxAttempts,
+      rejection: outcome.rejection,
+      ...meta,
+    }
+  );
+  throw new NonRetryableError(
+    `Image rejected by content filter after ${MAX_CONTENT_ATTEMPTS} attempts and a softened prompt: ${outcome.rejection}`,
+    'ContentRejectionExhausted'
+  );
+}

--- a/src/lib/workflows/element-sheet-workflow.ts
+++ b/src/lib/workflows/element-sheet-workflow.ts
@@ -31,16 +31,15 @@ import {
 import { generateId } from '@/lib/db/id';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import type { SequenceElement, SequenceElementMinimal } from '@/lib/db/schema';
-import {
-  generateImageWithProvider,
-  type ImageGenerationParams,
-} from '@/lib/image/image-generation';
+import type { ImageGenerationParams } from '@/lib/image/image-generation';
 import { recordProvenance } from '@/lib/compliance/provenance';
 import { buildElementSheetPrompt } from '@/lib/prompts/element-prompt';
 import { rejectionReasonMessage } from '@/lib/workflows/replace-element-workflow';
 import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
 import { uploadResponse } from '@/lib/storage/upload-response';
+import { contentRejectionSummary } from '@/lib/ai/content-rejection';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { generateImageSoftening } from '@/lib/workflows/content-soften';
 import type {
   ElementSheetWorkflowInput,
   ElementSheetWorkflowResult,
@@ -94,20 +93,22 @@ export function collectElementResults(
   settled: Array<PromiseSettledResult<SequenceElementMinimal>>,
   entries: Array<Pick<ElementBibleEntry, 'token'>>
 ): SequenceElementMinimal[] {
-  const failures: string[] = [];
+  const failures: { name: string; reason: string }[] = [];
   const elements: SequenceElementMinimal[] = [];
   for (const [index, outcome] of settled.entries()) {
     if (outcome.status === 'rejected') {
-      failures.push(
-        `${entries[index]?.token ?? `index ${index}`}: ${rejectionReasonMessage(outcome.reason)}`
-      );
+      failures.push({
+        name: entries[index]?.token ?? `index ${index}`,
+        reason: rejectionReasonMessage(outcome.reason),
+      });
       continue;
     }
     elements.push(outcome.value);
   }
   if (failures.length > 0) {
     throw new Error(
-      `Element reference generation failed for ${failures.length}/${settled.length} element(s) — ${failures.join('; ')}`
+      contentRejectionSummary(failures) ??
+        `Element reference generation failed for ${failures.length}/${settled.length} element(s) — ${failures.map((f) => `${f.name}: ${f.reason}`).join('; ')}`
     );
   }
   return elements;
@@ -171,7 +172,7 @@ export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementShe
           return existing;
         }
 
-        const generationParams: ImageGenerationParams = {
+        const builtParams: ImageGenerationParams = {
           model: imageModel,
           prompt: buildElementSheetPrompt(entry, styleConfig),
           // Square reference: the object fills the shot regardless of the
@@ -180,14 +181,22 @@ export class ElementSheetWorkflow extends OpenStoryWorkflowEntrypoint<ElementShe
           numImages: 1,
         };
 
-        const imageResult = await step.do(
-          `generate-element-image-${index}`,
-          async () => {
-            return await generateImageWithProvider(generationParams, {
-              scopedDb: scopedDb.credentials,
-            });
-          }
-        );
+        // Reseeds on a content flag, then one softened prompt (#1293).
+        const generation = await generateImageSoftening({
+          step,
+          scopedDb,
+          workflowRunId: event.instanceId,
+          userId: input.userId,
+          sequenceId,
+          kind: 'element-sheet',
+          logTag: '[ElementSheetWorkflow:cf]',
+          subject: `element ${entry.token}`,
+          stepName: `generate-element-image-${index}`,
+          params: builtParams,
+          meta: { elementId: entry.elementId },
+        });
+        const imageResult = generation.result;
+        const generationParams = generation.params;
 
         // Before the deduction guard — see recordFalUsageStep (#1069).
         const falUsage = await recordFalUsageStep(

--- a/src/lib/workflows/library-location-sheet-workflow.ts
+++ b/src/lib/workflows/library-location-sheet-workflow.ts
@@ -19,10 +19,7 @@ import {
 } from '@/lib/billing/workflow-deduction';
 import { generateId } from '@/lib/db/id';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
-import {
-  generateImageWithProvider,
-  type ImageGenerationParams,
-} from '@/lib/image/image-generation';
+import type { ImageGenerationParams } from '@/lib/image/image-generation';
 import {
   buildLibraryLocationSheetPrompt,
   buildLocationPreviewPrompt,
@@ -32,6 +29,7 @@ import { getLocationChannel } from '@/lib/realtime';
 import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
 import { uploadResponse } from '@/lib/storage/upload-response';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { generateImageSoftening } from '@/lib/workflows/content-soften';
 import type {
   LibraryLocationSheetWorkflowInput,
   LibraryLocationSheetWorkflowResult,
@@ -93,16 +91,21 @@ export class LibraryLocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<Li
       }
     );
 
-    // Step 2: Generate the location sheet image
-    const imageResult = await step.do('generate-sheet-image', async () => {
-      logger.info(
-        `[LibraryLocationSheetWorkflow:cf] Generating 3x3 grid sheet for ${input.locationName} with model ${generationParams.model}`
-      );
-
-      return generateImageWithProvider(generationParams, {
-        scopedDb: scopedDb.credentials,
-      });
+    // Step 2: Generate the location sheet image — reseeds on a content flag,
+    // then one softened prompt (#1293).
+    const sheetGeneration = await generateImageSoftening({
+      step,
+      scopedDb,
+      workflowRunId: event.instanceId,
+      userId: input.userId,
+      kind: 'library-location-sheet',
+      logTag: '[LibraryLocationSheetWorkflow:cf]',
+      subject: `3x3 grid sheet for ${input.locationName}`,
+      stepName: 'generate-sheet-image',
+      params: generationParams,
+      meta: { locationDbId: input.locationDbId },
     });
+    const imageResult = sheetGeneration.result;
 
     // Before the deduction guard — see recordFalUsageStep (#1069).
     const sheetUsage = await recordFalUsageStep(
@@ -174,33 +177,34 @@ export class LibraryLocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<Li
 
     // Step 4: Generate preview establishing shot for card thumbnail
     const hasReferenceImages = input.referenceImageUrls.length > 0;
-    const previewResult = await step.do('generate-preview-image', async () => {
-      const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
-      const prompt = buildLocationPreviewPrompt(
+    const previewParams: ImageGenerationParams = {
+      model: input.imageModel ?? DEFAULT_IMAGE_MODEL,
+      prompt: buildLocationPreviewPrompt(
         input.locationName,
         input.locationDescription,
         hasReferenceImages
-      );
+      ),
+      imageSize: 'landscape_16_9',
+      numImages: 1,
+    } satisfies ImageGenerationParams;
 
-      logger.info(
-        `[LibraryLocationSheetWorkflow:cf] Generating preview establishing shot for ${input.locationName}`
-      );
+    if (hasReferenceImages) {
+      previewParams.referenceImageUrls = input.referenceImageUrls;
+    }
 
-      const previewParams: ImageGenerationParams = {
-        model,
-        prompt,
-        imageSize: 'landscape_16_9',
-        numImages: 1,
-      } satisfies ImageGenerationParams;
-
-      if (hasReferenceImages) {
-        previewParams.referenceImageUrls = input.referenceImageUrls;
-      }
-
-      return generateImageWithProvider(previewParams, {
-        scopedDb: scopedDb.credentials,
-      });
+    const previewGeneration = await generateImageSoftening({
+      step,
+      scopedDb,
+      workflowRunId: event.instanceId,
+      userId: input.userId,
+      kind: 'library-location-preview',
+      logTag: '[LibraryLocationSheetWorkflow:cf]',
+      subject: `preview establishing shot for ${input.locationName}`,
+      stepName: 'generate-preview-image',
+      params: previewParams,
+      meta: { locationDbId: input.locationDbId },
     });
+    const previewResult = previewGeneration.result;
 
     // Before the deduction guard — see recordFalUsageStep (#1069).
     const previewUsage = await recordFalUsageStep(

--- a/src/lib/workflows/library-talent-sheet-workflow.ts
+++ b/src/lib/workflows/library-talent-sheet-workflow.ts
@@ -23,10 +23,7 @@ import {
 } from '@/lib/billing/workflow-deduction';
 import { generateId } from '@/lib/db/id';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
-import {
-  generateImageWithProvider,
-  type ImageGenerationParams,
-} from '@/lib/image/image-generation';
+import type { ImageGenerationParams } from '@/lib/image/image-generation';
 import { buildLibraryTalentSheetPrompt } from '@/lib/prompts/character-prompt';
 import { cropTalentSheetPortrait } from '@/lib/talent/crop-sheet-portrait';
 import { recordProvenance } from '@/lib/compliance/provenance';
@@ -35,6 +32,7 @@ import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
 import { copyStoredImage } from '@/lib/storage/copy-stored-image';
 import { uploadResponse } from '@/lib/storage/upload-response';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { generateImageSoftening } from '@/lib/workflows/content-soften';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
   LibraryTalentSheetWorkflowInput,
@@ -123,37 +121,40 @@ export class LibraryTalentSheetWorkflow extends OpenStoryWorkflowEntrypoint<Libr
       });
     } else {
       // Step 2: Generate the talent sheet image with references
-      const imageResult = await step.do('generate-sheet-image', async () => {
-        const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
-        const hasReferenceImages =
-          input.referenceImageUrls && input.referenceImageUrls.length > 0;
-        const prompt = buildLibraryTalentSheetPrompt(
+      const model = input.imageModel ?? DEFAULT_IMAGE_MODEL;
+      const hasReferenceImages =
+        input.referenceImageUrls && input.referenceImageUrls.length > 0;
+      const generationParams: ImageGenerationParams = {
+        model,
+        prompt: buildLibraryTalentSheetPrompt(
           input.talentName,
           input.talentDescription,
           hasReferenceImages
-        );
+        ),
+        imageSize: 'landscape_16_9',
+        numImages: 1,
+        resolution: '2K',
+      } satisfies ImageGenerationParams;
 
-        logger.info(
-          `[LibraryTalentSheetWorkflow:cf] Generating sheet with model ${model}${hasReferenceImages ? ' (with reference images)' : ' (text-to-image only)'}`
-        );
+      // Only include referenceImageUrls if provided
+      if (hasReferenceImages) {
+        generationParams.referenceImageUrls = input.referenceImageUrls;
+      }
 
-        const generationParams: ImageGenerationParams = {
-          model,
-          prompt,
-          imageSize: 'landscape_16_9',
-          numImages: 1,
-          resolution: '2K',
-        } satisfies ImageGenerationParams;
-
-        // Only include referenceImageUrls if provided
-        if (hasReferenceImages) {
-          generationParams.referenceImageUrls = input.referenceImageUrls;
-        }
-
-        return await generateImageWithProvider(generationParams, {
-          scopedDb: scopedDb.credentials,
-        });
+      // Reseeds on a content flag, then one softened prompt (#1293).
+      const generation = await generateImageSoftening({
+        step,
+        scopedDb,
+        workflowRunId: event.instanceId,
+        userId: input.userId,
+        kind: 'talent-sheet',
+        logTag: '[LibraryTalentSheetWorkflow:cf]',
+        subject: `sheet${hasReferenceImages ? ' (with reference images)' : ' (text-to-image only)'}`,
+        stepName: 'generate-sheet-image',
+        params: generationParams,
+        meta: { talentId: input.talentId },
       });
+      const imageResult = generation.result;
 
       // Before the deduction guard — see recordFalUsageStep (#1069).
       sheetUsage = await recordFalUsageStep(

--- a/src/lib/workflows/location-sheet-workflow.ts
+++ b/src/lib/workflows/location-sheet-workflow.ts
@@ -22,16 +22,14 @@ import {
 } from '@/lib/billing/workflow-deduction';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import { generateId } from '@/lib/db/id';
-import {
-  generateImageWithProvider,
-  type ImageGenerationParams,
-} from '@/lib/image/image-generation';
+import type { ImageGenerationParams } from '@/lib/image/image-generation';
 import { buildLocationSheetPrompt } from '@/lib/prompts/location-prompt';
 import { recordProvenance } from '@/lib/compliance/provenance';
 import { getGenerationChannel } from '@/lib/realtime';
 import { STORAGE_BUCKETS } from '@/lib/storage/buckets';
 import { uploadResponse } from '@/lib/storage/upload-response';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { generateImageSoftening } from '@/lib/workflows/content-soften';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
   LocationSheetWorkflowInput,
@@ -85,7 +83,7 @@ export class LocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<LocationS
     });
 
     // Step 1: Validate and build prompt
-    const generationParams: ImageGenerationParams = await step.do(
+    const builtParams: ImageGenerationParams = await step.do(
       'build-prompt',
       async () => {
         // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- runtime guard
@@ -129,16 +127,23 @@ export class LocationSheetWorkflow extends OpenStoryWorkflowEntrypoint<LocationS
       }
     );
 
-    // Step 2: Generate the location reference image
-    const imageResult = await step.do('generate-reference-image', async () => {
-      logger.info(
-        `[LocationSheetWorkflow:cf] Generating reference for ${input.locationName} with model ${generationParams.model}`
-      );
-
-      return await generateImageWithProvider(generationParams, {
-        scopedDb: scopedDb.credentials,
-      });
+    // Step 2: Generate the location reference image — reseeds on a content
+    // flag, then one softened prompt (#1293).
+    const generation = await generateImageSoftening({
+      step,
+      scopedDb,
+      workflowRunId: event.instanceId,
+      userId: input.userId,
+      sequenceId: input.sequenceId,
+      kind: 'location-sheet',
+      logTag: '[LocationSheetWorkflow:cf]',
+      subject: `reference for ${input.locationName}`,
+      stepName: 'generate-reference-image',
+      params: builtParams,
+      meta: { locationDbId: input.locationDbId },
     });
+    const imageResult = generation.result;
+    const generationParams = generation.params;
 
     // Before the deduction guard — see recordFalUsageStep (#1069).
     const falUsage = await recordFalUsageStep(

--- a/src/lib/workflows/shot-variant-workflow.ts
+++ b/src/lib/workflows/shot-variant-workflow.ts
@@ -19,10 +19,7 @@ import {
   getVariantGridConfig,
 } from '@/lib/constants/aspect-ratios';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
-import {
-  generateImageWithProvider,
-  type ImageGenerationParams,
-} from '@/lib/image/image-generation';
+import type { ImageGenerationParams } from '@/lib/image/image-generation';
 import { recordProvenance } from '@/lib/compliance/provenance';
 import { uploadImageToStorage } from '@/lib/image/image-storage';
 import { r2KeyFromUrl } from '@/lib/storage/buckets';
@@ -33,6 +30,7 @@ import {
 import { getVariantImagePrompt } from '@/lib/prompts/variant-image';
 import { getGenerationChannel } from '@/lib/realtime';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
+import { generateImageSoftening } from '@/lib/workflows/content-soften';
 import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type {
   ShotVariantWorkflowInput,
@@ -43,7 +41,13 @@ import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'shot-variant']);
 
-type PrepResult = { params: ImageGenerationParams; versionId: string };
+type PrepResult = {
+  params: ImageGenerationParams;
+  versionId: string;
+  /** Authored grid prompt (pre-legend) — what a content soften rewrites. */
+  basePrompt: string;
+  references: ReferenceImageDescription[];
+};
 
 export class ShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<ShotVariantWorkflowInput> {
   protected override async runImpl(
@@ -115,7 +119,12 @@ export class ShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<ShotVariant
         // half of this guard already covers; resolving the anchor here instead
         // would re-read a pointer the spawn never saw.
         if (!input.shotId || !input.sequenceId || !input.frameId) {
-          return { params, versionId: '' };
+          return {
+            params,
+            versionId: '',
+            basePrompt,
+            references: allReferences,
+          };
         }
         // The trigger's frame (frame id ≠ shot id), checked for existence only.
         const frame = await scopedDb.liveRead.frames.getById(input.frameId);
@@ -144,7 +153,12 @@ export class ShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<ShotVariant
           { shotId: input.shotId, status: 'generating' }
         );
 
-        return { params, versionId: version.id };
+        return {
+          params,
+          versionId: version.id,
+          basePrompt,
+          references: allReferences,
+        };
       }
     );
 
@@ -152,14 +166,35 @@ export class ShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<ShotVariant
       return { variantImageUrl: '' };
     }
 
-    const imageResult = await step.do('generate-image', async () => {
-      logger.info(
-        `[ShotVariantWorkflow] Generating variant grid ${input.shotId} with model ${prep.params.model}`
-      );
-      return generateImageWithProvider(prep.params, {
-        scopedDb: scopedDb.credentials,
-      });
+    // Reseeds on a content flag, then one softened prompt rebuilt with the
+    // same reference legend (#1293).
+    const generation = await generateImageSoftening({
+      step,
+      scopedDb,
+      workflowRunId,
+      userId: input.userId,
+      sequenceId: input.sequenceId,
+      kind: 'variant-grid',
+      logTag: '[ShotVariantWorkflow]',
+      subject: `variant grid ${input.shotId}`,
+      stepName: 'generate-image',
+      params: prep.params,
+      prompt: prep.basePrompt,
+      rebuild: (softened) => {
+        const rebuilt = buildReferenceImagePrompt(
+          softened,
+          prep.references,
+          IMAGE_MODELS[prep.params.model].maxPromptLength
+        );
+        return {
+          ...prep.params,
+          prompt: rebuilt.prompt,
+          referenceImageUrls: rebuilt.referenceUrls,
+        };
+      },
+      meta: { shotId: input.shotId },
     });
+    const imageResult = generation.result;
 
     // Before the deduction guard — see recordFalUsageStep (#1069). Native
     // xAI images have no fal units; sampling them would corrupt fal medians.

--- a/src/lib/workflows/soften-image-prompt.ts
+++ b/src/lib/workflows/soften-image-prompt.ts
@@ -10,7 +10,6 @@
  * on Grok Imagine 2 skips the swap and softens in place.
  */
 
-import { z } from 'zod';
 import {
   CONTENT_REJECTION_FALLBACK_EVENT,
   CONTENT_REJECTION_RETRY_EVENT,
@@ -34,7 +33,7 @@ import { getLogger } from '@/lib/observability/logger';
 import { buildReferenceImagePrompt } from '@/lib/prompts/reference-image-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import type { ImageWorkflowInput } from '@/lib/workflow/types';
-import { durableLLMCallCf } from '@/lib/workflows/llm-call-helper';
+import { softenRejectedImagePrompt } from '@/lib/workflows/content-soften';
 import { computeShotImageSceneHash } from '@/lib/workflows/sheet-snapshots';
 import type { WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
@@ -49,11 +48,6 @@ const MAX_IMAGE_ATTEMPTS = 3;
 
 /** Fallback after selected-model reseeds exhaust. Skip when already this. */
 const IMAGE_CONTENT_FALLBACK_MODEL: TextToImageModel = 'grok_imagine_image';
-
-/** Plain `z.string()` — no min/max (Bedrock rejects integer bounds). */
-export const softenImagePromptResponseSchema = z.object({
-  prompt: z.string(),
-});
 
 export type GenerateImageWithContentRetryResult = {
   result: ImageGenerationResult;
@@ -106,55 +100,6 @@ function rebuildParams(
     prompt: enhancedPrompt,
     referenceImageUrls: referenceUrls.length > 0 ? referenceUrls : undefined,
   };
-}
-
-async function softenRejectedImagePrompt(
-  step: WorkflowStep,
-  args: {
-    scopedDb: WorkflowScopedDb;
-    workflowRunId: string;
-    sequenceId?: string;
-    userId: string;
-    prompt: string;
-    rejection: string;
-    analysisModelId: AnalysisModelId;
-    shotId?: string;
-    model: string;
-  }
-): Promise<string> {
-  const response = await durableLLMCallCf(
-    step,
-    {
-      name: 'soften-image-prompt',
-      phase: { number: 4, name: 'Softening image prompt…' },
-      promptName: 'phase/soften-image-prompt-chat',
-      promptVariables: {
-        prompt: args.prompt,
-        rejection: args.rejection,
-      },
-      modelId: args.analysisModelId,
-      responseSchema: softenImagePromptResponseSchema,
-      additionalMetadata: {
-        shotId: args.shotId,
-        model: args.model,
-      },
-    },
-    {
-      sequenceId: args.sequenceId,
-      userId: args.userId,
-      workflowRunId: args.workflowRunId,
-      scopedDb: args.scopedDb,
-    }
-  );
-
-  const softened = response.prompt.trim();
-  if (!softened) {
-    throw new Error('Softened prompt was empty');
-  }
-  if (softened === args.prompt.trim()) {
-    throw new Error('Softened prompt was unchanged');
-  }
-  return softened;
 }
 
 type PromptProvenance = {


### PR DESCRIPTION
## Related Issue

Closes #1293

## Summary of Changes

**Banner (the screenshot)** — `analyzeFailures` hard-coded `tone: 'error'` on every full-retry path, so a sequence whose `statusError` was a content rejection rendered the red destructive `Alert`. Full-retry paths now derive the tone from `statusError`; warning tone wins the title ("Content checker"), and the headline names who was blocked: *"Ron Weasley, Hermione Granger and Harry Potter didn't pass the content checker — regenerate to retry"*.

**Why that sequence needed a full retry** — three Harry Potter character sheets were rejected by the content checker 3/3 times on `gpt_image_2` (named franchise characters, deterministic), the character bible stops the sequence rather than render unanchored (#939), so it failed before any shots existed. Same-prompt reseeds can't fix a deterministic block and the #1272 soften pass only existed for stills.

**Soften pass on every image path** — new `src/lib/workflows/content-soften.ts`: `generateImageSoftening` = same-prompt reseeds (3) → LLM rewrite (`phase/soften-image-prompt-chat`) → one more render; a second content hit throws `NonRetryableError` with the real rejection. Wired into character sheets, location sheets, element sheets, library talent sheets, library location sheets (grid + preview), and variant grids (rebuilt with the reference legend). Stills keep `generateImageWithContentRetry` (Grok fallback + prompt-version persistence) and now share `softenRejectedImagePrompt`. First-attempt step names are unchanged so in-flight runs replay; retries/softened attempts suffix them.

**Soften prompt** — POLICY rule now tells the rewriter that a real-person or franchise/trademarked character name trips the checker on its own and to describe the look generically; the CAPS-token rule clarifies that a mixed-case `Name:` line in a sheet prompt may be rewritten.

**Blocked names survive to the banner** — `contentRejectionSummary` collapses bible-level (character bible, element sheets) content-only failures to `Blocked by the content checker: A, B`; parents only prefix, `contentRejectionSubjects` reads the tail back in the UI.

Not covered: the storyboard poster (already swallowed, non-critical) and upscale (fixed prompt, no user content).

## Risk Assessment

- [x] Medium
- [ ] Low
- [ ] High

Extra spend only after 3 content-flagged attempts: one LLM rewrite + one image render per sheet/grid. Sheet provenance records the softened prompt (no prompt-version table for sheets). Retry semantics for transient errors unchanged.

## Additional Notes

Tests: `content-soften.test.ts` (reseed→soften→rescue, exhaustion, transient passthrough, `rebuild`), `content-rejection.test.ts` (summary/subjects incl. truncation ellipsis), `failure-analysis.test.ts` (warning tone + named headline). Full suite: 2810 passing.