### PR TITLE
fix(scenes): auto-link @-mentioned cast into scene continuity on script save

### DIFF
--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -48,7 +48,12 @@ import {
   shotStalenessUnknown,
   useShotStaleness,
 } from '@/hooks/use-shot-staleness';
-import { useSaveSceneScript, type SceneWithScript } from '@/hooks/use-scenes';
+import {
+  sceneKeys,
+  useSaveSceneScript,
+  type SceneWithScript,
+} from '@/hooks/use-scenes';
+import { sceneFacetKeys } from '@/hooks/use-scene-facets';
 import { useSaveShotPrompt } from '@/hooks/use-prompt-variants';
 import type { FrameVariant, ShotVariant } from '@/lib/db/schema';
 import {
@@ -807,6 +812,19 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     }
   }, [editedImagePrompt, imagePrompt, handleSaveVisualPrompt]);
 
+  // A regenerate with an edited prompt auto-links @-mentioned cast/elements/
+  // locations into the scene continuity server-side (#683); refetch the scene
+  // rows and the facet membership so the Cast tab reflects it (#1341).
+  const invalidateContinuity = useCallback(() => {
+    if (!shot?.sequenceId) return;
+    void queryClient.invalidateQueries({
+      queryKey: sceneKeys.list(shot.sequenceId),
+    });
+    void queryClient.invalidateQueries({
+      queryKey: sceneFacetKeys.maps(shot.sequenceId),
+    });
+  }, [shot?.sequenceId, queryClient]);
+
   const handleRegenerate = useCallback(async () => {
     if (!shot?.id || !shot.sequenceId) return;
 
@@ -864,6 +882,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       // Don't invalidate immediately - let auto-polling pick up server updates
       // The optimistic update shows 'generating' instantly, and the workflow
       // will update the server status which auto-polling will detect
+      invalidateContinuity();
     } catch (error) {
       if (isInsufficientCreditsError(error)) {
         showFalGate();
@@ -887,6 +906,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     regenImageModel,
     editedImagePrompt,
     queryClient,
+    invalidateContinuity,
     onRegenerateStart,
     showFalGate,
   ]);
@@ -953,6 +973,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       });
 
       // Don't invalidate immediately - let auto-polling pick up server updates
+      invalidateContinuity();
     } catch (error) {
       if (isInsufficientCreditsError(error)) {
         showFalGate();
@@ -977,6 +998,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     editedMotionPrompt,
     generateAudio,
     queryClient,
+    invalidateContinuity,
     onRegenerateStart,
     showFalGate,
   ]);

--- a/src/functions/scenes.ts
+++ b/src/functions/scenes.ts
@@ -5,6 +5,7 @@ import {
   loadSceneContextBySequence,
 } from '@/lib/scenes/scene-script';
 import { ulidSchema } from '@/lib/schemas/id.schemas';
+import { rescanContinuityFromPrompt } from '@/lib/scenes/rescan-continuity-from-prompt';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -94,6 +95,27 @@ export const updateSceneScriptFn = createServerFn({ method: 'POST' })
         source: 'edit',
         createdBy: user.id,
       });
+
+      // Auto-link cast/element/location tags the user @-mentioned in the
+      // script into the scene's continuity (#1341) — the same additive rescan
+      // the shot-prompt paths run (#683). Continuity is what narrows the bible
+      // for prompt generation and picks reference images at render time, so
+      // without this an @-mentioned character never reaches the shot.
+      if (sceneRow.continuity) {
+        const rescan = await rescanContinuityFromPrompt({
+          scopedDb,
+          sequenceId: sequence.id,
+          existing: sceneRow.continuity,
+          promptText: data.extract,
+        });
+        if (rescan.changed) {
+          await scopedDb.scenes.update(
+            sceneId,
+            { continuity: rescan.continuity },
+            { throwOnMissing: false }
+          );
+        }
+      }
     }
 
     const refreshedScript =

--- a/src/hooks/use-scene-facets.ts
+++ b/src/hooks/use-scene-facets.ts
@@ -8,7 +8,7 @@
 import { getSceneFacetMapsFn } from '@/functions/scene-facets';
 import { useQuery } from '@tanstack/react-query';
 
-const sceneFacetKeys = {
+export const sceneFacetKeys = {
   all: ['scene-facets'] as const,
   maps: (sequenceId: string) =>
     [...sceneFacetKeys.all, 'maps', sequenceId] as const,

--- a/src/hooks/use-scenes.ts
+++ b/src/hooks/use-scenes.ts
@@ -5,6 +5,7 @@ import {
 } from '@/functions/scenes';
 import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { SceneRow } from '@/lib/db/schema';
+import { sceneFacetKeys } from '@/hooks/use-scene-facets';
 import { sequenceKeys } from '@/hooks/use-sequences';
 import { shotStalenessNamespace } from '@/hooks/use-shot-staleness';
 import { shotKeys } from '@/hooks/use-shots';
@@ -76,6 +77,13 @@ export function useSaveSceneScript(sequenceId: string) {
         }),
         queryClient.invalidateQueries({
           queryKey: sceneKeys.composedScript(sequenceId),
+        }),
+        // A script edit can auto-link @-mentioned cast/elements/locations into
+        // the scene's continuity (#1341): refetch the scene rows and the
+        // server-resolved facet membership the Cast tab reads.
+        queryClient.invalidateQueries({ queryKey: sceneKeys.list(sequenceId) }),
+        queryClient.invalidateQueries({
+          queryKey: sceneFacetKeys.maps(sequenceId),
         }),
         // Staleness is per-shot and keyed by shot id; the scene's shots aren't
         // enumerated here, so drop the whole staleness namespace.


### PR DESCRIPTION
Closes #1341

## Problem
@-mentioning a character while editing a scene's script did nothing: `updateSceneScriptFn` never ran the continuity auto-link that the shot-prompt paths already run (#683). Since `scene.continuity.characterTags` is what narrows the bible for prompt generation *and* what picks character reference images at render time, the mentioned character never reached the generated prompt or the shot's assets.

Separately, the Cast tab reads server-resolved facet maps that were never refetched after a rescan, so even a prompt-edit regenerate that did auto-link looked like a no-op for up to 30s.

## Fix
- `src/functions/scenes.ts` — on a changed script, run `rescanContinuityFromPrompt` on the extract and persist additions to the scene (additive; same helper as image/motion regenerate).
- `src/hooks/use-scenes.ts` — script save also invalidates the scene list + facet maps.
- `src/components/scenes/scene-script-prompts.tsx` — image/motion regenerate invalidate scene list + facet maps after the server call (the rescan happens there).
- `src/hooks/use-scene-facets.ts` — export `sceneFacetKeys`.

## Test plan
- [x] `bun typecheck`, `bun lint`, `bun run test` (extract-continuity + mention-roundtrip)
- [ ] Manual: @-mention a cast member in a scene script, save → Cast tab shows them; generate prompt + image → character sheet attached as reference.

Skipped: scenes with `continuity: null` are left alone (mirrors the shot-prompt guard).