### PR TITLE
fix(#1304): Regenerating Sequence actually retries the run

### DIFF
--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -72,7 +72,7 @@ import {
 import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
 import type { FrameVariant, ShotVariant } from '@/lib/db/schema';
 import type { ShotView } from '@/lib/shots/shot-view';
-import { analyzeFailures } from '@/lib/failures/failure-analysis';
+import { analyzeLoadedFailures } from '@/lib/failures/failure-analysis';
 import type { GenerationPhaseConfig } from '@/lib/realtime/generation-stream.reducer';
 import { useGenerationStream } from '@/lib/realtime/use-generation-stream';
 import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
@@ -1099,8 +1099,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
   const [isRetrying, setIsRetrying] = useState(false);
 
   const failureSummary = useMemo(
-    () =>
-      sequence ? analyzeFailures(shots ?? [], sequence, scenesById) : null,
+    () => analyzeLoadedFailures(shots, sequence, scenesById),
     [shots, sequence, scenesById]
   );
 

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -79,7 +79,7 @@ import { useStaleDetected } from '@/lib/realtime/use-stale-detected';
 import type { Sequence } from '@/types/database';
 import { usePostHog } from '@posthog/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from '@tanstack/react-router';
+
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -217,7 +217,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
   search = {},
 }) => {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const posthog = usePostHog();
 
   const { showGate: showBillingGate } = useFalBillingGate();
@@ -1105,10 +1104,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
     [shots, sequence, scenesById]
   );
 
-  const handleFullRetry = useCallback(() => {
-    void navigate({ to: '/sequences/$id/script', params: { id: sequenceId } });
-  }, [sequenceId, navigate]);
-
   const handleSmartRetry = useCallback(async () => {
     setIsRetrying(true);
     try {
@@ -1272,7 +1267,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         <FailureSummaryBanner
           summary={failureSummary}
           onRetry={() => void handleSmartRetry()}
-          onFullRetry={handleFullRetry}
+          onFullRetry={() => void handleSmartRetry()}
           isRetrying={isRetrying}
         />
       )}

--- a/src/components/sequence/failure-summary-banner.test.tsx
+++ b/src/components/sequence/failure-summary-banner.test.tsx
@@ -1,0 +1,34 @@
+import { CONTENT_REJECTION_USER_HINT } from '@/lib/ai/content-rejection';
+import type { FailureSummary } from '@/lib/failures/failure-analysis';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import { FailureSummaryBanner } from './failure-summary-banner';
+
+const contentSummary: FailureSummary = {
+  requiresFullRetry: true,
+  headline:
+    "Harry Potter didn't pass the content checker \u2014 regenerate to retry",
+  groups: [],
+  totalFailures: 1,
+  hasFailed: true,
+  error: 'Blocked by the content checker: Harry Potter',
+  tone: 'warning',
+};
+
+describe('FailureSummaryBanner', () => {
+  it('SSRs the content-checker title instead of Generation failed', () => {
+    const html = renderToStaticMarkup(
+      <FailureSummaryBanner
+        summary={contentSummary}
+        onRetry={() => undefined}
+        isRetrying={false}
+      />
+    );
+
+    expect(html).toContain('Content checker');
+    expect(html).toContain('pass the content checker');
+    expect(html).toContain('regenerate to retry');
+    expect(html).toContain(CONTENT_REJECTION_USER_HINT);
+    expect(html).not.toContain('Generation failed');
+  });
+});

--- a/src/lib/failures/failure-analysis.test.ts
+++ b/src/lib/failures/failure-analysis.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { analyzeFailures } from './failure-analysis';
+import { analyzeFailures, analyzeLoadedFailures } from './failure-analysis';
 import type { Frame, SceneRow, Shot, VideoVariant } from '@/lib/db/schema';
 import type { Sequence } from '@/lib/db/schema/sequences';
 import {
@@ -458,5 +458,55 @@ describe('analyzeFailures', () => {
 
     expect(result.hasFailed).toBe(false);
     expect(result.requiresFullRetry).toBe(false);
+  });
+});
+
+describe('analyzeLoadedFailures', () => {
+  test('returns null while shots are still loading so SSR does not emit a full-retry banner', () => {
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError: 'Generation was interrupted — use Retry to run it again.',
+    });
+
+    expect(analyzeLoadedFailures(undefined, sequence, SCENES)).toBeNull();
+  });
+
+  test('returns null while the sequence is still loading', () => {
+    expect(analyzeLoadedFailures([], undefined, SCENES)).toBeNull();
+  });
+
+  test('empty loaded shots still produce the content-checker banner', () => {
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError: 'Blocked by the content checker: Harry Potter',
+    });
+
+    const result = analyzeLoadedFailures([], sequence, SCENES);
+
+    expect(result?.tone).toBe('warning');
+    expect(result?.headline).toContain("didn't pass the content checker");
+  });
+
+  test('loaded shot-level content failures produce the content-checker banner', () => {
+    const shots = [
+      makeShot({
+        frame: {
+          imageStatus: 'failed',
+          imageError:
+            'The content could not be processed because it contained material flagged by a content checker.',
+        },
+        sources: { image: null },
+      }),
+    ];
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError: 'Generation was interrupted — use Retry to run it again.',
+    });
+
+    const result = analyzeLoadedFailures(shots, sequence, SCENES);
+
+    expect(result?.tone).toBe('warning');
+    expect(result?.headline).toContain("didn't pass the content checker");
+    expect(result?.headline).not.toContain('full retry required');
   });
 });

