### PR TITLE
 feat: improve low balance credit prompts

### DIFF
--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -98,7 +98,7 @@ export const CreditBalancePill: React.FC = () => {
         {/* Opens the add-credits modal, not the credits page (#1099) */}
         <SidebarMenuButton
           tooltip={tooltip}
-          onClick={openAddCreditsDialog}
+          onClick={() => openAddCreditsDialog()}
           aria-label={`Credit balance ${amount}. Add credits.`}
           className={cn(
             'animate-[balance-flash-in_300ms_ease-out_both]',

--- a/src/components/sequence/failure-summary-banner.tsx
+++ b/src/components/sequence/failure-summary-banner.tsx
@@ -135,7 +135,7 @@ export const FailureSummaryBanner: React.FC<FailureSummaryBannerProps> = ({
 
           {isCredits ? (
             <div className="mt-2 flex flex-wrap gap-2">
-              <Button size="sm" onClick={openAddCreditsDialog}>
+              <Button size="sm" onClick={() => openAddCreditsDialog()}>
                 <CreditCard />
                 Add credits
               </Button>

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -263,7 +263,9 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
             description="Pay-as-you-go wallet for AI generation at provider cost"
             action={
               stripeEnabled ? (
-                <Button onClick={openAddCreditsDialog}>Add credits</Button>
+                <Button onClick={() => openAddCreditsDialog()}>
+                  Add credits
+                </Button>
               ) : undefined
             }
           />

--- a/src/hooks/use-low-balance-warning.ts
+++ b/src/hooks/use-low-balance-warning.ts
@@ -1,10 +1,6 @@
-/**
- * Low Balance Warning Hook
- * Fires toast notifications when balance decreases and crosses threshold
- */
-
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
+import { openAddCreditsDialog } from './use-add-credits-dialog';
 import { openBillingGate } from './use-billing-gate-dialog';
 import { useBillingBalance } from './use-billing-balance';
 
@@ -20,38 +16,38 @@ export function useLowBalanceWarning() {
     const prevBalance = prevBalanceRef.current;
     prevBalanceRef.current = balance;
 
-    // Only warn on balance decrease, not on initial load
     if (prevBalance === null) return;
+
     if (balance >= prevBalance) {
-      // Balance went up — reset warning so it can fire again next time
       if (balance > lowBalanceThreshold) {
         hasWarnedRef.current = false;
       }
       return;
     }
 
-    // Balance decreased — check if we should warn
     if (hasWarnedRef.current) return;
 
-    // "Options" opens the billing gate — buying credits, asking the founder,
-    // fal.ai BYOK, and gift codes all live there (#1099).
     if (isZeroBalance) {
       hasWarnedRef.current = true;
-      toast.error('Your credit balance is $0', {
-        description: 'Generation is disabled until you add credits.',
+      toast.error('Balance is $0', {
+        description: 'Generation is off until you add credits.',
         action: {
-          label: 'Options',
-          onClick: openBillingGate,
+          label: 'Add $10',
+          onClick: () => openAddCreditsDialog(),
+        },
+        cancel: {
+          label: 'Other options',
+          onClick: () => openBillingGate(),
         },
         duration: 10_000,
       });
     } else if (isLowBalance) {
       hasWarnedRef.current = true;
-      toast.warning(`Balance is below $${lowBalanceThreshold}`, {
-        description: `Your balance is $${balance.toFixed(2)}.`,
+      toast.warning(`Balance is $${balance.toFixed(2)}`, {
+        description: 'Another short is about $13.',
         action: {
-          label: 'Options',
-          onClick: openBillingGate,
+          label: 'Add $10',
+          onClick: () => openAddCreditsDialog(),
         },
         duration: 8_000,
       });


### PR DESCRIPTION
## Summary

- Add a low-balance warning when credits decrease below the warning threshold.
- Show a clear `$0` balance warning when generation is disabled due to no credits.
- Provide direct actions from the warning toast to add credits or view other billing options.
- Make the credit balance pill and credit-related actions open the Add Credits dialog consistently.

## Validation

- `bunx tsc --noEmit` ✅
- Pre-commit checks passed:
  - dead-code ✅
  - format ✅
  - lint ✅
  - typecheck ✅

## Notes

The server-side billing/preflight checks remain authoritative; these changes improve the client-side credit UX and prompts.
