### PR TITLE
 fix: migrate Storybook MSW setup to v3

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -9,6 +9,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: [
+    'msw-storybook-addon',
     '@storybook/addon-docs',
     '@storybook/addon-a11y',
     '@storybook/addon-themes',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,7 +2,8 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RealtimeProvider } from '../src/lib/realtime/client';
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import { mswLoader } from 'msw-storybook-addon/csf3';
+import { setupWorker } from 'msw/browser';
 import { handlers } from '../src/lib/mocks/handlers';
 
 import '../src/styles/global.css';
@@ -12,9 +13,6 @@ import '../src/styles/global.css';
  * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
  * to learn how to customize it
  */
-initialize({
-  onUnhandledRequest: 'bypass',
-});
 
 // Create a client for Storybook
 const queryClient = new QueryClient({
@@ -65,7 +63,13 @@ const preview: Preview = {
     },
   },
 
-  loaders: [mswLoader],
+  loaders: [
+    mswLoader(async () => {
+      const worker = setupWorker();
+      await worker.start({ onUnhandledRequest: 'bypass' });
+      return worker;
+    }),
+  ],
 
   decorators: [
     withProviders,

--- a/.storybook/server-stub-plugin.ts
+++ b/.storybook/server-stub-plugin.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Plugin } from 'vite';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -108,7 +108,7 @@ export function serverStubPlugin(): Plugin {
         .map((n) => `export const ${n} = stub;`)
         .join('\n');
       return [
-        `import { stub } from '${STUB_RUNTIME}';`,
+        `import { stub } from '${pathToFileURL(STUB_RUNTIME).href}';`,
         `export default stub;`,
         namedLines,
       ].join('\n');


### PR DESCRIPTION
## Summary

- Migrate Storybook MSW configuration from msw-storybook-addon v2 to v3
- Replace the removed `initialize()` API with the v3 `mswLoader` setup
- Register `msw-storybook-addon` in Storybook addons
- Fix Windows Vite path resolution for the Storybook server stub

## Verification

- Storybook starts successfully
- Stories render in the preview iframe
- `git diff --check` passes
- Pre-commit checks pass:
  - dead-code
  - format
  - lint
  - typecheck