### PR TITLE
fix(workflow): treat deploy-time DO reset as transient, not a failure

### DIFF
--- a/src/lib/workflow/base-workflow.test.ts
+++ b/src/lib/workflow/base-workflow.test.ts
@@ -2,7 +2,8 @@
  * Behavioural tests for `OpenStoryWorkflowEntrypoint.run()`'s failure
  * handling, added for issue #839 (June 6 mass-abort cascade):
  *
- *   1. Engine aborts ("Aborting engine: Grace period complete") are transient
+ *   1. Engine aborts ("Aborting engine: Grace period complete") and deploy
+ *      DO resets ("Durable Object reset because its code was updated", #1331) are transient
  *      — CF resumes the instance afterwards — so run() must rethrow WITHOUT
  *      invoking `onFailure` (which marks user-facing rows failed) or
  *      notifying the parent of failure. The same applies when the abort
@@ -59,6 +60,7 @@ const { OpenStoryWorkflowEntrypoint } = await import('./base-workflow');
 const IN_FINITE_STATE =
   '(instance.in_finite_state) Instance reached a finite state, cannot send events to it';
 const ENGINE_ABORT = 'Aborting engine: Grace period complete';
+const DO_RESET = 'Durable Object reset because its code was updated.';
 
 type TestPayload = UserWorkflowContext & {
   _parent?: {
@@ -123,20 +125,23 @@ function makeWorkflow(impl: () => Promise<unknown>) {
 }
 
 describe('OpenStoryWorkflowEntrypoint.run', () => {
-  test('engine abort: rethrows without onFailure or parent failure-notify', async () => {
-    notifyParent.mockReset();
-    notifyParentOfFailure.mockReset();
-    const { workflow, onFailure } = makeWorkflow(() =>
-      Promise.reject(new Error(ENGINE_ABORT))
-    );
+  test.each([ENGINE_ABORT, DO_RESET])(
+    'platform interruption "%s": rethrows without onFailure or parent failure-notify',
+    async (message) => {
+      notifyParent.mockReset();
+      notifyParentOfFailure.mockReset();
+      const { workflow, onFailure } = makeWorkflow(() =>
+        Promise.reject(new Error(message))
+      );
 
-    await expect(workflow.run(makeEvent(true), makeStep())).rejects.toThrow(
-      'Grace period complete'
-    );
+      await expect(workflow.run(makeEvent(true), makeStep())).rejects.toThrow(
+        message
+      );
 
-    expect(onFailure).not.toHaveBeenCalled();
-    expect(notifyParentOfFailure).not.toHaveBeenCalled();
-  });
+      expect(onFailure).not.toHaveBeenCalled();
+      expect(notifyParentOfFailure).not.toHaveBeenCalled();
+    }
+  );
 
   test('success with dead parent: returns the result instead of failing', async () => {
     notifyParent.mockReset();

--- a/src/lib/workflow/errors.test.ts
+++ b/src/lib/workflow/errors.test.ts
@@ -35,6 +35,23 @@ describe('isEngineAbortError', () => {
     );
   });
 
+  test('matches the deploy-time Durable Object reset (#1331)', () => {
+    expect(
+      isEngineAbortError(
+        new Error('Durable Object reset because its code was updated.')
+      )
+    ).toBe(true);
+    // ElementSheet aggregates per-entry rejections into one message; the
+    // reset phrase must still classify when it is buried in that summary.
+    expect(
+      isEngineAbortError(
+        new Error(
+          'Element reference generation failed for 1/1 element(s) — lantern: Durable Object reset because its code was updated.'
+        )
+      )
+    ).toBe(true);
+  });
+
   test('does not match unrelated errors that mention a grace period', () => {
     // A true positive skips onFailure and parent notification, so a bare
     // "grace period" token from another layer must never classify as an
@@ -45,6 +62,7 @@ describe('isEngineAbortError', () => {
     expect(
       isEngineAbortError(new Error('grace period: 30 days remaining'))
     ).toBe(false);
+    expect(isEngineAbortError(new Error('password reset failed'))).toBe(false);
   });
 
   test('does not match ordinary failures', () => {

--- a/src/lib/workflow/errors.ts
+++ b/src/lib/workflow/errors.ts
@@ -30,20 +30,24 @@ function errorMessage(error: unknown): string {
 }
 
 /**
- * True when the Workflows engine is shutting the instance down mid-run —
- * `Aborting engine: Grace period complete`. CF emits this when the engine
- * restarts (every Worker deploy produces a burst; platform-side restarts do
- * too) and then RESUMES the instance from its persisted step cache. It is a
- * transient interruption, not a workflow failure: the base class must not run
- * `onFailure` (which would mark user-facing rows failed) or notify the parent
- * of failure. Matched on message text — the thrown value's class isn't part
- * of the public API. See issue #839 (2026-06-06 mass-abort cascade).
+ * True when the platform is tearing the instance down mid-run — a transient
+ * interruption after which CF RESUMES the instance from its persisted step
+ * cache, not a workflow failure. Two spellings:
+ *   - `Aborting engine: Grace period complete` — engine restart (#839,
+ *     2026-06-06 mass-abort cascade).
+ *   - `Durable Object reset because its code was updated` — a Worker deploy
+ *     evicting the isolate under an in-flight step (#1331, 2026-08-26: 16
+ *     user-visible failures across 6 deploys).
+ * The base class must not run `onFailure` (which would mark user-facing rows
+ * failed) or notify the parent of failure. Matched on message text — the
+ * thrown value's class isn't part of the public API — and on the full phrase,
+ * because a true positive here skips onFailure AND parent notification, so an
+ * app error that merely mentions a grace period or a reset must never match.
  */
 export function isEngineAbortError(error: unknown): boolean {
-  // Matched on the full phrase, not a bare "grace period" token — a true
-  // positive here skips onFailure AND parent notification, so an app error
-  // that merely mentions a grace period must never be classified as one.
-  return /aborting engine|grace period complete/i.test(errorMessage(error));
+  return /aborting engine|grace period complete|reset because its code was updated/i.test(
+    errorMessage(error)
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #1331

## Problem

Every `main` deploy evicts the Workflows engine's Durable Object under in-flight steps, which surfaces as `Durable Object reset because its code was updated`. The base class treated it as a real error: ran `onFailure` (marking rows failed), notified the parent of failure, and logged `Failure:`. 16 user-visible failed generations across 6 deploys on 2026-08-26.

## Fix

Cloudflare's docs classify this reset as transient — *"Retry the operation"* ([D1 debug table](https://developers.cloudflare.com/d1/observability/debug-d1/), [DO lifecycle](https://developers.cloudflare.com/durable-objects/concepts/durable-object-lifecycle/)); their [retry example](https://developers.cloudflare.com/d1/tutorials/using-read-replication-for-e-com/) matches `"reset because its code was updated"` literally. The Workflows engine resumes the instance from its step cache afterwards, exactly like the #839 engine abort.

So: add the phrase to `isEngineAbortError`. Every catch site already routes through it — base `run()` rethrows untouched (no `onFailure`, no parent failure-notify), the `emit-failure` cleanup path does the same, and ElementSheet's aggregated per-element message still classifies because the matcher works on wrapped messages (covered by tests).

## Tests

- `errors.test.ts`: exact message, ElementSheet-wrapped message, and a `password reset failed` negative.
- `base-workflow.test.ts`: engine-abort behavioural test now runs for both messages via `test.each`.