### PR TITLE
fix(motion): soften/fallback on content-flag exhaustion and name the flagged input

### DIFF
--- a/src/lib/ai/content-rejection.test.ts
+++ b/src/lib/ai/content-rejection.test.ts
@@ -151,7 +151,7 @@ describe('flaggedInputs / clipContentRejectionMessage (#1373)', () => {
 
   it('tells the user what was rejected, by whom, and what to change', () => {
     const message = clipContentRejectionMessage({
-      rejection: both,
+      rejections: [both],
       models: ['LTX 2.3 Pro', 'Grok Imagine Video 1.5'],
       softened: true,
     });
@@ -162,7 +162,7 @@ describe('flaggedInputs / clipContentRejectionMessage (#1373)', () => {
 
     expect(
       clipContentRejectionMessage({
-        rejection: 'body.image_url: flagged by a content checker',
+        rejections: ['body.image_url: flagged by a content checker'],
         models: ['LTX 2.3 Pro'],
         softened: false,
       })
@@ -172,13 +172,51 @@ describe('flaggedInputs / clipContentRejectionMessage (#1373)', () => {
 
     expect(
       clipContentRejectionMessage({
-        rejection:
+        rejections: [
           'Could not generate images with the given prompts and images.',
+        ],
         models: ['Veo 3.1'],
         softened: true,
       })
     ).toBe(
       'Content checker rejected the clip (Veo 3.1; softened prompt also rejected). Rewrite the motion prompt or regenerate the still. (Could not generate images with the given prompts and images.)'
+    );
+  });
+
+  it('keeps what the first attempts named when the rescue rejection is unprefixed', () => {
+    expect(
+      clipContentRejectionMessage({
+        rejections: [both, both, both, 'unsafe content'],
+        models: ['LTX 2.3 Pro', 'Grok Imagine Video 1.5'],
+        softened: true,
+      })
+    ).toMatch(/^Content checker rejected the still and the prompt \(/);
+  });
+
+  it('names studio inputs — a reference image, or nothing but the prompt', () => {
+    expect(
+      clipContentRejectionMessage({
+        rejections: ['body.image_urls.0: flagged by a content checker'],
+        models: ['Seedance 2.5'],
+        softened: false,
+        inputs: {
+          still: { name: 'a reference image', fix: 'Swap the reference image' },
+          prompt: 'the prompt',
+        },
+      })
+    ).toBe(
+      'Content checker rejected a reference image (Seedance 2.5). Swap the reference image.'
+    );
+    // No reference image was sent, so there is nothing but the prompt to fix.
+    expect(
+      clipContentRejectionMessage({
+        rejections: ['flagged by a content checker'],
+        models: ['Seedance 2.5'],
+        softened: false,
+        inputs: { prompt: 'the prompt' },
+      })
+    ).toBe(
+      'Content checker rejected the clip (Seedance 2.5). Rewrite the prompt. (flagged by a content checker)'
     );
   });
 });

--- a/src/lib/ai/content-rejection.test.ts
+++ b/src/lib/ai/content-rejection.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   CONTENT_REJECTION_PATTERNS,
+  clipContentRejectionMessage,
+  flaggedInputs,
   contentRejectionSubjects,
   contentRejectionSummary,
   isContentRejectionError,
@@ -117,5 +119,66 @@ describe('contentRejectionSummary / contentRejectionSubjects', () => {
     ).toBeNull();
     expect(contentRejectionSummary([])).toBeNull();
     expect(contentRejectionSubjects('Generation failed')).toEqual([]);
+  });
+});
+
+describe('flaggedInputs / clipContentRejectionMessage (#1373)', () => {
+  // The real LTX 2.3 Pro 422 from shot 01M0YXMK5BCZEKQ5TSZ4CPT51C, as
+  // `extractFalErrorMessage` renders it (loc-prefixed, `; `-joined).
+  const both =
+    'body.prompt: The content could not be processed because it contained material flagged by a content checker.; body.image_url: The content could not be processed because it contained material flagged by a content checker.';
+
+  it('names the still and the prompt separately', () => {
+    expect(flaggedInputs(both)).toEqual({
+      prompt: true,
+      image: true,
+      audio: false,
+    });
+    expect(flaggedInputs('body.prompt: flagged by a content checker')).toEqual({
+      prompt: true,
+      image: false,
+      audio: false,
+    });
+    expect(flaggedInputs('body.image_urls.0: flagged')).toMatchObject({
+      image: true,
+    });
+    expect(flaggedInputs('Output audio has sensitive content.')).toEqual({
+      prompt: false,
+      image: false,
+      audio: false,
+    });
+  });
+
+  it('tells the user what was rejected, by whom, and what to change', () => {
+    const message = clipContentRejectionMessage({
+      rejection: both,
+      models: ['LTX 2.3 Pro', 'Grok Imagine Video 1.5'],
+      softened: true,
+    });
+    expect(message).toBe(
+      'Content checker rejected the still and the prompt (LTX 2.3 Pro, then Grok Imagine Video 1.5; softened prompt also rejected). Regenerate the still or rewrite the motion prompt.'
+    );
+    expect(isContentRejectionError(message)).toBe(true);
+
+    expect(
+      clipContentRejectionMessage({
+        rejection: 'body.image_url: flagged by a content checker',
+        models: ['LTX 2.3 Pro'],
+        softened: false,
+      })
+    ).toBe(
+      'Content checker rejected the still (LTX 2.3 Pro). Regenerate the still.'
+    );
+
+    expect(
+      clipContentRejectionMessage({
+        rejection:
+          'Could not generate images with the given prompts and images.',
+        models: ['Veo 3.1'],
+        softened: true,
+      })
+    ).toBe(
+      'Content checker rejected the clip (Veo 3.1; softened prompt also rejected). Rewrite the motion prompt or regenerate the still. (Could not generate images with the given prompts and images.)'
+    );
   });
 });

--- a/src/lib/ai/content-rejection.ts
+++ b/src/lib/ai/content-rejection.ts
@@ -178,3 +178,61 @@ export function contentRejectionSubjects(error: string): string[] {
     .map((s) => s.trim())
     .filter(Boolean);
 }
+
+/**
+ * Which inputs a fal 422 named. `extractFalErrorMessage` prefixes each detail
+ * with its `loc` (`body.prompt: …; body.image_url: …`, #1373); a rejection
+ * without any prefix (Veo's "could not generate", BytePlus, aimock) classifies
+ * as nothing flagged and callers treat it as prompt-shaped.
+ */
+export function flaggedInputs(rejection: string): {
+  prompt: boolean;
+  image: boolean;
+  audio: boolean;
+} {
+  const fields = [...rejection.matchAll(/\bbody\.([\w.[\]]+):/g)].map(
+    (m) => m[1] ?? ''
+  );
+  return {
+    prompt: fields.some((f) => /prompt/i.test(f)),
+    image: fields.some((f) => /image|frame|element/i.test(f)),
+    audio: fields.some((f) => /audio/i.test(f)),
+  };
+}
+
+/**
+ * Terminal clip error once every remedy is spent. Names the flagged inputs and
+ * the models that refused them, then says what the user can change — a
+ * flagged still cannot be reseeded or softened away, only regenerated (#1373).
+ * Keeps "content checker" so `isContentRejectionError` still classifies it.
+ */
+export function clipContentRejectionMessage(args: {
+  rejection: string;
+  /** Display names in the order tried, e.g. `['LTX 2.3 Pro', 'Grok …']`. */
+  models: string[];
+  softened: boolean;
+}): string {
+  const flags = flaggedInputs(args.rejection);
+  const what =
+    flags.image && flags.prompt
+      ? 'the still and the prompt'
+      : flags.image
+        ? 'the still'
+        : flags.prompt
+          ? 'the prompt'
+          : flags.audio
+            ? 'the audio'
+            : 'the clip';
+  const hint = flags.image
+    ? `Regenerate the still${flags.prompt ? ' or rewrite the motion prompt' : ''}.`
+    : flags.prompt
+      ? 'Rewrite the motion prompt.'
+      : `Rewrite the motion prompt or regenerate the still. (${args.rejection})`;
+  const tried = [
+    args.models.join(', then '),
+    args.softened ? 'softened prompt also rejected' : null,
+  ]
+    .filter(Boolean)
+    .join('; ');
+  return `Content checker rejected ${what} (${tried}). ${hint}`;
+}

--- a/src/lib/ai/content-rejection.ts
+++ b/src/lib/ai/content-rejection.ts
@@ -207,27 +207,48 @@ export function flaggedInputs(rejection: string): {
  * Keeps "content checker" so `isContentRejectionError` still classifies it.
  */
 export function clipContentRejectionMessage(args: {
-  rejection: string;
+  /**
+   * Every rejection seen, in order. Flags OR across them — the rescue attempt's
+   * (fallback-model) rejection may lack the `body.<field>` prefix the first
+   * attempts carried, and must not erase what they named. The last is quoted
+   * when nothing was named.
+   */
+  rejections: string[];
   /** Display names in the order tried, e.g. `['LTX 2.3 Pro', 'Grok …']`. */
   models: string[];
   softened: boolean;
+  /**
+   * What this caller's inputs are called. Default is image-to-video (a start
+   * still + motion prompt). Studio text-to-video has no still — pass its
+   * reference image when it has one, or no `still` at all.
+   */
+  inputs?: {
+    still?: { name: string; fix: string };
+    prompt: string;
+  };
 }): string {
-  const flags = flaggedInputs(args.rejection);
+  const flags = flaggedInputs(args.rejections.join('; '));
+  const still = args.inputs
+    ? args.inputs.still
+    : { name: 'the still', fix: 'Regenerate the still' };
+  const promptName = args.inputs?.prompt ?? 'the motion prompt';
+  const stillFlagged = flags.image && still !== undefined;
   const what =
-    flags.image && flags.prompt
-      ? 'the still and the prompt'
-      : flags.image
-        ? 'the still'
+    stillFlagged && flags.prompt
+      ? `${still.name} and the prompt`
+      : stillFlagged
+        ? still.name
         : flags.prompt
           ? 'the prompt'
           : flags.audio
             ? 'the audio'
             : 'the clip';
-  const hint = flags.image
-    ? `Regenerate the still${flags.prompt ? ' or rewrite the motion prompt' : ''}.`
+  const lower = (s: string) => s.charAt(0).toLowerCase() + s.slice(1);
+  const hint = stillFlagged
+    ? `${still.fix}${flags.prompt ? ` or rewrite ${promptName}` : ''}.`
     : flags.prompt
-      ? 'Rewrite the motion prompt.'
-      : `Rewrite the motion prompt or regenerate the still. (${args.rejection})`;
+      ? `Rewrite ${promptName}.`
+      : `Rewrite ${promptName}${still ? ` or ${lower(still.fix)}` : ''}. (${args.rejections.at(-1) ?? ''})`;
   const tried = [
     args.models.join(', then '),
     args.softened ? 'softened prompt also rejected' : null,

--- a/src/lib/ai/fal-error.test.ts
+++ b/src/lib/ai/fal-error.test.ts
@@ -31,7 +31,7 @@ const REAL_FAL_CONTENT_FLAG_422 = {
 describe('extractFalErrorMessage', () => {
   it('reads the real fal content-flag 422 detail array (prod shape)', () => {
     expect(extractFalErrorMessage(withBody(REAL_FAL_CONTENT_FLAG_422))).toBe(
-      'The content could not be processed because it contained material flagged by a content checker.'
+      'body.prompt: The content could not be processed because it contained material flagged by a content checker.'
     );
   });
 

--- a/src/lib/ai/fal-error.ts
+++ b/src/lib/ai/fal-error.ts
@@ -12,7 +12,7 @@
  * ("Unprocessable Entity") and the real reason is lost.
  */
 type FalErrorBody = {
-  detail?: Array<{ msg: string; type?: string }> | string;
+  detail?: Array<{ msg: string; type?: string; loc?: string[] }> | string;
   error?: { message?: string } | string;
   message?: string;
 };
@@ -35,8 +35,13 @@ export function extractFalErrorMessage(error: unknown): string {
     }
 
     if (Array.isArray(detail) && detail.length > 0) {
-      // Join all detail messages (usually just one)
-      return detail.map((d) => d.msg).join('; ');
+      // Join all detail messages, each prefixed by the input it names
+      // (`body.prompt: …; body.image_url: …`). A content flag on the still
+      // and one on the prompt read identically without it (#1373); the
+      // prefix is what `flaggedInputs` classifies on.
+      return detail
+        .map((d) => (d.loc?.length ? `${d.loc.join('.')}: ${d.msg}` : d.msg))
+        .join('; ');
     }
   }
 

--- a/src/lib/api-v1/openapi.ts
+++ b/src/lib/api-v1/openapi.ts
@@ -113,6 +113,19 @@ const genStatusObject: JsonObject = {
   required: ['status', 'url'],
   properties: { status: statusEnum(GEN_STATUSES), url: nullableString },
 };
+const videoStatusObject: JsonObject = {
+  type: 'object',
+  required: ['status', 'url', 'error'],
+  properties: {
+    status: statusEnum(GEN_STATUSES),
+    url: nullableString,
+    error: {
+      ...nullableString,
+      description:
+        'Why the primary render failed. On a content check this names the flagged input (the still, the prompt, or both) and the model that refused it. Null unless status is "failed".',
+    },
+  },
+};
 const countsObject: JsonObject = {
   type: 'object',
   required: ['shots', 'imagesReady', 'videosReady', 'videosFailed'],
@@ -734,7 +747,7 @@ export function buildOpenApiDocument(): JsonObject {
             orderIndex: { type: 'integer' },
             title: nullableString,
             image: genStatusObject,
-            video: genStatusObject,
+            video: videoStatusObject,
           },
         },
         SequenceState: {

--- a/src/lib/api-v1/state.ts
+++ b/src/lib/api-v1/state.ts
@@ -39,7 +39,13 @@ type SequenceStateShot = {
   orderIndex: number;
   title: string | null;
   image: { status: ShotGenStatus; url: string | null };
-  video: { status: ShotGenStatus; url: string | null };
+  video: {
+    status: ShotGenStatus;
+    url: string | null;
+    /** Why the primary render failed — names the flagged input on a content
+     * check (#1373). Null unless `status` is "failed". */
+    error: string | null;
+  };
 };
 
 export type SequenceCounts = {
@@ -284,6 +290,10 @@ export async function buildSequenceState(
       video: {
         status: shot.videoStatus,
         url: share(shot.video?.url ?? null),
+        error:
+          shot.videoStatus === 'failed'
+            ? (shot.primaryVideo?.error ?? null)
+            : null,
       },
     };
   });

--- a/src/lib/db/scoped/shot-prompt-versions.test.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.test.ts
@@ -506,6 +506,46 @@ describe('shot_prompt_variants helper', () => {
     expect(selected?.inputHash).toBe('context-hash-1');
   });
 
+  it('softened row with select:false (variant-only rescue) lands in history and leaves the selection alone (#1373)', async () => {
+    const methods = createShotPromptVersionsMethods(db);
+    const original = await methods.write({
+      shotId,
+      promptType: 'motion',
+      text: 'User prompt',
+      source: 'user-edit',
+      inputHash: 'context-hash-1',
+      analysisModel: 'anthropic/claude-haiku-4.5',
+    });
+
+    const softened = await methods.write({
+      shotId,
+      promptType: 'motion',
+      text: 'Softened prompt',
+      source: 'softened',
+      inputHash: original.inputHash,
+      analysisModel: original.analysisModel,
+      select: false,
+    });
+    expect(softened.id).not.toBe(original.id);
+    expect(softened.inputHash).toBe('context-hash-1');
+
+    const history = await methods.listByShot(shotId, 'motion');
+    expect(history.map((r) => r.source)).toEqual(['softened', 'user-edit']);
+    // An alternate model's rescue never moves the primary shot's prompt.
+    expect((await selectedMotionVersion())?.id).toBe(original.id);
+
+    // The default (primary render) selects the rewrite, as the image path does.
+    const selected = await methods.write({
+      shotId,
+      promptType: 'motion',
+      text: 'Softened prompt for the primary',
+      source: 'softened',
+      inputHash: original.inputHash,
+      analysisModel: original.analysisModel,
+    });
+    expect((await selectedMotionVersion())?.id).toBe(selected.id);
+  });
+
   it('restoring an AI prompt that is currently live still appends a restored row (audit trail)', async () => {
     // Without the partial-index `source != 'restored'` exclusion, this case
     // hit onConflictDoNothing and silently returned the original AI row.

--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -47,6 +47,12 @@ type WriteShotPromptVersionBase = {
   dialogue?: MotionDialogue | null;
   audio?: MotionAudio | null;
   createdBy?: string | null;
+  /**
+   * `false`: append to history only — the shot keeps its selected prompt.
+   * A variant-only render's content-checker rescue (#1373) writes its
+   * rewrite this way so an alternate model never moves the primary prompt.
+   */
+  select?: boolean;
 };
 
 /**
@@ -78,7 +84,7 @@ export type WriteShotPromptVersionInput = WriteShotPromptVersionBase &
       }
     | {
         // `restored`: audit row for a repoint. `softened`: the content-checker
-        // rewrite motion re-rendered from (#1373); carries the rejected
+        // rewrite the clip was re-rendered from (#1373); carries the rejected
         // version's hash + model verbatim so staleness stays detectable.
         source: 'restored' | 'softened';
         inputHash: string | null;
@@ -222,6 +228,7 @@ export function createShotPromptVersionsMethods(db: Database) {
       if (!version) {
         throw new Error('Failed to insert shot prompt version');
       }
+      if (input.select === false) return version;
 
       // Mirror onto the shot AND repoint the selection at this version. The
       // `selectedMotionPromptVersionId` pointer was previously never set, so the

--- a/src/lib/db/scoped/shot-prompt-versions.ts
+++ b/src/lib/db/scoped/shot-prompt-versions.ts
@@ -77,7 +77,10 @@ export type WriteShotPromptVersionInput = WriteShotPromptVersionBase &
         analysisModel: string | null;
       }
     | {
-        source: 'restored';
+        // `restored`: audit row for a repoint. `softened`: the content-checker
+        // rewrite motion re-rendered from (#1373); carries the rejected
+        // version's hash + model verbatim so staleness stays detectable.
+        source: 'restored' | 'softened';
         inputHash: string | null;
         analysisModel: string | null;
       }

--- a/src/lib/prompts/workflow-prompts.ts
+++ b/src/lib/prompts/workflow-prompts.ts
@@ -1050,4 +1050,35 @@ Two rejection classes:
 </REJECTION>`,
     },
   ],
+
+  'phase/soften-motion-prompt-chat': [
+    {
+      role: 'system',
+      content: `You rewrite an image-to-video motion prompt that a video model rejected, so a retry can succeed. The still frame the clip animates from is fixed and already accepted; only the prompt text changes. Read <REJECTION> and pick the rewrite that matches it.
+
+Two rejection classes:
+- POLICY — content checker / NSFW / unsafe / sensitive / flagged. Soften graphic violence, gore, sexual/nude wording, self-harm, real-person likeness instructions, and explicit crime into cinematic implication (aftermath, tension, reaction, off-screen action). A name that identifies a real person or a well-known franchise / trademarked character trips likeness and IP checks on its own: drop the name and describe the figure generically — never name the franchise.
+- UNEXPECTED OUTPUT — "did not generate the expected output", "could not generate", "unexpected result". The model often rejects its own sample because the prompt's grammar is broken or it stacks unusual word combinations. Rewrite into plain, grammatical English: short clauses, one action per beat, no jammed modifiers or contradictory descriptors. Do not invent safer-sounding plot; the shot stays the same.
+
+### CRITICAL OUTPUT RULES
+1. You will be called via a structured output tool. Follow the provided schema exactly.
+2. Return one rewritten prompt in \`prompt\`. Natural language only — no headers, bullets, or quotation marks wrapping the whole prompt.
+3. Keep the same shot: subjects, action, camera movement, pacing, and any spoken dialogue lines (soften only the words the checker would object to). Do not add new characters, props, camera moves, or plot.
+4. Keep CHARACTER NAMES IN CAPS and UPPERCASE element tokens verbatim — they label reference images, not likenesses. Keep model-specific tags (e.g. dialogue markup, audio direction) in place.
+5. If the rejection is ambiguous, do both: clean the grammar AND soften any policy-risky wording.
+6. Never return the original unchanged.`,
+    },
+    {
+      role: 'user',
+      content: `Rewrite this motion prompt so a video model will accept it.
+
+<ORIGINAL_PROMPT>
+{{prompt}}
+</ORIGINAL_PROMPT>
+
+<REJECTION>
+{{rejection}}
+</REJECTION>`,
+    },
+  ],
 };

--- a/src/lib/realtime/index.ts
+++ b/src/lib/realtime/index.ts
@@ -212,6 +212,11 @@ export const realtimeSchema = {
       // Failure reason — carried on `failed` so the cache updater writes
       // `shots.videoError` live (see image:progress.error above). (#881)
       error: z.string().optional(),
+      // Content-checker rescue (#1373) — see image:progress above. Set on the
+      // retrying emit when this run appended a `softened` motion prompt
+      // version / swapped the clip to the fallback video model.
+      promptSoftened: z.boolean().optional(),
+      modelFallback: z.boolean().optional(),
     }),
 
     // Audio/music generation progress (shotId optional for sequence-level music)

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -390,8 +390,9 @@ export function updateQueryCacheFromEvent(
         );
       }
       // Content-checker rescue (#1373), mirroring the image handler: a
-      // softened motion prompt version repoints the shot's selection, and a
-      // fallback render moves the in-flight version to the Grok group.
+      // softened motion prompt version repoints the shot's selection (primary
+      // render) or lands in its history (variant-only), and a fallback render
+      // moves the in-flight version to the Grok group.
       if (promptSoftened && shotId) {
         debouncedInvalidate(
           queryClient,

--- a/src/lib/realtime/query-cache-updater.ts
+++ b/src/lib/realtime/query-cache-updater.ts
@@ -294,6 +294,8 @@ export function updateQueryCacheFromEvent(
       const videoUrl = getOptionalString(data, 'videoUrl');
       const status = data.status;
       const errorMessage = getOptionalString(data, 'error');
+      const promptSoftened = data.promptSoftened === true;
+      const modelFallback = data.modelFallback === true;
       // Variant-only (#547): an added (alternate) video model finished/failed —
       // its output belongs in `shot_variants`, NOT the live primary. Skip the
       // primary shots-list write (which would flip the displayed video to the
@@ -385,6 +387,38 @@ export function updateQueryCacheFromEvent(
           queryClient,
           segmentKeys.list(sequenceId),
           `segments:${sequenceId}`
+        );
+      }
+      // Content-checker rescue (#1373), mirroring the image handler: a
+      // softened motion prompt version repoints the shot's selection, and a
+      // fallback render moves the in-flight version to the Grok group.
+      if (promptSoftened && shotId) {
+        debouncedInvalidate(
+          queryClient,
+          promptVariantKeys.shot('motion', shotId),
+          `prompt-variants:motion:${shotId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          shotKeys.list(sequenceId),
+          `shots:${sequenceId}`
+        );
+      }
+      if (modelFallback && shotId) {
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-video-variants', sequenceId],
+          `video-variants:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          ['sequence-video-models', sequenceId],
+          `video-models:${sequenceId}`
+        );
+        debouncedInvalidate(
+          queryClient,
+          shotKeys.videoVersions(shotId),
+          `video-versions:${shotId}`
         );
       }
       break;

--- a/src/lib/realtime/use-generation-stream.ts
+++ b/src/lib/realtime/use-generation-stream.ts
@@ -284,20 +284,18 @@ export function useGenerationStream(
       updateQueryCacheFromEvent(queryClient, sequenceId, eventName, data);
 
       // Live-only (history replay does not use this handler). Tell the user
-      // the still is being retried from a rewritten prompt, and that the
-      // original is still in Versions.
-      if (
-        eventName === 'generation.image:progress' &&
-        data.promptSoftened === true
-      ) {
+      // the still / clip is being retried from a rewritten prompt or on the
+      // fallback model, and that the original is still in Versions (#1272,
+      // motion in #1373).
+      const isMediaProgress =
+        eventName === 'generation.image:progress' ||
+        eventName === 'generation.video:progress';
+      if (isMediaProgress && data.promptSoftened === true) {
         toast.info('Prompt rewritten to pass a content checker', {
           description: 'The original is kept in Versions.',
         });
       }
-      if (
-        eventName === 'generation.image:progress' &&
-        data.modelFallback === true
-      ) {
+      if (isMediaProgress && data.modelFallback === true) {
         toast.info('Retrying on Grok Imagine after the content checker', {
           description: 'The selected model is kept in Versions.',
         });

--- a/src/lib/workflow/no-mid-run-reads.test.ts
+++ b/src/lib/workflow/no-mid-run-reads.test.ts
@@ -293,6 +293,11 @@ const ALLOWED_LIVE_READS: Record<string, SanctionedRead[]> = {
       bucket: 'EXISTENCE-GUARD',
       why: 'Shot deleted mid-run is a stand-down, not a failure.',
     },
+    {
+      read: 'shotPromptVersions.getByIdForShot',
+      bucket: 'CLAIM-BY-ID',
+      why: 'The motion prompt version this clip renders from, named by the trigger snapshot — its hash + model are copied onto the softened row (#1373), as soften-image-prompt does for stills.',
+    },
   ],
   'recast-snapshot.ts': [
     {

--- a/src/lib/workflows/content-soften.ts
+++ b/src/lib/workflows/content-soften.ts
@@ -25,7 +25,7 @@ import {
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
-import type { TextToImageModel } from '@/lib/ai/models';
+import type { ImageToVideoModel, TextToImageModel } from '@/lib/ai/models';
 import {
   DEFAULT_ANALYSIS_MODEL,
   type AnalysisModelId,
@@ -50,34 +50,67 @@ export const MAX_CONTENT_ATTEMPTS = 3;
 export const IMAGE_CONTENT_FALLBACK_MODEL: TextToImageModel =
   'grok_imagine_image';
 
+/**
+ * Video fallback when the STILL was flagged (#1373): checker strictness differs
+ * per vendor, and a flagged input image cannot be reseeded or softened away.
+ * Grok, as for images. Skipped when already this.
+ */
+export const MOTION_CONTENT_FALLBACK_MODEL: ImageToVideoModel =
+  'grok_imagine_video_1_5';
+
 /** Plain `z.string()` — no min/max (Bedrock rejects integer bounds). */
 export const softenImagePromptResponseSchema = z.object({
   prompt: z.string(),
 });
 
-export async function softenRejectedImagePrompt(
+export type SoftenRejectedPromptArgs = {
+  scopedDb: WorkflowScopedDb;
+  workflowRunId: string;
+  sequenceId?: string;
+  userId: string;
+  prompt: string;
+  rejection: string;
+  analysisModelId: AnalysisModelId;
+  shotId?: string;
+  model: string;
+  reservationId?: string;
+  /** Durable step name — must be unique per call within a run. */
+  name?: string;
+};
+
+export function softenRejectedImagePrompt(
   step: WorkflowStep,
-  args: {
-    scopedDb: WorkflowScopedDb;
-    workflowRunId: string;
-    sequenceId?: string;
-    userId: string;
-    prompt: string;
-    rejection: string;
-    analysisModelId: AnalysisModelId;
-    shotId?: string;
-    model: string;
-    reservationId?: string;
-    /** Durable step name — must be unique per call within a run. */
-    name?: string;
-  }
+  args: SoftenRejectedPromptArgs
+): Promise<string> {
+  return softenRejectedPrompt(step, {
+    ...args,
+    name: args.name ?? 'soften-image-prompt',
+    promptName: 'phase/soften-image-prompt-chat',
+  });
+}
+
+/** Same rewrite for an image-to-video prompt (#1373). */
+export function softenRejectedMotionPrompt(
+  step: WorkflowStep,
+  args: SoftenRejectedPromptArgs
+): Promise<string> {
+  return softenRejectedPrompt(step, {
+    ...args,
+    name: args.name ?? 'soften-motion-prompt',
+    promptName: 'phase/soften-motion-prompt-chat',
+  });
+}
+
+async function softenRejectedPrompt(
+  step: WorkflowStep,
+  args: SoftenRejectedPromptArgs & { name: string; promptName: string }
 ): Promise<string> {
   const response = await durableLLMCallCf(
     step,
     {
-      name: args.name ?? 'soften-image-prompt',
-      phase: { number: 4, name: 'Softening image prompt…' },
-      promptName: 'phase/soften-image-prompt-chat',
+      name: args.name,
+      phase: { number: 4, name: 'Softening prompt…' },
+      promptName: args.promptName,
       promptVariables: {
         prompt: args.prompt,
         rejection: args.rejection,

--- a/src/lib/workflows/motion-workflow.test.ts
+++ b/src/lib/workflows/motion-workflow.test.ts
@@ -1,0 +1,404 @@
+/**
+ * MotionWorkflow's content-flag rescue (#1373).
+ *
+ * After the same-prompt reseeds exhaust, one more submit with the remedy the
+ * flagged input calls for: a softened prompt when the prompt was flagged, the
+ * Grok fallback when the still was, both when both. Pins the step names, which
+ * prompt/model the rescue submits, what the softened version write and the
+ * in-flight version update carry, the rescue emit, and the terminal message.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
+import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
+import type { MotionWorkflowInput } from '@/lib/workflow/types';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+
+const mockSubmit = vi.fn();
+const mockPoll = vi.fn();
+const mockSoften = vi.fn();
+const mockDeductWorkflowCredits = vi.fn();
+const emit = vi.fn(async () => {});
+
+vi.doMock('@/lib/motion/motion-generation', () => ({
+  submitMotionJob: mockSubmit,
+  pollMotionJob: mockPoll,
+  calculateMotionMetadata: () => ({ cost: 0, duration: 5 }),
+  motionCostFromUsage: () => ({
+    cost: 0,
+    unitsBilled: 0,
+    endpointId: 'fal/x',
+    recordFalUsage: false,
+  }),
+}));
+vi.doMock('@/lib/ai/fal-pricing-live', () => ({
+  getEffectiveFalPricing: async () => ({}),
+}));
+vi.doMock('@/lib/billing/cost-estimation', () => ({ gateEstimate: () => 0 }));
+vi.doMock('@/lib/billing/workflow-deduction', () => ({
+  deductWorkflowCredits: mockDeductWorkflowCredits,
+  recordFalUsageStep: vi.fn(async () => ({})),
+}));
+vi.doMock('@/lib/image/image-compress', () => ({
+  ensureImageUnderLimit: async () => null,
+}));
+vi.doMock('@/lib/motion/video-storage', () => ({
+  uploadVideoToStorage: async () => ({
+    success: true,
+    url: '/r2/videos/a.mp4',
+    path: 'a.mp4',
+  }),
+}));
+vi.doMock('@/lib/compliance/provenance', () => ({
+  recordProvenance: vi.fn(async () => {}),
+}));
+vi.doMock('@/lib/observability/ai-otel', () => ({
+  recordMediaGenerationSpan: () => {},
+}));
+vi.doMock('@/lib/realtime', () => ({
+  getGenerationChannel: () => ({ emit }),
+}));
+vi.doMock('@/lib/workflows/motion-workflow-persist', () => ({
+  persistMotionCompletion: async () => ({ status: 'completed' }),
+  persistMotionFailure: async () => {},
+}));
+vi.doMock('@/lib/workflows/content-soften', () => ({
+  MOTION_CONTENT_FALLBACK_MODEL: 'grok_imagine_video_1_5',
+  softenRejectedMotionPrompt: mockSoften,
+}));
+// Deterministic, readable hash so the fallback step's recompute is assertable.
+vi.doMock('@/lib/ai/input-hash', () => ({
+  computeVideoManifestInputHash: async (
+    manifest: { motionPromptVersionId: string | null }[],
+    model: string
+  ) => `${model}:${manifest[0]?.motionPromptVersionId ?? 'null'}`,
+}));
+
+const { MotionWorkflow } = await import('./motion-workflow');
+
+class Probe extends MotionWorkflow {
+  runBody(
+    event: Readonly<WorkflowEvent<MotionWorkflowInput>>,
+    step: WorkflowStep,
+    scopedDb: WorkflowScopedDb
+  ) {
+    return this.runImpl(event, step, scopedDb);
+  }
+}
+
+function makeWorkflow(): Probe {
+  type Ctor = ConstructorParameters<typeof Probe>;
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- runImpl never reads ctx
+  const ctx = undefined as unknown as Ctor[0];
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- runImpl never reads bindings
+  const env = {} as unknown as Ctor[1];
+  return new Probe(ctx, env);
+}
+
+function makeStep(): WorkflowStep & { names: string[] } {
+  const names: string[] = [];
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- stub: runImpl only uses `do` and `sleep`
+  return {
+    names,
+    do: vi.fn((name: string, fn: () => Promise<unknown>) => {
+      names.push(name);
+      return fn();
+    }),
+    sleep: vi.fn(async () => {}),
+  } as unknown as WorkflowStep & { names: string[] };
+}
+
+function makeScopedDb() {
+  const shotPromptVersions = {
+    write: vi.fn(async () => ({ id: 'spv-soft' })),
+  };
+  const videoVariants = {
+    appendVersion: vi.fn(async () => ({ id: 'vv-1' })),
+    update: vi.fn(async () => {}),
+  };
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- stub covering only the surface runImpl touches
+  const scopedDb = {
+    credentials: { resolveKey: async () => ({ source: 'platform' }) },
+    liveRead: {
+      shots: {
+        getById: async () => ({
+          id: 'shot-1',
+          sceneId: 'scene-1',
+          renderSegmentId: null,
+        }),
+      },
+      billing: { hasEnoughCredits: async () => true },
+    },
+    renderSegments: {
+      ensureForShot: async () => 'seg-1',
+      setPendingPromoteVersionId: async () => {},
+    },
+    claims: {
+      shotPromptVersions: {
+        getByIdForShot: async () => ({
+          inputHash: 'ctx-hash',
+          analysisModel: 'anthropic/claude-haiku-4.5',
+        }),
+      },
+    },
+    shotPromptVersions,
+    videoVariants,
+    provenance: {},
+  } as unknown as WorkflowScopedDb;
+  return { scopedDb, shotPromptVersions, videoVariants };
+}
+
+const MODEL = 'seedance_v2';
+const GROK = 'grok_imagine_video_1_5';
+const NAME = IMAGE_TO_VIDEO_MODELS[MODEL].name;
+const GROK_NAME = IMAGE_TO_VIDEO_MODELS[GROK].name;
+
+function makeEvent(
+  extra: Partial<MotionWorkflowInput> = {}
+): Readonly<WorkflowEvent<MotionWorkflowInput>> {
+  return {
+    payload: {
+      userId: 'u1',
+      teamId: 'team-1',
+      sequenceId: 'seq-1',
+      shotId: 'shot-1',
+      sceneId: 'scene-1',
+      imageUrl: '/r2/stills/a.png',
+      prompt: 'the original prompt',
+      model: MODEL,
+      motionPromptVersionId: 'spv-orig',
+      frameVersionId: 'fv-1',
+      reservationId: 'res-1',
+      duration: 5,
+      ...extra,
+    },
+    instanceId: 'run-1',
+    timestamp: new Date(),
+    workflowName: 'MotionWorkflow',
+  };
+}
+
+/** A fal 422 as `extractFalErrorMessage` renders it: loc-prefixed. */
+const flagged = (...fields: string[]) =>
+  new Error(
+    fields
+      .map((f) => `body.${f}: material flagged by a content checker.`)
+      .join('; ')
+  );
+const PROMPT = flagged('prompt');
+const STILL = flagged('image_url');
+const BOTH = flagged('prompt', 'image_url');
+
+const job = () => ({
+  jobId: 'job-1',
+  modelKey: MODEL,
+  via: 'fal' as const,
+  submittedAt: Date.now(),
+  usedOwnKey: false,
+});
+
+/** Reject the three reseeds with `error`; the rescue submit then succeeds. */
+function rejectReseeds(error: Error) {
+  mockSubmit
+    .mockRejectedValueOnce(error)
+    .mockRejectedValueOnce(error)
+    .mockRejectedValueOnce(error);
+}
+
+const submittedArgs = (call: number) =>
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- mock call args
+  mockSubmit.mock.calls[call]?.[0] as { prompt: string; model: string };
+
+const rescueEmit = () =>
+  emit.mock.calls
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- mock call args
+    .map((c) => (c as unknown as [string, Record<string, unknown>])[1])
+    .find((p) => p.attempt === 4);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSubmit.mockImplementation(async () => job());
+  mockPoll.mockResolvedValue({ status: 'completed', url: 'https://fal/a.mp4' });
+  mockSoften.mockResolvedValue('the softened prompt');
+});
+
+describe('MotionWorkflow content-flag rescue (#1373)', () => {
+  it('prompt flagged: softens, writes a selected version, repoints the manifest, resubmits on the same model', async () => {
+    rejectReseeds(PROMPT);
+    const { scopedDb, shotPromptVersions, videoVariants } = makeScopedDb();
+    const step = makeStep();
+
+    const result = await makeWorkflow().runBody(makeEvent(), step, scopedDb);
+
+    expect(result.videoUrl).toBe('/r2/videos/a.mp4');
+    expect(step.names).toEqual(
+      expect.arrayContaining([
+        'submit-motion-retry-2',
+        'load-motion-prompt-provenance',
+        'write-softened-motion-prompt',
+        'submit-motion-rescue',
+      ])
+    );
+    expect(step.names).not.toContain('switch-to-fallback-video-model');
+    expect(mockSubmit).toHaveBeenCalledTimes(4);
+    expect(submittedArgs(3)).toMatchObject({
+      prompt: 'the softened prompt',
+      model: MODEL,
+    });
+    expect(mockSoften).toHaveBeenCalledWith(
+      step,
+      expect.objectContaining({
+        prompt: 'the original prompt',
+        rejection: PROMPT.message,
+        shotId: 'shot-1',
+      })
+    );
+    expect(shotPromptVersions.write).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shotId: 'shot-1',
+        promptType: 'motion',
+        text: 'the softened prompt',
+        source: 'softened',
+        inputHash: 'ctx-hash',
+        analysisModel: 'anthropic/claude-haiku-4.5',
+        select: true,
+      })
+    );
+    expect(videoVariants.update).toHaveBeenCalledWith('vv-1', {
+      manifest: [
+        expect.objectContaining({ motionPromptVersionId: 'spv-soft' }),
+      ],
+      inputHash: `${MODEL}:spv-soft`,
+    });
+    expect(rescueEmit()).toMatchObject({
+      attempt: 4,
+      maxAttempts: 4,
+      model: MODEL,
+      promptSoftened: true,
+      modelFallback: false,
+    });
+  });
+
+  it('still flagged: no rewrite, moves the version to Grok and resubmits the original prompt there', async () => {
+    rejectReseeds(STILL);
+    const { scopedDb, shotPromptVersions, videoVariants } = makeScopedDb();
+    const step = makeStep();
+
+    await makeWorkflow().runBody(makeEvent(), step, scopedDb);
+
+    expect(mockSoften).not.toHaveBeenCalled();
+    expect(shotPromptVersions.write).not.toHaveBeenCalled();
+    expect(step.names).toContain('switch-to-fallback-video-model');
+    expect(submittedArgs(3)).toMatchObject({
+      prompt: 'the original prompt',
+      model: GROK,
+    });
+    expect(videoVariants.update).toHaveBeenCalledWith('vv-1', {
+      model: GROK,
+      inputHash: `${GROK}:spv-orig`,
+    });
+    expect(rescueEmit()).toMatchObject({
+      model: GROK,
+      promptSoftened: false,
+      modelFallback: true,
+    });
+  });
+
+  it('both flagged: softens AND swaps; the fallback hash covers the softened manifest', async () => {
+    rejectReseeds(BOTH);
+    const { scopedDb, videoVariants } = makeScopedDb();
+
+    await makeWorkflow().runBody(makeEvent(), makeStep(), scopedDb);
+
+    expect(submittedArgs(3)).toMatchObject({
+      prompt: 'the softened prompt',
+      model: GROK,
+    });
+    expect(videoVariants.update).toHaveBeenLastCalledWith('vv-1', {
+      model: GROK,
+      inputHash: `${GROK}:spv-soft`,
+    });
+    expect(rescueEmit()).toMatchObject({
+      promptSoftened: true,
+      modelFallback: true,
+    });
+  });
+
+  it('variant-only render appends the softened version without moving the primary selection', async () => {
+    rejectReseeds(PROMPT);
+    const { scopedDb, shotPromptVersions } = makeScopedDb();
+
+    await makeWorkflow().runBody(
+      makeEvent({ variantOnly: true }),
+      makeStep(),
+      scopedDb
+    );
+
+    expect(shotPromptVersions.write).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'softened', select: false })
+    );
+  });
+
+  it('a poll-phase rejection feeds the rescue like a submit rejection', async () => {
+    mockPoll
+      .mockResolvedValueOnce({ status: 'failed', error: PROMPT.message })
+      .mockResolvedValueOnce({ status: 'failed', error: PROMPT.message })
+      .mockResolvedValueOnce({ status: 'failed', error: PROMPT.message });
+    const { scopedDb } = makeScopedDb();
+    const step = makeStep();
+
+    await makeWorkflow().runBody(makeEvent(), step, scopedDb);
+
+    expect(step.names).toContain('write-softened-motion-prompt');
+    expect(submittedArgs(3)).toMatchObject({ prompt: 'the softened prompt' });
+  });
+
+  it('soften fails with only the prompt flagged: gives up naming the prompt, no 4th submit', async () => {
+    mockSubmit.mockRejectedValue(PROMPT);
+    mockSoften.mockRejectedValue(new Error('llm down'));
+    const { scopedDb, shotPromptVersions } = makeScopedDb();
+    const step = makeStep();
+
+    await expect(
+      makeWorkflow().runBody(makeEvent(), step, scopedDb)
+    ).rejects.toThrow(
+      `Content checker rejected the prompt (${NAME}). Rewrite the motion prompt.`
+    );
+    expect(mockSubmit).toHaveBeenCalledTimes(3);
+    expect(step.names).not.toContain('write-softened-motion-prompt');
+    expect(shotPromptVersions.write).not.toHaveBeenCalled();
+  });
+
+  it('still flagged while already on Grok: nothing left to try, three submits', async () => {
+    mockSubmit.mockRejectedValue(STILL);
+    const { scopedDb } = makeScopedDb();
+    const step = makeStep();
+
+    await expect(
+      makeWorkflow().runBody(makeEvent({ model: GROK }), step, scopedDb)
+    ).rejects.toThrow(
+      `Content checker rejected the still (${GROK_NAME}). Regenerate the still.`
+    );
+    expect(mockSubmit).toHaveBeenCalledTimes(3);
+    expect(step.names).not.toContain('switch-to-fallback-video-model');
+    expect(mockSoften).not.toHaveBeenCalled();
+  });
+
+  it('rescue also rejected: the message keeps what the reseeds named even when Grok says less', async () => {
+    mockSubmit
+      .mockRejectedValueOnce(BOTH)
+      .mockRejectedValueOnce(BOTH)
+      .mockRejectedValueOnce(BOTH)
+      // Native xAI shape: no `body.<field>` prefix.
+      .mockRejectedValueOnce(new Error('unsafe content'));
+    const { scopedDb } = makeScopedDb();
+
+    await expect(
+      makeWorkflow().runBody(makeEvent(), makeStep(), scopedDb)
+    ).rejects.toThrow(
+      `Content checker rejected the still and the prompt (${NAME}, then ${GROK_NAME}; softened prompt also rejected). Regenerate the still or rewrite the motion prompt.`
+    );
+    expect(mockSubmit).toHaveBeenCalledTimes(4);
+    expect(mockDeductWorkflowCredits).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -17,12 +17,25 @@
 
 import {
   CONTENT_REJECTION_EVENT,
+  CONTENT_REJECTION_FALLBACK_EVENT,
   CONTENT_REJECTION_RETRY_EVENT,
+  CONTENT_REJECTION_SOFTEN_EVENT,
+  clipContentRejectionMessage,
+  flaggedInputs,
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
 import { computeVideoManifestInputHash } from '@/lib/ai/input-hash';
 import { DEFAULT_VIDEO_MODEL, IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
+import {
+  DEFAULT_ANALYSIS_MODEL,
+  getAnalysisModelById,
+} from '@/lib/ai/models.config';
+import type { VideoManifest } from '@/lib/db/schema';
+import {
+  MOTION_CONTENT_FALLBACK_MODEL,
+  softenRejectedMotionPrompt,
+} from '@/lib/workflows/content-soften';
 import {
   deductWorkflowCredits,
   recordFalUsageStep,
@@ -186,12 +199,16 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     );
 
     // Step 1: Set status to generating and store model being used
-    const { shotDeleted, videoVersionId, sceneId } = await step.do(
+    const { shotDeleted, videoVersionId, sceneId, manifest } = await step.do(
       'set-generating-status',
       async (): Promise<{
         shotDeleted: boolean;
         videoVersionId: string | null;
         sceneId: string | null;
+        // The opened version's manifest, so a content-checker rescue (#1373)
+        // can repoint it at the softened prompt version. Absent on a run that
+        // cached this step before #1373.
+        manifest?: VideoManifest | null;
       }> => {
         if (!input.shotId) {
           return { shotDeleted: false, videoVersionId: null, sceneId: null };
@@ -241,6 +258,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
         // mirror of whichever version the shot's selection points at.
         const renderSceneId = input.sceneId ?? shot.sceneId;
         let openedVideoVersionId: string | null = null;
+        let manifest: VideoManifest | null = null;
         if (input.sequenceId) {
           if (!renderSceneId) {
             throw new WorkflowValidationError(
@@ -261,7 +279,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           // that a different still than the one this clip rendered from (the
           // render consumes `input.imageUrl`, snapshotted at the trigger). A
           // payload without it records null provenance, as pre-#1067 rows do.
-          const manifest = buildVideoManifest([
+          manifest = buildVideoManifest([
             {
               shotId: input.shotId,
               // No selection-pointer fallback: a payload without the field
@@ -318,6 +336,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           shotDeleted: false,
           videoVersionId: openedVideoVersionId,
           sceneId: renderSceneId,
+          manifest,
         };
       }
     );
@@ -363,18 +382,155 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // The job behind the clip that ultimately succeeded — its `submittedAt` /
     // `usedOwnKey` drive observation timing and credit deduction below.
     let succeededJob: Awaited<ReturnType<typeof submitMotionJob>> | null = null;
+    // Rescue attempt (#1373): once the reseeds exhaust, one more submit with
+    // the remedy the flagged input calls for — a rewritten prompt when the
+    // prompt was flagged, the fallback video model when the still was (a
+    // flagged still cannot be reseeded or softened away). Both feed the final
+    // error text so the user learns which input to change.
+    let prompt = input.prompt;
+    let activeModel = model;
+    let softened = false;
+    const triedModels: (typeof model)[] = [model];
+    const maxAttempts = MAX_MOTION_ATTEMPTS + 1;
 
-    for (let attempt = 0; attempt < MAX_MOTION_ATTEMPTS; attempt++) {
-      const tag = attempt === 0 ? '' : `-retry-${attempt}`;
+    for (let attempt = 0; attempt <= MAX_MOTION_ATTEMPTS; attempt++) {
+      const isRescue = attempt === MAX_MOTION_ATTEMPTS;
+      if (isRescue) {
+        // A rejection with no `body.<field>` prefix (Veo's "could not
+        // generate", sensitive audio) is prompt-shaped: soften.
+        const flags = flaggedInputs(lastRejection ?? '');
+        const swapModel =
+          flags.image && model !== MOTION_CONTENT_FALLBACK_MODEL;
+        const softenPrompt = flags.prompt || !flags.image;
+        if (!swapModel && !softenPrompt) break;
+
+        const logMeta = {
+          kind: 'motion',
+          model,
+          shotId: input.shotId,
+          sequenceId: input.sequenceId,
+          rejection: lastRejection,
+        };
+        if (softenPrompt) {
+          logger.warn(
+            `[MotionWorkflow:cf] same-prompt reseeds exhausted; softening prompt for shot ${input.shotId}`,
+            { event: CONTENT_REJECTION_SOFTEN_EVENT, ...logMeta }
+          );
+          const provenance = await step.do(
+            'load-motion-prompt-provenance',
+            async () => {
+              if (input.userEditProvenance) return input.userEditProvenance;
+              const original =
+                input.shotId && input.motionPromptVersionId
+                  ? await scopedDb.claims.shotPromptVersions.getByIdForShot(
+                      input.motionPromptVersionId,
+                      input.shotId
+                    )
+                  : null;
+              return {
+                inputHash: original?.inputHash ?? null,
+                analysisModel: original?.analysisModel ?? null,
+              };
+            }
+          );
+          try {
+            prompt = await softenRejectedMotionPrompt(step, {
+              scopedDb,
+              workflowRunId,
+              sequenceId: input.sequenceId,
+              userId: input.userId,
+              prompt: input.prompt,
+              rejection: lastRejection ?? 'unknown rejection',
+              analysisModelId:
+                getAnalysisModelById(provenance.analysisModel ?? '')?.id ??
+                DEFAULT_ANALYSIS_MODEL,
+              shotId: input.shotId,
+              model,
+              reservationId: input.reservationId,
+            });
+            softened = true;
+          } catch (error) {
+            logger.warn(
+              `[MotionWorkflow:cf] failed to soften prompt for shot ${input.shotId}`,
+              { err: error, rejection: lastRejection }
+            );
+            if (!swapModel) break;
+          }
+          if (softened && input.shotId) {
+            const shotId = input.shotId;
+            const softenedText = prompt;
+            await step.do('write-softened-motion-prompt', async () => {
+              // ponytail: stored as the assembled text with no dialogue/audio
+              // so a later render does not re-append them; per-model
+              // re-assembly resumes once the user regenerates the prompt.
+              const version = await scopedDb.shotPromptVersions.write({
+                shotId,
+                promptType: 'motion',
+                text: softenedText,
+                source: 'softened',
+                inputHash: provenance.inputHash,
+                analysisModel: provenance.analysisModel,
+                createdBy: input.userId,
+              });
+              if (videoVersionId && manifest) {
+                const rescued = manifest.map((e) => ({
+                  ...e,
+                  motionPromptVersionId: version.id,
+                }));
+                await scopedDb.videoVariants.update(videoVersionId, {
+                  manifest: rescued,
+                  inputHash: await computeVideoManifestInputHash(
+                    rescued,
+                    model
+                  ),
+                });
+              }
+            });
+          }
+        }
+        if (swapModel) {
+          logger.warn(
+            `[MotionWorkflow:cf] still flagged; falling back to ${MOTION_CONTENT_FALLBACK_MODEL} for shot ${input.shotId}`,
+            {
+              event: CONTENT_REJECTION_FALLBACK_EVENT,
+              ...logMeta,
+              fromModel: model,
+              model: MOTION_CONTENT_FALLBACK_MODEL,
+            }
+          );
+          activeModel = MOTION_CONTENT_FALLBACK_MODEL;
+          triedModels.push(activeModel);
+          if (videoVersionId) {
+            const versionId = videoVersionId;
+            // The in-flight version moves to the fallback model's group so the
+            // switcher shows what actually rendered; the hash follows.
+            await step.do('switch-to-fallback-video-model', async () => {
+              await scopedDb.videoVariants.update(versionId, {
+                model: MOTION_CONTENT_FALLBACK_MODEL,
+                ...(manifest
+                  ? {
+                      inputHash: await computeVideoManifestInputHash(
+                        manifest,
+                        MOTION_CONTENT_FALLBACK_MODEL
+                      ),
+                    }
+                  : {}),
+              });
+            });
+          }
+        }
+      }
+      const tag =
+        attempt === 0 ? '' : isRescue ? '-rescue' : `-retry-${attempt}`;
 
       // Step 3a: Submit. A content rejection surfaces as a sentinel (not
       // thrown) so the loop owns the retry; a non-content 422 stays a hard
       // stop; anything else throws for CF's per-step retry.
       const submitOutcome = await step.do(`submit-motion${tag}`, async () => {
         // Surface the same-model content-flag re-roll (#881) as in-flight retry
-        // state so the scenes UI shows "Retrying (N/3)…" instead of a spinner
+        // state so the scenes UI shows "Retrying (N/4)…" instead of a spinner
         // indistinguishable from a hang (#882). `attempt` is 0-indexed; show it
-        // 1-based.
+        // 1-based. The rescue emit also flags what changed (#1373).
         if (attempt > 0 && input.shotId && input.sequenceId) {
           await getGenerationChannel(input.sequenceId).emit(
             'generation.video:progress',
@@ -383,17 +539,23 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
               status: 'generating',
               phase: 'retrying',
               attempt: attempt + 1,
-              maxAttempts: MAX_MOTION_ATTEMPTS,
-              model,
+              maxAttempts,
+              model: activeModel,
               variantOnly: input.variantOnly,
+              ...(isRescue
+                ? {
+                    promptSoftened: softened,
+                    modelFallback: activeModel !== model,
+                  }
+                : {}),
             }
           );
         }
         try {
           const job = await submitMotionJob({
             imageUrl: startImageUrl,
-            prompt: input.prompt,
-            model,
+            prompt,
+            model: activeModel,
             duration: input.duration,
             fps: input.fps,
             motionBucket: input.motionBucket,
@@ -564,20 +726,29 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
 
     if (!videoUrl) {
       logger.error(
-        `[MotionWorkflow:cf] content-flag retry exhausted for shot ${input.shotId} after ${MAX_MOTION_ATTEMPTS} attempts`,
+        `[MotionWorkflow:cf] content-flag retry exhausted for shot ${input.shotId} after ${triedModels.length > 1 || softened ? maxAttempts : MAX_MOTION_ATTEMPTS} attempts`,
         {
           event: CONTENT_REJECTION_RETRY_EVENT,
           outcome: 'exhausted',
           kind: 'motion',
-          model,
-          attempts: MAX_MOTION_ATTEMPTS,
+          model: activeModel,
+          attempts:
+            triedModels.length > 1 || softened
+              ? maxAttempts
+              : MAX_MOTION_ATTEMPTS,
           shotId: input.shotId,
           sequenceId: input.sequenceId,
           rejection: lastRejection,
+          softened,
+          models: triedModels,
         }
       );
       throw new NonRetryableError(
-        `Motion generation rejected by content filter after ${MAX_MOTION_ATTEMPTS} attempts: ${lastRejection ?? 'unknown rejection'}`,
+        clipContentRejectionMessage({
+          rejection: lastRejection ?? 'unknown rejection',
+          models: triedModels.map((m) => IMAGE_TO_VIDEO_MODELS[m].name),
+          softened,
+        }),
         'ContentRejectionExhausted'
       );
     }
@@ -612,20 +783,20 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // output. Record it here instead, where all three are known.
     await step.do('record-motion-observation', async () => {
       recordMediaGenerationSpan({
-        model,
+        model: activeModel,
         provider: job.via,
         activity: 'video',
         durationMs: Date.now() - job.submittedAt,
         costMicros: actualCost,
         unitsBilled: billing.unitsBilled,
         usedOwnKey: job.usedOwnKey,
-        prompt: input.prompt,
+        prompt,
         outputUrl: videoUrl,
         observationName: 'motion',
         tags: ['motion'],
         userId: input.userId,
         sessionId: input.sequenceId,
-        metadata: { model, shotId: input.shotId },
+        metadata: { model: activeModel, shotId: input.shotId },
       });
     });
 
@@ -650,12 +821,12 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           scopedDb,
           costMicros: actualCost,
           usedOwnKey: job.usedOwnKey,
-          description: `Motion generation (${model})`,
+          description: `Motion generation (${activeModel})`,
           idempotencyKey: `${event.instanceId}:motion`,
           reservationId: input.reservationId,
           metadata: {
             ...falUsage,
-            model,
+            model: activeModel,
             shotId: input.shotId,
             sequenceId: input.sequenceId,
             duration: duration,
@@ -714,7 +885,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           sequenceId: input.sequenceId,
           sceneId,
           videoVersionId,
-          model,
+          model: activeModel,
           upload: { url: storageResult.url, path: storageResult.path },
           actorId: input.userId,
           variantOnly: input.variantOnly,
@@ -754,10 +925,10 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
             assetId: provenanceVersionId,
             storageKey: buildR2Key(STORAGE_BUCKETS.VIDEOS, storageResult.path),
             provider: 'fal',
-            model,
+            model: activeModel,
             providerRequestId: job.jobId,
             workflowRunId: event.instanceId,
-            prompt: input.prompt,
+            prompt,
             sequenceId: input.sequenceId,
             shotId,
             // Image-to-video: the start frame is a reference image, and whether

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -379,6 +379,9 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // this into a billed cost + unit count below, switching on the job's via.
     let billedUsage: TokenUsage | undefined;
     let lastRejection: string | null = null;
+    // Every rejection in order: the rescue's may lack the `body.<field>`
+    // prefix the reseeds carried, so the final message classifies on all.
+    const rejections: string[] = [];
     // The job behind the clip that ultimately succeeded — its `submittedAt` /
     // `usedOwnKey` drive observation timing and credit deduction below.
     let succeededJob: Awaited<ReturnType<typeof submitMotionJob>> | null = null;
@@ -605,6 +608,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
 
       if (!submitOutcome.ok) {
         lastRejection = submitOutcome.rejection;
+        rejections.push(lastRejection);
         logger.warn(
           `[MotionWorkflow:cf] content-flag rejection on submit attempt ${attempt + 1}/${MAX_MOTION_ATTEMPTS} for shot ${input.shotId}: ${submitOutcome.rejection}`
         );
@@ -726,6 +730,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
 
       if (rejected) {
         lastRejection = rejected;
+        rejections.push(rejected);
         logger.warn(
           `[MotionWorkflow:cf] content-flag rejection on poll attempt ${attempt + 1}/${MAX_MOTION_ATTEMPTS} for shot ${input.shotId}: ${rejected}`
         );
@@ -761,7 +766,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
       );
       throw new NonRetryableError(
         clipContentRejectionMessage({
-          rejection: lastRejection ?? 'unknown rejection',
+          rejections: rejections.length ? rejections : ['unknown rejection'],
           models: triedModels.map((m) => IMAGE_TO_VIDEO_MODELS[m].name),
           softened,
         }),

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -390,6 +390,9 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     let prompt = input.prompt;
     let activeModel = model;
     let softened = false;
+    // The manifest the in-flight version currently carries — repointed at the
+    // softened prompt version when the rescue rewrites it.
+    let renderManifest: VideoManifest | null = manifest ?? null;
     const triedModels: (typeof model)[] = [model];
     const maxAttempts = MAX_MOTION_ATTEMPTS + 1;
 
@@ -459,20 +462,30 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           if (softened && input.shotId) {
             const shotId = input.shotId;
             const softenedText = prompt;
-            await step.do('write-softened-motion-prompt', async () => {
-              // ponytail: stored as the assembled text with no dialogue/audio
-              // so a later render does not re-append them; per-model
-              // re-assembly resumes once the user regenerates the prompt.
-              const version = await scopedDb.shotPromptVersions.write({
-                shotId,
-                promptType: 'motion',
-                text: softenedText,
-                source: 'softened',
-                inputHash: provenance.inputHash,
-                analysisModel: provenance.analysisModel,
-                createdBy: input.userId,
-              });
-              if (videoVersionId && manifest) {
+            renderManifest = await step.do(
+              'write-softened-motion-prompt',
+              async () => {
+                // A primary render selects the rewrite (the original stays
+                // in Versions), as the image softener does for the frame.
+                // A variant-only render appends to history only: an
+                // alternate model's rescue must not move the primary shot's
+                // prompt out from under the primary clip (which would then
+                // read stale). ponytail: `input.prompt` is already
+                // model-assembled (dialogue prose + audio trailer baked in),
+                // so this row gets null dialogue/audio — a later render from
+                // it appends the model trailer a second time. Structured
+                // assembly resumes once the user regenerates the prompt.
+                const version = await scopedDb.shotPromptVersions.write({
+                  shotId,
+                  promptType: 'motion',
+                  text: softenedText,
+                  source: 'softened',
+                  inputHash: provenance.inputHash,
+                  analysisModel: provenance.analysisModel,
+                  createdBy: input.userId,
+                  select: !input.variantOnly,
+                });
+                if (!videoVersionId || !manifest) return manifest ?? null;
                 const rescued = manifest.map((e) => ({
                   ...e,
                   motionPromptVersionId: version.id,
@@ -484,8 +497,9 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
                     model
                   ),
                 });
+                return rescued;
               }
-            });
+            );
           }
         }
         if (swapModel) {
@@ -503,14 +517,16 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
           if (videoVersionId) {
             const versionId = videoVersionId;
             // The in-flight version moves to the fallback model's group so the
-            // switcher shows what actually rendered; the hash follows.
+            // switcher shows what actually rendered; the hash follows — over
+            // the softened manifest when the prompt was rescued too.
+            const hashManifest = renderManifest;
             await step.do('switch-to-fallback-video-model', async () => {
               await scopedDb.videoVariants.update(versionId, {
                 model: MOTION_CONTENT_FALLBACK_MODEL,
-                ...(manifest
+                ...(hashManifest
                   ? {
                       inputHash: await computeVideoManifestInputHash(
-                        manifest,
+                        hashManifest,
                         MOTION_CONTENT_FALLBACK_MODEL
                       ),
                     }

--- a/src/lib/workflows/studio-generation-workflow.test.ts
+++ b/src/lib/workflows/studio-generation-workflow.test.ts
@@ -259,8 +259,27 @@ describe('StudioGenerationWorkflow video', () => {
 
     await expect(
       makeWorkflow().runBody(makeEvent(VIDEO), makeStep(), scopedDb)
-    ).rejects.toThrow(/^Content checker rejected the clip \(Seedance/);
+    ).rejects.toThrow(
+      /^Content checker rejected the clip \(Seedance 2\.0\)\. Rewrite the prompt\. \(/
+    );
     expect(mockDeductWorkflowCredits).not.toHaveBeenCalled();
+  });
+
+  it('names a flagged reference image instead of a still that does not exist (#1373)', async () => {
+    mockSubmit.mockRejectedValue(
+      new Error('body.image_urls.0: flagged by a content checker')
+    );
+    const { scopedDb } = makeScopedDb();
+
+    await expect(
+      makeWorkflow().runBody(
+        makeEvent({ ...VIDEO, referenceImages: ['https://x/ref.png'] }),
+        makeStep(),
+        scopedDb
+      )
+    ).rejects.toThrow(
+      'Content checker rejected a reference image (Seedance 2.0). Swap the reference image.'
+    );
   });
 });
 

--- a/src/lib/workflows/studio-generation-workflow.test.ts
+++ b/src/lib/workflows/studio-generation-workflow.test.ts
@@ -259,7 +259,7 @@ describe('StudioGenerationWorkflow video', () => {
 
     await expect(
       makeWorkflow().runBody(makeEvent(VIDEO), makeStep(), scopedDb)
-    ).rejects.toThrow(/content filter after 3 attempts/);
+    ).rejects.toThrow(/^Content checker rejected the clip \(Seedance/);
     expect(mockDeductWorkflowCredits).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/workflows/studio-generation-workflow.ts
+++ b/src/lib/workflows/studio-generation-workflow.ts
@@ -341,9 +341,20 @@ export class StudioGenerationWorkflow extends OpenStoryWorkflowEntrypoint<Studio
     if (!videoUrl || !succeededJob) {
       throw new NonRetryableError(
         clipContentRejectionMessage({
-          rejection: lastRejection ?? 'unknown rejection',
+          rejections: [lastRejection ?? 'unknown rejection'],
           models: [IMAGE_TO_VIDEO_MODELS[videoModel].name],
           softened: false,
+          // Text-to-video: no start still to regenerate — the only image
+          // input is an optional reference (#1373).
+          inputs: {
+            still: input.referenceImages.length
+              ? {
+                  name: 'a reference image',
+                  fix: 'Swap the reference image',
+                }
+              : undefined,
+            prompt: 'the prompt',
+          },
         }),
         'ContentRejectionExhausted'
       );

--- a/src/lib/workflows/studio-generation-workflow.ts
+++ b/src/lib/workflows/studio-generation-workflow.ts
@@ -17,9 +17,11 @@
 
 import {
   CONTENT_REJECTION_EVENT,
+  clipContentRejectionMessage,
   isContentRejectionError,
 } from '@/lib/ai/content-rejection';
 import { extractFalErrorMessage } from '@/lib/ai/fal-error';
+import { IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
 import { ZERO_MICROS } from '@/lib/billing/money';
 import {
   deductWorkflowCredits,
@@ -338,7 +340,11 @@ export class StudioGenerationWorkflow extends OpenStoryWorkflowEntrypoint<Studio
 
     if (!videoUrl || !succeededJob) {
       throw new NonRetryableError(
-        `Video generation rejected by content filter after ${MAX_MOTION_ATTEMPTS} attempts: ${lastRejection ?? 'unknown rejection'}`,
+        clipContentRejectionMessage({
+          rejection: lastRejection ?? 'unknown rejection',
+          models: [IMAGE_TO_VIDEO_MODELS[videoModel].name],
+          softened: false,
+        }),
         'ContentRejectionExhausted'
       );
     }


### PR DESCRIPTION
Closes #1373

## What

After the same-model reseeds (#881) exhaust, `MotionWorkflow` makes **one rescue attempt** driven by what fal actually flagged:

| flagged | remedy |
|---|---|
| prompt (or an unprefixed rejection — Veo "could not generate", sensitive audio) | rewrite via new `phase/soften-motion-prompt-chat`, persisted as a `softened` shot prompt version (manifest repointed, hash recomputed) |
| still | swap the clip to `MOTION_CONTENT_FALLBACK_MODEL` (Grok Imagine Video 1.5) — a flagged input image cannot be reseeded or softened away; the in-flight `video_variants` row moves to the fallback model's group |
| both | both |
| still, already on Grok | no rescue — fail immediately with the named input |

- `extractFalErrorMessage` now keeps each detail's `loc` (`body.prompt: …; body.image_url: …`) — that prefix is what `flaggedInputs` classifies on.
- Terminal error names what was rejected, by whom, and what to change, e.g. `Content checker rejected the still and the prompt (LTX 2.3 Pro, then Grok Imagine Video 1.5; softened prompt also rejected). Regenerate the still or rewrite the motion prompt.` Still matches `isContentRejectionError`, so banners/overlays classify it as before.
- Rescue emits `promptSoftened` / `modelFallback` on `generation.video:progress` — same toast + cache invalidation as images (#1272). Emits the existing `content_rejection_soften` / `content_rejection_fallback` events with `kind: 'motion'`.
- API `SequenceState` shots gain `video.error` (OpenAPI updated).
- Studio clips reuse the same message builder so they name the flagged input too (no soften/fallback there).

## Tests

- `flaggedInputs` / `clipContentRejectionMessage` pinned against the real LTX 2.3 Pro 422 from the report.
- `fal-error.test` updated for the loc prefix; `no-mid-run-reads` allow-list gains the claim read; studio test expectation updated.
- `bun typecheck`, `bun lint`, `bun dead-code`, `bun run test` (318 files) green.