### PR TITLE
Remember sequences list filters, search, and support mode

### DIFF
--- a/e2e/tests/sequences.spec.ts
+++ b/e2e/tests/sequences.spec.ts
@@ -16,6 +16,63 @@ test.describe('Sequences', () => {
     await expect(page).toHaveURL(/\/sequences/);
   });
 
+  test('restores remembered search when returning to a bare /sequences', async ({
+    page,
+  }) => {
+    await page.goto('/sequences');
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'openstory:sequences-list:v1',
+        JSON.stringify({
+          search: 'night diner',
+          analysisModel: null,
+          imageModel: null,
+          aspectRatio: '9:16',
+          styleId: null,
+          supportMode: false,
+          hideInternal: false,
+        })
+      );
+    });
+    await page.goto('/sequences');
+
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('q'))
+      .toBe('night diner');
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get('aspectRatio'))
+      .toBe('9:16');
+    await expect(
+      page.getByRole('textbox', { name: 'Search by title…' })
+    ).toHaveValue('night diner');
+  });
+
+  test('remembered support mode does not break a non-admin list', async ({
+    page,
+  }) => {
+    await page.goto('/sequences');
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'openstory:sequences-list:v1',
+        JSON.stringify({
+          search: '',
+          analysisModel: null,
+          imageModel: null,
+          aspectRatio: null,
+          styleId: null,
+          supportMode: true,
+          hideInternal: false,
+        })
+      );
+    });
+    await page.goto('/sequences');
+
+    await expect(
+      page.getByRole('textbox', { name: 'Search by title…' })
+    ).toBeVisible();
+    await expect(page.getByText('Failed to load sequences')).toHaveCount(0);
+  });
+
   test('home page has script input', async ({ page }) => {
     await page.goto('/');
 

--- a/src/components/eval/eval-view.tsx
+++ b/src/components/eval/eval-view.tsx
@@ -19,6 +19,10 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { VideoIcon } from 'lucide-react';
 import { Link } from '@tanstack/react-router';
 import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type {
+  SequencesListPrefs,
+  SequencesListSearch,
+} from '@/lib/sequences/list-prefs';
 import { getCreatorIdentity } from './creator-identity';
 
 export type ViewMode = 'script' | 'prompts' | 'images' | 'motion';
@@ -58,34 +62,42 @@ export type SortCriteria = {
   direction: 'asc' | 'desc';
 };
 
-const defaultFilters: FilterState = {
-  search: '',
-  dateFrom: null,
-  dateTo: null,
-  analysisModel: null,
-  imageModel: null,
-  aspectRatio: null,
-  styleId: null,
-};
-
 type EvalViewProps = {
-  initialUserFilter?: string;
+  search: SequencesListSearch;
+  prefs: SequencesListPrefs;
+  setPrefs: (prefs: SequencesListPrefs) => void;
 };
 
-export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
+export const EvalView: React.FC<EvalViewProps> = ({
+  search,
+  prefs,
+  setPrefs,
+}) => {
   const [viewMode, setViewMode] = useState<ViewMode>('prompts');
-  const [filters, setFilters] = useState<FilterState>(() =>
-    initialUserFilter
-      ? { ...defaultFilters, search: initialUserFilter }
-      : defaultFilters
-  );
   const [sortCriteria, setSortCriteria] = useState<SortCriteria[]>([
     { field: 'createdAt', direction: 'desc' },
   ]);
-  const [supportMode, setSupportMode] = useState(Boolean(initialUserFilter));
-  const [hideInternal, setHideInternal] = useState(false);
 
-  const { data: adminStatus } = useQuery({
+  const filters: FilterState = useMemo(
+    () => ({
+      search: prefs.search,
+      dateFrom: null,
+      dateTo: null,
+      analysisModel: prefs.analysisModel,
+      imageModel: prefs.imageModel,
+      aspectRatio: prefs.aspectRatio,
+      styleId: prefs.styleId,
+    }),
+    [
+      prefs.search,
+      prefs.analysisModel,
+      prefs.imageModel,
+      prefs.aspectRatio,
+      prefs.styleId,
+    ]
+  );
+
+  const { data: adminStatus, isLoading: adminStatusLoading } = useQuery({
     queryKey: ['system-admin-status'],
     queryFn: () => isSystemAdminFn(),
     staleTime: 5 * 60 * 1000,
@@ -96,6 +108,11 @@ export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
     () => adminStatus?.internalDomains ?? [],
     [adminStatus?.internalDomains]
   );
+
+  // Admin query is gated on isAdmin so a remembered `support=true` cannot 403
+  // a non-admin. Stay in the loading skeleton until that check resolves.
+  const supportMode = isAdmin && prefs.supportMode;
+  const hideInternal = supportMode && prefs.hideInternal;
 
   const ownData = useSequencesWithShots();
   const adminData = useAdminAllSequencesWithShots(
@@ -117,7 +134,9 @@ export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
   const sequences: SequenceWithShots[] = supportMode
     ? adminData.data
     : ownData.data;
-  const isLoading = supportMode ? adminData.isLoading : ownData.isLoading;
+  const isLoading =
+    (prefs.supportMode && adminStatusLoading) ||
+    (supportMode ? adminData.isLoading : ownData.isLoading);
   const shotsLoadingMap = supportMode
     ? adminData.shotsLoadingMap
     : ownData.shotsLoadingMap;
@@ -156,7 +175,7 @@ export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
 
   // Deep link wins: when a specific user is requested, never hide them.
   const effectiveHideInternal =
-    hideInternal && !initialUserFilter && internalDomains.length > 0;
+    hideInternal && !search.user && internalDomains.length > 0;
 
   // Client-side filtering for both modes. In support mode the server also
   // filters by search so this is a no-op; keeping it for own-data mode.
@@ -205,17 +224,35 @@ export const EvalView: React.FC<EvalViewProps> = ({ initialUserFilter }) => {
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         filters={filters}
-        onFiltersChange={setFilters}
+        onFiltersChange={(next) =>
+          setPrefs({
+            search: next.search,
+            analysisModel: next.analysisModel,
+            imageModel: next.imageModel,
+            aspectRatio: next.aspectRatio,
+            styleId: next.styleId,
+            supportMode: prefs.supportMode,
+            hideInternal: prefs.hideInternal,
+          })
+        }
         styleOptions={styleOptions}
         sortCriteria={sortCriteria}
         onSortChange={setSortCriteria}
         supportMode={supportMode}
         isAdmin={isAdmin}
-        onSupportModeChange={setSupportMode}
+        onSupportModeChange={(value) =>
+          setPrefs({
+            ...prefs,
+            supportMode: value,
+            hideInternal: value ? prefs.hideInternal : false,
+          })
+        }
         hideInternal={hideInternal}
-        onHideInternalChange={setHideInternal}
+        onHideInternalChange={(value) =>
+          setPrefs({ ...prefs, hideInternal: value })
+        }
         hideInternalAvailable={internalDomains.length > 0}
-        hideInternalLocked={Boolean(initialUserFilter)}
+        hideInternalLocked={Boolean(search.user)}
       />
       {isLoading ? (
         <Card className="flex-1 p-4">

--- a/src/hooks/use-sequences-list-prefs.ts
+++ b/src/hooks/use-sequences-list-prefs.ts
@@ -1,0 +1,67 @@
+import { useIsomorphicLayoutEffect } from '@/hooks/use-isomorphic-layout-effect';
+import {
+  isDefaultSequencesListPrefs,
+  loadSequencesListPrefs,
+  prefsFromSearch,
+  prefsToSearch,
+  resolveSequencesListPrefs,
+  saveSequencesListPrefs,
+  searchSpecifiesPrefs,
+  type SequencesListPrefs,
+  type SequencesListSearch,
+} from '@/lib/sequences/list-prefs';
+import { useCallback, useRef } from 'react';
+
+type SequencesListNavigate = (opts: {
+  search: SequencesListSearch;
+  replace: boolean;
+}) => unknown;
+
+/**
+ * URL is the live snapshot of sequences-list prefs. localStorage fills a bare
+ * `/sequences` visit (sidebar / breadcrumb) so filters, search, and support
+ * mode survive leaving the page.
+ *
+ * `navigate` must be the sequences route's `Route.useNavigate()` so search
+ * writes land on this index, not a sibling like `/sequences/$id`.
+ */
+export function useSequencesListPrefs(
+  search: SequencesListSearch,
+  navigate: SequencesListNavigate
+) {
+  const restored = useRef(false);
+  const prefs = prefsFromSearch(search);
+
+  useIsomorphicLayoutEffect(() => {
+    if (restored.current) return;
+    restored.current = true;
+
+    if (searchSpecifiesPrefs(search)) {
+      saveSequencesListPrefs(prefsFromSearch(search));
+      return;
+    }
+
+    const resolved = resolveSequencesListPrefs(
+      search,
+      loadSequencesListPrefs()
+    );
+    if (isDefaultSequencesListPrefs(resolved)) return;
+    const nextSearch = prefsToSearch(resolved);
+    if (!searchSpecifiesPrefs(nextSearch)) return;
+    saveSequencesListPrefs(resolved);
+    void navigate({ search: nextSearch, replace: true });
+  }, [navigate, search]);
+
+  const setPrefs = useCallback(
+    (next: SequencesListPrefs) => {
+      saveSequencesListPrefs(next);
+      void navigate({
+        search: prefsToSearch(next, search.user),
+        replace: true,
+      });
+    },
+    [navigate, search.user]
+  );
+
+  return { prefs, setPrefs };
+}

--- a/src/lib/sequences/list-prefs.test.ts
+++ b/src/lib/sequences/list-prefs.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Sequences list prefs (#1314): URL search is the live snapshot; localStorage
+ * is what a bare /sequences visit restores. URL params never blend with
+ * stored values — a shared `?q=` must not turn on this browser's support mode.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mem = new Map<string, string>();
+const localStorageMock = {
+  getItem: (k: string) => mem.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    mem.set(k, v);
+  },
+  removeItem: (k: string) => {
+    mem.delete(k);
+  },
+};
+
+const storedPrefs = {
+  search: 'night diner',
+  analysisModel: 'analysis-1',
+  imageModel: 'image-1',
+  aspectRatio: '9:16' as const,
+  styleId: 'style-1',
+  supportMode: true,
+  hideInternal: true,
+};
+
+describe('sequences list prefs', () => {
+  beforeEach(() => {
+    mem.clear();
+    vi.stubGlobal('window', { localStorage: localStorageMock });
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads empty URL search as the default list prefs', async () => {
+    const { prefsFromSearch, DEFAULT_SEQUENCES_LIST_PREFS } =
+      await import('./list-prefs');
+
+    expect(prefsFromSearch({})).toEqual(DEFAULT_SEQUENCES_LIST_PREFS);
+  });
+
+  it('takes search from q, and user over q, forcing support on for the deep link', async () => {
+    const { prefsFromSearch } = await import('./list-prefs');
+
+    expect(prefsFromSearch({ q: 'cat' })).toMatchObject({
+      search: 'cat',
+      supportMode: false,
+    });
+    expect(
+      prefsFromSearch({
+        user: 'ada@example.com',
+        q: 'ignored',
+        support: false,
+        hideInternal: true,
+      })
+    ).toEqual({
+      search: 'ada@example.com',
+      analysisModel: null,
+      imageModel: null,
+      aspectRatio: null,
+      styleId: null,
+      supportMode: true,
+      hideInternal: false,
+    });
+  });
+
+  it('treats any list param as a complete URL snapshot', async () => {
+    const { searchSpecifiesPrefs } = await import('./list-prefs');
+
+    expect(searchSpecifiesPrefs({})).toBe(false);
+    expect(searchSpecifiesPrefs({ q: 'x' })).toBe(true);
+    expect(searchSpecifiesPrefs({ support: true })).toBe(true);
+    expect(searchSpecifiesPrefs({ user: 'ada@example.com' })).toBe(true);
+    expect(searchSpecifiesPrefs({ hideInternal: true })).toBe(true);
+  });
+
+  it('restores stored prefs only when the URL is bare', async () => {
+    const { resolveSequencesListPrefs } = await import('./list-prefs');
+
+    expect(resolveSequencesListPrefs({}, storedPrefs)).toEqual(storedPrefs);
+    expect(resolveSequencesListPrefs({}, null)).toEqual({
+      search: '',
+      analysisModel: null,
+      imageModel: null,
+      aspectRatio: null,
+      styleId: null,
+      supportMode: false,
+      hideInternal: false,
+    });
+  });
+
+  it('does not blend a partial URL with stored support mode or search', async () => {
+    const { resolveSequencesListPrefs } = await import('./list-prefs');
+
+    expect(resolveSequencesListPrefs({ q: 'shared' }, storedPrefs)).toEqual({
+      search: 'shared',
+      analysisModel: null,
+      imageModel: null,
+      aspectRatio: null,
+      styleId: null,
+      supportMode: false,
+      hideInternal: false,
+    });
+    expect(
+      resolveSequencesListPrefs({ user: 'ada@example.com' }, storedPrefs)
+    ).toMatchObject({
+      search: 'ada@example.com',
+      supportMode: true,
+      hideInternal: false,
+      analysisModel: null,
+    });
+  });
+
+  it('omits default prefs from the URL so /sequences stays canonical', async () => {
+    const { prefsToSearch, DEFAULT_SEQUENCES_LIST_PREFS } =
+      await import('./list-prefs');
+
+    expect(prefsToSearch(DEFAULT_SEQUENCES_LIST_PREFS)).toEqual({});
+    expect(
+      prefsToSearch({
+        search: 'cat',
+        analysisModel: 'analysis-1',
+        imageModel: null,
+        aspectRatio: '16:9',
+        styleId: 'style-1',
+        supportMode: true,
+        hideInternal: true,
+      })
+    ).toEqual({
+      q: 'cat',
+      analysisModel: 'analysis-1',
+      aspectRatio: '16:9',
+      styleId: 'style-1',
+      support: true,
+      hideInternal: true,
+    });
+  });
+
+  it('keeps the admin user param only while search still matches and support is on', async () => {
+    const { prefsToSearch } = await import('./list-prefs');
+    const user = 'ada@example.com';
+
+    expect(
+      prefsToSearch(
+        {
+          search: user,
+          analysisModel: null,
+          imageModel: null,
+          aspectRatio: null,
+          styleId: null,
+          supportMode: true,
+          hideInternal: false,
+        },
+        user
+      )
+    ).toEqual({ user });
+
+    expect(
+      prefsToSearch(
+        {
+          search: 'other',
+          analysisModel: null,
+          imageModel: null,
+          aspectRatio: null,
+          styleId: null,
+          supportMode: true,
+          hideInternal: false,
+        },
+        user
+      )
+    ).toEqual({ q: 'other', support: true });
+
+    expect(
+      prefsToSearch(
+        {
+          search: user,
+          analysisModel: null,
+          imageModel: null,
+          aspectRatio: null,
+          styleId: null,
+          supportMode: false,
+          hideInternal: false,
+        },
+        user
+      )
+    ).toEqual({ q: user });
+  });
+
+  it('round-trips prefs through localStorage and rejects garbage', async () => {
+    const {
+      loadSequencesListPrefs,
+      saveSequencesListPrefs,
+      SEQUENCES_LIST_PREFS_KEY,
+    } = await import('./list-prefs');
+
+    expect(loadSequencesListPrefs()).toBeNull();
+    saveSequencesListPrefs(storedPrefs);
+    expect(loadSequencesListPrefs()).toEqual(storedPrefs);
+
+    localStorage.setItem(SEQUENCES_LIST_PREFS_KEY, '{not json');
+    expect(loadSequencesListPrefs()).toBeNull();
+
+    localStorage.setItem(
+      SEQUENCES_LIST_PREFS_KEY,
+      JSON.stringify({ search: 'ok', aspectRatio: 'not-a-ratio' })
+    );
+    expect(loadSequencesListPrefs()).toMatchObject({
+      search: 'ok',
+      aspectRatio: null,
+      supportMode: false,
+    });
+  });
+});

--- a/src/lib/sequences/list-prefs.ts
+++ b/src/lib/sequences/list-prefs.ts
@@ -1,0 +1,159 @@
+/**
+ * Sequences list toolbar prefs (#1314).
+ *
+ * Live state lives in the /sequences search params (shareable, back/forward).
+ * localStorage is the memory for a bare `/sequences` visit (sidebar, breadcrumb).
+ *
+ * No `.default()` on the search schema: a default rewrites bare /sequences with
+ * a 307, which sours the sitemap entry (#814).
+ */
+import {
+  aspectRatioSchema,
+  type AspectRatio,
+} from '@/lib/constants/aspect-ratios';
+import { z } from 'zod';
+
+export const SEQUENCES_LIST_PREFS_KEY = 'openstory:sequences-list:v1';
+
+export const sequencesListSearchSchema = z.object({
+  user: z.string().email().optional(),
+  q: z.string().optional(),
+  analysisModel: z.string().optional(),
+  imageModel: z.string().optional(),
+  aspectRatio: aspectRatioSchema.optional(),
+  styleId: z.string().optional(),
+  support: z.boolean().optional(),
+  hideInternal: z.boolean().optional(),
+});
+
+export type SequencesListSearch = z.infer<typeof sequencesListSearchSchema>;
+
+export type SequencesListPrefs = {
+  search: string;
+  analysisModel: string | null;
+  imageModel: string | null;
+  aspectRatio: AspectRatio | null;
+  styleId: string | null;
+  supportMode: boolean;
+  hideInternal: boolean;
+};
+
+export const DEFAULT_SEQUENCES_LIST_PREFS: SequencesListPrefs = {
+  search: '',
+  analysisModel: null,
+  imageModel: null,
+  aspectRatio: null,
+  styleId: null,
+  supportMode: false,
+  hideInternal: false,
+};
+
+const optionalId = z.string().min(1).nullable().catch(null);
+
+const storedPrefsSchema = z.object({
+  search: z.string().catch(''),
+  analysisModel: optionalId,
+  imageModel: optionalId,
+  aspectRatio: aspectRatioSchema.nullable().catch(null),
+  styleId: optionalId,
+  supportMode: z.boolean().catch(false),
+  hideInternal: z.boolean().catch(false),
+});
+
+export function searchSpecifiesPrefs(search: SequencesListSearch): boolean {
+  return (
+    search.user != null ||
+    search.q != null ||
+    search.analysisModel != null ||
+    search.imageModel != null ||
+    search.aspectRatio != null ||
+    search.styleId != null ||
+    search.support != null ||
+    search.hideInternal != null
+  );
+}
+
+export function prefsFromSearch(
+  search: SequencesListSearch
+): SequencesListPrefs {
+  return {
+    search: search.user ?? search.q ?? '',
+    analysisModel: search.analysisModel ?? null,
+    imageModel: search.imageModel ?? null,
+    aspectRatio: search.aspectRatio ?? null,
+    styleId: search.styleId ?? null,
+    supportMode: Boolean(search.user) || Boolean(search.support),
+    hideInternal: search.user ? false : Boolean(search.hideInternal),
+  };
+}
+
+export function resolveSequencesListPrefs(
+  search: SequencesListSearch,
+  stored: SequencesListPrefs | null
+): SequencesListPrefs {
+  if (!searchSpecifiesPrefs(search)) {
+    return stored ?? DEFAULT_SEQUENCES_LIST_PREFS;
+  }
+  return prefsFromSearch(search);
+}
+
+export function isDefaultSequencesListPrefs(
+  prefs: SequencesListPrefs
+): boolean {
+  return (
+    prefs.search === '' &&
+    prefs.analysisModel == null &&
+    prefs.imageModel == null &&
+    prefs.aspectRatio == null &&
+    prefs.styleId == null &&
+    !prefs.supportMode &&
+    !prefs.hideInternal
+  );
+}
+
+export function prefsToSearch(
+  prefs: SequencesListPrefs,
+  currentUser?: string
+): SequencesListSearch {
+  const search: SequencesListSearch = {};
+  const keepUser =
+    Boolean(currentUser) && prefs.supportMode && prefs.search === currentUser;
+
+  if (keepUser && currentUser) {
+    search.user = currentUser;
+  } else if (prefs.search) {
+    search.q = prefs.search;
+  }
+
+  if (prefs.analysisModel) search.analysisModel = prefs.analysisModel;
+  if (prefs.imageModel) search.imageModel = prefs.imageModel;
+  if (prefs.aspectRatio) search.aspectRatio = prefs.aspectRatio;
+  if (prefs.styleId) search.styleId = prefs.styleId;
+  if (prefs.supportMode && !search.user) search.support = true;
+  if (prefs.hideInternal && prefs.supportMode && !search.user) {
+    search.hideInternal = true;
+  }
+  return search;
+}
+
+export function loadSequencesListPrefs(): SequencesListPrefs | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(SEQUENCES_LIST_PREFS_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    const result = storedPrefsSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSequencesListPrefs(prefs: SequencesListPrefs): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(SEQUENCES_LIST_PREFS_KEY, JSON.stringify(prefs));
+  } catch {
+    // private mode / quota
+  }
+}

--- a/src/routes/_app/sequences/index.tsx
+++ b/src/routes/_app/sequences/index.tsx
@@ -1,23 +1,20 @@
 import { SignInPrompt } from '@/components/auth/sign-in-prompt';
 import { EvalView } from '@/components/eval/eval-view';
 import { PageContainer } from '@/components/layout/page-container';
+import { useSequencesListPrefs } from '@/hooks/use-sequences-list-prefs';
 import { useUser } from '@/hooks/use-user';
+import { sequencesListSearchSchema } from '@/lib/sequences/list-prefs';
 import { createFileRoute } from '@tanstack/react-router';
 import { Video } from 'lucide-react';
-import { z } from 'zod';
-
-const searchSchema = z.object({
-  user: z.string().email().optional(),
-});
 
 export const Route = createFileRoute('/_app/sequences/')({
-  validateSearch: searchSchema,
+  validateSearch: sequencesListSearchSchema,
   component: SequencesPage,
   staticData: { breadcrumb: 'Sequences' },
 });
 
 function SequencesPage() {
-  const { user } = Route.useSearch();
+  const search = Route.useSearch();
   const { data: currentUser } = useUser();
 
   return (
@@ -28,7 +25,7 @@ function SequencesPage() {
     >
       <h1 className="sr-only">Your Sequences</h1>
       {currentUser ? (
-        <EvalView initialUserFilter={user} />
+        <SequencesEvalView search={search} />
       ) : (
         <SignInPrompt
           icon={<Video className="h-12 w-12" />}
@@ -38,4 +35,15 @@ function SequencesPage() {
       )}
     </PageContainer>
   );
+}
+
+function SequencesEvalView({
+  search,
+}: {
+  search: ReturnType<typeof Route.useSearch>;
+}) {
+  const navigate = Route.useNavigate();
+  const { prefs, setPrefs } = useSequencesListPrefs(search, navigate);
+
+  return <EvalView search={search} prefs={prefs} setPrefs={setPrefs} />;
 }


### PR DESCRIPTION
Fixes #1314

The sequences list kept search, filters, and support mode in React state, so they reset when you left via the sidebar or breadcrumb.

## Behavior
- Toolbar state is written to the URL (`q`, `analysisModel`, `imageModel`, `aspectRatio`, `styleId`, `support`, `hideInternal`) so refresh and back/forward keep it.
- The same snapshot is stored in `localStorage` (`openstory:sequences-list:v1`). A bare `/sequences` visit restores it.
- Admin `?user=` deep links still win (search + support on, hide-internal locked).
- Remembered support mode is applied only for system admins, so a non-admin cannot 403 the list.
- No `.default()` on search params, so `/sequences` stays a 200 for the sitemap.

## Tests
- Unit: URL vs stored merge, `?user=` precedence, localStorage round-trip.
- E2E: restore search + aspect ratio from storage; remembered support does not error for a non-admin.