### PR TITLE
fix(#1308): classify LLM content-filter stops and clamp max_tokens to the model's real ceiling

### DIFF
--- a/src/lib/ai/content-filter-finish.test.ts
+++ b/src/lib/ai/content-filter-finish.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Regression tests for #1304 — an Anthropic content-filter stop on the
+ * ANALYSIS call surfaced as an opaque `structured-output-missing-result` /
+ * `Failed to parse structured output as JSON`, was retried five times, and
+ * reached the user as "frame-prompt child(ren) returned no body for scene(s)
+ * [01M0…]".
+ *
+ * Verified against prod: OpenRouter returns `finish_reason: 'content_filter'`
+ * with zero content for the failing scene, on Anthropic-direct AND on
+ * AWS-hosted Claude (so it is the model's classifier, not the #1302 routing
+ * pin).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  contentFilterLlmMessage,
+  contentRejectionSummary,
+  isContentFilterFinish,
+  isContentRejectionError,
+} from '@/lib/ai/content-rejection';
+
+describe('isContentFilterFinish', () => {
+  it('detects a RUN_FINISHED that stopped on the safety classifier', () => {
+    expect(
+      isContentFilterFinish({
+        type: 'RUN_FINISHED',
+        finishReason: 'content_filter',
+      })
+    ).toBe(true);
+  });
+
+  it('ignores a normal completion', () => {
+    expect(
+      isContentFilterFinish({ type: 'RUN_FINISHED', finishReason: 'stop' })
+    ).toBe(false);
+  });
+
+  it('ignores a truncation, which IS worth retrying', () => {
+    expect(
+      isContentFilterFinish({ type: 'RUN_FINISHED', finishReason: 'length' })
+    ).toBe(false);
+  });
+
+  it('ignores other events and malformed provider shots', () => {
+    expect(isContentFilterFinish({ type: 'RUN_ERROR', code: 'refusal' })).toBe(
+      false
+    );
+    expect(
+      isContentFilterFinish({ type: 'RUN_FINISHED', finishReason: 42 })
+    ).toBe(false);
+    expect(isContentFilterFinish({ type: 'RUN_FINISHED' })).toBe(false);
+    expect(isContentFilterFinish(null)).toBe(false);
+    expect(isContentFilterFinish('RUN_FINISHED')).toBe(false);
+  });
+});
+
+describe('contentFilterLlmMessage', () => {
+  it('classifies as a content rejection so the UI treats it as a warning', () => {
+    const message = contentFilterLlmMessage('Scene 3');
+    // The severity/banner logic keys off this predicate; if it returns false
+    // the user gets a red "Generation failed" with no cause again.
+    expect(isContentRejectionError(message)).toBe(true);
+  });
+
+  it('names the blocked scene', () => {
+    expect(contentFilterLlmMessage('Scene 3')).toContain('Scene 3');
+  });
+});
+
+describe('batch aggregation', () => {
+  it('summarises an all-content-filter batch by scene, not by opaque id', () => {
+    const failures = [
+      { name: 'Scene 3', reason: contentFilterLlmMessage('Scene 3') },
+      { name: 'Scene 2', reason: contentFilterLlmMessage('Scene 2') },
+    ];
+    const summary = contentRejectionSummary(failures);
+    expect(summary).toBe('Blocked by the content checker: Scene 3, Scene 2');
+  });
+
+  it('keeps the diagnostic message when any failure was NOT a content filter', () => {
+    const failures = [
+      { name: 'Scene 3', reason: contentFilterLlmMessage('Scene 3') },
+      { name: 'Scene 4', reason: 'Network connection lost.' },
+    ];
+    expect(contentRejectionSummary(failures)).toBeNull();
+  });
+});

--- a/src/lib/ai/content-rejection.ts
+++ b/src/lib/ai/content-rejection.ts
@@ -87,8 +87,56 @@ export function isContentRejectionError(error: unknown): boolean {
   return CONTENT_REJECTION_PATTERNS.some((pattern) => pattern.test(message));
 }
 
