### PR TITLE
fix(#1317): send max_tokens so requireParameters keeps DeepSeek routable

### DIFF
--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -696,6 +696,24 @@ describe('llm-client', () => {
         });
       });
 
+      it('sends max_tokens, not max_completion_tokens, so requireParameters keeps DeepSeek routable', async () => {
+        // DeepSeek endpoints advertise `max_tokens` only; `max_completion_tokens`
+        // + requireParameters returned "No endpoints found" on the region fallback.
+        mockChat.mockReturnValue(textStream());
+
+        await drain(
+          callLLMStream({
+            model: 'deepseek/deepseek-v4-pro-0813',
+            max_tokens: 300,
+            messages: [{ role: 'user', content: 'test' }],
+          })
+        );
+
+        const options = mockChat.mock.calls[0]?.[0]?.modelOptions;
+        expect(options.maxTokens).toBe(300);
+        expect(options.maxCompletionTokens).toBeUndefined();
+      });
+
       it('caller-supplied provider preferences layer on top', async () => {
         mockChat.mockReturnValue(textStream());
 

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -398,7 +398,10 @@ function buildModelOptions(params: LLMRequestParams) {
   return {
     provider,
     ...(params.reasoning && { reasoning: params.reasoning }),
-    maxCompletionTokens: params.max_tokens,
+    // `maxTokens`, not `maxCompletionTokens`: DeepSeek endpoints advertise only
+    // `max_tokens`, so `max_completion_tokens` + requireParameters empties the
+    // candidate set ("No endpoints found…") on the region fallback.
+    maxTokens: params.max_tokens,
     temperature: params.temperature,
     topP: params.top_p,
     frequencyPenalty: params.frequency_penalty,


### PR DESCRIPTION
Closes #1317

Every DeepSeek call through OpenRouter — including the #1259 region fallback — failed with `No endpoints found that can handle the requested parameters`.

**Cause:** `buildModelOptions` sent `maxCompletionTokens` (`max_completion_tokens`) alongside `provider: { requireParameters: true }`. All 15 DeepSeek endpoints advertise `max_tokens` but not `max_completion_tokens` in `supported_parameters`, so the candidate set was empty. Bisected with curl: same request with `max_tokens` routes fine.

**Fix:** send `maxTokens` instead. Verified live against DeepSeek (structured output returns) and `anthropic/claude-sonnet-5` (unchanged). Regression test asserts `maxTokens` is set and `maxCompletionTokens` is not.