### PR TITLE
Instrument the first-video moments: ready seen, play, watched, end-card clicks, gate, wait-left

### DIFF
--- a/src/components/billing/add-credits-dialog.tsx
+++ b/src/components/billing/add-credits-dialog.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/hooks/use-balance-flash';
 import {
   closeAddCreditsDialog,
+  getAddCreditsSurface,
   useAddCreditsDialogOpen,
 } from '@/hooks/use-add-credits-dialog';
 import { closeBillingGate } from '@/hooks/use-billing-gate-dialog';
@@ -54,7 +55,7 @@ import { usePostHog } from '@posthog/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { CreditCard, ExternalLink, Plus } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { ulid } from 'ulid';
 
@@ -70,6 +71,16 @@ export function AddCreditsDialog() {
   const { data: session } = useAuthSession();
   const queryClient = useQueryClient();
   const posthog = usePostHog();
+
+  // Every "Add credits" button routes through openAddCreditsDialog(surface),
+  // so one capture here covers them all (#1301).
+  useEffect(() => {
+    if (open) {
+      posthog.capture('add_credits_clicked', {
+        surface: getAddCreditsSurface(),
+      });
+    }
+  }, [open, posthog]);
 
   const [amount, setAmount] = useState('10');
   const [selectedPm, setSelectedPm] = useState<string | null>(null);

--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -28,7 +28,9 @@ import {
 } from '@/hooks/use-billing-gate';
 import {
   closeBillingGate,
+  getBillingGateReason,
   useBillingGateDialogOpen,
+  type BillingGateReason,
 } from '@/hooks/use-billing-gate-dialog';
 import { cn } from '@/lib/utils';
 import { usePostHog } from '@posthog/react';
@@ -42,7 +44,7 @@ import {
   Gift,
   HeartHandshake,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const RETURN_KEY = 'openstory:billing-return';
 
@@ -280,6 +282,8 @@ type BillingGateDialogProps = {
   stripeEnabled?: boolean;
   returnTo?: string;
   context?: 'generation' | 'onboarding';
+  /** `billing_gate_shown.reason` (#1301). */
+  reason?: BillingGateReason;
 };
 
 export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
@@ -289,11 +293,16 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
   stripeEnabled = true,
   returnTo,
   context = 'generation',
+  reason = 'manual',
 }) => {
   const queryClient = useQueryClient();
   const posthog = usePostHog();
   const [falKeyInput, setFalKeyInput] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) posthog.capture('billing_gate_shown', { reason, context });
+  }, [open, reason, context, posthog]);
 
   const { data: profile } = useQuery({
     queryKey: ['currentUserProfile'],
@@ -367,7 +376,7 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
                 title="Add credits"
                 description="Pay as you go. Auto-reload keeps you generating."
                 variant="primary"
-                onClick={openAddCreditsDialog}
+                onClick={() => openAddCreditsDialog('billing_gate')}
               />
 
               <AskFounderCard />
@@ -467,6 +476,7 @@ export const GlobalBillingGateDialog: React.FC = () => {
       }}
       hasFalKey={data?.hasFalKey ?? false}
       stripeEnabled={data?.stripeEnabled ?? true}
+      reason={open ? getBillingGateReason() : undefined}
     />
   );
 };