+/**
+ * Provider finish reasons that mean "the model stopped because a safety
+ * classifier fired", as opposed to a transient fault. Anthropic returns this
+ * for the WHOLE analysis call (not just image generation), either with no
+ * content at all or with the response cut mid-token — see
+ * {@link contentFilterLlmMessage}.
+ */
+const CONTENT_FILTER_FINISH_REASONS: ReadonlySet<string> = new Set([
+  'content_filter',
+  'content-filter',
+]);
+
+/**
+ * True when a `RUN_FINISHED` stream event ended on a safety-classifier stop.
+ * Read defensively: the yielded event union is wide and a malformed provider
+ * shot can carry a non-string `finishReason`.
+ */
+export function isContentFilterFinish(event: unknown): boolean {
+  if (
+    !event ||
+    typeof event !== 'object' ||
+    !('type' in event) ||
+    event.type !== 'RUN_FINISHED' ||
+    !('finishReason' in event) ||
+    typeof event.finishReason !== 'string'
+  ) {
+    return false;
+  }
+  return CONTENT_FILTER_FINISH_REASONS.has(event.finishReason);
+}
+
 /** Overlay / list title — not "Generation failed". */
 export const CONTENT_REJECTION_USER_TITLE = 'Blocked by the content checker';
+
+/**
+ * Message for an LLM call the provider stopped on a content filter.
+ *
+ * Deliberately worded to match {@link CONTENT_REJECTION_PATTERNS} so the
+ * existing image-path classification (failure banners, `statusError` severity,
+ * PostHog rejection metrics) treats a filtered *analysis* call the same way it
+ * already treats a filtered *image* — as a warning naming the blocked subject,
+ * not an opaque "Generation failed".
+ *
+ * Without this the stop surfaced as `structured-output-missing-result` (empty
+ * response) or `Failed to parse structured output as JSON` (cut mid-token),
+ * neither of which tells the user their script tripped a safety classifier.
+ */
+export function contentFilterLlmMessage(subject: string): string {
+  return `${CONTENT_REJECTION_USER_TITLE}: ${subject} (stopped by the provider's content filter)`;
+}
 
 /** What the user can do next. */
 export const CONTENT_REJECTION_USER_HINT =

--- a/src/lib/ai/max-output-tokens.test.ts
+++ b/src/lib/ai/max-output-tokens.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Regression tests for #1308 — `max_tokens` was derived as
+ * `getContextWindow(model) * 0.5`, conflating the CONTEXT window with the
+ * OUTPUT ceiling. Prod sent 500,000 for `claude-opus-5`, whose real
+ * completion ceiling is 128,000; Gemini would have been sent 8× its ceiling.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  ANALYSIS_MODEL_IDS,
+  getContextWindow,
+  getMaxOutputTokens,
+  SCRIPT_ANALYSIS_MODELS,
+} from '@/lib/ai/models.config';
+
+describe('getMaxOutputTokens', () => {
+  it('never exceeds any model’s real completion ceiling', () => {
+    for (const model of SCRIPT_ANALYSIS_MODELS) {
+      expect(getMaxOutputTokens(model.id)).toBeLessThanOrEqual(
+        model.maxOutputTokens
+      );
+      expect(getMaxOutputTokens(model.id, 0.65)).toBeLessThanOrEqual(
+        model.maxOutputTokens
+      );
+      // The whole point: asking for the entire window still clamps.
+      expect(getMaxOutputTokens(model.id, 1)).toBeLessThanOrEqual(
+        model.maxOutputTokens
+      );
+    }
+  });
+
+  it('clamps the default analysis model instead of sending 500k', () => {
+    // The exact prod bug: half of a 1M context window.
+    expect(Math.floor(getContextWindow('anthropic/claude-opus-5') * 0.5)).toBe(
+      500_000
+    );
+    expect(getMaxOutputTokens('anthropic/claude-opus-5')).toBe(128_000);
+  });
+
+  it('keeps the fraction when it is below the ceiling', () => {
+    // deepseek-v3.2: 163,840 context, 147,456 ceiling — half the window
+    // (81,920) is legal, so the fraction still governs.
+    expect(getMaxOutputTokens('deepseek/deepseek-v3.2')).toBe(81_920);
+  });
+
+  it('is conservative for an unknown model', () => {
+    expect(getMaxOutputTokens('some/unlisted-model')).toBe(32_000);
+  });
+
+  it('always returns a positive budget', () => {
+    for (const id of ANALYSIS_MODEL_IDS) {
+      expect(getMaxOutputTokens(id, 0)).toBeGreaterThan(0);
+      expect(getMaxOutputTokens(id, -1)).toBeGreaterThan(0);
+    }
+  });
+});

