### PR TITLE
Change animatic to storyboard

### DIFF
--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -488,7 +488,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
           )}
           {isPreviewImage && !isVariantPreview && (
             <span className="absolute top-2 right-2 z-10 rounded bg-background/80 px-2 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm">
-              Animatic
+              Storyboard
             </span>
           )}
           {frameOverlay}

--- a/src/components/scenes/scene-thumbnail.tsx
+++ b/src/components/scenes/scene-thumbnail.tsx
@@ -96,7 +96,7 @@ const SceneThumbnailComponent: React.FC<SceneThumbnailProps> = ({
 
       {isPreview && (
         <span className="absolute top-1 right-1 rounded bg-background/80 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground backdrop-blur-sm">
-          Animatic
+          Storyboard
         </span>
       )}
 

--- a/src/components/scenes/scenes-view.stories.tsx
+++ b/src/components/scenes/scenes-view.stories.tsx
@@ -617,7 +617,7 @@ export const PreviewMode: Story = {
     docs: {
       description: {
         story:
-          'Shows preview mode where fast preview images are displayed while full-resolution thumbnails are still generating. Scenes 1-2 show the "Animatic" badge, Scene 3 has its final image ready (no badge).',
+          'Shows preview mode where fast preview images are displayed while full-resolution thumbnails are still generating. Scenes 1-2 show the "Storyboard" badge, Scene 3 has its final image ready (no badge).',
       },
     },
   },

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -219,7 +219,7 @@ export const IMAGE_MODELS = {
     vendor: 'Krea',
     license: 'open-source' as const,
     qualityRank: 99,
-    description: 'Ultra-fast animatic generation',
+    description: 'Ultra-fast storyboard generation',
     maxPromptLength: 2000,
     hidden: true,
   },


### PR DESCRIPTION
Closes #1347

The fast line-art preview shown before a scene's real thumbnail was badged "Animatic". An animatic is a timed sequence of panels; this is one static panel — call it "Storyboard".

- Badge text in `scene-thumbnail.tsx` and `scene-player.tsx`
- Storybook description + Krea 2 Turbo model description

**Left alone**
- `buildPreviewPrompt`'s `Animatic frame.` prefix — model-facing only, and the 12 krea-2-turbo e2e fixtures replay strictly on that exact string; changing it means re-recording against real fal for no user-visible gain.
- The `animatic` style catalog category ("Animatic & Previz") — a real style; touches the API v1 schema and seeded templates.