### PR TITLE
fix(#1323): retry on the vision fallback when DeepSeek rejects image input

### DIFF
--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -356,6 +356,47 @@ describe('llm-client', () => {
       );
     });
 
+    it('retries DeepSeek rejecting image input with the vision fallback (#1323)', async () => {
+      mockChat
+        .mockReturnValueOnce(
+          (async function* () {
+            yield {
+              type: 'RUN_ERROR',
+              message: 'No endpoints found that support image input',
+              model: 'deepseek/deepseek-v4-pro-0813',
+            };
+          })()
+        )
+        .mockReturnValueOnce(
+          (async function* () {
+            yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'vision answer' };
+          })()
+        );
+
+      const result = await callLLM({
+        model: 'deepseek/deepseek-v4-pro-0813',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', content: 'describe' },
+              {
+                type: 'image',
+                source: { type: 'url', value: 'https://cdn/el.png' },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result).toBe('vision answer');
+      expect(mockCreateAdapter).toHaveBeenNthCalledWith(
+        2,
+        'mistralai/mistral-small-2603',
+        undefined
+      );
+    });
+
     it('does not retry a region block after content was already yielded', async () => {
       mockChat.mockReturnValueOnce(
         (async function* () {

--- a/src/lib/ai/region-policy.test.ts
+++ b/src/lib/ai/region-policy.test.ts
@@ -18,6 +18,14 @@ describe('isRegionBlockedLlmError', () => {
     ).toBe(true);
   });
 
+  it('matches the text-only fallback rejecting image input (#1323)', () => {
+    expect(
+      isRegionBlockedLlmError(
+        'LLM stream error [model=deepseek/deepseek-v4-pro-0813]: No endpoints found that support image input'
+      )
+    ).toBe(true);
+  });
+
   it('does not match other provider errors', () => {
     expect(isRegionBlockedLlmError('LLM stream error: 401 Unauthorized')).toBe(
       false

--- a/src/lib/ai/region-policy.ts
+++ b/src/lib/ai/region-policy.ts
@@ -49,9 +49,14 @@ export const REGION_FALLBACK_TEXT_MODEL =
 export const REGION_FALLBACK_VISION_MODEL =
   'mistralai/mistral-small-2603' satisfies TextModel;
 
-/** Matches the provider error a geo-blocked model returns through OpenRouter. */
+/**
+ * Errors the region fallback recovers from: the geo-block itself, and the
+ * text-only DeepSeek fallback being handed images (#1323 — "No endpoints
+ * found that support image input"). Both retry on `regionFallbackModel`, which
+ * picks the vision-capable fallback when the messages carry images.
+ */
 export function isRegionBlockedLlmError(message: string): boolean {
-  return /not available in your region|unsupported_country_region/i.test(
+  return /not available in your region|unsupported_country_region|no endpoints found that support image input/i.test(
     message
   );
 }


### PR DESCRIPTION
Closes #1323

A user in an Anthropic-blocked region gets DeepSeek from the model picker (`resolveModelForCountry`). DeepSeek is text-only, so **Enhance script** with uploaded element images failed in prod (2026-08-26 04:07 UTC):

> Error: No endpoints found that support image input

`callLLMStream` / `withRegionFallback` already retry a geo-blocked call on `regionFallbackModel(model, hasImages)`, which returns `REGION_FALLBACK_VISION_MODEL` (Mistral) when the messages carry images. This PR adds the image-input rejection to `isRegionBlockedLlmError`, so the same retry fires — one matcher, every caller (Enhance stream, workflow steps) covered.

If the failing model is already the vision fallback, `regionFallbackModel` returns `null` and the error rethrows as before.

**Tests:** matcher accepts the prod error string; `callLLM` on `deepseek/…` with an image part retries once on `mistralai/mistral-small-2603`.