--- a/src/lib/ai/models.config.ts
+++ b/src/lib/ai/models.config.ts
@@ -11,6 +11,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 1,
     contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Default analysis model; frontier reasoning and coding',
   },
@@ -21,6 +22,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 1,
     contextWindow: 500_000,
+    maxOutputTokens: 450_000,
     // Accepts image input — required so the motion-prompt pass can be
     // conditioned on the rendered starting frame (#929). Conservative: only
     // models known to accept image input are `true`; text-only models fall
@@ -35,6 +37,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 2,
     contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Most intelligent Anthropic model, new tier above Opus',
   },
@@ -45,6 +48,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 3,
     contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'State-of-the-art coding and structured output',
   },
@@ -55,6 +59,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 4,
     contextWindow: 2_000_000,
+    maxOutputTokens: 1_800_000,
     vision: true,
     description: 'Lowest hallucination rate, flagship agentic model',
     hidden: true,
@@ -66,6 +71,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 5,
     contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Opus 5 low-latency; used for scene-split',
   },
@@ -76,6 +82,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 6,
     contextWindow: 1_000_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Frontier reasoning and coding',
     hidden: true,
@@ -87,6 +94,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'open-source' as const,
     qualityRank: 7,
     contextWindow: 262_144,
+    maxOutputTokens: 209_715,
     vision: true,
     description: 'Apache 2.0, 119B MoE, multimodal + agentic coding',
   },
@@ -97,6 +105,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'open-source' as const,
     qualityRank: 8,
     contextWindow: 1_048_576,
+    maxOutputTokens: 943_717,
     // Text-only.
     vision: false,
     description: 'Open-weights frontier reasoning, 1M context',
@@ -108,6 +117,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'open-source' as const,
     qualityRank: 8,
     contextWindow: 163_840,
+    maxOutputTokens: 147_456,
     // Text-only.
     vision: false,
     description: 'MIT license, MMLU 94.2, GPT-5 class reasoning',
@@ -120,6 +130,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'open-source' as const,
     qualityRank: 9,
     contextWindow: 1_048_576,
+    maxOutputTokens: 262_144,
     // GLM-5.2 is text-only. Image-bearing calls (the vision-conditioned motion
     // path, #929) transparently route to `DEFAULT_VISION_MODEL` — see
     // `resolveVisionModel`. GLM's own vision sibling GLM-4.6V was tried (#942)
@@ -135,6 +146,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 10,
     contextWindow: 1_048_576,
+    maxOutputTokens: 65_536,
     vision: true,
     description: 'Frontier multimodal reasoning with 1M context',
   },
@@ -145,6 +157,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 11,
     contextWindow: 1_050_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Latest GPT-5 series with 1M context',
   },
@@ -155,6 +168,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 12,
     contextWindow: 1_048_576,
+    maxOutputTokens: 65_536,
     vision: true,
     description: 'Fast multimodal with 1M context',
   },
@@ -165,6 +179,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 13,
     contextWindow: 400_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Fast reasoning with configurable effort modes',
   },
@@ -175,6 +190,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 14,
     contextWindow: 262_144,
+    maxOutputTokens: 131_072,
     vision: true,
     description: 'Fast multimodal with 4 reasoning effort modes',
   },
@@ -185,6 +201,7 @@ export const SCRIPT_ANALYSIS_MODELS = [
     license: 'proprietary' as const,
     qualityRank: 15,
     contextWindow: 400_000,
+    maxOutputTokens: 128_000,
     vision: true,
     description: 'Fastest and most cost-efficient GPT-5.4 variant',
   },
