### PR TITLE
Simplify image prompt and honour physics

### DIFF
--- a/src/lib/ai/scene-analysis.schema.ts
+++ b/src/lib/ai/scene-analysis.schema.ts
@@ -162,9 +162,6 @@ const visualPromptSchema = z.object({
   fullPrompt: z.string().meta({
     description: 'Complete image generation prompt with all visual details',
   }),
-  negativePrompt: z
-    .string()
-    .meta({ description: 'Elements to avoid in the generated image' }),
 });
 
 // No longer part of `motionPromptSchema` (#1035): `assembleMotionPrompt` uses

--- a/src/lib/ai/shot-list.derive.ts
+++ b/src/lib/ai/shot-list.derive.ts
@@ -76,10 +76,7 @@ function deriveVisualPrompt(
     ...sceneParts,
   ]);
 
-  return {
-    fullPrompt,
-    negativePrompt: '',
-  };
+  return { fullPrompt };
 }
 
 /**

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -920,7 +920,7 @@ The frame is the instant BEFORE the action in <CURRENT_SCENE>. Read that action 
 The frame must be photographable on a real set. Real-world scale between people, props and buildings (a football goal dwarfs the keeper; a doorway is taller than the person). Feet on ground that exists, hands on the object held, bodies supported by what they lean on. Distances and eyelines that make the action possible. A camera position that could exist in the space. Stage the scripted action plausibly; never change it.
 
 ### CHARACTERS
-Name in CAPS only, e.g. "SERENA". The character sheet carries appearance AND costume: never describe face, hair, skin, build, age, ethnicity or clothing. Mention wardrobe only where this scene changes it (a coat now on, a helmet off). Use <CHARACTER_BIBLE> for names alone.
+Use each character's full name exactly as written in <CHARACTER_BIBLE>, in CAPS, every time you mention them: "SCARLETT VEGA", never "SCARLETT" or "she" on first mention. The exact spelling is what binds the reference image. The character sheet carries appearance AND costume: never describe face, hair, skin, build, age, ethnicity or clothing. Mention wardrobe only where this scene changes it (a coat now on, a helmet off). Use <CHARACTER_BIBLE> for names alone.
 
 ### ELEMENTS
 Include an element from <ELEMENT_BIBLE> only if it is on camera at this instant, not merely spoken about. Bind it by role noun then token in parentheses, e.g. "holding the product from (HERO_PRODUCT)", "the screen shows (BONDI_SCREEN)". Say where it sits in the shot, never what it looks like, never any text on it, and never use the token as a word in the scene.

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -907,6 +907,9 @@ Respond with exactly {{numTalent}} matches.`,
       role: 'system',
       content: `You write the prompt for the first frame of a video shot: one still that an image model renders and a video model then animates.
 
+### OUTPUT
+You will be called via a structured output tool. Follow the provided schema exactly: the prompt goes in the fullPrompt field as plain prose. Never put JSON, braces or quotes inside it.
+
 ### LENGTH
 80-120 words. One paragraph of plain sentences. No headers, bullets or labels. Every phrase must change the picture; cut adjectives that don't.
 

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -905,45 +905,45 @@ Respond with exactly {{numTalent}} matches.`,
   'phase/visual-prompt-scene-generation-chat': [
     {
       role: 'system',
-      content: `You are a Cinematic Visual Prompt Generator for Nano Banana Pro. Your goal is to generate a single, dense text prompt to accompany a character reference image.
+      content: `You write the image prompt for the first frame of a video shot. Output one dense paragraph of natural language; a reference image supplies each character's appearance.
 
-### CRITICAL OUTPUT RULES
-1. You will be called via a structured output tool. Follow the provided schema exactly.
-2. **NO FORMATTING**: Inside the prompt string, use natural language only. No headers (e.g., "Subject:"), no bullet points.
+### OUTPUT
+1. You are called via a structured output tool. Follow the provided schema exactly.
+2. Natural language only inside the prompt: no headers (e.g. "Subject:"), bullets, or labels.
+3. One paragraph, in this order: [medium/style] + [CHARACTER NAME IN CAPS + wardrobe] + [pose at the first instant] + [environment] + [lighting] + [camera angle/lens].
 
-### VISUAL CONSTRUCTION STRATEGY
-1. **CHARACTER IDENTITY VIA REFERENCE IMAGE**: A reference image handles each character's physical appearance. Do NOT describe face, hair, skin, build, or body type in the prompt text. Instead, refer to each character by NAME IN CAPS (e.g., "SERENA"). From the <CHARACTER_BIBLE>, include ONLY their costume/wardrobe (standardClothing) and any costume-relevant distinguishingFeatures. Do not alter the costume defined in the Bible.
-2. **THE "STARTING FRAME"**: Describe the exact moment the scene begins. Focus on the *potential energy*—muscles tensed, mid-breath, looking off-camera. This is a still image that implies motion.
-3. **ENVIRONMENT & LIGHTING**: Since the character identity is handled by reference, spend 60% of your tokens on the atmosphere, lighting texture, depth of field, and background details.
-4. **DIRECTOR STYLE**: Apply the <DIRECTOR_STYLE> to the camera lens (e.g., "anamorphic flares"), film stock, and color palette.
-5. **ELEMENTS — reference image does the heavy lifting**: User-uploaded elements (logos, products, screenshots) are identified by UPPERCASE tokens (the same form the script uses, e.g. \`BONDI_SCREEN\`, \`BRAND_LOGO\`). The accompanying reference image carries their complete visual identity. Your text must NOT compete with that image.
+### THE FIRST FRAME
+This still is the instant the shot begins, before the action in <CURRENT_SCENE> happens. Read the scene's action and <SCENE_AFTER> first, then stage the frame so that action can physically unfold from it:
+- Put everyone where the action actually happens. Someone about to dive through a wave is already waist-deep in the water, not on dry sand; someone about to open a door is within arm's reach of it.
+- Leave room for the action. The direction of travel is open, and its target (goal, doorway, ledge, the other character) is in frame or clearly implied by the eyeline.
+- Pose is potential energy: weight shifted, muscles loaded, mid-breath, eyes on the target. A still that implies the next second.
 
-   **First, decide visibility in THIS starting frame:**
-   - Include only if physically present on-camera in this moment — held, worn, displayed on a screen in-shot, mounted on a wall, on the desk, in the background, etc.
-   - EXCLUDE if merely referenced in dialogue, implied, mentioned as something about to appear, described off-screen, or belongs to a later beat. A character *talking about* the product is not the same as the product being *seen*.
-   - If you exclude an element, REMOVE its token from continuity.elementTags[] so downstream reference-image binding stays in sync with the prompt.
+### PHYSICAL PLAUSIBILITY
+The frame must be photographable on a real set. Before writing, sanity-check scale, distance and mechanics:
+- Real-world scale between people, props and architecture: a football goal dwarfs the keeper, a doorway is taller than the person walking through it, a phone fits in a hand. When scale matters, state it relative to the character ("the crossbar well above his reach").
+- Contact and support: feet on ground that exists, hands on the object they hold, bodies supported by what they lean on. Water, sand, snow and stairs behave like themselves.
+- Distances and eyelines consistent with the action: a conversation across a table, a throw with its target in range.
+- The camera obeys physics too: a position that could exist in the space, a lens that gives the described framing.
+Never fix an impossible staging by changing the action; stage the scripted action plausibly.
 
-   **When you include one — map it explicitly to its reference image:** use phrasing that tells the model to USE the reference, like "displaying the UI from (BONDI_SCREEN)", "the screen shows (BONDI_SCREEN)", "wearing the logo from (BRAND_LOGO)", "holding the product from (HERO_PRODUCT)". Place the UPPERCASE token in parentheses immediately after the role-noun. Prefer this explicit-map phrasing at the earliest natural mention in the prompt — it disambiguates which reference drives which object. Use the EXACT UPPERCASE token from <ELEMENT_BIBLE>, verbatim.
+### CHARACTERS
+A reference image handles each character's face, hair, skin, build and body type. Do NOT describe appearance. Name them IN CAPS (e.g. "SERENA") and take ONLY their costume (standardClothing) and costume-relevant distinguishingFeatures from <CHARACTER_BIBLE>, unaltered.
 
-   **HARD PROHIBITIONS — these are what ruin outputs:**
-   - NEVER describe the element's internal visual content. No typography, no color scheme, no layout, no UI components (nav bars, panels, buttons, columns), no readable words or phrases, no product shape, no logo shape. The reference image already contains all of this — descriptive text here triggers "conditioning competition" where the model generates a *new* element based on your words instead of faithfully pasting in the reference.
-   - NEVER quote or invent any text ("luminous", "coastal breeze", "Sequences", product names, headlines) that you hope will appear on the element. If the reference has text, the reference has text. Do not instruct the model to render it.
-   - NEVER write the token as a brand name in prose (e.g. avoid "the BONDI_SCREEN platform" or "a BONDI_SCREEN-style interface"). The UPPERCASE token is an internal identifier, not part of the sentence's noun phrase.
-   - NEVER describe the token as on-screen text, signage, a label, or anything readable within the scene — it is an internal identifier, not content the viewer should see.
+### ENVIRONMENT, LIGHTING, STYLE
+Identity is already handled, so spend most of your words on atmosphere, lighting texture, depth of field and background detail. Apply <DIRECTOR_STYLE> to lens (e.g. "anamorphic flares"), film stock and palette. Compose for <ASPECT_RATIO>.
 
-   **What you CAN describe:** how the element sits in the physical shot — held, placed, mounted, in background, reflected, angled toward camera, partially occluded, blurred in bokeh, sharply in focus. Also its interaction with lighting (glare on the glossy surface, rim light across the bezel). Only reference elements listed in <ELEMENT_BIBLE>.
+### ELEMENTS (user-uploaded, referenced by UPPERCASE token)
+Reference images carry each element's complete visual identity; your text must not compete with them.
+- Include an element only if it is physically on-camera in this first instant (held, worn, on a screen in shot, mounted, on the desk, in the background). Exclude it if it is merely spoken about, implied, or belongs to a later beat.
+- When included, map it to its reference at the earliest natural mention: role-noun, then the EXACT token from <ELEMENT_BIBLE> in parentheses. "the screen shows (BONDI_SCREEN)", "wearing the logo from (BRAND_LOGO)", "holding the product from (HERO_PRODUCT)".
+- Describe only how it sits in the shot: held, mounted, angled toward camera, partially occluded, blurred in bokeh, glare or rim light on its surface.
+- NEVER describe an element's internal content (typography, colours, layout, UI parts, readable words, product or logo shape), NEVER invent text to appear on it, NEVER use the token as a brand name in prose or as anything readable in the scene. Only elements listed in <ELEMENT_BIBLE>.
 
-### CONTENT RULES (STRICT)
-1. **NO HOLOGRAPHIC SCREENS**: Do NOT describe floating interfaces, holograms, or HUDs. Technology must be physical (glass screens, tactile buttons, cables, metal) and grounded.
-2. **NO TEXT**: No subtitles, no signs, no dialogue. (Exception: text rendered on uploaded elements may appear — that is part of the element's identity.)
-3. **ONE SHOT**: Describe a single coherent frame.
-4. **ZERO MEMORY**: Re-describe the setting fully and name each character present with their costume. Do not refer to "the previous scene." Do NOT re-describe character physical appearance — the reference image provides identity.
-
-### PROMPT STRUCTURE (Flatten into one paragraph)
-[Medium/Style] + [CHARACTER NAME IN CAPS & Costume/Wardrobe] + [Specific Pose/Action] + [Detailed Environment] + [Lighting Conditions] + [Camera Angle/Lens]
-
-### CONTINUITY OUTPUT
-Set continuity.elementTags[] to the UPPERCASE tokens of elements you actually INCLUDED in the prompt per rule 5 — i.e. elements physically visible in this starting frame. Elements that are only referenced in dialogue or implied off-screen must NOT appear in elementTags[], since that list drives reference-image attachment.`,
+### HARD RULES
+- No holograms, floating interfaces or HUDs. Technology is physical and grounded.
+- No text, signs, subtitles or dialogue (text on an uploaded element's reference is fine).
+- One shot, one coherent frame.
+- Zero memory: fully re-describe the setting and name every character present with their costume. Never refer to "the previous scene".`,
     },
     {
       role: 'user',

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -905,45 +905,28 @@ Respond with exactly {{numTalent}} matches.`,
   'phase/visual-prompt-scene-generation-chat': [
     {
       role: 'system',
-      content: `You write the image prompt for the first frame of a video shot. Output one dense paragraph of natural language; a reference image supplies each character's appearance.
+      content: `You write the prompt for the first frame of a video shot: one still that an image model renders and a video model then animates.
 
-### OUTPUT
-1. You are called via a structured output tool. Follow the provided schema exactly.
-2. Natural language only inside the prompt: no headers (e.g. "Subject:"), bullets, or labels.
-3. One paragraph, in this order: [medium/style] + [CHARACTER NAME IN CAPS + wardrobe] + [pose at the first instant] + [environment] + [lighting] + [camera angle/lens].
+### LENGTH
+80-120 words. One paragraph of plain sentences. No headers, bullets or labels. Every phrase must change the picture; cut adjectives that don't.
 
-### THE FIRST FRAME
-This still is the instant the shot begins, before the action in <CURRENT_SCENE> happens. Read the scene's action and <SCENE_AFTER> first, then stage the frame so that action can physically unfold from it:
-- Put everyone where the action actually happens. Someone about to dive through a wave is already waist-deep in the water, not on dry sand; someone about to open a door is within arm's reach of it.
-- Leave room for the action. The direction of travel is open, and its target (goal, doorway, ledge, the other character) is in frame or clearly implied by the eyeline.
-- Pose is potential energy: weight shifted, muscles loaded, mid-breath, eyes on the target. A still that implies the next second.
+### ORDER
+Shot size and lens. Who is in frame and what they are doing at this exact instant. Where they are. Light. Style.
 
-### PHYSICAL PLAUSIBILITY
-The frame must be photographable on a real set. Before writing, sanity-check scale, distance and mechanics:
-- Real-world scale between people, props and architecture: a football goal dwarfs the keeper, a doorway is taller than the person walking through it, a phone fits in a hand. When scale matters, state it relative to the character ("the crossbar well above his reach").
-- Contact and support: feet on ground that exists, hands on the object they hold, bodies supported by what they lean on. Water, sand, snow and stairs behave like themselves.
-- Distances and eyelines consistent with the action: a conversation across a table, a throw with its target in range.
-- The camera obeys physics too: a position that could exist in the space, a lens that gives the described framing.
-Never fix an impossible staging by changing the action; stage the scripted action plausibly.
+### STAGING
+The frame is the instant BEFORE the action in <CURRENT_SCENE>. Read that action and <SCENE_AFTER> first, then place subjects where the action physically happens (a wave-dive starts in the water, not on the sand) with room in frame for it to unfold: direction of travel open, its target in frame or on the eyeline. Pose is potential energy: weight shifted, eyes on the target.
+
+### PHYSICS
+The frame must be photographable on a real set. Real-world scale between people, props and buildings (a football goal dwarfs the keeper; a doorway is taller than the person). Feet on ground that exists, hands on the object held, bodies supported by what they lean on. Distances and eyelines that make the action possible. A camera position that could exist in the space. Stage the scripted action plausibly; never change it.
 
 ### CHARACTERS
-A reference image handles each character's face, hair, skin, build and body type. Do NOT describe appearance. Name them IN CAPS (e.g. "SERENA") and take ONLY their costume (standardClothing) and costume-relevant distinguishingFeatures from <CHARACTER_BIBLE>, unaltered.
+Name in CAPS plus costume from <CHARACTER_BIBLE> only. Never describe face, hair, skin, build, age or ethnicity: the reference image carries identity.
 
-### ENVIRONMENT, LIGHTING, STYLE
-Identity is already handled, so spend most of your words on atmosphere, lighting texture, depth of field and background detail. Apply <DIRECTOR_STYLE> to lens (e.g. "anamorphic flares"), film stock and palette. Compose for <ASPECT_RATIO>.
-
-### ELEMENTS (user-uploaded, referenced by UPPERCASE token)
-Reference images carry each element's complete visual identity; your text must not compete with them.
-- Include an element only if it is physically on-camera in this first instant (held, worn, on a screen in shot, mounted, on the desk, in the background). Exclude it if it is merely spoken about, implied, or belongs to a later beat.
-- When included, map it to its reference at the earliest natural mention: role-noun, then the EXACT token from <ELEMENT_BIBLE> in parentheses. "the screen shows (BONDI_SCREEN)", "wearing the logo from (BRAND_LOGO)", "holding the product from (HERO_PRODUCT)".
-- Describe only how it sits in the shot: held, mounted, angled toward camera, partially occluded, blurred in bokeh, glare or rim light on its surface.
-- NEVER describe an element's internal content (typography, colours, layout, UI parts, readable words, product or logo shape), NEVER invent text to appear on it, NEVER use the token as a brand name in prose or as anything readable in the scene. Only elements listed in <ELEMENT_BIBLE>.
+### ELEMENTS
+Include an element from <ELEMENT_BIBLE> only if it is on camera at this instant, not merely spoken about. Bind it by role noun then token in parentheses, e.g. "holding the product from (HERO_PRODUCT)", "the screen shows (BONDI_SCREEN)". Say where it sits in the shot, never what it looks like, never any text on it, and never use the token as a word in the scene.
 
 ### HARD RULES
-- No holograms, floating interfaces or HUDs. Technology is physical and grounded.
-- No text, signs, subtitles or dialogue (text on an uploaded element's reference is fine).
-- One shot, one coherent frame.
-- Zero memory: fully re-describe the setting and name every character present with their costume. Never refer to "the previous scene".`,
+No text, signs or subtitles. No holograms or floating UI. One coherent frame. Fully state the setting and everyone present; never refer to another scene. Apply <DIRECTOR_STYLE> to lens, stock and palette; compose for <ASPECT_RATIO>.`,
     },
     {
       role: 'user',

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -920,7 +920,7 @@ The frame is the instant BEFORE the action in <CURRENT_SCENE>. Read that action 
 The frame must be photographable on a real set. Real-world scale between people, props and buildings (a football goal dwarfs the keeper; a doorway is taller than the person). Feet on ground that exists, hands on the object held, bodies supported by what they lean on. Distances and eyelines that make the action possible. A camera position that could exist in the space. Stage the scripted action plausibly; never change it.
 
 ### CHARACTERS
-Name in CAPS plus costume from <CHARACTER_BIBLE> only. Never describe face, hair, skin, build, age or ethnicity: the reference image carries identity.
+Name in CAPS only, e.g. "SERENA". The character sheet carries appearance AND costume: never describe face, hair, skin, build, age, ethnicity or clothing. Mention wardrobe only where this scene changes it (a coat now on, a helmet off). Use <CHARACTER_BIBLE> for names alone.
 
 ### ELEMENTS
 Include an element from <ELEMENT_BIBLE> only if it is on camera at this instant, not merely spoken about. Bind it by role noun then token in parentheses, e.g. "holding the product from (HERO_PRODUCT)", "the screen shows (BONDI_SCREEN)". Say where it sits in the shot, never what it looks like, never any text on it, and never use the token as a word in the scene.

--- a/src/lib/workflows/frame-prompt-workflow.ts
+++ b/src/lib/workflows/frame-prompt-workflow.ts
@@ -129,30 +129,9 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
             ? JSON.stringify(sceneAfter, null, 2)
             : '(none)',
           scene: JSON.stringify(scene, null, 2),
-          // Identity comes from reference images (#1349): hand the LLM only
-          // the fields it may use, instead of the full entry plus a rule
-          // not to look at the rest. Locations keep their description — it
-          // IS the environment, and a location reference is optional.
-          characterBible: JSON.stringify(
-            narrowed.characterBible.map(
-              ({ name, standardClothing, distinguishingFeatures }) => ({
-                name,
-                standardClothing,
-                distinguishingFeatures,
-              })
-            ),
-            null,
-            2
-          ),
+          characterBible: JSON.stringify(narrowed.characterBible, null, 2),
           locationBible: JSON.stringify(narrowed.locationBible, null, 2),
-          elementBible: JSON.stringify(
-            narrowed.elementBible.map(({ token, firstMention }) => ({
-              token,
-              scriptMention: firstMention.text,
-            })),
-            null,
-            2
-          ),
+          elementBible: JSON.stringify(narrowed.elementBible, null, 2),
           styleConfig: JSON.stringify(styleConfig, null, 2),
           aspectRatio,
         }

--- a/src/lib/workflows/frame-prompt-workflow.ts
+++ b/src/lib/workflows/frame-prompt-workflow.ts
@@ -129,9 +129,30 @@ export class FramePromptWorkflow extends OpenStoryWorkflowEntrypoint<FramePrompt
             ? JSON.stringify(sceneAfter, null, 2)
             : '(none)',
           scene: JSON.stringify(scene, null, 2),
-          characterBible: JSON.stringify(narrowed.characterBible, null, 2),
+          // Identity comes from reference images (#1349): hand the LLM only
+          // the fields it may use, instead of the full entry plus a rule
+          // not to look at the rest. Locations keep their description — it
+          // IS the environment, and a location reference is optional.
+          characterBible: JSON.stringify(
+            narrowed.characterBible.map(
+              ({ name, standardClothing, distinguishingFeatures }) => ({
+                name,
+                standardClothing,
+                distinguishingFeatures,
+              })
+            ),
+            null,
+            2
+          ),
           locationBible: JSON.stringify(narrowed.locationBible, null, 2),
-          elementBible: JSON.stringify(narrowed.elementBible, null, 2),
+          elementBible: JSON.stringify(
+            narrowed.elementBible.map(({ token, firstMention }) => ({
+              token,
+              scriptMention: firstMention.text,
+            })),
+            null,
+            2
+          ),
           styleConfig: JSON.stringify(styleConfig, null, 2),
           aspectRatio,
         }


### PR DESCRIPTION
Closes #1349

## What
- **Rewrote the visual-prompt system prompt** (`phase/visual-prompt-scene-generation-chat`): ~25% shorter, model-agnostic (no longer addressed to "Nano Banana Pro"), and drops the dead `continuity.elementTags[]` output instructions — that field left the response schema in #867 so the LLM was being told to emit something it couldn't.
- **First-frame staging**: the prompt now tells the LLM to read the scene action and `<SCENE_AFTER>` first, then place subjects where the action physically happens (a wave-dive starts waist-deep in the water, not on the sand), leave room in frame for the direction of travel, and pose for potential energy.
- **Physical plausibility**: explicit sanity-checks on real-world scale between people/props/architecture (goal vs. keeper), contact and support, distances/eyelines, and a camera position that could exist in the space. It must stage the scripted action plausibly rather than swap in a different one.
- **Dropped `negativePrompt`** from `visualPromptSchema`: the workflow only ever persisted `fullPrompt`; nothing sent the negative prompt to an image model. Less output per shot for free.

## Safety
- The **user** message template is byte-for-byte unchanged, so all recorded aimock `visual-prompts` fixtures still match (they match on the user message; `systemHash` is recorder metadata only).
- Existing fixtures that still return `negativePrompt` replay fine — `z.object().parse` strips unknown keys.
- `bun typecheck`, `bun lint`, and the touching unit tests (schema budget, shot-list derive, llm-call-helper, validate-example, scene-persistence) pass.