### PR TITLE
fix: let signed-out visitors submit feedback

### DIFF
--- a/src/components/feedback/feedback-dialog.tsx
+++ b/src/components/feedback/feedback-dialog.tsx
@@ -1,5 +1,7 @@
 /**
  * Super-simple feedback dialog — one message field, send email + product event.
+ * Works signed out too (the sidebar shows it to everyone): visitors get an
+ * optional email field so we can reply.
  */
 
 import { Button } from '@/components/ui/button';
@@ -11,8 +13,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { submitFeedbackFn } from '@/functions/feedback';
+import { useUser } from '@/hooks/use-user';
 import { useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 
@@ -23,9 +27,11 @@ type FeedbackDialogProps = {
 
 export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
   const [message, setMessage] = useState('');
+  const { data: user } = useUser();
 
   const mutation = useMutation({
-    mutationFn: (text: string) => submitFeedbackFn({ data: { message: text } }),
+    mutationFn: (input: { message: string; email?: string }) =>
+      submitFeedbackFn({ data: input }),
     onSuccess: () => {
       setMessage('');
     },
@@ -39,11 +45,15 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
     }
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const trimmed = message.trim();
     if (!trimmed || mutation.isPending) return;
-    mutation.mutate(trimmed);
+    const email = new FormData(e.currentTarget).get('email');
+    mutation.mutate({
+      message: trimmed,
+      email: typeof email === 'string' ? email : undefined,
+    });
   };
 
   return (
@@ -69,6 +79,18 @@ export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
                 Bugs, ideas, or anything else — send a short note.
               </DialogDescription>
             </DialogHeader>
+
+            {!user && (
+              <Input
+                type="email"
+                name="email"
+                autoComplete="email"
+                inputMode="email"
+                maxLength={254}
+                placeholder="Email (optional — if you'd like a reply)"
+                aria-label="Email (optional)"
+              />
+            )}
 
             <Textarea
               name="message"

--- a/src/functions/feedback.ts
+++ b/src/functions/feedback.ts
@@ -1,15 +1,23 @@
 /**
  * In-app feedback — sidebar dialog posts here, we email CONTACT_EMAIL.
+ *
+ * Anonymous-first: the sidebar shows Feedback to everyone, so this must not
+ * require a session — a visitor's message used to bounce with "Authentication
+ * required" and was lost. Signed-in users are identified from the session;
+ * visitors may leave an optional email.
  */
 
+import { scheduleFlushAnalytics } from '#flush-scheduler';
+import { getAuth } from '@/lib/auth/config';
+import { resolveUserTeam } from '@/lib/db/scoped';
 import { ValidationError } from '@/lib/errors';
 import { CONTACT_EMAIL } from '@/lib/marketing/constants';
 import { captureProductEvent } from '@/lib/observability/product-events';
 import { sendFeedbackEmail } from '@/lib/services/email-service';
 import { createServerFn } from '@tanstack/react-start';
+import { getRequest } from '@tanstack/react-start/server';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
-import { authWithTeamMiddleware } from './middleware';
 
 const feedbackInputSchema = z.object({
   message: z
@@ -17,30 +25,47 @@ const feedbackInputSchema = z.object({
     .trim()
     .min(1, 'Write a short message')
     .max(2000, 'Keep it under 2000 characters'),
+  /** Reply address for visitors without a session; ignored when signed in. */
+  email: z
+    .string()
+    .trim()
+    .email('Enter a valid email')
+    .max(254)
+    .or(z.literal(''))
+    .optional(),
 });
 
 export const submitFeedbackFn = createServerFn({ method: 'POST' })
-  .middleware([authWithTeamMiddleware])
   .validator(zodValidator(feedbackInputSchema))
-  .handler(async ({ data, context }) => {
+  .handler(async ({ data }) => {
+    const session = await getAuth().api.getSession({
+      headers: getRequest().headers,
+    });
+    const user = session?.user ?? null;
+    const team = user ? await resolveUserTeam(user.id) : null;
+    const userEmail = user?.email ?? data.email ?? '';
+
     const result = await sendFeedbackEmail({
       to: CONTACT_EMAIL,
-      userName: context.user.name,
-      userEmail: context.user.email,
-      teamId: context.teamId,
+      userName: user?.name ?? 'Anonymous visitor',
+      userEmail: userEmail || 'not provided',
+      teamId: team?.teamId ?? '—',
       message: data.message,
     });
 
     captureProductEvent({
-      distinctId: context.user.id,
+      distinctId: user?.id ?? 'anonymous',
       event: 'feedback_submitted',
       properties: {
-        teamId: context.teamId,
-        userEmail: context.user.email,
+        teamId: team?.teamId ?? null,
+        userEmail: userEmail || null,
+        anonymous: !user,
         emailSent: result.success,
         messageLength: data.message.length,
       },
     });
+    // No auth middleware here, so no analyticsFlushMiddleware — flush ourselves.
+    await scheduleFlushAnalytics();
 
     if (!result.success) {
       throw new ValidationError(

--- a/src/functions/middleware.ts
+++ b/src/functions/middleware.ts
@@ -28,7 +28,11 @@ import {
   restrictionNotice,
 } from '@/lib/compliance/enforcement';
 import { loadComplianceState } from '@/lib/compliance/generation-gate';
-import { AccountRestrictedError, NotFoundError } from '@/lib/errors';
+import {
+  AccountRestrictedError,
+  AuthenticationError,
+  NotFoundError,
+} from '@/lib/errors';
 import {
   errorHeadline,
   getLogger,
@@ -370,7 +374,7 @@ export const authMiddleware = createMiddleware({ type: 'function' }).server(
     const session = await auth.api.getSession({ headers: request.headers });
 
     if (!session?.user) {
-      throw new Error('Authentication required');
+      throw new AuthenticationError('Authentication required');
     }
 
     return next({


### PR DESCRIPTION
## What

The sidebar shows **Feedback** to everyone (the app is anonymous-first), but `submitFeedbackFn` was wrapped in `authWithTeamMiddleware`, so a signed-out visitor's message bounced with a bare "Authentication required" and was lost. Seen in prod at 2026-08-26 00:12Z: an anonymous visitor on the composer clicked Feedback → Send, got the error, and left 4s later.

- `submitFeedbackFn` resolves the session itself instead of requiring one. Anonymous senders are emailed as "Anonymous visitor" with an optional reply email; signed-in users are unchanged (name/email/team from the session).
- `FeedbackDialog` shows an optional email input only when signed out.
- `authMiddleware` throws `AuthenticationError` (401) instead of a plain `Error`, so anonymous bounces on other server fns stop logging as `code: UNKNOWN` server faults.

## Notes

- `feedback_submitted` now carries `anonymous: true/false`; anonymous events use `distinctId: 'anonymous'`.
- No auth middleware means no `analyticsFlushMiddleware`, so the handler calls `scheduleFlushAnalytics()` itself.
- No issue for this one (per Tom).

## Verification

`bun typecheck`, `bun lint`, `bun format:check`, `bun dead-code`, `bun run test src/functions src/lib/observability` (157 passed) all green; lefthook pre-commit passed.