### PR TITLE
fix(#1322): chunk frames/shots/frameVariants id reads under D1's 100-param cap

### DIFF
--- a/src/lib/db/scoped/frame-variants.test.ts
+++ b/src/lib/db/scoped/frame-variants.test.ts
@@ -28,7 +28,15 @@ import { type Client, createClient } from '@libsql/client';
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { createFramePromptVersionsMethods } from './frame-prompt-versions';
 import { createFrameVariantsMethods } from './frame-variants';
 
@@ -1125,5 +1133,37 @@ describe("frameVariants kind: 'preview' (#1101)", () => {
     );
     const byFrame = await m.listLatestPreviewsByFrameIds([frameId]);
     expect(byFrame.get(frameId)?.url).toBe('https://fal.media/real.png');
+  });
+});
+
+describe('frameVariants.getSelectedByFrameIds (#1322)', () => {
+  it("chunks the id list under D1's 100-param ceiling and returns every selection", async () => {
+    // The scenes page loads this for every frame of a sequence; a >100-frame
+    // sequence threw `too many SQL variables` on D1. libsql has no cap, so the
+    // spy is what pins the fan-out.
+    const m = createFrameVariantsMethods(db);
+    const ids: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      const id = generateId();
+      ids.push(id);
+      await db
+        .insert(frames)
+        .values({ id, shotId, sequenceId, orderIndex: i + 1, role: 'first' });
+      const [v] = await db
+        .insert(frameVariants)
+        .values({ frameId: id, sequenceId, model: 'm', status: 'completed' })
+        .returning();
+      if (!v) throw new Error('test setup: variant insert returned nothing');
+      await db
+        .update(frames)
+        .set({ selectedImageVersionId: v.id })
+        .where(eq(frames.id, id));
+    }
+    const select = vi.spyOn(db, 'select');
+    const byFrame = await m.getSelectedByFrameIds(ids);
+    expect(byFrame.size).toBe(200);
+    for (const id of ids) expect(byFrame.get(id)?.frameId).toBe(id);
+    expect(select).toHaveBeenCalledTimes(3);
+    select.mockRestore();
   });
 });

--- a/src/lib/db/scoped/frame-variants.ts
+++ b/src/lib/db/scoped/frame-variants.ts
@@ -805,17 +805,27 @@ export function createFrameVariantsMethods(db: Database) {
       frameIds: string[]
     ): Promise<Map<string, FrameVariant>> => {
       if (frameIds.length === 0) return new Map();
-      const rows = await db
-        .select({ frameId: frames.id, version: frameVariants })
-        .from(frames)
-        .innerJoin(
-          frameVariants,
-          eq(frameVariants.id, frames.selectedImageVersionId)
-        )
-        .where(
-          and(inArray(frames.id, frameIds), isNull(frameVariants.discardedAt))
-        );
-      return new Map(rows.map((r) => [r.frameId, r.version]));
+      const byFrame = new Map<string, FrameVariant>();
+      for (let i = 0; i < frameIds.length; i += PREVIEW_BY_FRAMES_BATCH) {
+        const rows = await db
+          .select({ frameId: frames.id, version: frameVariants })
+          .from(frames)
+          .innerJoin(
+            frameVariants,
+            eq(frameVariants.id, frames.selectedImageVersionId)
+          )
+          .where(
+            and(
+              inArray(
+                frames.id,
+                frameIds.slice(i, i + PREVIEW_BY_FRAMES_BATCH)
+              ),
+              isNull(frameVariants.discardedAt)
+            )
+          );
+        for (const r of rows) byFrame.set(r.frameId, r.version);
+      }
+      return byFrame;
     },
 
     /**

--- a/src/lib/db/scoped/frames.test.ts
+++ b/src/lib/db/scoped/frames.test.ts
@@ -22,7 +22,15 @@ import { type Client, createClient } from '@libsql/client';
 import { eq } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { createFramesMethods } from './frames';
 
 let client: Client;
@@ -298,5 +306,27 @@ describe('frames.setPendingPromoteVersionId (#1101)', () => {
       .from(frames)
       .where(eq(frames.id, frame.id));
     expect(cleared?.pendingPromoteVersionId).toBeNull();
+  });
+});
+
+describe('frames.getByIds (#1322)', () => {
+  it("chunks the id list under D1's 100-param ceiling and returns every row", async () => {
+    // libsql has no bound-param cap, so a single IN(…) would pass here and
+    // throw `too many SQL variables` on D1 — assert the fan-out directly.
+    const m = createFramesMethods(db);
+    const ids: string[] = [];
+    for (let i = 0; i < 200; i++) {
+      const id = generateId();
+      ids.push(id);
+      await db
+        .insert(frames)
+        .values({ id, shotId, sequenceId, orderIndex: i, role: 'first' });
+    }
+    const select = vi.spyOn(db, 'select');
+    const rows = await m.getByIds(ids);
+    expect(rows).toHaveLength(200);
+    expect(new Set(rows.map((r) => r.id))).toEqual(new Set(ids));
+    expect(select).toHaveBeenCalledTimes(3);
+    select.mockRestore();
   });
 });

--- a/src/lib/db/scoped/frames.ts
+++ b/src/lib/db/scoped/frames.ts
@@ -88,6 +88,11 @@ type FrameMirrorColumn =
 /** Fields `update` accepts — everything on a frame except the mirror columns. */
 export type FrameUpdateInput = Omit<Partial<NewFrame>, FrameMirrorColumn>;
 
