### PR TITLE
fix(#1332): bound RealtimeChannel prune and SSE fan-out

### DIFF
--- a/src/lib/realtime/client.tsx
+++ b/src/lib/realtime/client.tsx
@@ -21,9 +21,9 @@ import type {
  * Exactly **one** `EventSource` is open at a time, carrying the union of every
  * channel the mounted hooks have registered: `/api/realtime?channels=a,b,c`
  * fans out to one `RealtimeChannel` Durable Object per channel server-side and
- * merges them back into that single stream. The DO holds the stream open, so
- * the browser's native `EventSource` reconnect is the only reconnection logic
- * we need — no manual reconnect loop.
+ * merges them back into that single stream. The DO holds each sub-stream open.
+ * EventSource reconnects the merged `/api/realtime` response if it dies; the
+ * worker also re-subscribes to a channel's DO if that sub-stream ends (#1332).
  *
  * One connection per channel is NOT a valid alternative: browsers cap
  * concurrent HTTP/1.1 connections per origin at 6, and an SSE stream holds its

--- a/src/lib/realtime/realtime-channel.do.test.ts
+++ b/src/lib/realtime/realtime-channel.do.test.ts
@@ -1,0 +1,430 @@
+/**
+ * RealtimeChannel Durable Object — history cap + SSE backpressure (#1332).
+ *
+ * Unit tests run in Node, so SQLite is `node:sqlite` and `cloudflare:workers`
+ * is the vitest stub. The seam is the DO's public HTTP API (`/emit`,
+ * `/history`, `/subscribe`) plus `alarm()`.
+ */
+
+import { DatabaseSync, type SQLInputValue } from 'node:sqlite';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  HISTORY_MAX_ROWS,
+  RealtimeChannel,
+  SSE_MAX_BUFFERED_CHUNKS,
+} from './realtime-channel.do';
+
+const CHANNEL = 'billing:team-1';
+const THIRTY_DAYS_MS = 60 * 60 * 24 * 30 * 1000;
+
+type SqlRow = Record<string, unknown>;
+
+type SqlCursor = {
+  toArray: () => SqlRow[];
+  one: () => SqlRow;
+  rowsWritten: number;
+  rowsRead: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function numberField(row: unknown, key: string): number {
+  if (!isRecord(row) || typeof row[key] !== 'number') {
+    throw new Error(`expected numeric ${key}`);
+  }
+  return row[key];
+}
+
+function stringField(row: unknown, key: string): string {
+  if (!isRecord(row) || typeof row[key] !== 'string') {
+    throw new Error(`expected string ${key}`);
+  }
+  return row[key];
+}
+
+function requireValue<T>(value: T | undefined, label: string): T {
+  if (value === undefined) throw new Error(`missing ${label}`);
+  return value;
+}
+
+function toSqlValue(value: unknown): SQLInputValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'bigint'
+  ) {
+    return value;
+  }
+  throw new Error(`unsupported sql binding: ${typeof value}`);
+}
+
+function execSql(
+  db: DatabaseSync,
+  query: string,
+  bindings: unknown[]
+): SqlCursor {
+  const statements = query
+    .split(';')
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  let rows: SqlRow[] = [];
+  let rowsWritten = 0;
+  let rowsRead = 0;
+
+  for (let i = 0; i < statements.length; i++) {
+    const sql = requireValue(statements[i], `sql statement ${i}`);
+    const params = i === statements.length - 1 ? bindings : [];
+    const head = sql.replace(/\s+/g, ' ').slice(0, 12).toUpperCase();
+    const isQuery = head.startsWith('SELECT') || /RETURNING/i.test(sql);
+
+    if (isQuery) {
+      const stmt = db.prepare(sql);
+      const sqlParams = params.map(toSqlValue);
+      rows = sqlParams.length > 0 ? stmt.all(...sqlParams) : stmt.all();
+      rowsRead += rows.length;
+    } else if (params.length > 0) {
+      const info = db.prepare(sql).run(...params.map(toSqlValue));
+      rowsWritten += Number(info.changes);
+    } else {
+      db.exec(sql);
+    }
+  }
+
+  return {
+    toArray: () => rows,
+    one: () => {
+      if (rows.length !== 1) {
+        throw new Error(`expected 1 row, got ${rows.length}`);
+      }
+      return requireValue(rows[0], 'sql row');
+    },
+    rowsWritten,
+    rowsRead,
+  };
+}
+
+function createHarness(): {
+  channel: RealtimeChannel;
+  db: DatabaseSync;
+  getAlarm: () => number | null;
+} {
+  const db = new DatabaseSync(':memory:');
+  let alarm: number | null = null;
+  const ctx = {
+    storage: {
+      sql: {
+        exec: (query: string, ...bindings: unknown[]) =>
+          execSql(db, query, bindings),
+      },
+      getAlarm: async () => alarm,
+      setAlarm: async (when: number | Date) => {
+        alarm = typeof when === 'number' ? when : when.getTime();
+      },
+      deleteAlarm: async () => {
+        alarm = null;
+      },
+    },
+  };
+
+  const channel = new RealtimeChannel(
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- Node sqlite stand-in for DO storage
+    ctx as unknown as DurableObjectState,
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- DO under test does not read env
+    {} as Cloudflare.Env
+  );
+  return { channel, db, getAlarm: () => alarm };
+}
+
+async function emit(
+  channel: RealtimeChannel,
+  data: unknown,
+  event = 'billing.balance:updated'
+): Promise<Response> {
+  return channel.fetch(
+    new Request(`https://realtime.do/emit?channel=${CHANNEL}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ event, data }),
+    })
+  );
+}
+
+async function history(
+  channel: RealtimeChannel
+): Promise<Array<{ id: string; data: string }>> {
+  const response = await channel.fetch(
+    new Request(`https://realtime.do/history?channel=${CHANNEL}`)
+  );
+  return response.json();
+}
+
+function eventCount(db: DatabaseSync): number {
+  return numberField(
+    db.prepare('SELECT COUNT(*) AS count FROM events').get(),
+    'count'
+  );
+}
+
+function parseSse(buffer: string): { frames: unknown[]; rest: string } {
+  const frames: unknown[] = [];
+  let rest = buffer;
+  let boundary = rest.indexOf('\n\n');
+  while (boundary !== -1) {
+    const raw = rest.slice(0, boundary);
+    rest = rest.slice(boundary + 2);
+    const line = raw.startsWith('data:') ? raw.slice(5).trim() : raw.trim();
+    if (line) frames.push(JSON.parse(line) as unknown);
+    boundary = rest.indexOf('\n\n');
+  }
+  return { frames, rest };
+}
+
+function isUserEvent(
+  frame: unknown
+): frame is { id: string; event: string; data: unknown } {
+  return (
+    typeof frame === 'object' &&
+    frame !== null &&
+    'event' in frame &&
+    !('type' in frame)
+  );
+}
+
+function requireBody(
+  body: ReadableStream<Uint8Array> | null
+): ReadableStream<Uint8Array> {
+  expect(body).not.toBeNull();
+  if (body === null) throw new Error('missing response body');
+  return body;
+}
+
+async function readSseUntilDone(
+  body: ReadableStream<Uint8Array>,
+  timeoutMs = 1_000
+): Promise<unknown[]> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  const frames: unknown[] = [];
+
+  const timeout = AbortSignal.timeout(timeoutMs);
+  const onTimeout = (): void => {
+    void reader.cancel();
+  };
+  timeout.addEventListener('abort', onTimeout);
+
+  try {
+    let reading = true;
+    while (reading) {
+      const result = await reader.read();
+      if (result.done) {
+        reading = false;
+        continue;
+      }
+      buf += decoder.decode(result.value, { stream: true });
+      const parsed = parseSse(buf);
+      frames.push(...parsed.frames);
+      buf = parsed.rest;
+    }
+  } finally {
+    timeout.removeEventListener('abort', onTimeout);
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released by cancel
+    }
+  }
+  return frames;
+}
+
+async function collectWhile(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal
+): Promise<unknown[]> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = '';
+  const frames: unknown[] = [];
+  signal.addEventListener('abort', () => {
+    void reader.cancel();
+  });
+  try {
+    let reading = true;
+    while (reading && !signal.aborted) {
+      const result = await reader.read();
+      if (result.done) {
+        reading = false;
+        continue;
+      }
+      buf += decoder.decode(result.value, { stream: true });
+      const parsed = parseSse(buf);
+      frames.push(...parsed.frames);
+      buf = parsed.rest;
+    }
+  } catch {
+    // cancel() rejects the reader; that's the abort path
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released
+    }
+  }
+  return frames;
+}
+
+const abortControllers: AbortController[] = [];
+
+afterEach(() => {
+  for (const ac of abortControllers) ac.abort();
+  abortControllers.length = 0;
+  vi.restoreAllMocks();
+});
+
+describe('RealtimeChannel history cap (#1332)', () => {
+  it('creates an index on events.ts so TTL deletes are not a full scan', () => {
+    const { db } = createHarness();
+    const indexes = db
+      .prepare(
+        `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'events'`
+      )
+      .all();
+    const names = indexes.map((row) => stringField(row, 'name'));
+    expect(names).toContain('events_ts');
+  });
+
+  it('prunes oldest rows on emit so a chatty channel never exceeds the cap', async () => {
+    const { channel, db } = createHarness();
+    const extra = 25;
+    for (let n = 1; n <= HISTORY_MAX_ROWS + extra; n++) {
+      const response = await emit(channel, { n });
+      expect(response.status).toBe(204);
+    }
+
+    expect(eventCount(db)).toBe(HISTORY_MAX_ROWS);
+    const messages = await history(channel);
+    expect(messages).toHaveLength(HISTORY_MAX_ROWS);
+    const first = requireValue(messages[0], 'first history message');
+    const last = requireValue(messages.at(-1), 'last history message');
+    expect(JSON.parse(first.data)).toEqual({ n: extra + 1 });
+    expect(JSON.parse(last.data)).toEqual({
+      n: HISTORY_MAX_ROWS + extra,
+    });
+  });
+
+  it('alarm TTL-deletes expired rows using the ts column', async () => {
+    const t0 = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(t0);
+    const { channel, db } = createHarness();
+    await emit(channel, { n: 1 });
+    await emit(channel, { n: 2 });
+    expect(eventCount(db)).toBe(2);
+
+    vi.spyOn(Date, 'now').mockReturnValue(t0 + THIRTY_DAYS_MS + 1);
+    await channel.alarm();
+    expect(eventCount(db)).toBe(0);
+    expect(await history(channel)).toEqual([]);
+  });
+
+  it('alarm caps a leftover mountain without the NOT IN subquery', async () => {
+    const { channel, db } = createHarness();
+    const insert = db.prepare(
+      'INSERT INTO events (event, data, ts) VALUES (?, ?, ?)'
+    );
+    const mountain = HISTORY_MAX_ROWS + 1_500;
+    const ts = Date.now();
+    for (let i = 0; i < mountain; i++) {
+      insert.run('billing.balance:updated', JSON.stringify({ i }), ts);
+    }
+    expect(eventCount(db)).toBe(mountain);
+
+    for (let i = 0; i < 20; i++) {
+      await channel.alarm();
+      if (eventCount(db) <= HISTORY_MAX_ROWS) break;
+    }
+
+    expect(eventCount(db)).toBe(HISTORY_MAX_ROWS);
+    const seqs = db
+      .prepare('SELECT MIN(seq) AS min, MAX(seq) AS max FROM events')
+      .get();
+    expect(numberField(seqs, 'max') - numberField(seqs, 'min') + 1).toBe(
+      HISTORY_MAX_ROWS
+    );
+  });
+
+  it('schedules a prune alarm on first emit', async () => {
+    const { channel, getAlarm } = createHarness();
+    expect(getAlarm()).toBeNull();
+    await emit(channel, { n: 1 });
+    expect(getAlarm()).toBeGreaterThan(Date.now());
+  });
+});
+
+describe('RealtimeChannel SSE backpressure (#1332)', () => {
+  it('delivers events to a subscriber that is reading', async () => {
+    const { channel } = createHarness();
+    const ac = new AbortController();
+    abortControllers.push(ac);
+
+    const response = await channel.fetch(
+      new Request(`https://realtime.do/subscribe?channel=${CHANNEL}`, {
+        signal: ac.signal,
+      })
+    );
+    const body = requireBody(response.body);
+
+    const collected = collectWhile(body, ac.signal);
+    await emit(channel, { n: 1 });
+    await emit(channel, { n: 2 });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    ac.abort();
+
+    const frames = await collected;
+    const payloads = frames.filter(isUserEvent).map((frame) => frame.data);
+    expect(payloads).toEqual([{ n: 1 }, { n: 2 }]);
+  });
+
+  it('closes a stalled subscriber instead of buffering every subsequent event', async () => {
+    const { channel } = createHarness();
+    const ac = new AbortController();
+    abortControllers.push(ac);
+
+    const stalled = await channel.fetch(
+      new Request(`https://realtime.do/subscribe?channel=${CHANNEL}`, {
+        signal: ac.signal,
+      })
+    );
+    const stalledBody = requireBody(stalled.body);
+
+    const burst = SSE_MAX_BUFFERED_CHUNKS + 8;
+    for (let n = 1; n <= burst; n++) {
+      await emit(channel, { n });
+    }
+
+    const frames = await readSseUntilDone(stalledBody);
+    const userFrames = frames.filter(isUserEvent);
+    expect(userFrames.length).toBeLessThan(burst);
+
+    const liveAc = new AbortController();
+    abortControllers.push(liveAc);
+    const live = await channel.fetch(
+      new Request(`https://realtime.do/subscribe?channel=${CHANNEL}`, {
+        signal: liveAc.signal,
+      })
+    );
+    const liveFrames = collectWhile(requireBody(live.body), liveAc.signal);
+    await emit(channel, { n: 'after-drop' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    liveAc.abort();
+
+    const delivered = (await liveFrames)
+      .filter(isUserEvent)
+      .map((frame) => frame.data);
+    expect(delivered).toContainEqual({ n: 'after-drop' });
+  });
+});

--- a/src/lib/realtime/realtime-channel.do.test.ts
+++ b/src/lib/realtime/realtime-channel.do.test.ts
@@ -11,6 +11,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   HISTORY_MAX_ROWS,
+  PRUNE_BATCH_ROWS,
+  PRUNE_CATCHUP_MS,
   RealtimeChannel,
   SSE_MAX_BUFFERED_CHUNKS,
 } from './realtime-channel.do';
@@ -108,18 +110,25 @@ function execSql(
   };
 }
 
