### PR TITLE
feat(#1293): Grok fallback before softening for sheets and variant grids

### DIFF
--- a/src/lib/workflows/content-soften.test.ts
+++ b/src/lib/workflows/content-soften.test.ts
@@ -1,5 +1,6 @@
 /**
- * Shared content-rejection reseeds + one softened prompt retry (#1293).
+ * Shared content-rejection reseeds → Grok fallback → one softened prompt
+ * retry (#1293).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
@@ -7,7 +8,8 @@ import type { ImageGenerationParams } from '@/lib/image/build-image-request';
 import type { ImageGenerationResult } from '@/lib/image/image-generation';
 import type { WorkflowStep } from 'cloudflare:workers';
 
-const generateImageWithProvider = vi.fn();
+const generateImageWithProvider =
+  vi.fn<(p: ImageGenerationParams) => Promise<ImageGenerationResult>>();
 vi.doMock('@/lib/image/image-generation', async () => {
   const real = await vi.importActual<
     typeof import('@/lib/image/image-generation')
@@ -18,8 +20,11 @@ vi.doMock('@/lib/image/image-generation', async () => {
 const durableLLMCallCf = vi.fn();
 vi.doMock('@/lib/workflows/llm-call-helper', () => ({ durableLLMCallCf }));
 
-const { generateImageSoftening, MAX_CONTENT_ATTEMPTS } =
-  await import('./content-soften');
+const {
+  generateImageSoftening,
+  IMAGE_CONTENT_FALLBACK_MODEL,
+  MAX_CONTENT_ATTEMPTS,
+} = await import('./content-soften');
 const { NonRetryableError } = await import('cloudflare:workflows');
 
 const stepNames: string[] = [];
@@ -41,16 +46,16 @@ const PARAMS: ImageGenerationParams = {
   numImages: 1,
 };
 
-function okResult(prompt: string): ImageGenerationResult {
+function okResult(p: ImageGenerationParams): ImageGenerationResult {
   return {
     imageUrls: ['https://cdn/img.jpg'],
-    parameters: { ...PARAMS, prompt },
+    parameters: p,
     generatedAt: '2026-08-25T00:00:00.000Z',
     processingTimeMs: 12,
     via: 'fal',
     metadata: {
-      prompt,
-      model: PARAMS.model,
+      prompt: p.prompt,
+      model: p.model,
       endpointId: 'fal-ai/nano-banana-2',
       dimensions: [],
       file_sizes: [],
@@ -60,6 +65,20 @@ function okResult(prompt: string): ImageGenerationResult {
 }
 
 const contentError = () => new Error('material flagged by a content checker.');
+
+/** Reject `n` renders, then succeed with whatever params arrive. */
+function rejectThenOk(n: number) {
+  for (let i = 0; i < n; i++) {
+    generateImageWithProvider.mockRejectedValueOnce(contentError());
+  }
+  generateImageWithProvider.mockImplementationOnce(
+    async (p: ImageGenerationParams) => okResult(p)
+  );
+}
+
+/** Model each render was asked for, in order. */
+const modelsTried = () =>
+  generateImageWithProvider.mock.calls.map((c) => c[0].model);
 
 function run(
   overrides: Partial<Parameters<typeof generateImageSoftening>[0]> = {}
@@ -86,14 +105,33 @@ beforeEach(() => {
 });
 
 describe('generateImageSoftening', () => {
-  it('reseeds, then softens once and renders the rewritten prompt', async () => {
-    generateImageWithProvider
-      .mockRejectedValueOnce(contentError())
-      .mockRejectedValueOnce(contentError())
-      .mockRejectedValueOnce(contentError())
-      .mockImplementationOnce(async (p: ImageGenerationParams) =>
-        okResult(p.prompt)
-      );
+  it('reseeds, then renders the ORIGINAL prompt on Grok before softening', async () => {
+    rejectThenOk(MAX_CONTENT_ATTEMPTS);
+
+    const out = await run();
+
+    expect(modelsTried()).toEqual([
+      'nano_banana_2',
+      'nano_banana_2',
+      'nano_banana_2',
+      IMAGE_CONTENT_FALLBACK_MODEL,
+    ]);
+    expect(out.softened).toBe(false);
+    expect(out.params).toMatchObject({
+      model: IMAGE_CONTENT_FALLBACK_MODEL,
+      prompt: PARAMS.prompt,
+    });
+    expect(durableLLMCallCf).not.toHaveBeenCalled();
+    expect(stepNames).toEqual([
+      'generate-sheet-image',
+      'generate-sheet-image-retry-1',
+      'generate-sheet-image-retry-2',
+      'generate-sheet-image-fallback',
+    ]);
+  });
+
+  it('softens once on Grok when the fallback also flags', async () => {
+    rejectThenOk(MAX_CONTENT_ATTEMPTS + 1);
     durableLLMCallCf.mockResolvedValue({
       prompt: 'Name: a boy wizard\nA boy wizard in school robes',
     });
@@ -101,23 +139,34 @@ describe('generateImageSoftening', () => {
     const out = await run();
 
     expect(generateImageWithProvider).toHaveBeenCalledTimes(
-      MAX_CONTENT_ATTEMPTS + 1
+      MAX_CONTENT_ATTEMPTS + 2
     );
     expect(out.softened).toBe(true);
-    expect(out.params.prompt).toBe(
-      'Name: a boy wizard\nA boy wizard in school robes'
-    );
+    expect(out.params).toMatchObject({
+      model: IMAGE_CONTENT_FALLBACK_MODEL,
+      prompt: 'Name: a boy wizard\nA boy wizard in school robes',
+    });
     expect(durableLLMCallCf).toHaveBeenCalledTimes(1);
     expect(durableLLMCallCf.mock.calls[0]?.[1]).toMatchObject({
       name: 'soften-generate-sheet-image',
       promptVariables: { prompt: PARAMS.prompt },
     });
-    expect(stepNames).toEqual([
-      'generate-sheet-image',
-      'generate-sheet-image-retry-1',
-      'generate-sheet-image-retry-2',
-      'generate-sheet-image-softened',
-    ]);
+    expect(stepNames.at(-1)).toBe('generate-sheet-image-softened');
+  });
+
+  it('skips the swap and softens in place when already on Grok', async () => {
+    rejectThenOk(MAX_CONTENT_ATTEMPTS);
+    durableLLMCallCf.mockResolvedValue({ prompt: 'A boy wizard' });
+
+    const out = await run({
+      params: { ...PARAMS, model: IMAGE_CONTENT_FALLBACK_MODEL },
+    });
+
+    expect(modelsTried()).toEqual(
+      Array<string>(MAX_CONTENT_ATTEMPTS + 1).fill(IMAGE_CONTENT_FALLBACK_MODEL)
+    );
+    expect(out.softened).toBe(true);
+    expect(stepNames).not.toContain('generate-sheet-image-fallback');
   });
 
   it('fails hard with the real rejection when the softened prompt is also flagged', async () => {
@@ -128,28 +177,31 @@ describe('generateImageSoftening', () => {
     await expect(run()).rejects.toThrow(/softened prompt.*content checker/);
   });
 
-  it('rethrows transient errors so Cloudflare retries the step, without softening', async () => {
+  it('rethrows transient errors so Cloudflare retries the step, without swapping or softening', async () => {
     generateImageWithProvider.mockRejectedValueOnce(new Error('ECONNRESET'));
 
     await expect(run()).rejects.toThrow('ECONNRESET');
+    expect(generateImageWithProvider).toHaveBeenCalledTimes(1);
     expect(durableLLMCallCf).not.toHaveBeenCalled();
   });
 
-  it('uses `rebuild` so the softened prompt keeps its reference legend', async () => {
-    generateImageWithProvider
-      .mockRejectedValueOnce(contentError())
-      .mockRejectedValueOnce(contentError())
-      .mockRejectedValueOnce(contentError())
-      .mockImplementationOnce(async (p: ImageGenerationParams) =>
-        okResult(p.prompt)
-      );
+  it('uses `rebuild` for both the swap and the softened prompt so the reference legend is re-sized per model', async () => {
+    rejectThenOk(MAX_CONTENT_ATTEMPTS + 1);
     durableLLMCallCf.mockResolvedValue({ prompt: 'softened' });
+    const rebuild = vi.fn(
+      (p: string, model: ImageGenerationParams['model']) => ({
+        ...PARAMS,
+        model,
+        prompt: `${p} | Image 1: HARRY`,
+      })
+    );
 
-    const out = await run({
-      prompt: 'authored',
-      rebuild: (p) => ({ ...PARAMS, prompt: `${p} | Image 1: HARRY` }),
-    });
+    const out = await run({ prompt: 'authored', rebuild });
 
+    expect(rebuild.mock.calls).toEqual([
+      ['authored', IMAGE_CONTENT_FALLBACK_MODEL],
+      ['softened', IMAGE_CONTENT_FALLBACK_MODEL],
+    ]);
     expect(durableLLMCallCf.mock.calls[0]?.[1]).toMatchObject({
       promptVariables: { prompt: 'authored' },
     });

--- a/src/lib/workflows/content-soften.ts
+++ b/src/lib/workflows/content-soften.ts
@@ -4,23 +4,28 @@
  * and location sheets, variant grids.
  *
  * Same-prompt reseeds first (#881) — stochastic checker hits often clear on a
- * fresh seed. When they don't, rewrite the prompt with an LLM (policy soften
- * and/or plainer grammar, #1272) and generate once more. One soften pass
- * bounds the loop; a second content hit fails the run with the real
- * rejection so the parent can name it. Transient errors throw so Cloudflare
- * retries the named generate step.
+ * fresh seed. When they don't, render the ORIGINAL prompt once on Grok
+ * Imagine 2 (its checker is more permissive, #1272; skipped when already on
+ * it). If that also flags, rewrite the prompt with an LLM (policy soften
+ * and/or plainer grammar) and generate once more on whichever model is
+ * current. One soften pass bounds the loop; a second content hit fails the
+ * run with the real rejection so the parent can name it. Transient errors
+ * throw so Cloudflare retries the named generate step.
  *
- * Shot stills use `generateImageWithContentRetry` (adds the Grok fallback and
- * prompt-version persistence); both paths share `softenRejectedImagePrompt`.
+ * Shot stills use `generateImageWithContentRetry` (same ladder, plus the
+ * `frame_variants` row for the swap and prompt-version persistence); both
+ * paths share `softenRejectedImagePrompt` and the fallback model.
  */
 
 import { z } from 'zod';
 import {
+  CONTENT_REJECTION_FALLBACK_EVENT,
   CONTENT_REJECTION_RETRY_EVENT,
   CONTENT_REJECTION_SOFTEN_EVENT,
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
+import type { TextToImageModel } from '@/lib/ai/models';
 import {
   DEFAULT_ANALYSIS_MODEL,
   type AnalysisModelId,
@@ -38,8 +43,12 @@ import { NonRetryableError } from 'cloudflare:workflows';
 
 const logger = getLogger(['openstory', 'workflow', 'content-soften']);
 
-/** Same-prompt reseeds before the prompt is rewritten (#881). */
+/** Same-prompt reseeds before the model swap / prompt rewrite (#881). */
 export const MAX_CONTENT_ATTEMPTS = 3;
+
+/** Fallback after selected-model reseeds exhaust. Skipped when already this. */
+export const IMAGE_CONTENT_FALLBACK_MODEL: TextToImageModel =
+  'grok_imagine_image';
 
 /** Plain `z.string()` — no min/max (Bedrock rejects integer bounds). */
 export const softenImagePromptResponseSchema = z.object({
@@ -112,21 +121,26 @@ export type GenerateImageSofteningArgs = {
   subject: string;
   /**
    * Durable step name of the first attempt — keep the caller's historical
-   * name so in-flight runs replay. Retries and the softened attempt suffix it.
+   * name so in-flight runs replay. Retries, the fallback and the softened
+   * attempt suffix it.
    */
   stepName: string;
   params: ImageGenerationParams;
   /** Authored prompt to soften. Defaults to `params.prompt`. */
   prompt?: string;
-  /** Params for the softened prompt. Defaults to swapping `params.prompt`. */
-  rebuild?: (prompt: string) => ImageGenerationParams;
+  /**
+   * Params for a (prompt, model) pair — called for the fallback swap (original
+   * prompt, Grok) and the softened retry. Defaults to swapping both fields on
+   * `params`; pass one when the prompt carries a model-sized reference legend.
+   */
+  rebuild?: (prompt: string, model: TextToImageModel) => ImageGenerationParams;
   /** Ids for structured logs. */
   meta?: Record<string, unknown>;
 };
 
 export type GenerateImageSofteningResult = {
   result: ImageGenerationResult;
-  /** Params actually rendered — softened when `softened` is true. */
+  /** Params actually rendered — a different model and/or prompt on rescue. */
   params: ImageGenerationParams;
   softened: boolean;
 };
@@ -140,7 +154,16 @@ export async function generateImageSoftening(
 ): Promise<GenerateImageSofteningResult> {
   const { step, scopedDb, logTag, subject, stepName } = args;
   const meta = { kind: args.kind, sequenceId: args.sequenceId, ...args.meta };
-  const maxAttempts = MAX_CONTENT_ATTEMPTS + 1;
+  const prompt = args.prompt ?? args.params.prompt;
+  const rebuild =
+    args.rebuild ??
+    ((p: string, model: TextToImageModel) => ({
+      ...args.params,
+      prompt: p,
+      model,
+    }));
+  const canFallback = args.params.model !== IMAGE_CONTENT_FALLBACK_MODEL;
+  const maxAttempts = MAX_CONTENT_ATTEMPTS + (canFallback ? 1 : 0) + 1;
 
   const generateOnce = (
     name: string,
@@ -164,12 +187,13 @@ export async function generateImageSoftening(
       }
     });
 
+  let params = args.params;
   let lastRejection: string | null = null;
   for (let attempt = 0; attempt < MAX_CONTENT_ATTEMPTS; attempt++) {
     const tag = attempt === 0 ? '' : `-retry-${attempt}`;
     const outcome = await generateOnce(
       `${stepName}${tag}`,
-      args.params,
+      params,
       attempt + 1
     );
     if (outcome.ok) {
@@ -179,13 +203,13 @@ export async function generateImageSoftening(
           {
             event: CONTENT_REJECTION_RETRY_EVENT,
             outcome: 'rescued',
-            model: args.params.model,
+            model: params.model,
             attempts: attempt + 1,
             ...meta,
           }
         );
       }
-      return { result: outcome.result, params: args.params, softened: false };
+      return { result: outcome.result, params, softened: false };
     }
     lastRejection = outcome.rejection;
     logger.warn(
@@ -193,18 +217,51 @@ export async function generateImageSoftening(
     );
   }
 
+  if (canFallback) {
+    const fromModel = params.model;
+    logger.warn(
+      `${logTag} same-prompt reseeds exhausted; falling back to ${IMAGE_CONTENT_FALLBACK_MODEL} for ${subject}`,
+      {
+        event: CONTENT_REJECTION_FALLBACK_EVENT,
+        fromModel,
+        model: IMAGE_CONTENT_FALLBACK_MODEL,
+        rejection: lastRejection,
+        ...meta,
+      }
+    );
+    params = rebuild(prompt, IMAGE_CONTENT_FALLBACK_MODEL);
+    const outcome = await generateOnce(
+      `${stepName}-fallback`,
+      params,
+      MAX_CONTENT_ATTEMPTS + 1
+    );
+    if (outcome.ok) {
+      logger.info(`${logTag} fallback model rescued ${subject}`, {
+        event: CONTENT_REJECTION_FALLBACK_EVENT,
+        outcome: 'rescued',
+        fromModel,
+        model: params.model,
+        ...meta,
+      });
+      return { result: outcome.result, params, softened: false };
+    }
+    lastRejection = outcome.rejection;
+    logger.warn(
+      `${logTag} fallback model also flagged for ${subject}: ${outcome.rejection}`
+    );
+  }
+
   const rejection = lastRejection ?? 'unknown rejection';
   logger.warn(
-    `${logTag} same-prompt reseeds exhausted; softening prompt for ${subject}`,
+    `${logTag} ${canFallback ? 'fallback flagged' : 'same-prompt reseeds exhausted'}; softening prompt for ${subject}`,
     {
       event: CONTENT_REJECTION_SOFTEN_EVENT,
-      model: args.params.model,
+      model: params.model,
       rejection,
       ...meta,
     }
   );
 
-  const prompt = args.prompt ?? args.params.prompt;
   let softened: string;
   try {
     softened = await softenRejectedImagePrompt(step, {
@@ -215,7 +272,7 @@ export async function generateImageSoftening(
       prompt,
       rejection,
       analysisModelId: args.analysisModelId ?? DEFAULT_ANALYSIS_MODEL,
-      model: args.params.model,
+      model: params.model,
       name: `soften-${stepName}`,
     });
   } catch (error) {
@@ -229,9 +286,7 @@ export async function generateImageSoftening(
     );
   }
 
-  const params = args.rebuild
-    ? args.rebuild(softened)
-    : { ...args.params, prompt: softened };
+  params = rebuild(softened, params.model);
   const outcome = await generateOnce(
     `${stepName}-softened`,
     params,

--- a/src/lib/workflows/shot-variant-workflow.ts
+++ b/src/lib/workflows/shot-variant-workflow.ts
@@ -180,14 +180,15 @@ export class ShotVariantWorkflow extends OpenStoryWorkflowEntrypoint<ShotVariant
       stepName: 'generate-image',
       params: prep.params,
       prompt: prep.basePrompt,
-      rebuild: (softened) => {
+      rebuild: (nextPrompt, model) => {
         const rebuilt = buildReferenceImagePrompt(
-          softened,
+          nextPrompt,
           prep.references,
-          IMAGE_MODELS[prep.params.model].maxPromptLength
+          IMAGE_MODELS[model].maxPromptLength
         );
         return {
           ...prep.params,
+          model,
           prompt: rebuilt.prompt,
           referenceImageUrls: rebuilt.referenceUrls,
         };

--- a/src/lib/workflows/soften-image-prompt.ts
+++ b/src/lib/workflows/soften-image-prompt.ts
@@ -33,7 +33,10 @@ import { getLogger } from '@/lib/observability/logger';
 import { buildReferenceImagePrompt } from '@/lib/prompts/reference-image-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import type { ImageWorkflowInput } from '@/lib/workflow/types';
-import { softenRejectedImagePrompt } from '@/lib/workflows/content-soften';
+import {
+  IMAGE_CONTENT_FALLBACK_MODEL,
+  softenRejectedImagePrompt,
+} from '@/lib/workflows/content-soften';
 import { computeShotImageSceneHash } from '@/lib/workflows/sheet-snapshots';
 import type { WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
@@ -45,9 +48,6 @@ const logger = getLogger(['openstory', 'workflow', 'image', 'soften']);
  * (#881). Matches motion / character sheet.
  */
 const MAX_IMAGE_ATTEMPTS = 3;
-
-/** Fallback after selected-model reseeds exhaust. Skip when already this. */
-const IMAGE_CONTENT_FALLBACK_MODEL: TextToImageModel = 'grok_imagine_image';
 
 export type GenerateImageWithContentRetryResult = {
   result: ImageGenerationResult;


### PR DESCRIPTION
## Related Issue

Follow-up to #1294 (merged) for #1293 — parity with the shot-still ladder.

## Summary of Changes

`generateImageSoftening` (character / location / element sheets, library talent + location sheets, variant grids) now matches stills: **reseed ×3 → render the original prompt on Grok Imagine 2 → soften on Grok → one render**. The swap is skipped when the caller is already on Grok. Grok's checker is more permissive, so a named-character block like the Harry Potter sheets is usually rescued *without* a rewrite.

- `IMAGE_CONTENT_FALLBACK_MODEL` moves to `content-soften.ts`; the still path imports it.
- `rebuild(prompt, model)` is now called for both the swap and the softened retry, so variant grids re-size their reference legend per model.
- New durable step `<stepName>-fallback`; first-attempt names unchanged.
- Sheet provenance already records the rendered `params.model`, so the swap is visible. No DB changes.

## Risk Assessment

- [ ] Medium
- [x] Low
- [ ] High

One extra Grok render only after 3 content-flagged attempts; softening now costs at most one further render on Grok.

## Additional Notes

`content-soften.test.ts`: swap-rescue, soften-on-Grok, skip-when-already-Grok, exhaustion, transient passthrough, `rebuild` per model.