@@ -239,6 +256,34 @@ export const ANALYSIS_MODEL_IDS = getAllModelIds();
 export function getContextWindow(modelId: string): number {
   const model = SCRIPT_ANALYSIS_MODELS.find((m) => m.id === modelId);
   return model?.contextWindow ?? 128_000;
+}
+
+/**
+ * Conservative output ceiling for an unknown model — below every ceiling in
+ * the table, so a model we don't know can never be sent an over-limit budget.
+ */
+const DEFAULT_MAX_OUTPUT_TOKENS = 32_000;
+
+/**
+ * The output-token budget to send for a call, as a fraction of the context
+ * window but never above what the model can actually emit (#1308).
+ *
+ * Call sites used to send `getContextWindow(model) * 0.5` as `max_tokens`,
+ * which conflates two different limits: half of Opus 5's 1M context is
+ * 500,000, but its real completion ceiling is 128,000 — and half of Gemini's
+ * 1,048,576 is 8× its 65,536 ceiling. The fraction still expresses "leave
+ * room for the input"; the clamp keeps the request legal.
+ *
+ * Ceilings are `top_provider.max_completion_tokens` from OpenRouter's
+ * `/api/v1/models`, the same catalogue that serves the calls.
+ */
+export function getMaxOutputTokens(modelId: string, fraction = 0.5): number {
+  const model = SCRIPT_ANALYSIS_MODELS.find((m) => m.id === modelId);
+  const ceiling = model?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+  const budget = Math.floor(
+    (model?.contextWindow ?? 128_000) * Math.min(Math.max(fraction, 0), 1)
+  );
+  return Math.max(1, Math.min(budget, ceiling));
 }
 
 /**

--- a/src/lib/workflows/frame-prompt-batch-workflow.ts
+++ b/src/lib/workflows/frame-prompt-batch-workflow.ts
@@ -12,6 +12,7 @@
  * shot-creation time in `scene-split-workflow` and threaded here via
  * `shotMapping` (#991). */
 
+import { contentRejectionSummary } from '@/lib/ai/content-rejection';
 import type { Scene, VisualPrompt } from '@/lib/ai/scene-analysis.schema';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
@@ -125,6 +126,7 @@ export class FramePromptBatchWorkflow extends OpenStoryWorkflowEntrypoint<FrameP
           childResult: FramePromptResult;
         }> = [];
         const failedSceneIds: string[] = [];
+        const failures: Array<{ name: string; reason: string }> = [];
 
         for (const [index, outcome] of settled.entries()) {
           const scene = scenes[index];
@@ -135,7 +137,16 @@ export class FramePromptBatchWorkflow extends OpenStoryWorkflowEntrypoint<FrameP
                 err: outcome.reason,
               }
             );
-            if (scene) failedSceneIds.push(scene.sceneId);
+            if (scene) {
+              failedSceneIds.push(scene.sceneId);
+              failures.push({
+                name: `Scene ${scene.sceneNumber}`,
+                reason:
+                  outcome.reason instanceof Error
+                    ? outcome.reason.message
+                    : String(outcome.reason),
+              });
+            }
             continue;
           }
           successResults.push(outcome.value);
@@ -145,9 +156,15 @@ export class FramePromptBatchWorkflow extends OpenStoryWorkflowEntrypoint<FrameP
           // NonRetryableError (not WorkflowValidationError) because the base
           // class's re-wrap only runs at the runImpl catch boundary; a throw
           // inside step.do gets retried by CF's step machinery first.
+          //
+          // When EVERY child was stopped by a content filter, say so and name
+          // the scenes: that message survives to `sequence.statusError`, where
+          // the existing rejection classification renders it as a warning the
+          // user can act on (#1304). Anything else keeps the diagnostic text.
           throw new NonRetryableError(
-            `frame-prompt child(ren) returned no body for scene(s) [${failedSceneIds.join(', ')}]. ` +
-              `Check sub-workflow logs for the upstream failure.`,
+            contentRejectionSummary(failures) ??
+              `frame-prompt child(ren) returned no body for scene(s) [${failedSceneIds.join(', ')}]. ` +
+                `Check sub-workflow logs for the upstream failure.`,
             'WorkflowValidationError'
           );
         }

