### PR TITLE
fix(#1358): resolve scene-split LLM key for the model actually called

### DIFF
--- a/src/lib/ai/create-adapter.test.ts
+++ b/src/lib/ai/create-adapter.test.ts
@@ -256,17 +256,20 @@ describe('native xAI routing (issue #1167)', () => {
     expect(grokCalls.at(-1)?.model).toBe('grok-4.20-0309-reasoning');
   });
 
-  it('keeps a non-Grok model on OpenRouter even when the key says xai', () => {
-    // Defence in depth: an xAI key is only ever resolved for a Grok model, so
-    // this pairing means something upstream is wrong. Sending Sonnet to xAI
-    // would 404 on a model it does not serve; OpenRouter still answers.
-    createAdapter('anthropic/claude-sonnet-5', {
-      key: 'xai-team',
-      via: 'xai',
-    });
+  it('throws when a via:"xai" key is paired with a non-Grok model (#1358)', () => {
+    // Scene-split used to resolve the analysis-model (Grok) key and then call
+    // Opus Fast. OpenRouter answers that pairing with "Missing Authentication
+    // header" — its text for any non-sk-or key. Fail loudly instead.
+    expect(() =>
+      createAdapter('anthropic/claude-opus-5-fast', {
+        key: 'xai-team',
+        via: 'xai',
+      })
+    ).toThrow(/xAI key cannot be sent to OpenRouter/);
 
     expect(createGrokTextMock).not.toHaveBeenCalled();
-    expect(lastCall().kind).toBe('keyed');
+    expect(createOpenRouterTextMock).not.toHaveBeenCalled();
+    expect(openRouterTextMock).not.toHaveBeenCalled();
   });
 
   it('falls back to OpenRouter for a Grok model with no xAI key', () => {

--- a/src/lib/ai/create-adapter.ts
+++ b/src/lib/ai/create-adapter.ts
@@ -146,6 +146,16 @@ export function createAdapter(model: TextModel, keyInfo?: LlmKeyInfo) {
     });
   }
 
+  // An xAI key on the OpenRouter branch is the #1358 mismatch: resolveLlmKey
+  // was asked for a Grok model, then the call used a different one. OpenRouter
+  // answers that with "Missing Authentication header" (its text for any
+  // non-sk-or key). Throw so the next mismatch is a stack, not a 401 puzzle.
+  if (via === 'xai') {
+    throw new Error(
+      `xAI key cannot be sent to OpenRouter (model '${model}'). Resolve the LLM key for the model being called, not a different analysis model.`
+    );
+  }
+
   // During E2E recording, aimock proxies our OpenRouter calls upstream and
   // *buffers* the entire SSE response before relaying — see
   // node_modules/@copilotkit/aimock/dist/recorder.js. That buffering window

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -980,12 +980,12 @@ No text, signs or subtitles. No holograms or floating UI. One coherent frame. Fu
 
 You will be called via a structured output tool. Follow the provided schema exactly: every field below is its own top-level key. Do not nest fields, and do not collapse several of them into one paragraph.
 
-Still — what a single frame looks like (each its own string):
-- \`mood\`: the emotional register of the image
+Still — what a single frame looks like:
+- \`mood\`: the emotional register of the image (string)
 - \`artStyle\`: the visual language (e.g. photoreal live action, cel animation)
 - \`medium\`: capture/render medium (e.g. 35mm anamorphic, phone, CGI)
 - \`lighting\`: sources, direction, quality
-- \`colorPalette\`: 3–6 hex colors (e.g. "#0a0a14"), dominant first
+- \`colorPalette\`: array of 3–6 hex strings (e.g. ["#0a0a14", "#e8322f"]), dominant first — never a single comma-separated string
 - \`colorGrading\`: specific grading moves, not a mood adjective
 
 Camera and cutting — cannot be inferred from a still:

--- a/src/lib/style/auto-style.test.ts
+++ b/src/lib/style/auto-style.test.ts
@@ -294,6 +294,7 @@ describe('autoStyleResponseSchema collapsed look/motion (#1304)', () => {
     expect(json.properties?.colorPalette).toMatchObject({
       type: 'array',
       items: { type: 'string' },
+      description: expect.stringMatching(/array of 3–6 hex/i),
     });
     expect(json.required).toEqual(
       expect.arrayContaining([

--- a/src/lib/style/auto-style.test.ts
+++ b/src/lib/style/auto-style.test.ts
@@ -198,6 +198,66 @@ describe('autoStyleResponseSchema collapsed look/motion (#1304)', () => {
     ).toBe(true);
   });
 
+  it('splits a comma-separated colorPalette string instead of failing the parse', () => {
+    // Captured 2026-08-28 from anthropic/claude-sonnet-5 via OpenRouter on
+    // sequence 01M1352KQT8288MYT5THGKK8AX (trace 73a15d673d005d7c8bd0e4a290c4af1c).
+    // The prompt listed colorPalette under "each its own string" with a single
+    // hex example, so Sonnet emitted a CSV instead of an array. Zod then
+    // threw `colorPalette: Invalid input: expected array, received string`.
+    const parsed = autoStyleResponseSchema.parse({
+      name: 'Quiet Doorstep Mourning',
+      description:
+        'A restrained 1957 period drama moment where grief passes silently between two people in a dim apartment doorway.',
+      mood: 'Restrained, quietly devastating grief held beneath a surface of formal politeness and unspoken history',
+      artStyle:
+        'Photoreal live-action period drama, understated and observational rather than theatrical',
+      medium:
+        '35mm spherical film emulation, shallow depth of field, fine natural grain',
+      lighting:
+        'Soft available light motivated from a hallway window and a single interior lamp',
+      colorPalette: '#2b241d, #4a3f33, #6e5c47, #8c7a63, #1d1a16, #a89b82',
+      colorGrading:
+        'Desaturated warm-neutral base with lifted blacks, muted highlights',
+      camera:
+        'Locked-off to near-static handheld with almost imperceptible drift',
+      shots:
+        'Doorway two-shot, close medium on Henri, settled interior two-shot',
+      pace: 'slow',
+      energy: 1,
+      category: 'film',
+      tags: ['period drama', 'restrained grief'],
+      references: [
+        'post-war European apartment interiors with worn wooden doorframes',
+      ],
+    });
+    expect(parsed.colorPalette).toEqual([
+      '#2b241d',
+      '#4a3f33',
+      '#6e5c47',
+      '#8c7a63',
+      '#1d1a16',
+      '#a89b82',
+    ]);
+    expect(
+      StyleConfigSchema.safeParse(autoStyleDraftFromResponse(parsed).config)
+        .success
+    ).toBe(true);
+  });
+
+  it('splits a space-separated colorPalette string', () => {
+    const parsed = autoStyleResponseSchema.parse({
+      name: 'Bare Bones',
+      description: 'Almost nothing.',
+      category: 'film',
+      tags: [],
+      colorPalette: '#0a0a14 #e8322f #2bd1ff',
+      energy: 3,
+      pace: 'measured',
+      references: [],
+    });
+    expect(parsed.colorPalette).toEqual(['#0a0a14', '#e8322f', '#2bd1ff']);
+  });
+
   it('lifts nested look/motion objects onto the flat fields', () => {
     const parsed = autoStyleResponseSchema.parse({
       name: 'Nested Noir',
@@ -231,12 +291,17 @@ describe('autoStyleResponseSchema collapsed look/motion (#1304)', () => {
     const json = z.toJSONSchema(autoStyleResponseSchema);
     expect(json.properties).not.toHaveProperty('look');
     expect(json.properties).not.toHaveProperty('motion');
+    expect(json.properties?.colorPalette).toMatchObject({
+      type: 'array',
+      items: { type: 'string' },
+    });
     expect(json.required).toEqual(
       expect.arrayContaining([
         'mood',
         'artStyle',
         'medium',
         'lighting',
+        'colorPalette',
         'colorGrading',
         'camera',
         'shots',

--- a/src/lib/style/auto-style.ts
+++ b/src/lib/style/auto-style.ts
@@ -133,7 +133,10 @@ export const autoStyleResponseSchema = z.preprocess(
     artStyle: z.string(),
     medium: z.string(),
     lighting: z.string(),
-    colorPalette: z.array(z.string()),
+    colorPalette: z.array(z.string()).meta({
+      description:
+        'Array of 3–6 hex color strings (e.g. ["#0a0a14", "#e8322f"]), dominant first. Not a comma-separated string.',
+    }),
     colorGrading: z.string(),
     camera: z.string(),
     shots: z.string(),

--- a/src/lib/style/auto-style.ts
+++ b/src/lib/style/auto-style.ts
@@ -70,6 +70,21 @@ function firstProse(...candidates: unknown[]): string | undefined {
 }
 
 /**
+ * Non-enforcing routes emit `colorPalette` as a CSV or space-separated
+ * string (sequence 01M1352KQT8288MYT5THGKK8AX, Sonnet 5 via OpenRouter).
+ * Split it so the array schema can still parse. Arrays pass through.
+ */
+function coercePalette(value: unknown): unknown {
+  if (Array.isArray(value) || typeof value !== 'string') return value;
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  const parts = trimmed.includes(',')
+    ? trimmed.split(',')
+    : trimmed.split(/\s+/);
+  return parts.map((part) => part.trim()).filter(Boolean);
+}
+
+/**
  * Non-enforcing routes (OpenRouter→Opus 5, #1304) have emitted `look` /
  * `motion` prose instead of the flat recipe keys, or nested the fields
  * under objects with those names. Lift those into the flat fields so a
@@ -96,6 +111,7 @@ function coerceCollapsedAutoStyle(raw: unknown): unknown {
     lighting:
       firstProse(raw.lighting, lookObj?.lighting, lookProse) ??
       fallback.lighting,
+    colorPalette: coercePalette(raw.colorPalette ?? lookObj?.colorPalette),
     colorGrading:
       firstProse(raw.colorGrading, lookObj?.colorGrading, lookProse) ??
       fallback.colorGrading,

--- a/src/lib/workflows/scene-split-workflow.test.ts
+++ b/src/lib/workflows/scene-split-workflow.test.ts
@@ -183,7 +183,14 @@ const INPUT: SceneSplitWorkflowInput = {
   elements: [],
 };
 
-function makeScopedDb(): WorkflowScopedDb {
+function makeScopedDb(
+  resolveLlmKey: (model?: string) => Promise<{
+    source: string;
+    via: string;
+    key: string;
+  }> = () =>
+    Promise.resolve({ source: 'platform', via: 'openrouter', key: 'k' })
+): WorkflowScopedDb {
   let shotSeq = 0;
   const shot = () => {
     shotSeq++;
@@ -191,8 +198,7 @@ function makeScopedDb(): WorkflowScopedDb {
   };
   const scopedDb = {
     credentials: {
-      resolveLlmKey: () =>
-        Promise.resolve({ source: 'platform', via: 'env', key: 'k' }),
+      resolveLlmKey,
     },
     liveRead: {
       compliance: {
@@ -234,11 +240,13 @@ function makeScopedDb(): WorkflowScopedDb {
   return scopedDb as unknown as WorkflowScopedDb;
 }
 
-function makeEvent(): Readonly<WorkflowEvent<SceneSplitWorkflowInput>> {
+function makeEvent(
+  payload: SceneSplitWorkflowInput = INPUT
+): Readonly<WorkflowEvent<SceneSplitWorkflowInput>> {
   // The stub satisfies WorkflowEvent structurally, so no assertion is needed
   // — and asserting anyway now trips no-unnecessary-type-assertion.
   return {
-    payload: INPUT,
+    payload,
     instanceId: 'split_run_A',
     workflowName: 'scene-split',
     timestamp: new Date(0),
@@ -434,6 +442,7 @@ describe('SceneSplitWorkflow stream step config', () => {
   beforeEach(() => {
     triggerWorkflow.mockReset();
     triggerWorkflow.mockResolvedValue('run_1');
+    vi.mocked(callLLMStream).mockClear();
     streamChunks = singleDoneChunk();
     feed.mockReset();
   });
@@ -461,6 +470,41 @@ describe('SceneSplitWorkflow stream step config', () => {
         ([params]) => params.observationName === 'phase-1-scene-bibles'
       )?.[0];
     expect(bibleCall?.model).toBe(INPUT.modelId);
+  });
+
+  test('resolves the scenes-call key for SCENE_SPLIT_MODEL, not a Grok analysis model (#1358)', async () => {
+    const grokKey = {
+      source: 'platform' as const,
+      via: 'xai' as const,
+      key: 'xai-platform-key',
+    };
+    const splitKey = {
+      source: 'platform' as const,
+      via: 'openrouter' as const,
+      key: 'or-platform-key',
+    };
+    const resolveLlmKey = vi.fn(async (model?: string) =>
+      model === 'x-ai/grok-4.6' ? grokKey : splitKey
+    );
+
+    await makeWorkflow().split(
+      makeEvent({ ...INPUT, modelId: 'x-ai/grok-4.6' }),
+      makeStep(),
+      makeScopedDb(resolveLlmKey)
+    );
+
+    expect(resolveLlmKey).toHaveBeenCalledWith(SCENE_SPLIT_MODEL);
+    const sceneCall = sceneSplittingLlmCalls()[0]?.[0];
+    expect(sceneCall?.model).toBe(SCENE_SPLIT_MODEL);
+    expect(sceneCall?.apiKey).toEqual(splitKey);
+
+    const bibleCall = vi
+      .mocked(callLLMStream)
+      .mock.calls.find(
+        ([params]) => params.observationName === 'phase-1-scene-bibles'
+      )?.[0];
+    expect(bibleCall?.model).toBe('x-ai/grok-4.6');
+    expect(bibleCall?.apiKey).toEqual(grokKey);
   });
 });
 

--- a/src/lib/workflows/scene-split-workflow.ts
+++ b/src/lib/workflows/scene-split-workflow.ts
@@ -340,7 +340,8 @@ export class SceneSplitWorkflow extends OpenStoryWorkflowEntrypoint<SceneSplitWo
           script: gutteredScript,
         });
 
-        const llmKeyInfo = await scopedDb.credentials.resolveLlmKey(modelId);
+        const llmKeyInfo =
+          await scopedDb.credentials.resolveLlmKey(SCENE_SPLIT_MODEL);
 
         logger.info(
           `[SceneSplitWorkflow:cf] [LLM:${LOG_NAME}] Starting streaming call`,


### PR DESCRIPTION
## Related Issue

Closes #1358

## Summary of Changes

Scene-split pinned `SCENE_SPLIT_MODEL` (`anthropic/claude-opus-5-fast`) but resolved the LLM key for the sequence analysis model. After native Grok (#1167), a Grok analysis model resolves to the platform xAI key. `createAdapter` then sent `Bearer <xai key>` to OpenRouter, which answered **Missing Authentication header**.

- Resolve the scenes-call key for `SCENE_SPLIT_MODEL`, not `modelId`. Bibles still use the analysis model for both the call and the key.
- `createAdapter`: a `via: 'xai'` key never reaches the OpenRouter branch — it throws instead of becoming a 401 puzzle.
- Unit tests: Grok analysis model + Opus Fast scenes call → OpenRouter key on the scenes call, xAI key on bibles; `via: 'xai'` + non-Grok model throws.

**Model pin:** kept `SCENE_SPLIT_MODEL`. `models.config.ts` already records why — Grok 4.6 + medium reasoning spends minutes thinking before the first boundary token; Opus 5 Fast split a prose ad in 2.4s and a 19-heading screenplay in 4s. Native routing does not change that reasoning budget. Swapping the scenes call to the user's analysis model is a separate experiment, not required to unblock prod.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Key routing only. Sequences whose analysis model is already Claude were already resolving an OpenRouter/fal key and are unchanged.

## Additional Notes

Prod sequence `01M12V7A0YDJT37W0KTV4175Y2` (analysis model `x-ai/grok-4.6`, no BYOK) was the repro: `keyVia: "xai"` on the `claude-opus-5-fast` call, 3 retries each trigger.