### PR TITLE
 fix: migrate Storybook MSW addon to v3

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-a11y',
     '@storybook/addon-themes',
+    'msw-storybook-addon',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,7 +2,8 @@ import { withThemeByClassName } from '@storybook/addon-themes';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RealtimeProvider } from '../src/lib/realtime/client';
-import { initialize, mswLoader } from 'msw-storybook-addon';
+import { mswLoader } from 'msw-storybook-addon/csf3';
+import { setupWorker } from 'msw/browser';
 import { handlers } from '../src/lib/mocks/handlers';
 
 import '../src/styles/global.css';
@@ -12,9 +13,6 @@ import '../src/styles/global.css';
  * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
  * to learn how to customize it
  */
-initialize({
-  onUnhandledRequest: 'bypass',
-});
 
 // Create a client for Storybook
 const queryClient = new QueryClient({
@@ -64,8 +62,13 @@ const preview: Preview = {
       test: 'todo',
     },
   },
-
-  loaders: [mswLoader],
+  loaders: [
+    mswLoader(async () => {
+      const worker = setupWorker();
+      await worker.start({ onUnhandledRequest: 'bypass' });
+      return worker;
+    }),
+  ],
 
   decorators: [
     withProviders,


### PR DESCRIPTION
## Description

Fixes #1245.

Migrates the Storybook MSW configuration from the v2 API to the v3 API.

### Changes

- Replace the removed `initialize` API with `mswLoader` from `msw-storybook-addon/csf3`
- Configure the MSW worker using `setupWorker`
- Preserve `onUnhandledRequest: 'bypass'`
- Register `msw-storybook-addon` in Storybook's addons configuration

### Verification

- `git diff --check` passes
- Pre-commit `dead-code`, `format`, `lint`, and `typecheck` checks pass
- Storybook starts without the original `initialize` export error

The production Storybook build currently encounters an unrelated Windows path-resolution error in the existing `server-stub` Vite plugin.