--- a/src/lib/workflows/frame-prompt-workflow.ts
+++ b/src/lib/workflows/frame-prompt-workflow.ts
@@ -9,6 +9,11 @@
  * the anchor frame — not into `scene.metadata` (#713). Spawned per scene by
  * `FramePromptBatchWorkflow`. */
 
+import {
+  CONTENT_REJECTION_EVENT,
+  contentFilterLlmMessage,
+  isContentFilterFinish,
+} from '@/lib/ai/content-rejection';
 import { createAdapter, resolveNativeGrokModel } from '@/lib/ai/create-adapter';
 import { computeVisualPromptInputHash } from '@/lib/ai/input-hash';
 import {
@@ -18,7 +23,7 @@ import {
   PROMPT_REASONING,
   throwNotedRunError,
 } from '@/lib/ai/llm-client';
-import { getContextWindow } from '@/lib/ai/models.config';
+import { getMaxOutputTokens } from '@/lib/ai/models.config';
 import { narrowShotPromptContext } from '@/lib/ai/prompt-context';
 import {
   type VisualPrompt,
@@ -38,6 +43,7 @@ import { WorkflowValidationError } from '@/lib/workflow/errors';
 import type { FramePromptWorkflowInput } from '@/lib/workflow/types';
 import { chat } from '@tanstack/ai';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import { NonRetryableError } from 'cloudflare:workflows';
 
 const logger = getLogger(['openstory', 'workflow', 'frame-prompt']);
 
@@ -214,6 +220,7 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
           let lastEmitAt = 0;
           let structuredObject: unknown;
           let runError = null;
+          let contentFiltered = false;
 
           const flushDelta = async () => {
             if (!channel || !streamConfig || !pendingDelta) return;
@@ -226,7 +233,7 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
             });
           };
 
-          const maxTokens = Math.floor(getContextWindow(analysisModelId) * 0.5);
+          const maxTokens = getMaxOutputTokens(analysisModelId);
           const native = !!resolveNativeGrokModel(analysisModelId, llmKeyInfo);
           const modelOptions = native
             ? {
@@ -260,6 +267,14 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
             debug: false,
           })) {
             usageCapture.noteFromStreamEvent(streamEvent);
+            // A safety-classifier stop ends the run with `finishReason:
+            // 'content_filter'` and either no content or content cut
+            // mid-token. Note it here so the failure below is classified as a
+            // content rejection instead of an opaque parse error (#1304).
+            if (isContentFilterFinish(streamEvent)) {
+              contentFiltered = true;
+              continue;
+            }
             const noted = extractRunError(streamEvent);
             if (noted) {
               runError ??= noted;
@@ -297,6 +312,19 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
             }
           }
           throwNotedRunError(runError);
