### PR TITLE
fix(#1302): pin Anthropic OpenRouter calls to Anthropic's own endpoint

### DIFF
--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -662,21 +662,22 @@ describe('llm-client', () => {
           yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'hi' };
         })();
 
-      it('keeps Anthropic models off Azure by default', async () => {
-        // Azure-hosted Claude rejects our analysis schemas ("compiled grammar
-        // is too large"); Anthropic's own endpoint accepts them.
+      it("pins Anthropic models to Anthropic's own endpoint", async () => {
+        // Vertex advertises response_format without structured_outputs (#1285);
+        // Azure's grammar is too small. Pinning with `only` is what actually
+        // excludes them — requireParameters does not, and with Vertex off at
+        // the account it emptied the candidate set (#1302).
         mockChat.mockReturnValue(textStream());
 
         await drain(
           callLLMStream({
-            model: 'anthropic/claude-fable-5',
+            model: 'anthropic/claude-opus-5',
             messages: [{ role: 'user', content: 'test' }],
           })
         );
 
         expect(mockChat.mock.calls[0]?.[0]?.modelOptions.provider).toEqual({
-          requireParameters: true,
-          ignore: ['azure'],
+          only: ['anthropic'],
         });
       });
 
@@ -702,14 +703,13 @@ describe('llm-client', () => {
           callLLMStream({
             model: 'anthropic/claude-sonnet-5',
             messages: [{ role: 'user', content: 'test' }],
-            provider: { only: ['anthropic'] },
+            provider: { allowFallbacks: false },
           })
         );
 
         expect(mockChat.mock.calls[0]?.[0]?.modelOptions.provider).toEqual({
-          requireParameters: true,
-          ignore: ['azure'],
           only: ['anthropic'],
+          allowFallbacks: false,
         });
       });
     });

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -379,17 +379,20 @@ function toGrokReasoningEffort(
 // chat(). The public LLMRequestParams surface keeps its OpenAI-style
 // snake_case names; this is the single mapping point.
 function buildModelOptions(params: LLMRequestParams) {
-  // `requireParameters`: only route to upstreams that support every parameter
-  // we send. Without it OpenRouter treats `response_format` as a soft
-  // preference — Google Vertex advertises `response_format` but not
-  // `structured_outputs`, so a Claude call landing there returned free-form
-  // JSON with no error (#1285). Azure-hosted Claude compiles strict schemas
-  // against a much smaller grammar budget and rejects ours ("The compiled
-  // grammar is too large"), so Anthropic models stay off Azure. Caller-supplied
-  // preferences layer on top.
+  // Anthropic models: pin to Anthropic's own endpoint. OpenRouter also hosts
+  // Claude on Google Vertex (advertises `response_format` but not
+  // `structured_outputs` — silent free-form JSON, #1285) and Azure (grammar
+  // too small for our schemas). `requireParameters: true` was meant to skip
+  // those hosts, but Vertex still matches on `response_format`, and once
+  // Vertex is disabled at the account the remaining filter
+  // (`requireParameters` + ignore azure) empties the candidate set (#1302:
+  // "No endpoints found that can handle the requested parameters").
+  // `only: ['anthropic']` is the actual selection; requireParameters stays
+  // for every other vendor. Caller-supplied preferences layer on top.
   const provider: ProviderPreferences = {
-    requireParameters: true,
-    ...(params.model.startsWith('anthropic/') && { ignore: ['azure'] }),
+    ...(params.model.startsWith('anthropic/')
+      ? { only: ['anthropic'] }
+      : { requireParameters: true }),
     ...params.provider,
   };
   return {


### PR DESCRIPTION
## Related Issue

Closes #1302

## Summary of Changes

Pin `anthropic/*` OpenRouter calls to Anthropic's own endpoint (`provider.only: ['anthropic']`) instead of filtering with `requireParameters` + `ignore: ['azure']`.

OpenRouter also hosts Claude on Google Vertex and Azure. Vertex advertises `response_format` but not `structured_outputs` and returns free-form JSON (#1285). Azure's grammar is too small for our schemas. `requireParameters: true` does not actually exclude Vertex (it still matches on `response_format`), and once Vertex is disabled at the OpenRouter account the remaining filter empties the candidate set — "No endpoints found that can handle the requested parameters".

Non-Anthropic models still send `requireParameters: true`. Caller-supplied provider preferences still layer on top.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Routing change only for Anthropic models. If Anthropic's first-party endpoint is down, the call fails instead of silently landing on Vertex. Unit tests cover the default pin, the non-Anthropic requireParameters path, and caller overlay.

## Additional Notes

This matches the diagnosis that the error showed up after turning Vertex off at the account. The pin does not depend on that toggle.