--- a/src/lib/failures/failure-analysis.ts
+++ b/src/lib/failures/failure-analysis.ts
@@ -152,6 +152,21 @@ function buildHeadline(
   return failure;
 }
 
+/**
+ * `analyzeFailures` only once the shot list has resolved. `shots ?? []` on a
+ * failed sequence is the same shape as "analysis never produced shots", so
+ * SSR would emit the generic full-retry banner and hydration would replace it
+ * with the content-checker banner once shots land.
+ */
+export function analyzeLoadedFailures(
+  shots: ShotView[] | undefined,
+  sequence: Sequence | undefined,
+  scenesById: ScenesById
+): FailureSummary | null {
+  if (!sequence || shots === undefined) return null;
+  return analyzeFailures(shots, sequence, scenesById);
+}
+
 export function analyzeFailures(
   // The still's lifecycle lives on the anchor frame (#989) and the video's on
   // the segment's primary render (#1067).

--- a/src/routes/_app/sequences/$id/scenes.tsx
+++ b/src/routes/_app/sequences/$id/scenes.tsx
@@ -1,4 +1,8 @@
 import { ScenesView } from '@/components/scenes/scenes-view';
+import { getScenesFn } from '@/functions/scenes';
+import { getShotsFn } from '@/functions/shots';
+import { sceneKeys } from '@/hooks/use-scenes';
+import { shotKeys } from '@/hooks/use-shots';
 import { scenesSearchSchema } from '@/lib/scenes/scene-selection';
 import { createFileRoute } from '@tanstack/react-router';
 
@@ -6,6 +10,21 @@ export const Route = createFileRoute('/_app/sequences/$id/scenes')({
   component: ScenesPage,
   validateSearch: scenesSearchSchema,
   staticData: { breadcrumb: 'Scenes' },
+  // FailureSummaryBanner classifies content-checker vs full-retry from the
+  // shot list. Prefetch so the content banner is in the SSR HTML instead of
+  // hydrating over a generic "Generation failed" from `shots ?? []`.
+  loader: async ({ params, context: { queryClient } }) => {
+    await Promise.all([
+      queryClient.ensureQueryData({
+        queryKey: shotKeys.list(params.id),
+        queryFn: () => getShotsFn({ data: { sequenceId: params.id } }),
+      }),
+      queryClient.ensureQueryData({
+        queryKey: sceneKeys.list(params.id),
+        queryFn: () => getScenesFn({ data: { sequenceId: params.id } }),
+      }),
+    ]);
+  },
 });
 
 function ScenesPage() {


### PR DESCRIPTION
## Related Issue

Closes #1304 (follow-up)

## Summary of Changes

The scenes failure banner labeled **Regenerate Sequence** for full retries. Its click handler navigated to `/sequences/$id/script` and never called `smartRetryFn`, so sequences that died in analyze-script (including the auto-style Zod failures) could not be restarted from the UI.

Wire that button to the same retry path as partial Retry.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High