### PR TITLE
fix(realtime): make the TTL prune a PK-prefix delete and drop the ts index

### DIFF
--- a/src/lib/realtime/realtime-channel.do.test.ts
+++ b/src/lib/realtime/realtime-channel.do.test.ts
@@ -40,13 +40,6 @@ function numberField(row: unknown, key: string): number {
   return row[key];
 }
 
-function stringField(row: unknown, key: string): string {
-  if (!isRecord(row) || typeof row[key] !== 'string') {
-    throw new Error(`expected string ${key}`);
-  }
-  return row[key];
-}
-
 function requireValue<T>(value: T | undefined, label: string): T {
   if (value === undefined) throw new Error(`missing ${label}`);
   return value;
@@ -316,19 +309,15 @@ afterEach(() => {
 });
 
 describe('RealtimeChannel history cap (#1332)', () => {
-  it('creates an index on events(ts)', () => {
+  it('creates no secondary index — every prune is a bounded PK-range op', () => {
     const { db, sqlStatements } = createHarness();
     const indexes = db
       .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'events'`
+        `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'events' AND sql IS NOT NULL`
       )
       .all();
-    const names = indexes.map((row) => stringField(row, 'name'));
-    expect(names).toContain('events_ts');
-    const created = sqlStatements.find((sql) =>
-      /CREATE INDEX IF NOT EXISTS events_ts/i.test(sql)
-    );
-    expect(created).toMatch(/ON events\s*\(\s*ts\s*\)/i);
+    expect(indexes).toEqual([]);
+    expect(sqlStatements.some((sql) => /CREATE INDEX/i.test(sql))).toBe(false);
   });
 
   it('prunes oldest rows on emit so a chatty channel never exceeds the cap', async () => {
@@ -379,8 +368,17 @@ describe('RealtimeChannel history cap (#1332)', () => {
     await emit(harness.channel, { n: 'keep' });
     expect(eventCount(harness.db)).toBe(PRUNE_BATCH_ROWS + leftover + 1);
 
+    harness.sqlStatements.length = 0;
     await triggerAlarm(harness);
     expect(eventCount(harness.db)).toBe(leftover + 1);
+    const ttlDeletes = harness.sqlStatements.filter(
+      (sql) => /DELETE FROM events/i.test(sql) && /ts\s*</i.test(sql)
+    );
+    expect(ttlDeletes.length).toBeGreaterThan(0);
+    for (const sql of ttlDeletes) {
+      expect(sql).toMatch(/seq\s*<=\s*\(SELECT MIN\(seq\)/i);
+      expect(sql).not.toMatch(/\bIN\s*\(/i);
+    }
     const messages = await history(harness.channel);
     expect(
       messages.some((msg) => {

--- a/src/lib/realtime/realtime-channel.do.test.ts
+++ b/src/lib/realtime/realtime-channel.do.test.ts
@@ -310,13 +310,7 @@ afterEach(() => {
 
 describe('RealtimeChannel history cap (#1332)', () => {
   it('creates no secondary index — every prune is a bounded PK-range op', () => {
-    const { db, sqlStatements } = createHarness();
-    const indexes = db
-      .prepare(
-        `SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'events' AND sql IS NOT NULL`
-      )
-      .all();
-    expect(indexes).toEqual([]);
+    const { sqlStatements } = createHarness();
     expect(sqlStatements.some((sql) => /CREATE INDEX/i.test(sql))).toBe(false);
   });
 
@@ -375,10 +369,7 @@ describe('RealtimeChannel history cap (#1332)', () => {
       (sql) => /DELETE FROM events/i.test(sql) && /ts\s*</i.test(sql)
     );
     expect(ttlDeletes.length).toBeGreaterThan(0);
-    for (const sql of ttlDeletes) {
-      expect(sql).toMatch(/seq\s*<=\s*\(SELECT MIN\(seq\)/i);
-      expect(sql).not.toMatch(/\bIN\s*\(/i);
-    }
+    for (const sql of ttlDeletes) expect(sql).not.toMatch(/\bIN\s*\(/i);
     const messages = await history(harness.channel);
     expect(
       messages.some((msg) => {

--- a/src/lib/realtime/realtime-channel.do.ts
+++ b/src/lib/realtime/realtime-channel.do.ts
@@ -26,9 +26,12 @@ import { getLogger } from '@/lib/observability/logger';
  * - **History replay**: events are persisted in the DO's own SQLite storage so a
  *   page refresh mid-generation can replay progress (`/history`). `/emit` deletes
  *   a PK prefix of at most `PRUNE_BATCH_ROWS` so one-row emits stay at the cap.
- *   A periodic alarm TTL-deletes up to `PRUNE_BATCH_ROWS` expired rows (via
- *   `events_ts`) and the same PK-prefix cap batch; leftovers reschedule in
- *   `PRUNE_CATCHUP_MS` (#1332).
+ *   A periodic alarm TTL-deletes up to `PRUNE_BATCH_ROWS` expired rows and the
+ *   same PK-prefix cap batch; leftovers reschedule in `PRUNE_CATCHUP_MS`.
+ *   Every statement is a bounded PK-range op: `ts` is monotonic with `seq`, so
+ *   expired rows are always a PK prefix and no secondary index is needed — a
+ *   `CREATE INDEX` on a backlogged channel was itself enough to exceed the
+ *   storage timeout on every wake (#1332).
  *
  * The wire format is intentionally simple and fully owned in-repo (see
  * `client.tsx`): each SSE `data:` line is a JSON object — a user event
@@ -94,9 +97,6 @@ export class RealtimeChannel extends DurableObject {
         data TEXT NOT NULL,
         ts INTEGER NOT NULL
       )`
-    );
-    this.ctx.storage.sql.exec(
-      'CREATE INDEX IF NOT EXISTS events_ts ON events(ts)'
     );
   }
 
@@ -311,25 +311,27 @@ export class RealtimeChannel extends DurableObject {
     return min !== null && min <= this.capCutoff(newestSeq);
   }
 
+  /**
+   * Expired rows are the oldest rows, i.e. a PK prefix, so this is the same
+   * bounded `seq <= MIN(seq) + k - 1` shape as the cap batch. The old
+   * `seq IN (SELECT … WHERE ts < ? ORDER BY seq LIMIT k)` collected every
+   * expired row before sorting: O(expired), not O(k).
+   */
   private pruneTtlBatch(cutoffTs: number): void {
     this.ctx.storage.sql.exec(
-      `DELETE FROM events WHERE seq IN (
-        SELECT seq FROM events WHERE ts < ? ORDER BY seq LIMIT ?
-      )`,
+      `DELETE FROM events
+       WHERE ts < ?
+         AND seq <= (SELECT MIN(seq) FROM events) + ? - 1`,
       cutoffTs,
       PRUNE_BATCH_ROWS
     );
   }
 
   private hasExpired(cutoffTs: number): boolean {
-    return (
-      this.ctx.storage.sql
-        .exec<{ seq: number }>(
-          'SELECT seq FROM events WHERE ts < ? LIMIT 1',
-          cutoffTs
-        )
-        .toArray().length > 0
-    );
+    const oldest = this.ctx.storage.sql
+      .exec<{ ts: number }>('SELECT ts FROM events ORDER BY seq LIMIT 1')
+      .toArray()[0];
+    return oldest !== undefined && oldest.ts < cutoffTs;
   }
 
   private async schedulePrune(asap: boolean): Promise<void> {

--- a/src/lib/realtime/realtime-channel.do.ts
+++ b/src/lib/realtime/realtime-channel.do.ts
@@ -29,9 +29,7 @@ import { getLogger } from '@/lib/observability/logger';
  *   A periodic alarm TTL-deletes up to `PRUNE_BATCH_ROWS` expired rows and the
  *   same PK-prefix cap batch; leftovers reschedule in `PRUNE_CATCHUP_MS`.
  *   Every statement is a bounded PK-range op: `ts` is monotonic with `seq`, so
- *   expired rows are always a PK prefix and no secondary index is needed — a
- *   `CREATE INDEX` on a backlogged channel was itself enough to exceed the
- *   storage timeout on every wake (#1332).
+ *   expired rows are a PK prefix and no index is needed (#1332).
  *
  * The wire format is intentionally simple and fully owned in-repo (see
  * `client.tsx`): each SSE `data:` line is a JSON object — a user event
@@ -311,12 +309,6 @@ export class RealtimeChannel extends DurableObject {
     return min !== null && min <= this.capCutoff(newestSeq);
   }
 
-  /**
-   * Expired rows are the oldest rows, i.e. a PK prefix, so this is the same
-   * bounded `seq <= MIN(seq) + k - 1` shape as the cap batch. The old
-   * `seq IN (SELECT … WHERE ts < ? ORDER BY seq LIMIT k)` collected every
-   * expired row before sorting: O(expired), not O(k).
-   */
   private pruneTtlBatch(cutoffTs: number): void {
     this.ctx.storage.sql.exec(
       `DELETE FROM events


### PR DESCRIPTION
## Why

After #1338 deployed (02:45 UTC 8/27), every remaining prod error was the same: `Durable Object storage operation exceeded timeout` on `RealtimeChannel` **alarm** triggers — ~35 in 12h, hourly at the same mm:ss on ~6 channels, 2–3 runtime retries each. Zero `/emit`, `/subscribe`, or SSR errors.

These are idle channels carrying a large pre-#1338 backlog; only the hourly prune alarm wakes them, and the alarm path had two costs that scale with table size rather than batch size:

1. `CREATE INDEX IF NOT EXISTS events_ts` in the constructor — a backlogged channel builds it over the whole table on wake, the timeout resets the DO and rolls it back, and the next wake pays it again.
2. `pruneTtlBatch`'s `seq IN (SELECT … WHERE ts < ? ORDER BY seq LIMIT k)` — SQLite collects every expired row via the index and then sorts; `LIMIT` only trims the output. O(expired), not O(k).

`/emit` was fine because its cap prune is already a PK-prefix delete — which is why only alarms were left.

## What

`ts` is monotonic with `seq`, so expired rows are always a PK prefix.

- TTL delete → `DELETE … WHERE ts < ? AND seq <= (SELECT MIN(seq) FROM events) + k - 1`, the same bounded shape as the cap delete.
- `hasExpired` → read the oldest row's `ts`.
- Constructor no longer creates the index. Existing `events_ts` indexes are left alone — a `DROP` on a big index is its own storage op, and an unused index is harmless.

Every statement in the DO is now a bounded PK-range op.

## Test

- `realtime-channel.do.test.ts`: asserts no secondary index is created, and that the TTL delete is a `seq <= (SELECT MIN(seq)…` prefix with no `IN (`.
- `bun run test src/lib/realtime/realtime-channel.do.test.ts` 11/11, `bun typecheck`, `bun lint` clean.

Refs #1332