-function createHarness(): {
+type Harness = {
   channel: RealtimeChannel;
   db: DatabaseSync;
   getAlarm: () => number | null;
-} {
+  consumeAlarm: () => void;
+  sqlStatements: string[];
+};
+
+function createHarness(): Harness {
   const db = new DatabaseSync(':memory:');
   let alarm: number | null = null;
+  const sqlStatements: string[] = [];
   const ctx = {
     storage: {
       sql: {
-        exec: (query: string, ...bindings: unknown[]) =>
-          execSql(db, query, bindings),
+        exec: (query: string, ...bindings: unknown[]) => {
+          sqlStatements.push(query);
+          return execSql(db, query, bindings);
+        },
       },
       getAlarm: async () => alarm,
       setAlarm: async (when: number | Date) => {
@@ -137,7 +146,21 @@ function createHarness(): {
     // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- DO under test does not read env
     {} as Cloudflare.Env
   );
-  return { channel, db, getAlarm: () => alarm };
+  return {
+    channel,
+    db,
+    getAlarm: () => alarm,
+    consumeAlarm: () => {
+      alarm = null;
+    },
+    sqlStatements,
+  };
+}
+
+/** Workerd clears the scheduled alarm before `alarm()` runs. */
+async function triggerAlarm(harness: Harness): Promise<void> {
+  harness.consumeAlarm();
+  await harness.channel.alarm();
 }
 
 async function emit(
@@ -212,13 +235,7 @@ async function readSseUntilDone(
   let buf = '';
   const frames: unknown[] = [];
 
-  const timeout = AbortSignal.timeout(timeoutMs);
-  const onTimeout = (): void => {
-    void reader.cancel();
-  };
-  timeout.addEventListener('abort', onTimeout);
-
-  try {
+  const readAll = async (): Promise<unknown[]> => {
     let reading = true;
     while (reading) {
       const result = await reader.read();
@@ -231,15 +248,27 @@ async function readSseUntilDone(
       frames.push(...parsed.frames);
       buf = parsed.rest;
     }
+    return frames;
+  };
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      void reader.cancel();
+      reject(new Error('subscribe stream did not close'));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([readAll(), timeout]);
   } finally {
-    timeout.removeEventListener('abort', onTimeout);
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
     try {
       reader.releaseLock();
     } catch {
       // already released by cancel
     }
   }
-  return frames;
 }
 
 async function collectWhile(
@@ -287,8 +316,8 @@ afterEach(() => {
 });
 
 describe('RealtimeChannel history cap (#1332)', () => {
-  it('creates an index on events.ts so TTL deletes are not a full scan', () => {
-    const { db } = createHarness();
+  it('creates an index on events(ts)', () => {
+    const { db, sqlStatements } = createHarness();
     const indexes = db
       .prepare(
         `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'events'`
@@ -296,6 +325,10 @@ describe('RealtimeChannel history cap (#1332)', () => {
       .all();
     const names = indexes.map((row) => stringField(row, 'name'));
     expect(names).toContain('events_ts');
+    const created = sqlStatements.find((sql) =>
+      /CREATE INDEX IF NOT EXISTS events_ts/i.test(sql)
+    );
+    expect(created).toMatch(/ON events\s*\(\s*ts\s*\)/i);
   });
 
   it('prunes oldest rows on emit so a chatty channel never exceeds the cap', async () => {
@@ -320,20 +353,75 @@ describe('RealtimeChannel history cap (#1332)', () => {
   it('alarm TTL-deletes expired rows using the ts column', async () => {
     const t0 = 1_700_000_000_000;
     vi.spyOn(Date, 'now').mockReturnValue(t0);
-    const { channel, db } = createHarness();
-    await emit(channel, { n: 1 });
-    await emit(channel, { n: 2 });
-    expect(eventCount(db)).toBe(2);
+    const harness = createHarness();
+    await emit(harness.channel, { n: 1 });
+    await emit(harness.channel, { n: 2 });
+    expect(eventCount(harness.db)).toBe(2);
 
     vi.spyOn(Date, 'now').mockReturnValue(t0 + THIRTY_DAYS_MS + 1);
-    await channel.alarm();
-    expect(eventCount(db)).toBe(0);
-    expect(await history(channel)).toEqual([]);
+    await triggerAlarm(harness);
+    expect(eventCount(harness.db)).toBe(0);
+    expect(await history(harness.channel)).toEqual([]);
   });
 
-  it('alarm caps a leftover mountain without the NOT IN subquery', async () => {
-    const { channel, db } = createHarness();
-    const insert = db.prepare(
+  it('alarm TTL-deletes at most one batch and keeps unexpired rows', async () => {
+    const t0 = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(t0);
+    const harness = createHarness();
+    const insert = harness.db.prepare(
+      'INSERT INTO events (event, data, ts) VALUES (?, ?, ?)'
+    );
+    const expiredTs = t0 - THIRTY_DAYS_MS - 1;
+    const leftover = 50;
+    for (let i = 0; i < PRUNE_BATCH_ROWS + leftover; i++) {
+      insert.run('billing.balance:updated', JSON.stringify({ i }), expiredTs);
+    }
+    await emit(harness.channel, { n: 'keep' });
+    expect(eventCount(harness.db)).toBe(PRUNE_BATCH_ROWS + leftover + 1);
+
+    await triggerAlarm(harness);
+    expect(eventCount(harness.db)).toBe(leftover + 1);
+    const messages = await history(harness.channel);
+    expect(
+      messages.some((msg) => {
+        const parsed = JSON.parse(msg.data) as unknown;
+        return isRecord(parsed) && parsed.n === 'keep';
+      })
+    ).toBe(true);
+  });
+
+  it('one alarm cap delete is a bounded PK prefix, not NOT IN', async () => {
+    const harness = createHarness();
+    const insert = harness.db.prepare(
+      'INSERT INTO events (event, data, ts) VALUES (?, ?, ?)'
+    );
+    const extra = 100;
+    const mountain = HISTORY_MAX_ROWS + PRUNE_BATCH_ROWS + extra;
+    const ts = Date.now();
+    for (let i = 0; i < mountain; i++) {
+      insert.run('billing.balance:updated', JSON.stringify({ i }), ts);
+    }
+    expect(eventCount(harness.db)).toBe(mountain);
+
+    harness.sqlStatements.length = 0;
+    await triggerAlarm(harness);
+
+    expect(eventCount(harness.db)).toBe(HISTORY_MAX_ROWS + extra);
+    const capDeletes = harness.sqlStatements.filter(
+      (sql) =>
+        /DELETE FROM events/i.test(sql) &&
+        /seq\s*<=/i.test(sql) &&
+        !/ts\s*</i.test(sql)
+    );
+    expect(capDeletes.length).toBeGreaterThan(0);
+    for (const sql of capDeletes) {
+      expect(sql).not.toMatch(/NOT IN/i);
+    }
+  });
+
+  it('alarm caps a leftover mountain in repeated batches and keeps newest seqs', async () => {
+    const harness = createHarness();
+    const insert = harness.db.prepare(
       'INSERT INTO events (event, data, ts) VALUES (?, ?, ?)'
     );
     const mountain = HISTORY_MAX_ROWS + 1_500;
@@ -341,20 +429,19 @@ describe('RealtimeChannel history cap (#1332)', () => {
     for (let i = 0; i < mountain; i++) {
       insert.run('billing.balance:updated', JSON.stringify({ i }), ts);
     }
-    expect(eventCount(db)).toBe(mountain);
+    expect(eventCount(harness.db)).toBe(mountain);
 
     for (let i = 0; i < 20; i++) {
-      await channel.alarm();
-      if (eventCount(db) <= HISTORY_MAX_ROWS) break;
+      await triggerAlarm(harness);
+      if (eventCount(harness.db) <= HISTORY_MAX_ROWS) break;
     }
 
-    expect(eventCount(db)).toBe(HISTORY_MAX_ROWS);
-    const seqs = db
+    expect(eventCount(harness.db)).toBe(HISTORY_MAX_ROWS);
+    const seqs = harness.db
       .prepare('SELECT MIN(seq) AS min, MAX(seq) AS max FROM events')
       .get();
-    expect(numberField(seqs, 'max') - numberField(seqs, 'min') + 1).toBe(
-      HISTORY_MAX_ROWS
-    );
+    expect(numberField(seqs, 'max')).toBe(mountain);
+    expect(numberField(seqs, 'min')).toBe(mountain - HISTORY_MAX_ROWS + 1);
   });
 
   it('schedules a prune alarm on first emit', async () => {
@@ -362,6 +449,23 @@ describe('RealtimeChannel history cap (#1332)', () => {
     expect(getAlarm()).toBeNull();
     await emit(channel, { n: 1 });
     expect(getAlarm()).toBeGreaterThan(Date.now());
+  });
+
+  it('reschedules a catch-up alarm when a cap batch leaves the table over the cap', async () => {
+    const t0 = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(t0);
+    const harness = createHarness();
+    const insert = harness.db.prepare(
+      'INSERT INTO events (event, data, ts) VALUES (?, ?, ?)'
+    );
+    const mountain = HISTORY_MAX_ROWS + PRUNE_BATCH_ROWS + 50;
+    for (let i = 0; i < mountain; i++) {
+      insert.run('billing.balance:updated', JSON.stringify({ i }), t0);
+    }
+
+    await triggerAlarm(harness);
+    expect(eventCount(harness.db)).toBeGreaterThan(HISTORY_MAX_ROWS);
+    expect(harness.getAlarm()).toBe(t0 + PRUNE_CATCHUP_MS);
   });
 });
 
@@ -408,6 +512,7 @@ describe('RealtimeChannel SSE backpressure (#1332)', () => {
 
     const frames = await readSseUntilDone(stalledBody);
     const userFrames = frames.filter(isUserEvent);
+    expect(userFrames.length).toBeLessThanOrEqual(SSE_MAX_BUFFERED_CHUNKS);
     expect(userFrames.length).toBeLessThan(burst);
 
     const liveAc = new AbortController();
@@ -426,5 +531,43 @@ describe('RealtimeChannel SSE backpressure (#1332)', () => {
       .filter(isUserEvent)
       .map((frame) => frame.data);
     expect(delivered).toContainEqual({ n: 'after-drop' });
+  });
+
+  it('drops only the stalled subscriber; a live sibling still receives events', async () => {
+    const { channel } = createHarness();
+    const liveAc = new AbortController();
+    const stallAc = new AbortController();
+    abortControllers.push(liveAc, stallAc);
+
+    const live = await channel.fetch(
+      new Request(`https://realtime.do/subscribe?channel=${CHANNEL}`, {
+        signal: liveAc.signal,
+      })
+    );
+    const stalled = await channel.fetch(
+      new Request(`https://realtime.do/subscribe?channel=${CHANNEL}`, {
+        signal: stallAc.signal,
+      })
+    );
+    const liveFrames = collectWhile(requireBody(live.body), liveAc.signal);
+
+    const burst = SSE_MAX_BUFFERED_CHUNKS + 8;
+    for (let n = 1; n <= burst; n++) {
+      await emit(channel, { n });
+    }
+
+    const stalledFrames = await readSseUntilDone(requireBody(stalled.body));
+    expect(stalledFrames.filter(isUserEvent).length).toBeLessThanOrEqual(
+      SSE_MAX_BUFFERED_CHUNKS
+    );
+
+    await emit(channel, { n: 'after-stall-drop' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    liveAc.abort();
+
+    const delivered = (await liveFrames)
+      .filter(isUserEvent)
+      .map((frame) => frame.data);
+    expect(delivered).toContainEqual({ n: 'after-stall-drop' });
   });
 });

--- a/src/lib/realtime/realtime-channel.do.ts
+++ b/src/lib/realtime/realtime-channel.do.ts
@@ -1,5 +1,7 @@
 import { DurableObject } from 'cloudflare:workers';
 
+import { getLogger } from '@/lib/observability/logger';
+
 /**
  * Cloudflare-native realtime broker. One Durable Object instance per channel
  * (keyed by `idFromName(channel)`), replacing the previous Upstash
@@ -9,27 +11,43 @@ import { DurableObject } from 'cloudflare:workers';
  * - **Fan-out**: workers/workflows POST events to `/emit`; the DO broadcasts
  *   them to every connected SSE subscriber. Because a DO is a single addressable
  *   instance, all subscribers for a channel land on the same object, so an
- *   in-memory writer set is sufficient for cross-isolate fan-out (the emitter
+ *   in-memory subscriber set is sufficient for cross-isolate fan-out (the emitter
  *   runs in a Workflow isolate, the subscriber in a request isolate).
  * - **Long-lived SSE**: the DO holds each `/subscribe` stream open itself, which
  *   fixes the reconnect loop the old request-isolate handler suffered (Workers
  *   don't hold an SSE stream open — see the kill-switch note that used to live
- *   in `providers.tsx`).
+ *   in `providers.tsx`). Each subscriber is a pull-driven `ReadableStream` with
+ *   a bounded pending queue: a stalled client is dropped rather than buffering
+ *   unbounded chunks in the isolate (#1332). EventSource reconnects and replays
+ *   from `/history`.
  * - **History replay**: events are persisted in the DO's own SQLite storage so a
- *   page refresh mid-generation can replay progress (`/history`). A periodic
- *   alarm prunes rows past the TTL / row cap.
+ *   page refresh mid-generation can replay progress (`/history`). `/emit` prunes
+ *   to the row cap so a chatty channel never accumulates a mountain, and a
+ *   periodic alarm TTL-deletes expired rows in PK-range batches (#1332).
  *
  * The wire format is intentionally simple and fully owned in-repo (see
  * `client.tsx`): each SSE `data:` line is a JSON object — a user event
  * `{ id, event, channel, data }` or a system event `{ type: 'connected' | 'ping' }`.
  */
 
+const logger = getLogger(['openstory', 'realtime', 'channel']);
+
 /** Keep replayable history for 30 days (matches the old Redis stream expiry). */
 const HISTORY_EXPIRE_SECS = 60 * 60 * 24 * 30;
 /** Hard cap on stored rows per channel so a chatty channel can't grow without bound. */
-const HISTORY_MAX_ROWS = 2000;
+export const HISTORY_MAX_ROWS = 2000;
+/**
+ * Per-subscriber SSE buffer. Cloudflare's `WritableStreamDefaultWriter.desiredSize`
+ * is stubbed (always 1 / 0 / null), so this is the actual backpressure bound:
+ * if a client doesn't pull, pending chunks pile up here and we drop them.
+ */
+export const SSE_MAX_BUFFERED_CHUNKS = 32;
 /** How often the prune alarm runs while a channel still has stored events. */
 const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
+/** Catch-up cadence when a leftover mountain still exceeds the cap / TTL. */
+const PRUNE_CATCHUP_MS = 5_000;
+/** Rows deleted per prune statement so one storage op cannot exceed the timeout. */
+const PRUNE_BATCH_ROWS = 1_000;
 /** SSE keepalive cadence — keeps intermediaries from dropping an idle stream. */
 const PING_INTERVAL_MS = 25_000;
 
@@ -47,8 +65,17 @@ export type ChannelHistoryMessage = {
   ts: number;
 };
 
+type Subscriber = {
+  channel: string;
+  pending: Uint8Array[];
+  controller: ReadableStreamDefaultController<Uint8Array> | null;
+  notify: (() => void) | null;
+  closed: boolean;
+  ping: ReturnType<typeof setInterval> | null;
+};
+
 export class RealtimeChannel extends DurableObject {
-  private readonly writers = new Set<WritableStreamDefaultWriter<Uint8Array>>();
+  private readonly subscribers = new Set<Subscriber>();
   private readonly encoder = new TextEncoder();
 
   constructor(ctx: DurableObjectState, env: Cloudflare.Env) {
@@ -61,6 +88,9 @@ export class RealtimeChannel extends DurableObject {
         data TEXT NOT NULL,
         ts INTEGER NOT NULL
       )`
+    );
+    this.ctx.storage.sql.exec(
+      'CREATE INDEX IF NOT EXISTS events_ts ON events(ts)'
     );
   }
 
@@ -96,7 +126,8 @@ export class RealtimeChannel extends DurableObject {
       .one();
     const id = String(row.seq);
 
-    await this.ensurePruneAlarm();
+    this.pruneCapBatch(row.seq);
+    await this.schedulePrune(this.stillOverCap(row.seq));
     this.broadcast({ id, event: body.event, channel, data: body.data });
 
     return new Response(null, { status: 204 });
@@ -123,29 +154,49 @@ export class RealtimeChannel extends DurableObject {
   }
 
   private handleSubscribe(request: Request, channel: string): Response {
-    const { readable, writable } = new TransformStream<
-      Uint8Array,
-      Uint8Array
-    >();
-    const writer = writable.getWriter();
-    this.writers.add(writer);
-
-    void writer
-      .write(this.shot({ type: 'connected', channel }))
-      .catch(() => this.dropWriter(writer));
-
-    const ping = setInterval(() => {
-      writer.write(this.shot({ type: 'ping' })).catch(() => {
-        clearInterval(ping);
-        this.dropWriter(writer);
-      });
-    }, PING_INTERVAL_MS);
-
-    const cleanup = () => {
-      clearInterval(ping);
-      this.dropWriter(writer);
+    const subscriber: Subscriber = {
+      channel,
+      pending: [],
+      controller: null,
+      notify: null,
+      closed: false,
+      ping: null,
     };
-    request.signal.addEventListener('abort', cleanup);
+
+    const readable = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        subscriber.controller = controller;
+        this.subscribers.add(subscriber);
+        this.enqueue(subscriber, this.shot({ type: 'connected', channel }));
+        subscriber.ping = setInterval(() => {
+          this.enqueue(subscriber, this.shot({ type: 'ping' }));
+        }, PING_INTERVAL_MS);
+      },
+      pull: async (controller) => {
+        while (subscriber.pending.length === 0 && !subscriber.closed) {
+          await new Promise<void>((resolve) => {
+            subscriber.notify = resolve;
+          });
+        }
+        if (subscriber.closed) {
+          try {
+            controller.close();
+          } catch {
+            // already closed by dropSubscriber
+          }
+          return;
+        }
+        const chunk = subscriber.pending.shift();
+        if (chunk) controller.enqueue(chunk);
+      },
+      cancel: () => {
+        this.dropSubscriber(subscriber, 'abort');
+      },
+    });
+
+    request.signal.addEventListener('abort', () => {
+      this.dropSubscriber(subscriber, 'abort');
+    });
 
     return new Response(readable, {
       headers: {
@@ -163,42 +214,122 @@ export class RealtimeChannel extends DurableObject {
     data: unknown;
   }): void {
     const shot = this.shot(event);
-    for (const writer of this.writers) {
-      writer.write(shot).catch(() => this.dropWriter(writer));
+    for (const subscriber of this.subscribers) {
+      this.enqueue(subscriber, shot);
     }
+  }
+
+  private enqueue(subscriber: Subscriber, chunk: Uint8Array): void {
+    if (subscriber.closed) return;
+    if (subscriber.pending.length >= SSE_MAX_BUFFERED_CHUNKS) {
+      this.dropSubscriber(subscriber, 'overflow');
+      return;
+    }
+    subscriber.pending.push(chunk);
+    subscriber.notify?.();
+    subscriber.notify = null;
+  }
+
+  private dropSubscriber(
+    subscriber: Subscriber,
+    reason: 'abort' | 'overflow'
+  ): void {
+    if (subscriber.closed) return;
+    subscriber.closed = true;
+    this.subscribers.delete(subscriber);
+    subscriber.pending.length = 0;
+    if (subscriber.ping !== null) {
+      clearInterval(subscriber.ping);
+      subscriber.ping = null;
+    }
+    if (reason === 'overflow') {
+      logger.warn('dropping slow SSE subscriber', {
+        channel: subscriber.channel,
+      });
+    }
+    try {
+      subscriber.controller?.close();
+    } catch {
+      // already closed
+    }
+    subscriber.controller = null;
+    subscriber.notify?.();
+    subscriber.notify = null;
   }
 
   private shot(payload: unknown): Uint8Array {
     return this.encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);
   }
 
-  private dropWriter(writer: WritableStreamDefaultWriter<Uint8Array>): void {
-    if (!this.writers.delete(writer)) return;
-    writer.close().catch(() => {});
+  private capCutoff(newestSeq: number): number {
+    return newestSeq - HISTORY_MAX_ROWS;
   }
 
-  private async ensurePruneAlarm(): Promise<void> {
+  /**
+   * PK-range delete of at most `PRUNE_BATCH_ROWS` oldest rows past the cap.
+   * `seq <= MAX(seq) - HISTORY_MAX_ROWS` is O(k) on the primary key; the old
+   * `seq NOT IN (ORDER BY seq DESC LIMIT n)` form is quadratic on SQLite.
+   */
+  private pruneCapBatch(newestSeq: number): void {
+    const cutoff = this.capCutoff(newestSeq);
+    if (cutoff < 1) return;
+    this.ctx.storage.sql.exec(
+      `DELETE FROM events
+       WHERE seq <= ?
+         AND seq <= (SELECT MIN(seq) FROM events) + ? - 1`,
+      cutoff,
+      PRUNE_BATCH_ROWS
+    );
+  }
+
+  private stillOverCap(newestSeq: number): boolean {
+    const min = this.ctx.storage.sql
+      .exec<{ m: number | null }>('SELECT MIN(seq) AS m FROM events')
+      .one().m;
+    return min !== null && min <= this.capCutoff(newestSeq);
+  }
+
+  private pruneTtlBatch(cutoffTs: number): void {
+    this.ctx.storage.sql.exec(
+      `DELETE FROM events WHERE seq IN (
+        SELECT seq FROM events WHERE ts < ? ORDER BY seq LIMIT ?
+      )`,
+      cutoffTs,
+      PRUNE_BATCH_ROWS
+    );
+  }
+
+  private hasExpired(cutoffTs: number): boolean {
+    return (
+      this.ctx.storage.sql
+        .exec<{ seq: number }>(
+          'SELECT seq FROM events WHERE ts < ? LIMIT 1',
+          cutoffTs
+        )
+        .toArray().length > 0
+    );
+  }
+
+  private async schedulePrune(asap: boolean): Promise<void> {
     const existing = await this.ctx.storage.getAlarm();
-    if (existing === null) {
-      await this.ctx.storage.setAlarm(Date.now() + PRUNE_INTERVAL_MS);
+    const when = Date.now() + (asap ? PRUNE_CATCHUP_MS : PRUNE_INTERVAL_MS);
+    if (existing === null || (asap && existing > when)) {
+      await this.ctx.storage.setAlarm(when);
     }
   }
 
   override async alarm(): Promise<void> {
-    const cutoff = Date.now() - HISTORY_EXPIRE_SECS * 1000;
-    this.ctx.storage.sql.exec('DELETE FROM events WHERE ts < ?', cutoff);
-    this.ctx.storage.sql.exec(
-      `DELETE FROM events WHERE seq NOT IN (
-        SELECT seq FROM events ORDER BY seq DESC LIMIT ?
-      )`,
-      HISTORY_MAX_ROWS
-    );
+    const cutoffTs = Date.now() - HISTORY_EXPIRE_SECS * 1000;
+    this.pruneTtlBatch(cutoffTs);
 
-    const remaining = this.ctx.storage.sql
-      .exec<{ count: number }>('SELECT COUNT(*) AS count FROM events')
-      .one().count;
-    if (remaining > 0) {
-      await this.ctx.storage.setAlarm(Date.now() + PRUNE_INTERVAL_MS);
-    }
+    const newest = this.ctx.storage.sql
+      .exec<{ seq: number | null }>('SELECT MAX(seq) AS seq FROM events')
+      .one().seq;
+    if (newest === null) return;
+
+    this.pruneCapBatch(newest);
+
+    const more = this.hasExpired(cutoffTs) || this.stillOverCap(newest);
+    await this.schedulePrune(more);
   }
 }

--- a/src/lib/realtime/realtime-channel.do.ts
+++ b/src/lib/realtime/realtime-channel.do.ts
@@ -17,13 +17,18 @@ import { getLogger } from '@/lib/observability/logger';
  *   fixes the reconnect loop the old request-isolate handler suffered (Workers
  *   don't hold an SSE stream open — see the kill-switch note that used to live
  *   in `providers.tsx`). Each subscriber is a pull-driven `ReadableStream` with
- *   a bounded pending queue: a stalled client is dropped rather than buffering
- *   unbounded chunks in the isolate (#1332). EventSource reconnects and replays
- *   from `/history`.
+ *   a bounded pending queue: a stalled `/subscribe` consumer is dropped rather
+ *   than buffering unbounded chunks in the isolate (#1332). The merged
+ *   `/api/realtime` pump re-subscribes that channel for live events only;
+ *   missed frames are not replayed. Browser EventSource reconnects the merged
+ *   stream if it dies. Progress replay is a separate `/history` fetch on page
+ *   refresh / hook remount.
  * - **History replay**: events are persisted in the DO's own SQLite storage so a
- *   page refresh mid-generation can replay progress (`/history`). `/emit` prunes
- *   to the row cap so a chatty channel never accumulates a mountain, and a
- *   periodic alarm TTL-deletes expired rows in PK-range batches (#1332).
+ *   page refresh mid-generation can replay progress (`/history`). `/emit` deletes
+ *   a PK prefix of at most `PRUNE_BATCH_ROWS` so one-row emits stay at the cap.
+ *   A periodic alarm TTL-deletes up to `PRUNE_BATCH_ROWS` expired rows (via
+ *   `events_ts`) and the same PK-prefix cap batch; leftovers reschedule in
+ *   `PRUNE_CATCHUP_MS` (#1332).
  *
  * The wire format is intentionally simple and fully owned in-repo (see
  * `client.tsx`): each SSE `data:` line is a JSON object — a user event
@@ -37,17 +42,18 @@ const HISTORY_EXPIRE_SECS = 60 * 60 * 24 * 30;
 /** Hard cap on stored rows per channel so a chatty channel can't grow without bound. */
 export const HISTORY_MAX_ROWS = 2000;
 /**
- * Per-subscriber SSE buffer. Cloudflare's `WritableStreamDefaultWriter.desiredSize`
- * is stubbed (always 1 / 0 / null), so this is the actual backpressure bound:
- * if a client doesn't pull, pending chunks pile up here and we drop them.
+ * Per-subscriber pending-chunk cap. We do not use a TransformStream writer:
+ * Workers stub `WritableStreamDefaultWriter.desiredSize` to 1/0/null, so it
+ * cannot bound memory. If pull() does not drain this queue, we close the
+ * subscriber rather than grow it.
  */
 export const SSE_MAX_BUFFERED_CHUNKS = 32;
 /** How often the prune alarm runs while a channel still has stored events. */
 const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 /** Catch-up cadence when a leftover mountain still exceeds the cap / TTL. */
-const PRUNE_CATCHUP_MS = 5_000;
+export const PRUNE_CATCHUP_MS = 5_000;
 /** Rows deleted per prune statement so one storage op cannot exceed the timeout. */
-const PRUNE_BATCH_ROWS = 1_000;
+export const PRUNE_BATCH_ROWS = 1_000;
 /** SSE keepalive cadence — keeps intermediaries from dropping an idle stream. */
 const PING_INTERVAL_MS = 25_000;
 
@@ -165,6 +171,14 @@ export class RealtimeChannel extends DurableObject {
 
     const readable = new ReadableStream<Uint8Array>({
       start: (controller) => {
+        if (subscriber.closed) {
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+          return;
+        }
         subscriber.controller = controller;
         this.subscribers.add(subscriber);
         this.enqueue(subscriber, this.shot({ type: 'connected', channel }));
@@ -173,21 +187,24 @@ export class RealtimeChannel extends DurableObject {
         }, PING_INTERVAL_MS);
       },
       pull: async (controller) => {
-        while (subscriber.pending.length === 0 && !subscriber.closed) {
+        for (;;) {
+          if (subscriber.closed) {
+            try {
+              controller.close();
+            } catch {
+              // already closed by dropSubscriber
+            }
+            return;
+          }
+          const chunk = subscriber.pending.shift();
+          if (chunk) {
+            controller.enqueue(chunk);
+            return;
+          }
           await new Promise<void>((resolve) => {
             subscriber.notify = resolve;
           });
         }
-        if (subscriber.closed) {
-          try {
-            controller.close();
-          } catch {
-            // already closed by dropSubscriber
-          }
-          return;
-        }
-        const chunk = subscriber.pending.shift();
-        if (chunk) controller.enqueue(chunk);
       },
       cancel: () => {
         this.dropSubscriber(subscriber, 'abort');
@@ -197,6 +214,9 @@ export class RealtimeChannel extends DurableObject {
     request.signal.addEventListener('abort', () => {
       this.dropSubscriber(subscriber, 'abort');
     });
+    if (request.signal.aborted) {
+      this.dropSubscriber(subscriber, 'abort');
+    }
 
     return new Response(readable, {
       headers: {
@@ -266,9 +286,11 @@ export class RealtimeChannel extends DurableObject {
   }
 
   /**
-   * PK-range delete of at most `PRUNE_BATCH_ROWS` oldest rows past the cap.
-   * `seq <= MAX(seq) - HISTORY_MAX_ROWS` is O(k) on the primary key; the old
-   * `seq NOT IN (ORDER BY seq DESC LIMIT n)` form is quadratic on SQLite.
+   * Deletes at most `PRUNE_BATCH_ROWS` oldest rows still past the cap:
+   * `seq <= MIN(seq) + k - 1` ANDed with `seq <= newest - HISTORY_MAX_ROWS`.
+   * That is a PK prefix of size k, so one storage op cannot exceed the DO
+   * timeout. The old `seq NOT IN (… ORDER BY seq DESC LIMIT n)` deleted the
+   * entire overflow in one statement.
    */
   private pruneCapBatch(newestSeq: number): void {
     const cutoff = this.capCutoff(newestSeq);

--- a/src/routes/api/realtime.ts
+++ b/src/routes/api/realtime.ts
@@ -102,24 +102,20 @@ export const Route = createFileRoute('/api/realtime')({
 
         request.signal.addEventListener('abort', close);
 
-        const pump = async (channel: string): Promise<void> => {
-          const stub = namespace.get(namespace.idFromName(channel));
-          const response = await stub.fetch(
-            new Request(
-              `https://realtime.do/subscribe?channel=${encodeURIComponent(channel)}`,
-              { signal: abort.signal }
-            )
-          );
-          if (!response.body) return;
-
-          const reader = response.body.getReader();
+        const drain = async (
+          body: ReadableStream<Uint8Array>
+        ): Promise<void> => {
+          const reader = body.getReader();
           const decoder = new TextDecoder();
           let buffer = '';
-
-          while (!closed) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
+          let reading = true;
+          while (reading && !closed) {
+            const result = await reader.read();
+            if (result.done) {
+              reading = false;
+              continue;
+            }
+            buffer += decoder.decode(result.value, { stream: true });
 
             let boundary = buffer.indexOf('\n\n');
             while (boundary !== -1) {
@@ -130,6 +126,23 @@ export const Route = createFileRoute('/api/realtime')({
               if (payload && !isSystemEvent(payload)) send(payload);
               boundary = buffer.indexOf('\n\n');
             }
+          }
+        };
+
+        const pump = async (channel: string): Promise<void> => {
+          // Re-subscribe if the DO drops this writer (slow-client overflow
+          // #1332, or a storage-timeout reset). The merged EventSource stays
+          // up so sibling channels keep flowing.
+          while (!closed) {
+            const stub = namespace.get(namespace.idFromName(channel));
+            const response = await stub.fetch(
+              new Request(
+                `https://realtime.do/subscribe?channel=${encodeURIComponent(channel)}`,
+                { signal: abort.signal }
+              )
+            );
+            if (!response.body) return;
+            await drain(response.body);
           }
         };
 

--- a/src/routes/api/realtime.ts
+++ b/src/routes/api/realtime.ts
@@ -21,6 +21,33 @@ import { authRequestMiddleware } from '@/functions/middleware';
 const MAX_CHANNELS = 64;
 /** Keepalive cadence for the merged stream. Sub-stream pings are filtered out. */
 const PING_INTERVAL_MS = 25_000;
+/** First pause before re-subscribing a dropped DO stream (#1332). */
+const RECONNECT_MIN_MS = 250;
+/** Cap so a crashing DO cannot tight-loop `/subscribe`. */
+const RECONNECT_MAX_MS = 5_000;
+
+function nextReconnectDelay(currentMs: number): number {
+  if (currentMs < RECONNECT_MIN_MS) return RECONNECT_MIN_MS;
+  return Math.min(currentMs * 2, RECONNECT_MAX_MS);
+}
+
+function waitForReconnect(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+    const onAbort = (): void => {
+      clearTimeout(id);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    const id = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
 
 /** A DO frame is `data: {json}\n\n`; system frames carry `type` and stop here. */
 function parseFrame(frame: string): unknown {
@@ -108,41 +135,65 @@ export const Route = createFileRoute('/api/realtime')({
           const reader = body.getReader();
           const decoder = new TextDecoder();
           let buffer = '';
-          let reading = true;
-          while (reading && !closed) {
-            const result = await reader.read();
-            if (result.done) {
-              reading = false;
-              continue;
-            }
-            buffer += decoder.decode(result.value, { stream: true });
+          try {
+            let reading = true;
+            while (reading && !closed) {
+              const result = await reader.read();
+              if (result.done) {
+                reading = false;
+                continue;
+              }
+              buffer += decoder.decode(result.value, { stream: true });
 
-            let boundary = buffer.indexOf('\n\n');
-            while (boundary !== -1) {
-              const payload = parseFrame(buffer.slice(0, boundary));
-              buffer = buffer.slice(boundary + 2);
-              // Each DO emits its own connected/ping frames; the merged stream
-              // publishes exactly one of each instead of N.
-              if (payload && !isSystemEvent(payload)) send(payload);
-              boundary = buffer.indexOf('\n\n');
+              let boundary = buffer.indexOf('\n\n');
+              while (boundary !== -1) {
+                const payload = parseFrame(buffer.slice(0, boundary));
+                buffer = buffer.slice(boundary + 2);
+                // Each DO emits its own connected/ping frames; the merged
+                // stream publishes exactly one of each instead of N.
+                if (payload && !isSystemEvent(payload)) send(payload);
+                boundary = buffer.indexOf('\n\n');
+              }
+            }
+          } finally {
+            try {
+              await reader.cancel();
+            } catch {
+              // already cancelled / released
             }
           }
         };
 
         const pump = async (channel: string): Promise<void> => {
-          // Re-subscribe if the DO drops this writer (slow-client overflow
-          // #1332, or a storage-timeout reset). The merged EventSource stays
-          // up so sibling channels keep flowing.
+          // Re-subscribe if this channel's DO stream ends (overflow close
+          // #1332, or an isolate reset). Live events only — missed frames
+          // are not replayed from `/history`. Sibling pumps keep the merged
+          // EventSource up. Errors and empty bodies retry with backoff so a
+          // reset cannot silently kill one multiplexed channel, and a billing
+          // burst cannot tight-loop `/subscribe`.
+          let delayMs = 0;
           while (!closed) {
-            const stub = namespace.get(namespace.idFromName(channel));
-            const response = await stub.fetch(
-              new Request(
-                `https://realtime.do/subscribe?channel=${encodeURIComponent(channel)}`,
-                { signal: abort.signal }
-              )
-            );
-            if (!response.body) return;
-            await drain(response.body);
+            try {
+              if (delayMs > 0) {
+                await waitForReconnect(delayMs, abort.signal);
+              }
+              const stub = namespace.get(namespace.idFromName(channel));
+              const response = await stub.fetch(
+                new Request(
+                  `https://realtime.do/subscribe?channel=${encodeURIComponent(channel)}`,
+                  { signal: abort.signal }
+                )
+              );
+              if (!response.body) {
+                delayMs = nextReconnectDelay(delayMs);
+                continue;
+              }
+              await drain(response.body);
+              delayMs = nextReconnectDelay(delayMs);
+            } catch {
+              if (abort.signal.aborted) return;
+              delayMs = nextReconnectDelay(delayMs);
+            }
           }
         };
 

--- a/src/test/cloudflare-workers.stub.ts
+++ b/src/test/cloudflare-workers.stub.ts
@@ -15,6 +15,15 @@ export class WorkflowEntrypoint {
   }
 }
 
+export class DurableObject {
+  protected ctx: unknown;
+  protected env: unknown;
+  constructor(ctx?: unknown, env?: unknown) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+}
+
 export const env: Record<string, unknown> = {};
 
 export function waitUntil(_promise: Promise<unknown>): void {}


### PR DESCRIPTION
## Related Issue

Closes #1332

## Summary of Changes

Two production failure modes on `RealtimeChannel` in one day of logs: prune-alarm storage timeouts (38 DO resets) and unbounded SSE fan-out OOMs (14 subscribers dropped at once on `billing:<teamId>`).

### 1. Prune alarm exceeded storage timeout

- `CREATE INDEX IF NOT EXISTS events_ts ON events(ts)` so TTL delete is not a full scan.
- Replace the quadratic `DELETE … WHERE seq NOT IN (ORDER BY seq DESC LIMIT n)` with a primary-key range delete (`seq <= MAX(seq) - cap`), batched so one storage op cannot timeout on a leftover mountain.
- Prune on `/emit` as well, so a chatty billing channel never accumulates past 2000 rows between hourly alarms.

### 2. Unbounded SSE fan-out OOM

Cloudflare's `WritableStreamDefaultWriter.desiredSize` is stubbed (always 1 / 0 / null), so checking `desiredSize <= 0` cannot see a stalled client. Subscribers are now pull-driven `ReadableStream`s with a 32-chunk pending queue. Overflow drops that subscriber; the merged `/api/realtime` pump re-subscribes so sibling channels keep flowing. EventSource reconnects and `/history` still replays.

## Risk Assessment

- [x] Medium
- [ ] Low
- [ ] High

DO reset/OOM is production-impacting; the change is isolated to the realtime broker. History still keeps the newest 2000 events. A slow client may miss live frames until the pump re-subscribes (then they see new events; refresh still replays history).

## Tests

`bun run test src/lib/realtime/realtime-channel.do.test.ts`

Covers ts index, emit-time cap, TTL alarm, leftover-mountain cap, live SSE delivery, and stalled-subscriber drop.