+// One bound param per id; 90 keeps each query under D1's 100-bound-parameter
+// ceiling (#1322). Unit tests run on libsql, which has no such cap — an
+// unchunked list passes CI and throws `too many SQL variables` on D1.
+const FRAMES_BY_IDS_BATCH = 90;
+
 export function createFramesMethods(db: Database) {
   return {
     getById: async (frameId: string): Promise<Frame | null> => {
@@ -100,7 +105,18 @@ export function createFramesMethods(db: Database) {
 
     getByIds: async (frameIds: string[]): Promise<Frame[]> => {
       if (frameIds.length === 0) return [];
-      return await db.select().from(frames).where(inArray(frames.id, frameIds));
+      const rows: Frame[] = [];
+      for (let i = 0; i < frameIds.length; i += FRAMES_BY_IDS_BATCH) {
+        rows.push(
+          ...(await db
+            .select()
+            .from(frames)
+            .where(
+              inArray(frames.id, frameIds.slice(i, i + FRAMES_BY_IDS_BATCH))
+            ))
+        );
+      }
+      return rows;
     },
 
     /**

--- a/src/lib/db/scoped/shots-by-ids.test.ts
+++ b/src/lib/db/scoped/shots-by-ids.test.ts
@@ -16,8 +16,17 @@ import { relations } from '@/lib/db/schema/relations';
 import { type Client, createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { createSequencesMethods } from './sequences';
+import { createShotsMethods } from './shots';
 
 let client: Client;
 let db: Database;
@@ -158,5 +167,23 @@ describe('listShotsByIds', () => {
 
     expect(result).toHaveLength(2 * 3);
     expect(result.every((f) => f.sequenceId !== otherSeqId)).toBe(true);
+  });
+});
+
+describe('shots.getByIds (#1322)', () => {
+  it("chunks the id list under D1's 100-param ceiling and returns every row", async () => {
+    // 70 sequences × 3 shots = 210 ids → 3 batches of ≤90. libsql has no
+    // bound-param cap, so the spy is what pins the fan-out.
+    await seedSequences(styleId, 70);
+    const all = await db.select({ id: shots.id }).from(shots);
+    const ids = all.map((s) => s.id);
+    expect(ids).toHaveLength(210);
+
+    const select = vi.spyOn(db, 'select');
+    const rows = await createShotsMethods(db).getByIds(ids);
+    expect(rows).toHaveLength(210);
+    expect(new Set(rows.map((r) => r.id))).toEqual(new Set(ids));
+    expect(select).toHaveBeenCalledTimes(3);
+    select.mockRestore();
   });
 });

--- a/src/lib/db/scoped/shots.ts
+++ b/src/lib/db/scoped/shots.ts
@@ -64,6 +64,10 @@ export type ShotWithAnchorFrame = Shot & { anchorFrameId: string };
 // well under D1's 100-bound-parameter ceiling (see `ensureAnchorFrames`).
 const ANCHOR_FRAMES_BATCH = 9;
 
+// One bound param per id; 90 keeps `getByIds` under D1's 100-bound-parameter
+// ceiling (#1322). libsql (unit tests) has no such cap.
+const SHOTS_BY_IDS_BATCH = 90;
+
 // No `hasVideo` filter: it had no callers, and its condition was inverted
 // (`hasVideo: true` pushed `video_url IS NULL`). Whether a shot has a video is
 // now a question about its render segment's selection pointer, not a shot
@@ -312,7 +316,16 @@ export function createShotsMethods(db: Database) {
 
     getByIds: async (shotIds: string[]): Promise<Shot[]> => {
       if (shotIds.length === 0) return [];
-      return await db.select().from(shots).where(inArray(shots.id, shotIds));
+      const rows: Shot[] = [];
+      for (let i = 0; i < shotIds.length; i += SHOTS_BY_IDS_BATCH) {
+        rows.push(
+          ...(await db
+            .select()
+            .from(shots)
+            .where(inArray(shots.id, shotIds.slice(i, i + SHOTS_BY_IDS_BATCH))))
+        );
+      }
+      return rows;
     },
 
     getWithSequence: async (


### PR DESCRIPTION
Closes #1322

Opening a sequence with more than ~100 frames failed on the scenes page with `too many SQL variables at offset 1082: SQLITE_ERROR` (11 prod hits on 2026-08-26). D1 caps bound parameters at 100; three same-shape readers still issued one `IN (…)` over every id:

- `frames.getByIds`
- `shots.getByIds`
- `frameVariants.getSelectedByFrameIds`

Each is now chunked at 90, the same pattern #1019 applied to `framePromptVersions.getSelectedByFrameIds` and the other scoped readers.

**Tests:** one per method with 200–210 ids. libsql has no param cap, so a plain "returns every row" assertion can't regress — each test also spies on `db.select` and asserts 3 calls, which is what actually pins the fan-out.