### PR TITLE
fix(generation): remove 'Meanwhile: watch a sample in this style' link

### DIFF
--- a/src/components/generation/generation-progress-banner.tsx
+++ b/src/components/generation/generation-progress-banner.tsx
@@ -2,7 +2,6 @@ import {
   type BannerPhase,
   ProgressBanner,
 } from '@/components/generation/progress-banner';
-import { Link } from '@tanstack/react-router';
 import { PHASE_DESCRIPTIONS } from '@/lib/generation/phase-descriptions';
 import {
   estimateSceneCount,
@@ -83,21 +82,8 @@ export const GenerationProgressBanner: React.FC<
       onOpenChange={setIsOpen}
       leaveHint={
         willEmail ? (
-          <>
-            We&rsquo;ll email you when it&rsquo;s ready. Meanwhile:{' '}
-            <Link to="/gallery" className="underline underline-offset-2">
-              watch a sample in this style
-            </Link>
-          </>
-        ) : (
-          <>
-            Click around or create something else while you&rsquo;re waiting.
-            Meanwhile:{' '}
-            <Link to="/gallery" className="underline underline-offset-2">
-              watch a sample in this style
-            </Link>
-          </>
-        )
+          <>We&rsquo;ll email you when it&rsquo;s ready.</>
+        ) : undefined
       }
     />
   );

--- a/src/components/generation/render-wait-copy.tsx
+++ b/src/components/generation/render-wait-copy.tsx
@@ -1,5 +1,3 @@
-import { Link } from '@tanstack/react-router';
-
 type RenderWaitCopyProps = {
   /** Whole minutes remaining, at least 1. */
   etaMinutes: number;
@@ -16,21 +14,7 @@ export const RenderWaitCopy: React.FC<RenderWaitCopyProps> = ({
   willEmail,
 }) => (
   <span>
-    {willEmail ? (
-      <span>
-        Rendering, about {etaMinutes} min. We&rsquo;ll email you when it&rsquo;s
-        ready. Meanwhile:{' '}
-        <Link to="/gallery" className="underline underline-offset-2">
-          watch a sample in this style
-        </Link>
-      </span>
-    ) : (
-      <span>
-        Rendering, about {etaMinutes} min. Meanwhile:{' '}
-        <Link to="/gallery" className="underline underline-offset-2">
-          watch a sample in this style
-        </Link>
-      </span>
-    )}
+    Rendering, about {etaMinutes} min.
+    {willEmail && <> We&rsquo;ll email you when it&rsquo;s ready.</>}
   </span>
 );


### PR DESCRIPTION
Closes #1345

Drops the "Meanwhile: watch a sample in this style" gallery link from both render-wait copy sites (`RenderWaitCopy` and the `GenerationProgressBanner` leave hint). The no-email banner variant now falls back to `ProgressBanner`'s default "Click around or create something else while you're waiting".