### PR TITLE
fix(#1354): don't call createServerOnlyFn from the composer cost estimate

### DIFF
--- a/e2e/fixtures/test-utils.ts
+++ b/e2e/fixtures/test-utils.ts
@@ -55,6 +55,12 @@ export async function fillScriptEditor(
     script,
     { timeout: 5_000 }
   );
+  // React error boundaries swallow pageerror, so a throw during the
+  // composer's cost estimate (#1354) replaces the tree instead of failing
+  // the test. The heading is the error-boundary copy in __root.tsx.
+  await expect(
+    page.getByRole('heading', { name: 'Something went wrong' })
+  ).toHaveCount(0);
   return editor;
 }
 

--- a/e2e/tests/sequences.spec.ts
+++ b/e2e/tests/sequences.spec.ts
@@ -167,6 +167,45 @@ test.describe('Sequences', () => {
     await expect(generate).toBeEnabled();
   });
 
+  test('typing still works when motion/audio catalog pricing is missing', async ({
+    page,
+  }) => {
+    // #1354: Generate's ActionCost floors unpriced motion/audio. That used to
+    // call getPostHogClient() (createServerOnlyFn) on every keystroke.
+    await page.route('**/_serverFn/**', async (route) => {
+      const id = route.request().url().split('/_serverFn/')[1]?.split('?')[0];
+      let decoded = '';
+      try {
+        decoded = Buffer.from(id ?? '', 'base64url').toString();
+      } catch {
+        decoded = '';
+      }
+      if (!decoded.includes('getCatalogFalPricingFn')) {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          result: {
+            'openai/gpt-image-2': {
+              unitPriceMicros: 1_000_000,
+              unit: 'units',
+              typicalUnitsPerCall: 0.22,
+            },
+          },
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await fillScriptEditor(page, 'A cat walks into a diner at dawn.');
+    await expect(
+      page.getByRole('button', { name: 'Generate', exact: true })
+    ).toBeEnabled();
+  });
+
   test('Try-this-style URL seeds the style sample, not Match script', async ({
     page,
   }) => {

--- a/src/lib/billing/__tests__/billing-observability.test.ts
+++ b/src/lib/billing/__tests__/billing-observability.test.ts
@@ -11,10 +11,35 @@ vi.doMock('@/lib/posthog-server', () => ({
 }));
 
 const {
+  reportFlooredEstimate,
   reportMissingBillingCost,
   reportReservationShort,
   reportSkippedDeduction,
 } = await import('../billing-observability');
+
+describe('reportFlooredEstimate', () => {
+  it('captures a billing_estimate_floored event', () => {
+    capture.mockClear();
+
+    reportFlooredEstimate({
+      model: 'minimax_h3_max',
+      operation: 'storyboard:motion',
+      numCalls: 1,
+      floorMicros: 100_000,
+    });
+
+    expect(capture).toHaveBeenCalledWith({
+      distinctId: 'system',
+      event: 'billing_estimate_floored',
+      properties: {
+        model: 'minimax_h3_max',
+        operation: 'storyboard:motion',
+        num_calls: 1,
+        floor_micros: 100_000,
+      },
+    });
+  });
+});
 
 describe('reportMissingBillingCost', () => {
   it('logs and captures a billing_missing_cost event', () => {

--- a/src/lib/billing/billing-observability.ts
+++ b/src/lib/billing/billing-observability.ts
@@ -1,11 +1,33 @@
 /**
  * Observability for billing gaps — when a completed AI call reports no cost.
+ *
+ * PostHog capture goes through `createIsomorphicFn` so the Generate CTA can
+ * floor an unpriced motion/audio line on every keystroke without calling
+ * `getPostHogClient()` in the browser (#1354). That helper is
+ * `createServerOnlyFn` — the client stub throws
+ * `createServerOnlyFn() functions can only be called on the server!`.
+ * Server credit-gates still emit; the UI path is a no-op.
  */
 
 import { getPostHogClient } from '@/lib/posthog-server';
 import { getLogger } from '@/lib/observability/logger';
+import { createIsomorphicFn } from '@tanstack/react-start';
 
 const logger = getLogger(['openstory', 'billing', 'missing-cost']);
+
+type BillingCapture = {
+  distinctId: string;
+  event: string;
+  properties: Record<string, unknown>;
+};
+
+const captureBillingEvent = createIsomorphicFn()
+  .client((_payload: BillingCapture) => {
+    // Browser: posthog-node must not run. Server gates still capture.
+  })
+  .server((payload: BillingCapture) => {
+    getPostHogClient()?.capture(payload);
+  });
 
 export type MissingBillingCostContext = {
   source: string;
@@ -33,8 +55,7 @@ export type FlooredEstimateContext = {
  * anyone could count, and a floored gate is the same shape of unknown.
  */
 export function reportFlooredEstimate(ctx: FlooredEstimateContext): void {
-  const posthog = getPostHogClient();
-  posthog?.capture({
+  captureBillingEvent({
     distinctId: 'system',
     event: 'billing_estimate_floored',
     properties: {
@@ -62,8 +83,7 @@ export type BillingDriftContext = {
 export function reportBillingDrift(ctx: BillingDriftContext): void {
   logger.error('charge disagrees with fal billed cost', ctx);
 
-  const posthog = getPostHogClient();
-  posthog?.capture({
+  captureBillingEvent({
     distinctId: ctx.teamId,
     event: 'billing_drift',
     properties: {
@@ -104,8 +124,7 @@ export function reportReservationShort(ctx: ReservationShortContext): void {
     ctx
   );
 
-  const posthog = getPostHogClient();
-  posthog?.capture({
+  captureBillingEvent({
     distinctId: ctx.teamId ?? 'system',
     event: 'billing_reservation_short',
     properties: {
@@ -125,8 +144,7 @@ export function reportReservationShort(ctx: ReservationShortContext): void {
 export function reportSkippedDeduction(ctx: SkippedDeductionContext): void {
   logger.warn('Completed AI generation skipped deduction', ctx);
 
-  const posthog = getPostHogClient();
-  posthog?.capture({
+  captureBillingEvent({
     distinctId: ctx.teamId ?? 'system',
     event: 'billing_skipped_deduction',
     properties: {
@@ -143,8 +161,7 @@ export function reportSkippedDeduction(ctx: SkippedDeductionContext): void {
 export function reportMissingBillingCost(ctx: MissingBillingCostContext): void {
   logger.warn('Completed AI generation with no billable cost reported', ctx);
 
-  const posthog = getPostHogClient();
-  posthog?.capture({
+  captureBillingEvent({
     distinctId: ctx.teamId ?? 'system',
     event: 'billing_missing_cost',
     properties: {

--- a/src/lib/client-server-boundary.test.ts
+++ b/src/lib/client-server-boundary.test.ts
@@ -251,6 +251,28 @@ describe('client/server import boundary', () => {
       expect(specs).not.toContain('@srv/types');
       expect(specs).toContain('@srv/mixed');
     });
+
+    test('createIsomorphicFn .server() import is dropped — the #1354 shape', () => {
+      const specs = clientRetainedImports(`
+        import { getPostHogClient } from '@/lib/posthog-server';
+        import { createIsomorphicFn } from '@tanstack/react-start';
+        export const capture = createIsomorphicFn()
+          .client(() => {})
+          .server((p) => { getPostHogClient()?.capture(p); });
+      `);
+      expect(specs).not.toContain('@/lib/posthog-server');
+      expect(specs).toContain('@tanstack/react-start');
+    });
+
+    test('billing-observability does not retain posthog-server on the client', () => {
+      const source = readFileSync(
+        join(SRC, 'src/lib/billing/billing-observability.ts'),
+        'utf8'
+      );
+      expect(clientRetainedImports(source)).not.toContain(
+        '@/lib/posthog-server'
+      );
+    });
   });
 
   test('no server-only module is reachable from client components/hooks/functions', () => {


### PR DESCRIPTION
Fixes #1354

## What
Typing in the new-sequence script editor crashed the page with:

`createServerOnlyFn() functions can only be called on the server!`

(paraphrased in the issue as `createServerFunction` on the client)

## Why
Generate's ActionCost runs `estimateStoryboardCost` on every keystroke once the script is non-empty. Unpriced motion/audio lines (H3 Max after #1344, until the pricing cron has a row) go through `gateEstimate` → `reportFlooredEstimate` → `getPostHogClient()`. That helper is `createServerOnlyFn`, so the browser stub throws. React's error boundary swallows `pageerror`, which is why e2e still passed: local/test seed every catalog endpoint, so the floor path never ran.

## Fix
Route billing PostHog capture through `createIsomorphicFn` (client no-op, server still emits). Server credit-gates are unchanged.

## Tests
- `clientRetainedImports` pins that `billing-observability` no longer ships `posthog-server` to the client
- `fillScriptEditor` asserts the error-boundary heading is absent
- New composer e2e: image-only catalog pricing, type, Generate still enables