### PR TITLE
fix(#1328): show a top-up prompt instead of a scary credits error

### DIFF
--- a/src/components/eval/eval-sequence-metadata.stories.tsx
+++ b/src/components/eval/eval-sequence-metadata.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { SequenceListStatus } from './eval-sequence-metadata';
+
+const meta: Meta<typeof SequenceListStatus> = {
+  title: 'Sequence/SequenceListStatus',
+  component: SequenceListStatus,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SequenceListStatus>;
+
+export const CreditsShort: Story = {
+  name: 'Out of credits (#1328)',
+  args: {
+    sequence: {
+      status: 'failed',
+      statusError:
+        'Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.',
+      musicError: null,
+      shots: [],
+    },
+  },
+};
+
+export const GenerationFailed: Story = {
+  args: {
+    sequence: {
+      status: 'failed',
+      statusError: 'Child workflow scene-split failed',
+      musicError: null,
+      shots: [],
+    },
+  },
+};

--- a/src/components/eval/eval-sequence-metadata.test.tsx
+++ b/src/components/eval/eval-sequence-metadata.test.tsx
@@ -1,0 +1,87 @@
+import { CREDITS_SHORT_TITLE } from '@/lib/billing/credits-short';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import {
+  SequenceListStatus,
+  sequenceListFailure,
+} from './eval-sequence-metadata';
+
+const creditsError =
+  'Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.';
+
+const failedShot = {
+  frame: { imageStatus: 'failed' as const },
+  videoStatus: 'pending' as const,
+};
+
+describe('sequenceListFailure', () => {
+  it('treats a reservation-short failed sequence as credits, not an error (#1328)', () => {
+    expect(
+      sequenceListFailure({
+        status: 'failed',
+        statusError: creditsError,
+        musicError: null,
+        shots: [],
+      })
+    ).toEqual({ creditsShort: true, errorCount: 0 });
+  });
+
+  it('still counts a real generation failure as an error', () => {
+    expect(
+      sequenceListFailure({
+        status: 'failed',
+        statusError: 'Child workflow scene-split failed',
+        musicError: null,
+        shots: [],
+      })
+    ).toEqual({ creditsShort: false, errorCount: 1 });
+  });
+
+  it('counts shot failures even when the sequence is credits-short', () => {
+    expect(
+      sequenceListFailure({
+        status: 'failed',
+        statusError: creditsError,
+        musicError: null,
+        shots: [failedShot],
+      })
+    ).toEqual({ creditsShort: true, errorCount: 1 });
+  });
+});
+
+describe('SequenceListStatus', () => {
+  it('renders a muted top-up line instead of a red error icon', () => {
+    const html = renderToStaticMarkup(
+      <SequenceListStatus
+        sequence={{
+          status: 'failed',
+          statusError: creditsError,
+          musicError: null,
+          shots: [],
+        }}
+      />
+    );
+
+    expect(html).toContain(CREDITS_SHORT_TITLE);
+    expect(html).toContain('text-muted-foreground');
+    expect(html).not.toContain('1 error');
+    expect(html).not.toContain('text-destructive');
+  });
+
+  it('keeps the red error icon for real generation failures', () => {
+    const html = renderToStaticMarkup(
+      <SequenceListStatus
+        sequence={{
+          status: 'failed',
+          statusError: 'Child workflow scene-split failed',
+          musicError: null,
+          shots: [],
+        }}
+      />
+    );
+
+    expect(html).toContain('1 error');
+    expect(html).toContain('text-destructive');
+    expect(html).not.toContain(CREDITS_SHORT_TITLE);
+  });
+});

--- a/src/components/eval/eval-sequence-metadata.tsx
+++ b/src/components/eval/eval-sequence-metadata.tsx
@@ -4,10 +4,21 @@ import { ModelBadge } from '@/components/model/model-badge';
 import { StyleBadge } from '@/components/style/style-badge';
 import type { SequenceWithShots } from '@/hooks/use-sequences-with-shots';
 import { getImageModelById } from '@/lib/ai/models';
+import {
+  CREDITS_SHORT_TITLE,
+  isCreditsShortError,
+} from '@/lib/billing/credits-short';
 import { getAspectRatioData } from '@/lib/constants/aspect-ratios';
 import { formatDistanceToNow } from '@/lib/format-date';
 import { Link } from '@tanstack/react-router';
-import { AlertTriangle, Calendar, ImageIcon, Mail, User } from 'lucide-react';
+import {
+  AlertTriangle,
+  Calendar,
+  CreditCard,
+  ImageIcon,
+  Mail,
+  User,
+} from 'lucide-react';
 import { getCreatorIdentity } from './creator-identity';
 
 type EvalSequenceMetadataProps = {
@@ -81,7 +92,7 @@ export const EvalSequenceMetadata: React.FC<EvalSequenceMetadataProps> = ({
         {sequence.shots.length === 1 ? 'scene' : 'scenes'}
       </div>
 
-      <SequenceErrors sequence={sequence} />
+      <SequenceListStatus sequence={sequence} />
     </div>
   );
 };
@@ -116,27 +127,54 @@ const CreatorIdentity: React.FC<{ sequence: SequenceWithShots }> = ({
   );
 };
 
-const SequenceErrors: React.FC<{ sequence: SequenceWithShots }> = ({
-  sequence,
-}) => {
+type SequenceListFailureInput = {
+  status: SequenceWithShots['status'];
+  statusError: SequenceWithShots['statusError'];
+  musicError: SequenceWithShots['musicError'];
+  shots: ReadonlyArray<{
+    frame: { imageStatus: string | null };
+    videoStatus: string | null;
+  }>;
+};
+
+export function sequenceListFailure(sequence: SequenceListFailureInput): {
+  creditsShort: boolean;
+  errorCount: number;
+} {
+  const creditsShort =
+    sequence.status === 'failed' && isCreditsShortError(sequence.statusError);
   let errorCount = 0;
-
-  if (sequence.status === 'failed') errorCount++;
+  if (sequence.status === 'failed' && !creditsShort) errorCount++;
   if (sequence.musicError) errorCount++;
-
   errorCount += sequence.shots.filter(
     (f) => f.frame.imageStatus === 'failed'
   ).length;
   errorCount += sequence.shots.filter((f) => f.videoStatus === 'failed').length;
+  return { creditsShort, errorCount };
+}
 
-  if (errorCount === 0) return null;
+export const SequenceListStatus: React.FC<{
+  sequence: SequenceListFailureInput;
+}> = ({ sequence }) => {
+  const { creditsShort, errorCount } = sequenceListFailure(sequence);
+  if (!creditsShort && errorCount === 0) return null;
 
   return (
-    <div className="flex items-center gap-1 text-xs text-destructive">
-      <AlertTriangle className="h-3 w-3 shrink-0" />
-      <span>
-        {errorCount} {errorCount === 1 ? 'error' : 'errors'}
-      </span>
+    <div className="flex flex-col gap-1">
+      {creditsShort && (
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          <CreditCard className="h-3 w-3 shrink-0" />
+          <span>{CREDITS_SHORT_TITLE}</span>
+        </div>
+      )}
+      {errorCount > 0 && (
+        <div className="flex items-center gap-1 text-xs text-destructive">
+          <AlertTriangle className="h-3 w-3 shrink-0" />
+          <span>
+            {errorCount} {errorCount === 1 ? 'error' : 'errors'}
+          </span>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/eval/eval-sequences-mobile.tsx
+++ b/src/components/eval/eval-sequences-mobile.tsx
@@ -13,6 +13,7 @@ import { getAspectRatioData } from '@/lib/constants/aspect-ratios';
 import { getAnalysisModelById } from '@/lib/ai/models.config';
 import { Link } from '@tanstack/react-router';
 import { ChevronRight, Mail, User } from 'lucide-react';
+import { SequenceListStatus } from './eval-sequence-metadata';
 import { getCreatorIdentity } from './creator-identity';
 
 // Strip cell height in px. Widths follow each sequence's aspect ratio so the
@@ -182,6 +183,7 @@ const MobileReelRow: React.FC<MobileReelRowProps> = ({
             {sequence.title || 'Untitled Sequence'}
           </Link>
           <CreatorIdentity sequence={sequence} />
+          <SequenceListStatus sequence={sequence} />
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {hasVariants && (

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -1132,7 +1132,11 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
     setIsRetrying(true);
     try {
       const result = await smartRetryFn({ data: { sequenceId } });
-      toast.success(`Retrying: ${result.retriedItems.join(', ')}`);
+      toast.success(
+        result.retryType === 'full'
+          ? 'Continuing generation'
+          : `Retrying: ${result.retriedItems.join(', ')}`
+      );
       void queryClient.invalidateQueries({
         queryKey: ['sequence', sequenceId],
       });

--- a/src/components/sequence/failure-summary-banner.stories.tsx
+++ b/src/components/sequence/failure-summary-banner.stories.tsx
@@ -1,0 +1,65 @@
+import { CREDITS_SHORT_TITLE } from '@/lib/billing/credits-short';
+import type { FailureSummary } from '@/lib/failures/failure-analysis';
+import type { Meta, StoryObj } from '@storybook/react';
+import { FailureSummaryBanner } from './failure-summary-banner';
+
+const meta: Meta<typeof FailureSummaryBanner> = {
+  title: 'Sequence/FailureSummaryBanner',
+  component: FailureSummaryBanner,
+  parameters: {
+    layout: 'padded',
+  },
+  args: {
+    onRetry: () => undefined,
+    isRetrying: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FailureSummaryBanner>;
+
+const creditsSummary: FailureSummary = {
+  requiresFullRetry: true,
+  headline: CREDITS_SHORT_TITLE,
+  groups: [],
+  totalFailures: 1,
+  hasFailed: true,
+  error:
+    'Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.',
+  tone: 'credits',
+};
+
+const contentSummary: FailureSummary = {
+  requiresFullRetry: true,
+  headline:
+    "Harry Potter didn't pass the content checker \u2014 regenerate to retry",
+  groups: [],
+  totalFailures: 1,
+  hasFailed: true,
+  error: 'Blocked by the content checker: Harry Potter',
+  tone: 'warning',
+};
+
+const failedSummary: FailureSummary = {
+  requiresFullRetry: true,
+  headline: 'Generation failed \u2014 full retry required',
+  groups: [],
+  totalFailures: 1,
+  hasFailed: true,
+  error:
+    'Child workflow scene-split failed: Failed query: delete from "scenes"',
+  tone: 'error',
+};
+
+export const CreditsShort: Story = {
+  name: 'Out of credits (#1328)',
+  args: { summary: creditsSummary },
+};
+
+export const ContentChecker: Story = {
+  args: { summary: contentSummary },
+};
+
+export const GenerationFailed: Story = {
+  args: { summary: failedSummary },
+};

--- a/src/components/sequence/failure-summary-banner.test.tsx
+++ b/src/components/sequence/failure-summary-banner.test.tsx
@@ -1,4 +1,5 @@
 import { CONTENT_REJECTION_USER_HINT } from '@/lib/ai/content-rejection';
+import { CREDITS_SHORT_TITLE } from '@/lib/billing/credits-short';
 import type { FailureSummary } from '@/lib/failures/failure-analysis';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
@@ -13,6 +14,17 @@ const contentSummary: FailureSummary = {
   hasFailed: true,
   error: 'Blocked by the content checker: Harry Potter',
   tone: 'warning',
+};
+
+const creditsSummary: FailureSummary = {
+  requiresFullRetry: true,
+  headline: CREDITS_SHORT_TITLE,
+  groups: [],
+  totalFailures: 1,
+  hasFailed: true,
+  error:
+    'Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.',
+  tone: 'credits',
 };
 
 describe('FailureSummaryBanner', () => {
@@ -30,5 +42,27 @@ describe('FailureSummaryBanner', () => {
     expect(html).toContain('regenerate to retry');
     expect(html).toContain(CONTENT_REJECTION_USER_HINT);
     expect(html).not.toContain('Generation failed');
+  });
+
+  it('SSRs a top-up prompt instead of Generation failed (#1328)', () => {
+    const html = renderToStaticMarkup(
+      <FailureSummaryBanner
+        summary={creditsSummary}
+        onRetry={() => undefined}
+        isRetrying={false}
+      />
+    );
+
+    expect(html).toContain(CREDITS_SHORT_TITLE);
+    expect(html).toContain('This sequence has 11 scenes');
+    expect(html).toContain('Add $4.20 more');
+    expect(html).toContain('Add credits');
+    expect(html).toContain('Continue generation');
+    expect(html).toContain('role="status"');
+    expect(html).not.toContain('Generation failed');
+    expect(html).not.toContain('full retry required');
+    expect(html).not.toContain('Regenerate Sequence');
+    expect(html).not.toContain('text-destructive');
+    expect(html).not.toContain('font-mono');
   });
 });

--- a/src/components/sequence/failure-summary-banner.tsx
+++ b/src/components/sequence/failure-summary-banner.tsx
@@ -1,12 +1,24 @@
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { openAddCreditsDialog } from '@/hooks/use-add-credits-dialog';
 import {
   CONTENT_REJECTION_USER_HINT,
   CONTENT_REJECTION_USER_TITLE,
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
+import {
+  CREDITS_SHORT_TITLE,
+  creditsShortHint,
+} from '@/lib/billing/credits-short';
 import type { FailureSummary } from '@/lib/failures/failure-analysis';
-import { AlertCircle, Info, RotateCcw } from 'lucide-react';
+import {
+  AlertCircle,
+  CreditCard,
+  Info,
+  Loader2,
+  Play,
+  RotateCcw,
+} from 'lucide-react';
 
 function errorLabel(error: string | null | undefined): string {
   if (error && isContentRejectionError(error))
@@ -28,34 +40,51 @@ export const FailureSummaryBanner: React.FC<FailureSummaryBannerProps> = ({
   isRetrying,
 }) => {
   const isWarning = summary.tone === 'warning';
+  const isCredits = summary.tone === 'credits';
+  const calm = isWarning || isCredits;
+  const continueGeneration = () => {
+    if (summary.requiresFullRetry && onFullRetry) {
+      onFullRetry();
+      return;
+    }
+    onRetry();
+  };
+
   return (
     <Alert
-      variant={isWarning ? 'default' : 'destructive'}
+      variant={calm ? 'default' : 'destructive'}
       className="mx-4 mt-2"
+      role={isCredits ? 'status' : 'alert'}
     >
-      {isWarning ? (
+      {isCredits ? (
+        <CreditCard className="h-4 w-4" />
+      ) : isWarning ? (
         <Info className="h-4 w-4" />
       ) : (
         <AlertCircle className="h-4 w-4" />
       )}
       <AlertTitle>
-        {isWarning
-          ? 'Content checker'
-          : summary.requiresFullRetry
-            ? 'Generation failed'
-            : summary.headline}
+        {isCredits
+          ? CREDITS_SHORT_TITLE
+          : isWarning
+            ? 'Content checker'
+            : summary.requiresFullRetry
+              ? 'Generation failed'
+              : summary.headline}
       </AlertTitle>
       <AlertDescription>
-        {summary.requiresFullRetry || isWarning ? (
+        {isCredits ? (
+          <p>{creditsShortHint(summary.error)}</p>
+        ) : summary.requiresFullRetry || isWarning ? (
           <p>{summary.headline}</p>
         ) : null}
         {isWarning && <p>{CONTENT_REJECTION_USER_HINT}</p>}
 
-        {summary.groups.length === 0 && summary.error && !isWarning && (
+        {summary.groups.length === 0 && summary.error && !calm && (
           <p className="mt-1 text-xs font-mono">{errorLabel(summary.error)}</p>
         )}
 
-        {summary.groups.length > 0 && (
+        {summary.groups.length > 0 && !isCredits && (
           <details className="mt-2">
             <summary className="cursor-pointer text-xs underline">
               {isWarning ? 'Which shots' : 'View error details'}
@@ -85,24 +114,40 @@ export const FailureSummaryBanner: React.FC<FailureSummaryBannerProps> = ({
           </details>
         )}
 
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={
-            summary.requiresFullRetry && onFullRetry ? onFullRetry : onRetry
-          }
-          disabled={isRetrying}
-          className="mt-2"
-        >
-          <RotateCcw
-            className={`h-3 w-3 ${isRetrying ? 'animate-spin' : ''}`}
-          />
-          {isRetrying
-            ? 'Retrying\u2026'
-            : summary.requiresFullRetry
-              ? 'Regenerate Sequence'
-              : 'Retry'}
-        </Button>
+        {isCredits ? (
+          <div className="mt-2 flex flex-wrap gap-2">
+            <Button size="sm" onClick={openAddCreditsDialog}>
+              <CreditCard />
+              Add credits
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={continueGeneration}
+              disabled={isRetrying}
+            >
+              {isRetrying ? <Loader2 className="animate-spin" /> : <Play />}
+              {isRetrying ? 'Continuing\u2026' : 'Continue generation'}
+            </Button>
+          </div>
+        ) : (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={continueGeneration}
+            disabled={isRetrying}
+            className="mt-2"
+          >
+            <RotateCcw
+              className={`h-3 w-3 ${isRetrying ? 'animate-spin' : ''}`}
+            />
+            {isRetrying
+              ? 'Retrying\u2026'
+              : summary.requiresFullRetry
+                ? 'Regenerate Sequence'
+                : 'Retry'}
+          </Button>
+        )}
       </AlertDescription>
     </Alert>
   );

--- a/src/lib/billing/credits-short.test.ts
+++ b/src/lib/billing/credits-short.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { micros } from '@/lib/billing/money';
+import {
+  CREDITS_SHORT_TITLE,
+  creditsShortHint,
+  creditsShortStatusError,
+  isCreditsShortError,
+} from './credits-short';
+
+describe('isCreditsShortError', () => {
+  it('matches the persisted reservation-short statusError', () => {
+    expect(
+      isCreditsShortError(
+        'Not enough credits to generate images for 11 scenes. Add credits and retry.'
+      )
+    ).toBe(true);
+  });
+
+  it('matches when a child-workflow prefix wraps the statusError', () => {
+    expect(
+      isCreditsShortError(
+        'Child workflow analyze-script:1 failed: Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.'
+      )
+    ).toBe(true);
+  });
+
+  it('matches Error instances', () => {
+    expect(
+      isCreditsShortError(
+        new Error(
+          'Not enough credits to generate images for 3 scenes. Add credits, then continue.'
+        )
+      )
+    ).toBe(true);
+  });
+
+  it('does not match unrelated failures', () => {
+    expect(isCreditsShortError('Generation was interrupted')).toBe(false);
+    expect(isCreditsShortError('Blocked by the content checker')).toBe(false);
+    expect(isCreditsShortError(undefined)).toBe(false);
+  });
+});
+
+describe('creditsShortStatusError', () => {
+  it('names the scene count and how much more is needed', () => {
+    expect(
+      creditsShortStatusError({
+        sceneCount: 11,
+        neededMicros: micros(4_200_000),
+      })
+    ).toBe(
+      'Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.'
+    );
+  });
+
+  it('omits a $0.00 shortfall', () => {
+    expect(
+      creditsShortStatusError({
+        sceneCount: 4,
+        neededMicros: micros(0),
+      })
+    ).toBe(
+      'Not enough credits to generate images for 4 scenes. Add credits, then continue.'
+    );
+  });
+});
+
+describe('creditsShortHint', () => {
+  it('uses scene count and amount from the stored message', () => {
+    expect(
+      creditsShortHint(
+        creditsShortStatusError({
+          sceneCount: 11,
+          neededMicros: micros(4_200_000),
+        })
+      )
+    ).toBe(
+      'This sequence has 11 scenes — more than the first estimate. Add $4.20 more, then continue generation.'
+    );
+  });
+
+  it('still reads the pre-#1328 copy', () => {
+    expect(
+      creditsShortHint(
+        'Not enough credits to generate images for 11 scenes. Add credits and retry.'
+      )
+    ).toBe(
+      'This sequence has 11 scenes — more than the first estimate. Add credits, then continue generation.'
+    );
+  });
+
+  it('falls back when the message has no scene count', () => {
+    expect(creditsShortHint('Not enough credits to generate images.')).toBe(
+      'Scene split found more work than the first estimate. Add credits, then continue generation.'
+    );
+  });
+});
+
+describe('CREDITS_SHORT_TITLE', () => {
+  it('is a top-up prompt, not a failure', () => {
+    expect(CREDITS_SHORT_TITLE).toBe('Add credits to continue');
+    expect(CREDITS_SHORT_TITLE.toLowerCase()).not.toContain('fail');
+  });
+});

--- a/src/lib/billing/credits-short.ts
+++ b/src/lib/billing/credits-short.ts
@@ -1,0 +1,51 @@
+/**
+ * Scene-split found more stills/motion than the click envelope could grow to
+ * cover (#1310 / #1328). That is a top-up prompt, not a generation failure.
+ *
+ * The persisted `sequence.statusError` is the classification source (same
+ * pattern as content-checker warnings): match a stable phrase so a child-
+ * workflow prefix cannot hide it, and keep old copy ("Add credits and retry")
+ * working for sequences that already failed.
+ */
+
+import { microsToDisplayUsd, type Microdollars } from '@/lib/billing/money';
+
+export const CREDITS_SHORT_TITLE = 'Add credits to continue';
+
+const CREDITS_SHORT_PATTERN = /not enough credits to generate/i;
+const SCENE_COUNT_PATTERN = /images for (\d+) scenes/i;
+const AMOUNT_PATTERN = /add (\$[\d.]+) more/i;
+
+function messageOf(error: unknown): string {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  return '';
+}
+
+export function isCreditsShortError(error: unknown): boolean {
+  return CREDITS_SHORT_PATTERN.test(messageOf(error));
+}
+
+export function creditsShortStatusError(opts: {
+  sceneCount: number;
+  neededMicros: Microdollars;
+}): string {
+  const amountBit =
+    opts.neededMicros > 0
+      ? `Add ${microsToDisplayUsd(opts.neededMicros)} more, then continue.`
+      : 'Add credits, then continue.';
+  return `Not enough credits to generate images for ${opts.sceneCount} scenes. ${amountBit}`;
+}
+
+export function creditsShortHint(error: string | null | undefined): string {
+  const message = error ?? '';
+  const scenes = message.match(SCENE_COUNT_PATTERN)?.[1];
+  const amount = message.match(AMOUNT_PATTERN)?.[1];
+  const sceneBit = scenes
+    ? `This sequence has ${scenes} scenes — more than the first estimate.`
+    : 'Scene split found more work than the first estimate.';
+  const amountBit = amount
+    ? `Add ${amount} more, then continue generation.`
+    : 'Add credits, then continue generation.';
+  return `${sceneBit} ${amountBit}`;
+}

--- a/src/lib/billing/storyboard-envelope.wiring.test.ts
+++ b/src/lib/billing/storyboard-envelope.wiring.test.ts
@@ -48,6 +48,16 @@ describe('storyboard envelope wiring', () => {
     );
     expect(source).toMatch(/updateStatus\('failed'/);
     expect(source).toMatch(/NonRetryableError/);
+    expect(source).toMatch(/creditsShortStatusError/);
+  });
+
+  test('reservation:short does not toast as an error (#1328)', () => {
+    const source = readFileSync(
+      'src/lib/realtime/use-generation-stream.ts',
+      'utf8'
+    );
+    expect(source).not.toMatch(/toast\.error/);
+    expect(source).toMatch(/generation\.reservation:short/);
   });
 });
 

--- a/src/lib/failures/failure-analysis.test.ts
+++ b/src/lib/failures/failure-analysis.test.ts
@@ -168,6 +168,50 @@ describe('analyzeFailures', () => {
     expect(result.headline).toContain('full retry required');
   });
 
+  test('reservation-short sequence error (no shots) is a credits prompt, not a hard error', () => {
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError:
+        'Not enough credits to generate images for 11 scenes. Add $4.20 more, then continue.',
+    });
+
+    const result = analyzeFailures([], sequence, SCENES);
+
+    expect(result.requiresFullRetry).toBe(true);
+    expect(result.tone).toBe('credits');
+    expect(result.headline).toBe('Add credits to continue');
+    expect(result.headline).not.toContain('full retry required');
+    expect(result.headline).not.toContain('Generation failed');
+  });
+
+  test('reservation-short after scene-split (shots exist, no stills) is a credits prompt (#1328)', () => {
+    const shots = [
+      makeShot({
+        sources: {
+          motionPrompt: null,
+          video: null,
+          primaryVideo: render({ status: 'pending', url: null }),
+        },
+        frame: { imageStatus: 'pending' },
+      }),
+    ];
+    const sequence = makeSequence({
+      status: 'failed',
+      musicPrompt: null,
+      musicTags: null,
+      musicStatus: 'pending',
+      statusError:
+        'Not enough credits to generate images for 11 scenes. Add credits and retry.',
+    });
+
+    const result = analyzeFailures(shots, sequence, SCENES);
+
+    expect(result.requiresFullRetry).toBe(true);
+    expect(result.tone).toBe('credits');
+    expect(result.headline).toBe('Add credits to continue');
+    expect(result.groups).toHaveLength(0);
+  });
+
   test('content-checker sequence error (no shots) is a warning, not a hard error', () => {
     const sequence = makeSequence({
       status: 'failed',
@@ -474,6 +518,19 @@ describe('analyzeLoadedFailures', () => {
 
   test('returns null while the sequence is still loading', () => {
     expect(analyzeLoadedFailures([], undefined, SCENES)).toBeNull();
+  });
+
+  test('empty loaded shots still produce the credits-short banner', () => {
+    const sequence = makeSequence({
+      status: 'failed',
+      statusError:
+        'Not enough credits to generate images for 11 scenes. Add credits and retry.',
+    });
+
+    const result = analyzeLoadedFailures([], sequence, SCENES);
+
+    expect(result?.tone).toBe('credits');
+    expect(result?.headline).toBe('Add credits to continue');
   });
 
   test('empty loaded shots still produce the content-checker banner', () => {

--- a/src/lib/failures/failure-analysis.ts
+++ b/src/lib/failures/failure-analysis.ts
@@ -7,6 +7,10 @@ import {
   contentRejectionSubjects,
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
+import {
+  CREDITS_SHORT_TITLE,
+  isCreditsShortError,
+} from '@/lib/billing/credits-short';
 import type { SceneRow } from '@/lib/db/schema/scenes';
 import type { Shot } from '@/lib/db/schema/shots';
 import type { Sequence } from '@/lib/db/schema/sequences';
@@ -44,10 +48,11 @@ export type FailureSummary = {
   hasFailed: boolean;
   error?: string | null;
   /**
-   * Content-checker-only failures are a warning (edit script / prompt / retry),
-   * not a hard generation error. Mixed or infrastructure failures stay 'error'.
+   * Content-checker-only failures are a warning (edit script / prompt / retry).
+   * A reservation-short stop (#1328) is a credits prompt, not a generation
+   * error. Mixed or infrastructure failures stay 'error'.
    */
-  tone: 'error' | 'warning';
+  tone: 'error' | 'warning' | 'credits';
 };
 
 function sceneNumberOf(shot: Shot, scenesById: ScenesById): number {
@@ -69,9 +74,11 @@ function groupIsContentOnly(group: FailureGroup): boolean {
   return !!group.error && isContentRejectionError(group.error);
 }
 
-/** A sequence-level error is only a warning when it is a content rejection. */
+/** Sequence-level statusError → banner tone. Credits-short outranks a wrapped content-checker phrase. */
 function toneOf(error: string | null | undefined): FailureSummary['tone'] {
-  return error && isContentRejectionError(error) ? 'warning' : 'error';
+  if (error && isCreditsShortError(error)) return 'credits';
+  if (error && isContentRejectionError(error)) return 'warning';
+  return 'error';
 }
 
 const FULL_RETRY_HEADLINE = 'Generation failed \u2014 full retry required';
@@ -83,7 +90,9 @@ function listNames(names: string[]): string {
 }
 
 function fullRetryHeadline(error: string | null | undefined): string {
-  if (toneOf(error) !== 'warning') return FULL_RETRY_HEADLINE;
+  const tone = toneOf(error);
+  if (tone === 'credits') return CREDITS_SHORT_TITLE;
+  if (tone !== 'warning') return FULL_RETRY_HEADLINE;
   const subjects = contentRejectionSubjects(error ?? '');
   return `${subjects.length > 0 ? listNames(subjects) : 'Script'} didn't pass the content checker \u2014 regenerate to retry`;
 }

--- a/src/lib/realtime/use-generation-stream.ts
+++ b/src/lib/realtime/use-generation-stream.ts
@@ -302,15 +302,8 @@ export function useGenerationStream(
           description: 'The selected model is kept in Versions.',
         });
       }
-      if (eventName === 'generation.reservation:short') {
-        const sceneCount = Number(data.sceneCount);
-        const neededUsd = Number(data.neededUsd);
-        toast.error('Not enough credits to generate images', {
-          description: Number.isFinite(neededUsd)
-            ? `Need $${neededUsd.toFixed(2)} more${Number.isFinite(sceneCount) ? ` for ${sceneCount} scenes` : ''}.`
-            : 'Add credits and retry.',
-        });
-      }
+      // reservation:short is a top-up prompt, not a failure toast (#1328).
+      // The scenes banner is the persistent CTA.
 
       // Map event to typed action and dispatch
       const action = mapEventToAction(eventName, data);

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -30,6 +30,7 @@ import { resolveImageModels } from '@/lib/ai/resolve-image-models';
 import { resolveVideoModels } from '@/lib/ai/resolve-video-models';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import { estimateStoryboardRenderCost } from '@/lib/billing/cost-estimation';
+import { creditsShortStatusError } from '@/lib/billing/credits-short';
 import { microsToUsd } from '@/lib/billing/money';
 import { gateStoryboardRenders } from '@/lib/billing/storyboard-render-gate';
 import { generateId } from '@/lib/db/id';
@@ -533,7 +534,10 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
     if (!renderGate.spawnRenders) {
       // Gate already zeroed leftover. Fail the sequence and throw so the
       // parent does not mark it completed with no stills.
-      const shortMessage = `Not enough credits to generate images for ${scenes.length} scenes. Add credits and retry.`;
+      const shortMessage = creditsShortStatusError({
+        sceneCount: scenes.length,
+        neededMicros: renderGate.neededMicros,
+      });
       await step.do('emit-reservation-short', async () => {
         if (!sequenceId) return;
         await scopedDb


### PR DESCRIPTION
Fixes #1328

When scene-split finds more stills/motion than the click envelope can cover (`generation.reservation:short`, #1310), we used to mark the sequence failed and show a red **Generation failed — full retry required** banner with a **Regenerate Sequence** button. Scenes, bibles, and prompts are already saved — this is a top-up, not a crash.

## What changed

- Classify reservation-short `statusError` as `tone: 'credits'` (same idea as the content-checker warning).
- Banner is a calm **Add credits to continue** prompt: scene count + shortfall, **Add credits** (opens the existing dialog), **Continue generation** (existing full storyboard retry).
- Drop the `toast.error` on `reservation:short`.
- Persist how much more is needed in `statusError` so the banner can show `$4.20 more`. Old copy still classifies.

## Verify

Storybook: `Sequence/FailureSummaryBanner` → Out of credits (#1328)