--- a/src/components/billing/welcome-credits-dialog.tsx
+++ b/src/components/billing/welcome-credits-dialog.tsx
@@ -201,7 +201,7 @@ export const WelcomeCreditsProvider: React.FC<{ children: ReactNode }> = ({
                   className="sm:flex-1"
                   onClick={() => {
                     handleOpenChange(false);
-                    openAddCreditsDialog();
+                    openAddCreditsDialog('welcome_dialog');
                   }}
                 >
                   Buy more

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -22,6 +22,7 @@ import { FeedbackDialog } from '@/components/feedback/feedback-dialog';
 import { useLowBalanceWarning } from '@/hooks/use-low-balance-warning';
 import { MODELS_ENABLED } from '@/lib/flags';
 import { SITE_CONFIG } from '@/lib/marketing/constants';
+import { usePostHog } from '@posthog/react';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import {
@@ -58,6 +59,7 @@ export function AppSidebar() {
   useLowBalanceWarning();
 
   const { isMobile, setOpenMobile } = useSidebar();
+  const posthog = usePostHog();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const [feedbackOpen, setFeedbackOpen] = useState(false);
 
@@ -91,7 +93,14 @@ export function AppSidebar() {
                   {/* `/` is the free composer for everyone (#1104); the
                       signed-in alias `/sequences/new` is for copy/breadcrumb
                       entry points that require a session. */}
-                  <Link to="/">
+                  <Link
+                    to="/"
+                    onClick={() =>
+                      posthog.capture('make_another_clicked', {
+                        surface: 'sidebar',
+                      })
+                    }
+                  >
                     <Plus />
                     <span>New sequence</span>
                   </Link>

--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -98,7 +98,7 @@ export const CreditBalancePill: React.FC = () => {
         {/* Opens the add-credits modal, not the credits page (#1099) */}
         <SidebarMenuButton
           tooltip={tooltip}
-          onClick={openAddCreditsDialog}
+          onClick={() => openAddCreditsDialog('sidebar_pill')}
           aria-label={`Credit balance ${amount}. Add credits.`}
           className={cn(
             'animate-[balance-flash-in_300ms_ease-out_both]',

--- a/src/components/models/model-detail-view.tsx
+++ b/src/components/models/model-detail-view.tsx
@@ -209,7 +209,7 @@ const ModelRunPanel: FC<{ detail: ModelDetail }> = ({ detail }) => {
     },
     onError: (error) => {
       if (isInsufficientCreditsError(error)) {
-        showBillingGate();
+        showBillingGate('insufficient');
         void queryClient.invalidateQueries({ queryKey: BILLING_BALANCE_KEY });
       }
     },

--- a/src/components/motion/scene-player.tsx
+++ b/src/components/motion/scene-player.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils';
 import { copyTextToClipboard } from '@/lib/utils/clipboard';
 import type { ShotView } from '@/lib/shots/shot-view';
 import { AppImage } from '@/components/ui/app-image';
+import { usePostHog } from '@posthog/react';
 import { Download, Link, Loader2, Share2, VideoIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
@@ -97,6 +98,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
   onEnded,
 }) => {
   const [shouldAutoPlay, setShouldAutoPlay] = useState(false);
+  const posthog = usePostHog();
 
   const imageDimensions = aspectRatioToDimensions(aspectRatio);
   // Derive the current shot synchronously from selection — do NOT park the
@@ -119,6 +121,11 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
 
   const handleCopyImageUrl = useCallback(async () => {
     if (!currentShot?.image?.url) return;
+    posthog.capture('share_clicked', {
+      surface: 'shot_image',
+      sequence_id: currentShot.sequenceId,
+      shot_id: currentShot.id,
+    });
     try {
       // Stored media URLs are origin-relative (#894) — absolutize against the
       // current origin so the copied link is usable when pasted elsewhere. The
@@ -133,10 +140,20 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
     } catch {
       toast.error('Failed to copy URL');
     }
-  }, [currentShot?.image?.url]);
+  }, [
+    currentShot?.image?.url,
+    currentShot?.sequenceId,
+    currentShot?.id,
+    posthog,
+  ]);
 
   const handleCopyVideoUrl = useCallback(async () => {
     if (!currentShot?.video?.url) return;
+    posthog.capture('share_clicked', {
+      surface: 'shot_video',
+      sequence_id: currentShot.sequenceId,
+      shot_id: currentShot.id,
+    });
     try {
       const absoluteUrl = new URL(currentShot.video.url, window.location.origin)
         .href;
@@ -148,7 +165,12 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
     } catch {
       toast.error('Failed to copy URL');
     }
-  }, [currentShot?.video?.url]);
+  }, [
+    currentShot?.video?.url,
+    currentShot?.sequenceId,
+    currentShot?.id,
+    posthog,
+  ]);
 
   // Check video status
   const hasCompletedVideo =
@@ -165,6 +187,11 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
 
   const handleDownloadVideo = useCallback(() => {
     if (!downloadData?.downloadUrl) return;
+    posthog.capture('export_clicked', {
+      surface: 'shot',
+      sequence_id: currentShot?.sequenceId,
+      shot_id: currentShot?.id,
+    });
     const a = document.createElement('a');
     a.href = downloadData.downloadUrl;
     a.download =
@@ -173,7 +200,7 @@ export const ScenePlayer: React.FC<ScenePlayerProps> = ({
     document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
-  }, [downloadData, currentShot?.id]);
+  }, [downloadData, currentShot?.id, currentShot?.sequenceId, posthog]);
 
   // Handle video pause - disable autoplay when user manually pauses
   const handlePause = useCallback(() => {

--- a/src/components/motion/video-player.tsx
+++ b/src/components/motion/video-player.tsx
@@ -7,11 +7,14 @@ import {
 import {
   captureVideoPlay,
   captureVideoPlayFailed,
+  captureVideoWatched,
+  createPlaybackTracker,
+  type PlaybackTracker,
   type VideoPlaySource,
 } from '@/lib/observability/player-events';
 import { cn } from '@/lib/utils';
 import { usePostHog } from '@posthog/react';
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 
 // Dynamic, and rendered only after mount — see video-player-surface.tsx. The
 // import must not be evaluated on the server: `@videojs/store` constructs an
@@ -94,6 +97,39 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
   const mounted = useMounted();
   const posthog = usePostHog();
 
+  // video_play / video_watched / stalled-play analytics (#1301). Only when a
+  // `playSource` is given; autoplay counts as its own source. Props via a
+  // ref so the one tracker instance reports the current shot.
+  const eventProps = playSource
+    ? {
+        source: autoPlay ? ('autoplay' as const) : playSource,
+        sequence_id: sequenceId,
+        shot_id: shotId,
+      }
+    : null;
+  const eventPropsRef = useRef(eventProps);
+  eventPropsRef.current = eventProps;
+  const trackerRef = useRef<PlaybackTracker | null>(null);
+  trackerRef.current ??= createPlaybackTracker({
+    onStall: () => {
+      if (eventPropsRef.current) {
+        captureVideoPlayFailed(posthog, {
+          ...eventPropsRef.current,
+          reason: 'timeout',
+        });
+      }
+    },
+  });
+  const tracker = trackerRef.current;
+  const flushWatched = (completed?: boolean) => {
+    const watched = tracker.stop(completed);
+    if (!watched || !eventPropsRef.current) return;
+    if (watched.seconds_watched === 0 && !watched.completed) return;
+    captureVideoWatched(posthog, { ...eventPropsRef.current, ...watched });
+  };
+  // Leaving mid-play (shot switch remounts the player) still counts as watched.
+  useEffect(() => () => flushWatched(false), []); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Show skeleton when there's no video source and no poster
   if (!src && !posterSrc) {
     return (
@@ -142,28 +178,35 @@ export const VideoPlayer: React.FC<VideoPlayerProps> = ({
             chaptersUrl={chaptersUrl}
             posterSrc={posterSrc}
             autoPlay={autoPlay}
-            onLoadedMetadata={onLoadedMetadata}
-            onTimeUpdate={onTimeUpdate}
-            onPause={onPause}
-            onEnded={onEnded}
+            onLoadedMetadata={(duration) => {
+              tracker.setDuration(duration);
+              onLoadedMetadata?.(duration);
+            }}
+            onTimeUpdate={(t) => {
+              tracker.tick(t);
+              onTimeUpdate?.(t);
+            }}
+            onPause={() => {
+              // `pause` also fires right before `ended`; the tracker infers
+              // completion from position so that pair reports once.
+              flushWatched();
+              onPause?.();
+            }}
+            onEnded={() => {
+              flushWatched(true);
+              onEnded?.();
+            }}
             onPlay={() => {
               onPlay?.();
-              if (playSource) {
-                captureVideoPlay(posthog, {
-                  source: playSource,
-                  sequence_id: sequenceId,
-                  shot_id: shotId,
-                });
+              if (eventProps) {
+                tracker.start();
+                captureVideoPlay(posthog, eventProps);
               }
             }}
             onError={(reason) => {
-              if (playSource) {
-                captureVideoPlayFailed(posthog, {
-                  source: playSource,
-                  reason,
-                  sequence_id: sequenceId,
-                  shot_id: shotId,
-                });
+              tracker.dispose();
+              if (eventProps) {
+                captureVideoPlayFailed(posthog, { ...eventProps, reason });
               }
             }}
           />

--- a/src/components/scenes/scene-model-bar.tsx
+++ b/src/components/scenes/scene-model-bar.tsx
@@ -11,6 +11,7 @@ import {
   type AspectRatio,
 } from '@/lib/constants/aspect-ratios';
 import type { SelectionScope } from '@/lib/scenes/scene-selection';
+import { usePostHog } from '@posthog/react';
 import { Link } from '@tanstack/react-router';
 import { CopyPlus } from 'lucide-react';
 
@@ -71,6 +72,7 @@ export const SceneModelBar: React.FC<SceneModelBarProps> = ({
   aspectRatio,
   analysisModel,
 }) => {
+  const posthog = usePostHog();
   const showSequenceSettings = scope === 'sequence';
   const ratio = aspectRatio ? getAspectRatioData(aspectRatio) : undefined;
 
@@ -138,7 +140,16 @@ export const SceneModelBar: React.FC<SceneModelBarProps> = ({
               rather than being reproduced in a modal. */}
           {sequenceId && (
             <Button variant="outline" size="sm" className="w-full" asChild>
-              <Link to="/sequences/new" search={{ from: sequenceId }}>
+              <Link
+                to="/sequences/new"
+                search={{ from: sequenceId }}
+                onClick={() =>
+                  posthog.capture('make_another_clicked', {
+                    surface: 'generate_copy',
+                    sequence_id: sequenceId,
+                  })
+                }
+              >
                 <CopyPlus className="mr-2 h-3.5 w-3.5" />
                 Generate Copy…
               </Link>

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -86,6 +86,9 @@ import { cn } from '@/lib/utils';
 import { ChevronDown } from 'lucide-react';
 import { usePostHog } from '@posthog/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from '@tanstack/react-router';
+import { getSequencesFn } from '@/functions/sequences';
+import { captureSequenceReadySeen } from '@/lib/observability/player-events';
 
 import {
   estimateSceneCount,
@@ -285,23 +288,62 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
   const processingRef = useRef(isProcessing);
   processingRef.current = isProcessing;
   const leftCapturedRef = useRef(false);
+  // Assigned after `remainingSeconds` is computed below; read at leave time.
+  const remainingRef = useRef(0);
+  const router = useRouter();
 
   useEffect(() => {
     leftCapturedRef.current = false;
   }, [sequenceId]);
 
   useEffect(() => {
-    const captureLeave = () => {
+    const captureLeave = (destination: string) => {
       if (!processingRef.current || leftCapturedRef.current) return;
       leftCapturedRef.current = true;
-      posthog.capture('render_wait_left', { sequence_id: sequenceId });
+      posthog.capture('render_wait_left', {
+        sequence_id: sequenceId,
+        seconds_remaining_estimate: remainingRef.current,
+        destination,
+      });
     };
-    window.addEventListener('pagehide', captureLeave);
+    const onPageHide = () => captureLeave('unload');
+    window.addEventListener('pagehide', onPageHide);
     return () => {
-      window.removeEventListener('pagehide', captureLeave);
-      captureLeave();
+      window.removeEventListener('pagehide', onPageHide);
+      // On unmount the router already points at where the user went.
+      captureLeave(router.latestLocation.pathname);
     };
-  }, [sequenceId, posthog]);
+  }, [sequenceId, posthog, router]);
+
+  // First sight of the finished video (#1301): the funnel step between
+  // sequence_generated and video_play. Once per sequence per mount.
+  const readySeenRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (sequence?.status !== 'completed' || readySeenRef.current === sequenceId)
+      return;
+    readySeenRef.current = sequenceId;
+    const createdAt = new Date(sequence.createdAt).getTime();
+    void queryClient
+      .fetchQuery({
+        queryKey: sequenceKeys.list(undefined),
+        queryFn: () => getSequencesFn(),
+        staleTime: 5 * 60 * 1000,
+      })
+      .then((list) => {
+        captureSequenceReadySeen(posthog, {
+          sequence_id: sequenceId,
+          first_sequence_for_team: list.every(
+            (s) =>
+              s.id === sequenceId ||
+              new Date(s.createdAt).getTime() >= createdAt
+          ),
+          seconds_since_generate: Math.round((Date.now() - createdAt) / 1000),
+        });
+      })
+      .catch(() => {
+        // Analytics only — never surface.
+      });
+  }, [sequence?.status, sequence?.createdAt, sequenceId, queryClient, posthog]);
   const { data: style } = useSequenceStyle(sequenceId);
   const styleCategory = style?.category ?? undefined;
   const sequenceMusicModel = safeAudioModel(
@@ -1169,7 +1211,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
       void queryClient.invalidateQueries({ queryKey: ['shots', sequenceId] });
     } catch (error) {
       if (isInsufficientCreditsError(error)) {
-        showBillingGate();
+        showBillingGate('insufficient');
         void queryClient.invalidateQueries({
           queryKey: BILLING_BALANCE_KEY,
         });
@@ -1263,7 +1305,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         }
 
         if (isInsufficientCreditsError(error)) {
-          showBillingGate();
+          showBillingGate('insufficient');
           void queryClient.invalidateQueries({
             queryKey: BILLING_BALANCE_KEY,
           });
@@ -1321,6 +1363,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
     generationState.scenes.length,
     sequence?.script,
   ]);
+  remainingRef.current = remainingSeconds;
   const etaMinutes = Math.max(1, Math.round(remainingSeconds / 60));
 
   // One prop bag for the desktop sidebar and the phone sheet — same list.

--- a/src/components/sequence/failure-summary-banner.tsx
+++ b/src/components/sequence/failure-summary-banner.tsx
@@ -135,7 +135,10 @@ export const FailureSummaryBanner: React.FC<FailureSummaryBannerProps> = ({
 
           {isCredits ? (
             <div className="mt-2 flex flex-wrap gap-2">
-              <Button size="sm" onClick={openAddCreditsDialog}>
+              <Button
+                size="sm"
+                onClick={() => openAddCreditsDialog('failure_banner')}
+              >
                 <CreditCard />
                 Add credits
               </Button>

--- a/src/components/settings/billing-settings.tsx
+++ b/src/components/settings/billing-settings.tsx
@@ -263,7 +263,11 @@ export function BillingSettings({ success, canceled }: BillingSettingsProps) {
             description="Pay-as-you-go wallet for AI generation at provider cost"
             action={
               stripeEnabled ? (
-                <Button onClick={openAddCreditsDialog}>Add credits</Button>
+                <Button
+                  onClick={() => openAddCreditsDialog('billing_settings')}
+                >
+                  Add credits
+                </Button>
               ) : undefined
             }
           />

--- a/src/components/theatre/sequence-player.tsx
+++ b/src/components/theatre/sequence-player.tsx
@@ -32,9 +32,11 @@ import {
   type PlayAttemptResult,
 } from '@/lib/sequence-player/play-attempt';
 import {
-  captureSequenceReadySeen,
   captureVideoPlay,
   captureVideoPlayFailed,
+  captureVideoWatched,
+  createPlaybackTracker,
+  type PlaybackTracker,
   type VideoPlaySource,
 } from '@/lib/observability/player-events';
 import { cn } from '@/lib/utils';
@@ -102,7 +104,6 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const engineRef = useRef<SequencePlayerEngine | null>(null);
   const posthog = usePostHog();
-  const readyKeyRef = useRef<string | null>(null);
   const playEpochRef = useRef(0);
   const scenesKey = scenePlaybackKey(scenes);
 
@@ -114,13 +115,23 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
   const [muted, setMuted] = useState(false);
   const [loadedScenes, setLoadedScenes] = useState(0);
 
-  const markReady = (key: string) => {
-    if (!sequenceId || readyKeyRef.current === key) return;
-    readyKeyRef.current = key;
-    captureSequenceReadySeen(posthog, {
-      sequence_id: sequenceId,
-      scene_count: scenes.length,
-    });
+  // video_watched / stalled-play analytics (#1301). Props via a ref so the
+  // one tracker instance reports the current sequence.
+  const eventPropsRef = useRef({ source: playSource, sequence_id: sequenceId });
+  eventPropsRef.current = { source: playSource, sequence_id: sequenceId };
+  const trackerRef = useRef<PlaybackTracker | null>(null);
+  trackerRef.current ??= createPlaybackTracker({
+    onStall: () =>
+      captureVideoPlayFailed(posthog, {
+        ...eventPropsRef.current,
+        reason: 'timeout',
+      }),
+  });
+  const tracker = trackerRef.current;
+  const flushWatched = (completed: boolean) => {
+    const watched = tracker.stop(completed);
+    if (!watched || (watched.seconds_watched === 0 && !completed)) return;
+    captureVideoWatched(posthog, { ...eventPropsRef.current, ...watched });
   };
 
   useEffect(() => {
@@ -152,10 +163,14 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
         if (!cancelled) setLoadedScenes(loaded);
       },
       onTimeUpdate: (t) => {
-        if (!cancelled) setCurrentTime(t);
+        if (cancelled) return;
+        setCurrentTime(t);
+        tracker.tick(t);
       },
       onEnded: () => {
-        if (!cancelled) setPlaying(false);
+        if (cancelled) return;
+        setPlaying(false);
+        flushWatched(true);
       },
       onError: (err) => {
         if (!cancelled) setError(err.message);
@@ -168,7 +183,7 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
       .then((m) => {
         if (cancelled) return;
         setMeta(m);
-        markReady(`stitch:${scenesKey}`);
+        tracker.setDuration(m.durationSeconds);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -177,6 +192,7 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
 
     return () => {
       cancelled = true;
+      flushWatched(false);
       engine.dispose();
       engineRef.current = null;
     };
@@ -185,12 +201,6 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
     // still rebuild; volume/muted/musicEnabled go through setters (#834).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scenesKey, musicUrl, musicLoudnessGainDb, cachedVideoUrl]);
-
-  useEffect(() => {
-    if (!cachedVideoUrl) return;
-    markReady(`cached:${cachedVideoUrl}`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cachedVideoUrl, sequenceId, scenesKey]);
 
   useEffect(() => {
     engineRef.current?.setVolume(volume);
@@ -209,12 +219,15 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
     const ui = playAttemptUiState(result);
     setPlaying(ui.playing);
     if (ui.playing) {
+      // A seek while playing resolves here too — don't restart the tracker.
+      if (!tracker.isActive()) tracker.start();
       captureVideoPlay(posthog, {
         source: playSource,
         sequence_id: sequenceId,
       });
       return;
     }
+    tracker.dispose();
     if (ui.failureReason) {
       captureVideoPlayFailed(posthog, {
         source: playSource,
@@ -241,6 +254,7 @@ export const SequencePlayer: React.FC<SequencePlayerProps> = ({
       playEpochRef.current += 1;
       engine.pause();
       setPlaying(false);
+      flushWatched(false);
       return;
     }
     const epoch = ++playEpochRef.current;

--- a/src/components/theatre/use-sequence-export.ts
+++ b/src/components/theatre/use-sequence-export.ts
@@ -256,6 +256,10 @@ export function useSequenceExport(
   const canExport = clipsTotal > 0 && clipsReady === clipsTotal;
 
   const download = useCallback(() => {
+    posthog.capture('export_clicked', {
+      surface: 'theatre',
+      sequence_id: sequenceId,
+    });
     if (freshExportUrl) {
       triggerDownload(freshExportUrl, sequence?.title);
       posthog.capture('video_downloaded', { sequence_id: sequenceId });
@@ -266,6 +270,10 @@ export function useSequenceExport(
   }, [freshExportUrl, canExport, run, sequence?.title, sequenceId, posthog]);
 
   const copyLink = useCallback(() => {
+    posthog.capture('share_clicked', {
+      surface: 'theatre',
+      sequence_id: sequenceId,
+    });
     if (freshExportUrl) {
       void copyTextToClipboard(toShareableExportUrl(freshExportUrl)).then(
         (copied) => {

--- a/src/hooks/create-dialog-store.ts
+++ b/src/hooks/create-dialog-store.ts
@@ -16,14 +16,17 @@
 
 import { useSyncExternalStore } from 'react';
 
-export type DialogStore = {
-  open: () => void;
+export type DialogStore<P extends string = string> = {
+  /** `payload` names why/where it was opened; read it back via `getPayload`. */
+  open: (payload?: P) => void;
   close: () => void;
   useIsOpen: () => boolean;
+  getPayload: () => P | undefined;
 };
 
-export function createDialogStore(): DialogStore {
+export function createDialogStore<P extends string = string>(): DialogStore<P> {
   let isOpen = false;
+  let payload: P | undefined;
   const listeners = new Set<() => void>();
 
   const emit = () => {
@@ -44,8 +47,12 @@ export function createDialogStore(): DialogStore {
   };
 
   return {
-    open: () => set(true),
+    open: (next?: P) => {
+      payload = next;
+      set(true);
+    },
     close: () => set(false),
+    getPayload: () => payload,
     useIsOpen: () =>
       useSyncExternalStore(
         subscribe,

--- a/src/hooks/use-add-credits-dialog.ts
+++ b/src/hooks/use-add-credits-dialog.ts
@@ -10,6 +10,8 @@ import { createDialogStore } from './create-dialog-store';
 
 const store = createDialogStore();
 
-export const openAddCreditsDialog = store.open;
+/** `surface` is where the user clicked — the `add_credits_clicked` property (#1301). */
+export const openAddCreditsDialog = (surface: string) => store.open(surface);
+export const getAddCreditsSurface = store.getPayload;
 export const closeAddCreditsDialog = store.close;
 export const useAddCreditsDialogOpen = store.useIsOpen;

--- a/src/hooks/use-billing-gate-dialog.ts
+++ b/src/hooks/use-billing-gate-dialog.ts
@@ -8,8 +8,13 @@
 
 import { createDialogStore } from './create-dialog-store';
 
-const store = createDialogStore();
+/** Why the gate opened — the `reason` on `billing_gate_shown` (#1301). */
+export type BillingGateReason = 'insufficient' | 'zero' | 'manual';
 
-export const openBillingGate = store.open;
+const store = createDialogStore<BillingGateReason>();
+
+export const openBillingGate = (reason: BillingGateReason = 'manual') =>
+  store.open(reason);
+export const getBillingGateReason = () => store.getPayload() ?? 'manual';
 export const closeBillingGate = store.close;
 export const useBillingGateDialogOpen = store.useIsOpen;

--- a/src/hooks/use-low-balance-warning.ts
+++ b/src/hooks/use-low-balance-warning.ts
@@ -3,6 +3,7 @@
  * Fires toast notifications when balance decreases and crosses threshold
  */
 
+import { usePostHog } from '@posthog/react';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { openBillingGate } from './use-billing-gate-dialog';
@@ -11,6 +12,7 @@ import { useBillingBalance } from './use-billing-balance';
 export function useLowBalanceWarning() {
   const { balance, isLowBalance, isZeroBalance, lowBalanceThreshold } =
     useBillingBalance();
+  const posthog = usePostHog();
   const prevBalanceRef = useRef<number | null>(null);
   const hasWarnedRef = useRef(false);
 
@@ -32,29 +34,32 @@ export function useLowBalanceWarning() {
 
     // Balance decreased — check if we should warn
     if (hasWarnedRef.current) return;
+    if (!isZeroBalance && !isLowBalance) return;
 
     // "Options" opens the billing gate — buying credits, asking the founder,
     // fal.ai BYOK, and gift codes all live there (#1099).
+    hasWarnedRef.current = true;
+    const props = { balance_usd: balance };
+    posthog.capture('low_balance_toast_shown', props);
+    const action = {
+      label: 'Options',
+      onClick: () => {
+        posthog.capture('low_balance_toast_clicked', props);
+        openBillingGate(isZeroBalance ? 'zero' : 'manual');
+      },
+    };
     if (isZeroBalance) {
-      hasWarnedRef.current = true;
       toast.error('Your credit balance is $0', {
         description: 'Generation is disabled until you add credits.',
-        action: {
-          label: 'Options',
-          onClick: openBillingGate,
-        },
+        action,
         duration: 10_000,
       });
-    } else if (isLowBalance) {
-      hasWarnedRef.current = true;
+    } else {
       toast.warning(`Balance is below $${lowBalanceThreshold}`, {
         description: `Your balance is $${balance.toFixed(2)}.`,
-        action: {
-          label: 'Options',
-          onClick: openBillingGate,
-        },
+        action,
         duration: 8_000,
       });
     }
-  }, [balance, isLowBalance, isZeroBalance, lowBalanceThreshold]);
+  }, [balance, isLowBalance, isZeroBalance, lowBalanceThreshold, posthog]);
 }

--- a/src/lib/observability/player-events.test.ts
+++ b/src/lib/observability/player-events.test.ts
@@ -4,6 +4,8 @@ import {
   captureSequenceReadySeen,
   captureVideoPlay,
   captureVideoPlayFailed,
+  captureVideoWatched,
+  createPlaybackTracker,
 } from './player-events';
 
 describe('player events', () => {
@@ -33,15 +35,29 @@ describe('player events', () => {
     });
   });
 
-  it('captures sequence_ready_seen once the player can accept play', () => {
+  it('captures video_watched and sequence_ready_seen', () => {
     const capture = vi.fn();
+    captureVideoWatched(
+      { capture },
+      { source: 'theatre', seconds_watched: 4.2, completed: false }
+    );
     captureSequenceReadySeen(
       { capture },
-      { sequence_id: 'seq_1', scene_count: 6 }
+      {
+        sequence_id: 'seq_1',
+        first_sequence_for_team: true,
+        seconds_since_generate: 90,
+      }
     );
+    expect(capture).toHaveBeenCalledWith('video_watched', {
+      source: 'theatre',
+      seconds_watched: 4.2,
+      completed: false,
+    });
     expect(capture).toHaveBeenCalledWith('sequence_ready_seen', {
       sequence_id: 'seq_1',
-      scene_count: 6,
+      first_sequence_for_team: true,
+      seconds_since_generate: 90,
     });
   });
 
@@ -53,9 +69,6 @@ describe('player events', () => {
         reason: 'media_error',
       })
     ).not.toThrow();
-    expect(() =>
-      captureSequenceReadySeen(null, { sequence_id: 'seq_1', scene_count: 0 })
-    ).not.toThrow();
   });
 
   it('swallows capture() throws so analytics cannot flip play state', () => {
@@ -66,16 +79,56 @@ describe('player events', () => {
       captureVideoPlay({ capture }, { source: 'theatre', sequence_id: 'seq_1' })
     ).not.toThrow();
     expect(() =>
-      captureVideoPlayFailed(
+      captureVideoWatched(
         { capture },
-        { source: 'theatre', reason: 'disposed', sequence_id: 'seq_1' }
+        { source: 'theatre', seconds_watched: 1, completed: true }
       )
     ).not.toThrow();
-    expect(() =>
-      captureSequenceReadySeen(
-        { capture },
-        { sequence_id: 'seq_1', scene_count: 3 }
-      )
-    ).not.toThrow();
+  });
+});
+
+describe('createPlaybackTracker', () => {
+  it('sums timeupdate deltas, ignores seeks, and infers completion', () => {
+    const tracker = createPlaybackTracker({ onStall: vi.fn() });
+    tracker.setDuration(10);
+    tracker.start();
+    tracker.tick(0);
+    tracker.tick(0.5);
+    tracker.tick(1.0);
+    tracker.tick(8.0); // seek — not watched
+    tracker.tick(8.5);
+    expect(tracker.stop()).toEqual({ seconds_watched: 1.5, completed: false });
+    // Nothing in progress → nothing to report (no double pause/ended event).
+    expect(tracker.stop()).toBeNull();
+
+    tracker.start();
+    tracker.tick(9.2);
+    tracker.tick(9.9);
+    expect(tracker.stop()).toEqual({ seconds_watched: 0.7, completed: true });
+  });
+
+  it('reports a stall when playback never advances, and not when it does', () => {
+    vi.useFakeTimers();
+    try {
+      const onStall = vi.fn();
+      const tracker = createPlaybackTracker({ onStall });
+      tracker.start();
+      tracker.tick(0);
+      vi.advanceTimersByTime(3_000);
+      expect(onStall).toHaveBeenCalledTimes(1);
+
+      tracker.start();
+      tracker.tick(0);
+      tracker.tick(0.1);
+      vi.advanceTimersByTime(3_000);
+      expect(onStall).toHaveBeenCalledTimes(1);
+
+      tracker.start();
+      tracker.stop(false);
+      vi.advanceTimersByTime(3_000);
+      expect(onStall).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/lib/observability/player-events.ts
+++ b/src/lib/observability/player-events.ts
@@ -1,12 +1,12 @@
 /**
  * Client-side playback events so "play did nothing" is measurable without
- * session replays (#1284).
+ * session replays (#1284, #1301).
  *
  * Failures must never break play — helpers no-op if posthog is missing or
  * if `capture()` throws.
  */
 
-export type VideoPlaySource = 'canvas' | 'theatre' | 'modal';
+export type VideoPlaySource = 'canvas' | 'theatre' | 'modal' | 'autoplay';
 
 export type PlayerCapture =
   | {
@@ -28,9 +28,18 @@ export type VideoPlayFailedProperties = {
   shot_id?: string;
 };
 
+export type VideoWatchedProperties = {
+  source: VideoPlaySource;
+  seconds_watched: number;
+  completed: boolean;
+  sequence_id?: string;
+  shot_id?: string;
+};
+
 export type SequenceReadySeenProperties = {
   sequence_id: string;
-  scene_count: number;
+  first_sequence_for_team: boolean;
+  seconds_since_generate: number;
 };
 
 function safeCapture(
@@ -59,9 +68,91 @@ export function captureVideoPlayFailed(
   safeCapture(posthog, 'video_play_failed', properties);
 }
 
+export function captureVideoWatched(
+  posthog: PlayerCapture,
+  properties: VideoWatchedProperties
+): void {
+  safeCapture(posthog, 'video_watched', properties);
+}
+
 export function captureSequenceReadySeen(
   posthog: PlayerCapture,
   properties: SequenceReadySeenProperties
 ): void {
   safeCapture(posthog, 'sequence_ready_seen', properties);
 }
+
+/** Play requested but `timeupdate` never advanced within this window. */
+const PLAY_STALL_MS = 3_000;
+
+/**
+ * Sums watched seconds from `timeupdate` positions (deltas ≥ 1 s are seeks,
+ * not watching) and reports a stall when playback never advances after
+ * `start()`. One instance per player; `stop()` returns what to report for
+ * `video_watched`, or null if no play was in progress.
+ */
+export function createPlaybackTracker(opts: {
+  onStall: () => void;
+  stallMs?: number;
+  setTimeout?: typeof globalThis.setTimeout;
+  clearTimeout?: typeof globalThis.clearTimeout;
+}) {
+  const stallMs = opts.stallMs ?? PLAY_STALL_MS;
+  const setT = opts.setTimeout ?? globalThis.setTimeout;
+  const clearT = opts.clearTimeout ?? globalThis.clearTimeout;
+  let active = false;
+  let watched = 0;
+  let last: number | null = null;
+  let duration = 0;
+  let timer: ReturnType<typeof setT> | undefined;
+
+  const disarm = () => {
+    if (timer !== undefined) clearT(timer);
+    timer = undefined;
+  };
+
+  return {
+    isActive: () => active,
+    setDuration(seconds: number) {
+      duration = seconds;
+    },
+    start() {
+      active = true;
+      watched = 0;
+      last = null;
+      disarm();
+      timer = setT(() => {
+        timer = undefined;
+        if (active) opts.onStall();
+      }, stallMs);
+    },
+    tick(position: number) {
+      if (!active) return;
+      if (last !== null) {
+        const delta = position - last;
+        if (delta > 0) disarm();
+        if (delta > 0 && delta < 1) watched += delta;
+      }
+      last = position;
+    },
+    /** `completed` defaults to "position reached the end". */
+    stop(
+      completed?: boolean
+    ): { seconds_watched: number; completed: boolean } | null {
+      disarm();
+      if (!active) return null;
+      active = false;
+      return {
+        seconds_watched: Math.round(watched * 10) / 10,
+        completed:
+          completed ?? (duration > 0 && (last ?? 0) >= duration - 0.25),
+      };
+    },
+    dispose() {
+      disarm();
+      active = false;
+    },
+  };
+}
+
+export type PlaybackTracker = ReturnType<typeof createPlaybackTracker>;

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -34,7 +34,7 @@ export function makeQueryClient() {
         // Out of credits is a billing problem, not an error toast — open the
         // globally-mounted gate dialog instead (#1099).
         if (isInsufficientCreditsError(error)) {
-          openBillingGate();
+          openBillingGate('insufficient');
           return;
         }
         // Mutations that render their own inline error opt out, so a failure

--- a/src/routes/_app/pricing.tsx
+++ b/src/routes/_app/pricing.tsx
@@ -43,7 +43,7 @@ function PricingPage() {
   const feePercent = formatPlatformFeePercent();
   const chargeFor100 = (100 * (1 + PLATFORM_FEE_PERCENT)).toFixed(0);
   const onAddCredits = () => {
-    requireAuth(() => openAddCreditsDialog());
+    requireAuth(() => openAddCreditsDialog('pricing'));
   };
 
   return (


### PR DESCRIPTION
Closes #1301

## What

Client PostHog events for the first-video funnel, so each question from the 57-replay analysis is a query:

| Event | Where | Properties |
|---|---|---|
| `sequence_ready_seen` | `ScenesView`, first render of `status === 'completed'` (once per sequence per mount) | `sequence_id`, `first_sequence_for_team`, `seconds_since_generate` |
| `video_play` | theatre (`SequencePlayer`), canvas/modal (`VideoPlayer`) | `source: canvas \| theatre \| modal \| autoplay`, `sequence_id`, `shot_id?` |
| `video_play_failed` | same | `reason` — existing engine reasons plus `timeout` (play resolved but `timeupdate` never advanced within 3 s) |
| `video_watched` | pause / ended / leaving mid-play | `seconds_watched`, `completed`, `source`, ids |
| `export_clicked` / `share_clicked` | theatre Download / Copy link; per-shot dropdown | `surface: theatre \| shot \| shot_image \| shot_video` |
| `make_another_clicked` | sidebar "New sequence", "Generate Copy…" | `surface: sidebar \| generate_copy` |
| `add_credits_clicked` | every `openAddCreditsDialog(surface)` caller | `surface` |
| `billing_gate_shown` | `BillingGateDialog` open | `reason: insufficient \| zero \| manual`, `context` |
| `low_balance_toast_shown` / `_clicked` | `use-low-balance-warning` | `balance_usd` |
| `render_wait_left` | leaving `/scenes` while `processing` | `seconds_remaining_estimate`, `destination` |

`sequence_ready_email_sent` (#1276) already exists server-side.

## How

- `createPlaybackTracker` (`player-events.ts`) sums `timeupdate` deltas (≥1 s = seek, ignored), infers completion from position (so the native `pause`→`ended` pair reports once), and arms the 3 s stall watchdog. Shared by both players; unit-tested.
- `sequence_ready_seen` moved out of `SequencePlayer` — it fired on any prepared player, including partial playback mid-generation. `first_sequence_for_team` comes from one `fetchQuery` of the team's sequence list (5-min stale), only when the completed state is first seen.
- `createDialogStore` gained a typed `open(payload)` / `getPayload()` so the globally-mounted add-credits and billing-gate dialogs capture with the opener's surface/reason from one place instead of at every button.

## Funnel

Saved insight: `user_signed_up → sequence_generated → sequence_ready_seen → video_play → (export_clicked | make_another_clicked | add_credits_clicked)` — link in the PR comments.