### PR TITLE
fix: gate sequence queries on session, never retry 401/403

### DIFF
--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -13,6 +13,7 @@ import type { SequenceMusicVariant } from '@/lib/db/schema';
 import type { VariantType } from '@/lib/db/schema/shot-variants';
 import { type CreateSequenceInput } from '@/lib/schemas/sequence.schemas';
 import type { Sequence } from '@/types/database';
+import { useAuthSession } from '@/lib/auth/session-query';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePostHog } from '@posthog/react';
 import { toast } from 'sonner';
@@ -125,14 +126,17 @@ export function useSetSequenceModel() {
   });
 }
 
-// Hook for listing sequences
+// Hook for listing sequences. The app shell is anonymous-browsable but the
+// fn requires auth, so don't fire (and error-log) it without a session (#1333).
 export function useSequences(teamId?: string) {
+  const { data: session } = useAuthSession();
   return useQuery<Sequence[]>({
     queryKey: sequenceKeys.list(teamId),
     queryFn: async () => {
       return getSequencesFn();
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
+    enabled: !!session,
   });
 }
 
@@ -147,6 +151,7 @@ export function useSequence(
     staleTime?: number;
   }
 ) {
+  const { data: session } = useAuthSession();
   return useQuery<Sequence>({
     queryKey: sequenceKeys.detail(id),
     queryFn: async () => {
@@ -155,7 +160,7 @@ export function useSequence(
     },
     throwOnError: true,
     staleTime: options?.staleTime ?? 1000,
-    enabled: !!id,
+    enabled: !!id && !!session,
     refetchInterval: options?.refetchInterval ?? false,
     refetchOnMount: 'always',
     refetchOnWindowFocus: true,

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -166,6 +166,18 @@ export function isInsufficientCreditsError(error: unknown): boolean {
 }
 
 /**
+ * 401/403 — the caller lacks a session or permission. Structural (`statusCode`
+ * survives the server-fn boundary via the adapter below) so it also matches
+ * Better Auth's `APIError`. A retry cannot succeed; it only repeats the log
+ * line (#1333).
+ */
+export function isAuthError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const status = (error as { statusCode?: unknown }).statusCode;
+  return status === 401 || status === 403;
+}
+
+/**
  * Display text for an arbitrary thrown value. A Zod failure — a live
  * `ZodError`, or one that crossed the server-fn boundary as its JSON `message`
  * (#1285) — collapses to one `path: message` line per issue instead of the raw

--- a/src/lib/query-client.test.ts
+++ b/src/lib/query-client.test.ts
@@ -1,6 +1,7 @@
-import { MutationObserver } from '@tanstack/react-query';
+import { MutationObserver, type QueryClient } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { AccountRestrictedError, AuthenticationError } from './errors';
 import { makeQueryClient } from './query-client';
 
 describe('MutationCache', () => {
@@ -58,5 +59,38 @@ describe('MutationCache', () => {
       queryKey: ['categories', 'org-1'],
     });
     expect(spy).toHaveBeenNthCalledWith(2, { queryKey: ['items', 'org-1'] });
+  });
+});
+
+describe('query retry default', () => {
+  const retryOf = (qc: QueryClient) => {
+    const retry = qc.getDefaultOptions().queries?.retry;
+    if (typeof retry !== 'function') throw new Error('retry must be a fn');
+    return retry;
+  };
+
+  it('never retries a 401/403 (#1333)', () => {
+    const retry = retryOf(makeQueryClient());
+    expect(retry(0, new AuthenticationError('Authentication required'))).toBe(
+      false
+    );
+    expect(retry(0, new AccountRestrictedError())).toBe(false);
+  });
+
+  it('keeps RQ default of 0 retries on the server for other errors', () => {
+    const retry = retryOf(makeQueryClient());
+    expect(retry(0, new Error('boom'))).toBe(false);
+  });
+
+  it('keeps RQ default of 3 retries in the browser for other errors', async () => {
+    vi.stubGlobal('window', {});
+    vi.resetModules();
+    const { makeQueryClient: makeBrowserQueryClient } =
+      await import('./query-client');
+    vi.unstubAllGlobals();
+    const retry = retryOf(makeBrowserQueryClient());
+    expect(retry(0, new Error('boom'))).toBe(true);
+    expect(retry(2, new Error('boom'))).toBe(true);
+    expect(retry(3, new Error('boom'))).toBe(false);
   });
 });

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,5 +1,5 @@
 import { openBillingGate } from '@/hooks/use-billing-gate-dialog';
-import { isInsufficientCreditsError } from '@/lib/errors';
+import { isAuthError, isInsufficientCreditsError } from '@/lib/errors';
 import { MutationCache, QueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
@@ -15,6 +15,8 @@ declare module '@tanstack/react-query' {
     };
   }
 }
+
+const MAX_QUERY_RETRIES = typeof window === 'undefined' ? 0 : 3;
 
 export function makeQueryClient() {
   let qc!: QueryClient;
@@ -44,6 +46,11 @@ export function makeQueryClient() {
     defaultOptions: {
       queries: {
         staleTime: 2 * 60 * 1000,
+        // RQ's own default is 3 retries in the browser, 0 on the server; keep
+        // that, but never retry a 401/403 — the session won't appear between
+        // attempts, and each attempt is another error-level log line (#1333).
+        retry: (failureCount, error) =>
+          !isAuthError(error) && failureCount < MAX_QUERY_RETRIES,
       },
     },
   });


### PR DESCRIPTION
Closes #1333

## Problem
`useSequences` / `useSequence` fired `getSequencesFn` / `getSequenceFn` for anonymous visitors of the app shell (studio reference picker, eval view). Each 401 was then retried 3× by TanStack Query's default, so one signed-out visit produced ~5 error-level `AUTHENTICATION_ERROR` logs — a third of prod error volume, and enough to trip the lowered PostHog alert thresholds.

## Fix
- **Caller:** `useSequences` / `useSequence` are `enabled` only with a session (`useAuthSession`, same pattern as `compliance-restriction-banner`).
- **Global:** query client default `retry` keeps RQ's 3-in-browser / 0-on-server, but never retries a 401/403 (`isAuthError`), so every gated serverFn stops multiplying auth errors.

`loggerMiddleware` is untouched — 401 stays at `error` so a real auth incident still pages (#1099).

## Tests
`src/lib/query-client.test.ts`: 401/403 never retried; server 0 / browser 3 retries preserved for other errors.