+          // A content filter is a property of the script, not a transient
+          // fault: every retry re-runs the same prompt and stops the same way.
+          // Fail fast and name the scene so the user can edit it, instead of
+          // burning five step retries (and their credits) on a certain loss.
+          if (contentFiltered && structuredObject === undefined) {
+            logger.warn(
+              `[FramePromptWorkflow:cf] [LLM:${LOG_NAME}] content filter stopped the run`,
+              { event: CONTENT_REJECTION_EVENT, sceneId: scene.sceneId }
+            );
+            throw new NonRetryableError(
+              contentFilterLlmMessage(`Scene ${scene.sceneNumber}`)
+            );
+          }
           await flushDelta();
           logger.info(
             `[FramePromptWorkflow:cf] [LLM:${LOG_NAME}] Streaming call succeeded`

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -24,7 +24,7 @@ import {
 import type { TextModel } from '@/lib/ai/models';
 import {
   analysisModelSupportsVision,
-  getContextWindow,
+  getMaxOutputTokens,
   resolveVisionModel,
 } from '@/lib/ai/models.config';
 import { withRegionFallback } from '@/lib/ai/region-policy';
@@ -167,7 +167,7 @@ function chatModelOptionsForCall(
   reasoning: boolean | undefined
 ) {
   const native = !!resolveNativeGrokModel(modelId, llmKeyInfo);
-  const maxTokens = Math.floor(getContextWindow(modelId) * 0.5);
+  const maxTokens = getMaxOutputTokens(modelId);
   if (native) {
     return {
       ...(reasoning

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -41,7 +41,7 @@ import {
   PROMPT_REASONING,
 } from '@/lib/ai/llm-client';
 import { PREVIEW_IMAGE_MODEL } from '@/lib/ai/models';
-import { getContextWindow, SCENE_SPLIT_MODEL } from '@/lib/ai/models.config';
+import { getMaxOutputTokens, SCENE_SPLIT_MODEL } from '@/lib/ai/models.config';
 import {
   type SceneSplitBiblesResult,
   type SceneSplitScenesResult,
@@ -325,10 +325,8 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
     // Both calls see the same numbered-gutter copy of the script: the scenes
     // call reports hintLine against it, the bibles call firstMention lines.
     const gutteredScript = addLineGutter(script);
-    const splitMaxTokens = Math.floor(
-      getContextWindow(SCENE_SPLIT_MODEL) * 0.65
-    );
-    const biblesMaxTokens = Math.floor(getContextWindow(modelId) * 0.65);
+    const splitMaxTokens = getMaxOutputTokens(SCENE_SPLIT_MODEL, 0.65);
+    const biblesMaxTokens = getMaxOutputTokens(modelId, 0.65);
 
     // The two LLM calls are independent given the script, so their steps run
     // concurrently — output length drives latency and the scenes stream is


### PR DESCRIPTION
## Related Issue

Closes #1308

## Summary of Changes

Two fixes to the script-analysis LLM path.

### 1. Content-filter stops are classified instead of surfacing as parse errors

Anthropic's safety classifier stops the analysis call on some scripts, ending the run with `finishReason: 'content_filter'` and either no content or content cut mid-token.

Reproduced deterministically against OpenRouter with the exact failing prod prompt:

```
{"provider":"Anthropic","finish_reason":"content_filter","chars":0,"parses":false}
```

**This is not the #1302 routing pin.** The same prompt fails identically on AWS-hosted Claude:

```
{"provider":"Claude Platform on AWS","finish_reason":"content_filter","chars":0,"parses":false}
```

The content-rejection layer (#1293 / #1272 / #881) covered image paths only. The LLM text path never inspected the finish reason the stream already carries, so a filter stop fell through to `JSON.parse(accumulated)` (partial) or "missing structured result" (empty). Three symptoms, one cause:

| Provider did | User saw |
|---|---|
| Stopped with zero content | `structured-output-missing-result: missing structured result` |
| Stopped mid-token | `Failed to parse structured output as JSON. Content: {"visual"…` |
| Both, ×5 retries per scene | `frame-prompt child(ren) returned no body for scene(s) [01M0…]` |

Because `content_filter` is deterministic, each scene burned five step retries and six billed LLM calls on a guaranteed loss.

- `isContentFilterFinish()` reads `RUN_FINISHED.finishReason`.
- `contentFilterLlmMessage()` is worded to match `CONTENT_REJECTION_PATTERNS`, so the existing banners, `statusError` severity and rejection metrics classify it as a warning automatically — no UI changes needed.
- `FramePromptWorkflow` throws `NonRetryableError` naming the scene.
- `FramePromptBatchWorkflow` reports **"Blocked by the content checker: Scene 3, Scene 2"** when every child was filtered; mixed failures keep the diagnostic text.

`finishReason: 'length'` is deliberately NOT treated as a filter — truncation should still retry.

### 2. `max_tokens` no longer sends a context-window fraction as an output limit

`getContextWindow(model) * 0.5` conflates two different limits. Prod sent **500,000** for `claude-opus-5`, whose real completion ceiling is **128,000**; Gemini would have been sent 8× its 65,536 ceiling.

Adds `maxOutputTokens` to each analysis model, taken from OpenRouter's `top_provider.max_completion_tokens` (the same catalogue that serves the calls), and `getMaxOutputTokens(modelId, fraction)` which keeps the fraction's "leave room for the input" intent but clamps to what the model can actually emit. Unknown models default to a conservative 32,000. Applied at all three call sites (`frame-prompt`, `llm-call-helper`, `scene-split`).

This was not causing the failures above — successful calls sent the same value — but it is wrong, and it makes a genuine `length` truncation impossible to reason about.

## Testing

- `content-filter-finish.test.ts` — 8 tests: detection, the `length` carve-out, malformed provider shots, and that the message classifies as a content rejection (if that predicate returns false the user gets an unexplained red failure again).
- `max-output-tokens.test.ts` — 5 tests, including a property check that no model at any fraction can exceed its ceiling.
- Full suite: **2,869 tests / 293 files passing**. `bun typecheck` clean.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Behaviour change is confined to a path that currently always fails. `max_tokens` only ever decreases, and stays above every observed completion (the largest in the failing window was 2,803 tokens).

## Not fixed here

A content-filtered analysis call still fails the sequence. A non-Anthropic fallback for analysis (mirroring the #1259 region fallback) would let these scripts through — worth a follow-up. Affected users get a clear, actionable message in the meantime.
