### PR TITLE
fix(#1372): fail-fast API v1 multi-ref creates without leftover sheet charges

### DIFF
--- a/src/functions/location-library.ts
+++ b/src/functions/location-library.ts
@@ -98,7 +98,7 @@ export const createLibraryLocationFn = createServerFn({ method: 'POST' })
     )
   )
   .handler(async ({ context, data }) => {
-    const newLocation = await createLibraryLocation(data, {
+    const { location: newLocation } = await createLibraryLocation(data, {
       scopedDb: context.scopedDb,
       user: context.user,
       teamId: context.teamId,

--- a/src/lib/api-v1/create.test.ts
+++ b/src/lib/api-v1/create.test.ts
@@ -1,0 +1,320 @@
+import type { Style } from '@/lib/db/schema';
+import type { ScopedDb } from '@/lib/db/scoped';
+import { ValidationError } from '@/lib/errors';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createLibraryTalent: vi.fn(),
+  createLibraryLocation: vi.fn(),
+  createSequences: vi.fn(),
+  enqueueLibraryTalentSheet: vi.fn(),
+  enqueueLibraryLocationSheet: vi.fn(),
+  enhanceScriptToString: vi.fn(),
+  uploadFile: vi.fn(async () => undefined),
+}));
+
+vi.mock('#storage', () => ({
+  uploadFile: mocks.uploadFile,
+  moveFile: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/lib/ai/script-enhancement', () => ({
+  enhanceScriptToString: mocks.enhanceScriptToString,
+}));
+
+vi.mock('@/lib/sequences/create-sequences', () => ({
+  createSequences: mocks.createSequences,
+}));
+
+vi.mock('@/lib/talent/create-library-talent', () => ({
+  createLibraryTalent: mocks.createLibraryTalent,
+}));
+
+vi.mock('@/lib/talent/enqueue-library-talent-sheet', () => ({
+  enqueueLibraryTalentSheet: mocks.enqueueLibraryTalentSheet,
+}));
+
+vi.mock('@/lib/locations/create-library-location', () => ({
+  createLibraryLocation: mocks.createLibraryLocation,
+  enqueueLibraryLocationSheet: mocks.enqueueLibraryLocationSheet,
+}));
+
+const { runOneShotCreate } = await import('./create');
+
+function makeStyle(): Style {
+  return {
+    id: 'style-1',
+    teamId: 'team-1',
+    sequenceId: null,
+    name: 'Cinematic Noir',
+    description: null,
+    config: {
+      mood: 'tense',
+      artStyle: 'noir',
+      lighting: 'low-key',
+      colorPalette: ['#000'],
+      cameraWork: 'handheld',
+      referenceFilms: [],
+      colorGrading: 'desaturated',
+    },
+    category: null,
+    tags: [],
+    isPublic: false,
+    isTemplate: false,
+    version: 1,
+    previewUrl: null,
+    sampleVideos: [],
+    recommendedImageModel: null,
+    recommendedVideoModel: null,
+    defaultAspectRatio: null,
+    useCases: [],
+    sortOrder: 100,
+    usageCount: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    createdBy: null,
+  };
+}
+
+const portraitAttestation = {
+  statementVersion: 'v1',
+  authorizationBasis: 'self',
+};
+
+const baseInput = {
+  script: 'A lighthouse keeper befriends a stranded whale.',
+  enhance: 'off' as const,
+  motion: false,
+  music: false,
+};
+
+function pngResponse(): Response {
+  return new Response(new Uint8Array([1, 2, 3, 4]), {
+    status: 200,
+    headers: { 'content-type': 'image/png' },
+  });
+}
+
+describe('runOneShotCreate', () => {
+  const talentDelete = vi.fn(async () => true);
+  const locationDelete = vi.fn(async () => true);
+  const callLog: string[] = [];
+
+  const ctx = {
+    user: { id: 'user-1' },
+    teamId: 'team-1',
+    // oxlint-disable-next-line typescript/no-unsafe-type-assertion -- stub covering styles.list + talent/location list/delete
+    scopedDb: {
+      styles: { list: async () => [makeStyle()] },
+      talent: { list: async () => [], delete: talentDelete },
+      locations: { list: async () => [], delete: locationDelete },
+    } as unknown as ScopedDb,
+  };
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    callLog.length = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => pngResponse())
+    );
+
+    mocks.createLibraryTalent.mockImplementation(
+      async (input: { name: string; enqueueSheet?: boolean }) => {
+        callLog.push(
+          `createTalent:${input.name}:${String(input.enqueueSheet)}`
+        );
+        return {
+          talent: { id: `tal-${input.name}`, name: input.name },
+          sheetWorkflowRunId: null,
+          deferredSheet: {
+            talentId: `tal-${input.name}`,
+            workflowInput: {
+              userId: 'user-1',
+              teamId: 'team-1',
+              talentId: `tal-${input.name}`,
+              talentName: input.name,
+            },
+            activity: 'sheet',
+            deduplicationId: `dedup-${input.name}`,
+          },
+        };
+      }
+    );
+
+    mocks.createLibraryLocation.mockImplementation(
+      async (input: { name: string }) => {
+        callLog.push(`createLocation:${input.name}`);
+        return {
+          location: { id: `loc-${input.name}`, name: input.name },
+          sheetWorkflowInput: {
+            userId: 'user-1',
+            teamId: 'team-1',
+            locationDbId: `loc-${input.name}`,
+            locationName: input.name,
+            referenceImageUrls: [],
+            sequenceId: 'library',
+          },
+        };
+      }
+    );
+
+    mocks.createSequences.mockImplementation(async () => {
+      callLog.push('createSequences');
+      return {
+        entries: [
+          {
+            sequence: { id: 'seq-1', status: 'processing' },
+            workflowRunId: 'wf-1',
+          },
+        ],
+      };
+    });
+
+    mocks.enqueueLibraryTalentSheet.mockImplementation(async () => {
+      callLog.push('enqueueTalentSheet');
+      return 'sheet-run';
+    });
+    mocks.enqueueLibraryLocationSheet.mockImplementation(async () => {
+      callLog.push('enqueueLocationSheet');
+    });
+  });
+
+  it('ingests every character reference before insert and enqueues sheets only after the sequence exists', async () => {
+    const result = await runOneShotCreate(
+      {
+        ...baseInput,
+        characters: [
+          {
+            name: 'Ada',
+            isHuman: true,
+            referenceImageUrls: [
+              'https://cdn.example/ada-1.png',
+              'https://cdn.example/ada-2.png',
+              'https://cdn.example/ada-3.png',
+            ],
+            portraitAttestation,
+          },
+          {
+            name: 'Grace',
+            isHuman: true,
+            referenceImageUrls: [
+              'https://cdn.example/grace-1.png',
+              'https://cdn.example/grace-2.png',
+              'https://cdn.example/grace-3.png',
+            ],
+            portraitAttestation,
+          },
+        ],
+      },
+      ctx
+    );
+
+    expect(result.sequences[0]?.id).toBe('seq-1');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(6);
+    expect(mocks.createLibraryTalent).toHaveBeenCalledTimes(2);
+    expect(mocks.createLibraryTalent.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        name: 'Ada',
+        enqueueSheet: false,
+        referenceImageUrls: expect.arrayContaining([
+          expect.stringContaining('/r2/talent/'),
+        ]),
+      })
+    );
+    expect(
+      mocks.createLibraryTalent.mock.calls[0]?.[0].referenceImageUrls
+    ).toHaveLength(3);
+
+    const createIdx = callLog.indexOf('createTalent:Ada:false');
+    const sequenceIdx = callLog.indexOf('createSequences');
+    const enqueueIdx = callLog.indexOf('enqueueTalentSheet');
+    expect(createIdx).toBeGreaterThanOrEqual(0);
+    expect(sequenceIdx).toBeGreaterThan(createIdx);
+    expect(enqueueIdx).toBeGreaterThan(sequenceIdx);
+    expect(talentDelete).not.toHaveBeenCalled();
+  });
+
+  it('fails a bad reference before creating talent and names the character plus URL', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: URL | RequestInfo) => {
+        const url =
+          input instanceof URL
+            ? input.href
+            : typeof input === 'string'
+              ? input
+              : input.url;
+        if (url.includes('ada-2')) {
+          return Promise.reject(
+            new DOMException('The operation was aborted.', 'TimeoutError')
+          );
+        }
+        return pngResponse();
+      })
+    );
+
+    await expect(
+      runOneShotCreate(
+        {
+          ...baseInput,
+          characters: [
+            {
+              name: 'Ada',
+              isHuman: true,
+              referenceImageUrls: [
+                'https://cdn.example/ada-1.png',
+                'https://cdn.example/ada-2.png',
+                'https://cdn.example/ada-3.png',
+              ],
+              portraitAttestation,
+            },
+          ],
+        },
+        ctx
+      )
+    ).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof ValidationError)) return false;
+      expect(error.message).toContain('Character "Ada" reference image #2');
+      expect(error.message).toContain('(timeout)');
+      expect(error.message).toContain('https://cdn.example/ada-2.png');
+      return true;
+    });
+
+    expect(mocks.createLibraryTalent).not.toHaveBeenCalled();
+    expect(mocks.createSequences).not.toHaveBeenCalled();
+    expect(mocks.enqueueLibraryTalentSheet).not.toHaveBeenCalled();
+    expect(talentDelete).not.toHaveBeenCalled();
+  });
+
+  it('rolls back inline talents and does not enqueue sheets when sequence create fails', async () => {
+    mocks.createSequences.mockImplementation(async () => {
+      callLog.push('createSequences');
+      throw new ValidationError(
+        'Already generating this script — open the existing sequence.'
+      );
+    });
+
+    await expect(
+      runOneShotCreate(
+        {
+          ...baseInput,
+          characters: [
+            {
+              name: 'Ada',
+              isHuman: true,
+              referenceImageUrls: ['https://cdn.example/ada-1.png'],
+              portraitAttestation,
+            },
+          ],
+        },
+        ctx
+      )
+    ).rejects.toThrow(/Already generating this script/);
+
+    expect(mocks.createLibraryTalent).toHaveBeenCalledTimes(1);
+    expect(talentDelete).toHaveBeenCalledWith('tal-Ada');
+    expect(mocks.enqueueLibraryTalentSheet).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api-v1/create.ts
+++ b/src/lib/api-v1/create.ts
@@ -3,8 +3,11 @@
  * human-friendly input into a fully-resolved `CreateSequenceInput` and hands it
  * to the shared `createSequences` core:
  *
- *   enhance (optional) → resolve style/talent/location/elements →
- *   validate via createSequenceSchema → createSequences → response
+ *   ingest hosted refs (no DB) → enhance (optional) →
+ *   insert talents/locations without billed sheets →
+ *   validate via createSequenceSchema → createSequences →
+ *   enqueue sheets → response. On failure after insert, inline library
+ *   rows are deleted so a hung fetch cannot leave charged sheets.
  *
  * Returns the created sequence ids + workflow run ids (generation is async) and
  * the enhanced script when enhancement ran.
@@ -15,11 +18,20 @@ import { toEnhanceInputs } from '@/lib/ai/enhance-inputs';
 import { isShortScript } from '@/lib/ai/should-enhance';
 import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
 import type { ScopedDb } from '@/lib/db/scoped';
-import { createLibraryLocation } from '@/lib/locations/create-library-location';
+import {
+  createLibraryLocation,
+  enqueueLibraryLocationSheet,
+} from '@/lib/locations/create-library-location';
+import { getLogger } from '@/lib/observability/logger';
 import { createSequenceSchema } from '@/lib/schemas/sequence.schemas';
 import { createSequences } from '@/lib/sequences/create-sequences';
 import { STORAGE_BUCKETS, type StorageBucket } from '@/lib/storage/buckets';
 import { createLibraryTalent } from '@/lib/talent/create-library-talent';
+import {
+  enqueueLibraryTalentSheet,
+  type EnqueueLibraryTalentSheetParams,
+} from '@/lib/talent/enqueue-library-talent-sheet';
+import type { LibraryLocationSheetWorkflowInput } from '@/lib/workflow/types';
 import type { SequenceStatus } from '@/lib/db/schema/sequences';
 import { createSequenceLink } from './discovery';
 import {
@@ -38,6 +50,8 @@ import {
   resolveTalentIds,
 } from './resolve';
 import { ingestImageToTempBucket } from './safe-fetch';
+
+const logger = getLogger(['openstory', 'api-v1', 'create']);
 
 export type OneShotContext = {
   scopedDb: ScopedDb;
@@ -85,38 +99,116 @@ export type OneShotWaitResult = {
   _links: HalLinks;
 };
 
+type CharacterCreate = Exclude<
+  NonNullable<ApiCreateSequenceInput['characters']>[number],
+  string
+>;
+type LocationCreate = Exclude<
+  NonNullable<ApiCreateSequenceInput['locations']>[number],
+  string
+>;
+
+function inlineCreates<T>(items: readonly (string | T)[] | undefined): T[] {
+  if (!items) return [];
+  return items.filter((item): item is T => typeof item !== 'string');
+}
+
 /** Ingest hosted reference image URLs into a bucket's temp area → temp URLs. */
 async function ingestReferenceImages(
   urls: string[] | undefined,
   bucket: StorageBucket,
-  teamId: string
+  teamId: string,
+  labelFor: (index: number) => string
 ): Promise<string[]> {
   if (!urls || urls.length === 0) return [];
   const ingested = await Promise.all(
-    urls.map((url) => ingestImageToTempBucket(url, bucket, teamId))
+    urls.map((url, index) =>
+      ingestImageToTempBucket(url, bucket, teamId, {
+        label: labelFor(index),
+      })
+    )
   );
   return ingested.map((i) => i.publicUrl);
+}
+
+async function ingestInlineCharacterImages(
+  items: ApiCreateSequenceInput['characters'],
+  teamId: string
+): Promise<Map<CharacterCreate, string[]>> {
+  const map = new Map<CharacterCreate, string[]>();
+  await Promise.all(
+    inlineCreates<CharacterCreate>(items).map(async (item) => {
+      const urls = await ingestReferenceImages(
+        item.referenceImageUrls,
+        STORAGE_BUCKETS.TALENT,
+        teamId,
+        (index) => `Character "${item.name}" reference image #${index + 1}`
+      );
+      map.set(item, urls);
+    })
+  );
+  return map;
+}
+
+async function ingestInlineLocationImages(
+  items: ApiCreateSequenceInput['locations'],
+  teamId: string
+): Promise<Map<LocationCreate, string[]>> {
+  const map = new Map<LocationCreate, string[]>();
+  await Promise.all(
+    inlineCreates<LocationCreate>(items).map(async (item) => {
+      const urls = await ingestReferenceImages(
+        item.referenceImageUrls,
+        STORAGE_BUCKETS.LOCATIONS,
+        teamId,
+        (index) => `Location "${item.name}" reference image #${index + 1}`
+      );
+      map.set(item, urls);
+    })
+  );
+  return map;
+}
+
+async function rollbackInlineCreates(
+  ctx: OneShotContext,
+  talentIds: string[],
+  locationIds: string[]
+): Promise<void> {
+  const results = await Promise.allSettled([
+    ...talentIds.map((id) => ctx.scopedDb.talent.delete(id)),
+    ...locationIds.map((id) => ctx.scopedDb.locations.delete(id)),
+  ]);
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      logger.warn(
+        'Failed to roll back inline library row after create failure',
+        {
+          err: result.reason,
+        }
+      );
+    }
+  }
 }
 
 export async function runOneShotCreate(
   input: ApiCreateSequenceInput,
   ctx: OneShotContext
 ): Promise<OneShotResult> {
-  // 1. Optionally enhance the script. `always` forces it; `auto` enhances only
-  //    a short/thin script (same heuristic as the new-sequence nudge); `off`
-  //    leaves it verbatim.
+  // 1. Resolve style and ingest every hosted image (elements + inline
+  //    character/location refs) with no DB writes. A black-holing image host
+  //    fails the request before any library row or billed sheet exists
+  //    (#1372). Style + elements must be ready before enhancement (#855).
   const willEnhance =
     input.enhance === 'always' ||
     (input.enhance === 'auto' && isShortScript(input.script));
 
-  // Resolve the style and ingest any elements up front: the enhancer is
-  // style-aware AND weaves uploaded elements into the script, so both must be
-  // ready before we enhance — exactly what the UI passes to the same enhancer
-  // (issue #855). The element ingest is reused for the sequence in step 3.
-  const [style, elementUploads] = await Promise.all([
-    resolveStyle(ctx.scopedDb, input.style),
-    ingestElements(ctx.teamId, input.elements),
-  ]);
+  const [style, elementUploads, ingestedCharacters, ingestedLocations] =
+    await Promise.all([
+      resolveStyle(ctx.scopedDb, input.style),
+      ingestElements(ctx.teamId, input.elements),
+      ingestInlineCharacterImages(input.characters, ctx.teamId),
+      ingestInlineLocationImages(input.locations, ctx.teamId),
+    ]);
 
   let script = input.script;
   let enhancedScript: string | undefined;
@@ -137,108 +229,136 @@ export async function runOneShotCreate(
     }
   }
 
-  // 2. Resolve the remaining references in parallel — cast + locations. Both are
-  //    unified lists (ref strings + inline create objects); inline-create
-  //    delegates to the real library-create cores (which trigger sheet
-  //    generation), so the storyboard workflow's sheet/vision-wait gates block
-  //    on the new entities before matching.
-  const [suggestedTalentIds, suggestedLocationIds] = await Promise.all([
-    resolveTalentIds(
-      {
-        talent: ctx.scopedDb.talent,
-        createTalent: async (item) => {
-          const { talent } = await createLibraryTalent(
-            {
-              name: item.name,
-              description: item.description,
-              isHuman: item.isHuman,
-              referenceImageUrls: await ingestReferenceImages(
-                item.referenceImageUrls,
-                STORAGE_BUCKETS.TALENT,
-                ctx.teamId
-              ),
-              portraitAttestation: item.portraitAttestation,
-            },
-            ctx
-          );
-          return talent;
+  // 2. Insert inline cast + locations without triggering billed sheets.
+  //    Sheets enqueue only after `createSequences` succeeds so a later
+  //    failure cannot charge the team for work that produced no sequence.
+  const createdTalentIds: string[] = [];
+  const createdLocationIds: string[] = [];
+  const deferredTalentSheets: EnqueueLibraryTalentSheetParams[] = [];
+  const deferredLocationSheets: Array<{
+    locationId: string;
+    workflowInput: LibraryLocationSheetWorkflowInput;
+  }> = [];
+
+  try {
+    const [suggestedTalentIds, suggestedLocationIds] = await Promise.all([
+      resolveTalentIds(
+        {
+          talent: ctx.scopedDb.talent,
+          createTalent: async (item) => {
+            const { talent, deferredSheet } = await createLibraryTalent(
+              {
+                name: item.name,
+                description: item.description,
+                isHuman: item.isHuman,
+                referenceImageUrls: ingestedCharacters.get(item) ?? [],
+                portraitAttestation: item.portraitAttestation,
+                enqueueSheet: false,
+              },
+              ctx
+            );
+            createdTalentIds.push(talent.id);
+            if (deferredSheet) deferredTalentSheets.push(deferredSheet);
+            return talent;
+          },
         },
+        input.characters
+      ),
+      resolveLocationIds(
+        {
+          locations: ctx.scopedDb.locations,
+          createLocation: async (item) => {
+            const { location, sheetWorkflowInput } =
+              await createLibraryLocation(
+                {
+                  name: item.name,
+                  description: item.description,
+                  referenceImageUrls: ingestedLocations.get(item) ?? [],
+                },
+                ctx,
+                { enqueueSheet: false }
+              );
+            createdLocationIds.push(location.id);
+            deferredLocationSheets.push({
+              locationId: location.id,
+              workflowInput: sheetWorkflowInput,
+            });
+            return location;
+          },
+        },
+        input.locations
+      ),
+    ]);
+
+    // 3. Assemble + validate the strict create input. createSequenceSchema applies
+    //    model defaults and validates every model key, so an invalid model id
+    //    surfaces as a 400 rather than a downstream throw.
+    const parsed = createSequenceSchema.parse({
+      title: input.title,
+      script,
+      styleId: style.id,
+      // Mirror the new-sequence page: fall back to the style's recommended aspect
+      // ratio when the caller doesn't pin one.
+      aspectRatio:
+        input.aspectRatio ?? style.defaultAspectRatio ?? DEFAULT_ASPECT_RATIO,
+      analysisModels: input.analysisModels,
+      imageModels: input.imageModels,
+      videoModels: input.videoModels,
+      autoGenerateMotion: input.motion,
+      autoGenerateMusic: input.music,
+      audioModels: input.audioModels,
+      // Same duration chip as Enhance / dashboard Generate ActionCost (#1140).
+      targetDurationSeconds: input.targetSeconds,
+      suggestedTalentIds: suggestedTalentIds.length
+        ? suggestedTalentIds
+        : undefined,
+      suggestedLocationIds: suggestedLocationIds.length
+        ? suggestedLocationIds
+        : undefined,
+      elementUploads: elementUploads.length ? elementUploads : undefined,
+    });
+
+    // 4. Run the shared create core (credits → fan-out → trigger storyboard).
+    const { entries } = await createSequences(parsed, {
+      ...ctx,
+      notify: false,
+    });
+
+    // Sequence rows exist — now it's safe to bill sheet generation. Failures
+    // here must not fail the create: the client already has sequence ids, and
+    // the storyboard wait-for-sheets gate will surface a missing sheet.
+    await Promise.allSettled([
+      ...deferredTalentSheets.map((sheet) => enqueueLibraryTalentSheet(sheet)),
+      ...deferredLocationSheets.map(({ locationId, workflowInput }) =>
+        enqueueLibraryLocationSheet(workflowInput, locationId)
+      ),
+    ]);
+
+    return {
+      sequences: entries.map(({ sequence, workflowRunId }) => {
+        const statusUrl = `${API_V1_BASE}/sequences/${sequence.id}`;
+        return {
+          id: sequence.id,
+          status: sequence.status,
+          workflowRunId,
+          statusUrl,
+          _links: {
+            self: getLink(statusUrl, 'Sequence status'),
+            poll: waitLink(
+              statusUrl,
+              'Long-poll this sequence (e.g. ?wait=60s)'
+            ),
+          } satisfies HalLinks,
+        };
+      }),
+      enhancedScript,
+      _links: {
+        self: createSequenceLink(),
+        root: getLink(API_V1_BASE, 'API root / instructions'),
       },
-      input.characters
-    ),
-    resolveLocationIds(
-      {
-        locations: ctx.scopedDb.locations,
-        createLocation: async (item) =>
-          createLibraryLocation(
-            {
-              name: item.name,
-              description: item.description,
-              referenceImageUrls: await ingestReferenceImages(
-                item.referenceImageUrls,
-                STORAGE_BUCKETS.LOCATIONS,
-                ctx.teamId
-              ),
-            },
-            ctx
-          ),
-      },
-      input.locations
-    ),
-  ]);
-
-  // 3. Assemble + validate the strict create input. createSequenceSchema applies
-  //    model defaults and validates every model key, so an invalid model id
-  //    surfaces as a 400 rather than a downstream throw.
-  const parsed = createSequenceSchema.parse({
-    title: input.title,
-    script,
-    styleId: style.id,
-    // Mirror the new-sequence page: fall back to the style's recommended aspect
-    // ratio when the caller doesn't pin one.
-    aspectRatio:
-      input.aspectRatio ?? style.defaultAspectRatio ?? DEFAULT_ASPECT_RATIO,
-    analysisModels: input.analysisModels,
-    imageModels: input.imageModels,
-    videoModels: input.videoModels,
-    autoGenerateMotion: input.motion,
-    autoGenerateMusic: input.music,
-    audioModels: input.audioModels,
-    // Same duration chip as Enhance / dashboard Generate ActionCost (#1140).
-    targetDurationSeconds: input.targetSeconds,
-    suggestedTalentIds: suggestedTalentIds.length
-      ? suggestedTalentIds
-      : undefined,
-    suggestedLocationIds: suggestedLocationIds.length
-      ? suggestedLocationIds
-      : undefined,
-    elementUploads: elementUploads.length ? elementUploads : undefined,
-  });
-
-  // 4. Run the shared create core (credits → fan-out → trigger storyboard).
-  const { entries } = await createSequences(parsed, {
-    ...ctx,
-    notify: false,
-  });
-
-  return {
-    sequences: entries.map(({ sequence, workflowRunId }) => {
-      const statusUrl = `${API_V1_BASE}/sequences/${sequence.id}`;
-      return {
-        id: sequence.id,
-        status: sequence.status,
-        workflowRunId,
-        statusUrl,
-        _links: {
-          self: getLink(statusUrl, 'Sequence status'),
-          poll: waitLink(statusUrl, 'Long-poll this sequence (e.g. ?wait=60s)'),
-        } satisfies HalLinks,
-      };
-    }),
-    enhancedScript,
-    _links: {
-      self: createSequenceLink(),
-      root: getLink(API_V1_BASE, 'API root / instructions'),
-    },
-  };
+    };
+  } catch (error) {
+    await rollbackInlineCreates(ctx, createdTalentIds, createdLocationIds);
+    throw error;
+  }
 }

--- a/src/lib/api-v1/errors.test.ts
+++ b/src/lib/api-v1/errors.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ValidationError } from '@/lib/errors';
+import { z } from 'zod';
+
+const { mockWarn, mockError } = vi.hoisted(() => ({
+  mockWarn: vi.fn(),
+  mockError: vi.fn(),
+}));
+
+vi.mock('@/lib/observability/logger', () => ({
+  getLogger: () => ({
+    error: mockError,
+    warn: mockWarn,
+    info: vi.fn(),
+    debug: vi.fn(),
+  }),
+  toErrorPayload: (error: unknown) => ({ message: String(error) }),
+}));
+
+const { runApiV1Handler } = await import('./errors');
+
+describe('runApiV1Handler', () => {
+  beforeEach(() => {
+    mockWarn.mockClear();
+    mockError.mockClear();
+  });
+
+  it('logs 4xx OpenStory errors at warn with the error code', async () => {
+    const response = await runApiV1Handler(async () => {
+      throw new ValidationError(
+        'Character "Ada" reference image #2 could not be fetched (timeout): https://slow.example/a.png'
+      );
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: expect.stringContaining('could not be fetched'),
+        details: undefined,
+      },
+    });
+    expect(mockWarn).toHaveBeenCalledWith(
+      'api/v1 handler rejected: {code} {message}',
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+        status: 400,
+      })
+    );
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('logs Zod validation failures at warn', async () => {
+    await runApiV1Handler(async () => {
+      throw new z.ZodError([
+        {
+          code: 'custom',
+          path: ['script'],
+          message: 'Required',
+        },
+      ]);
+    });
+
+    expect(mockWarn).toHaveBeenCalledWith(
+      'api/v1 handler rejected: {code} {message}',
+      expect.objectContaining({
+        code: 'VALIDATION_ERROR',
+        status: 400,
+      })
+    );
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it('logs 5xx at error, not warn', async () => {
+    const response = await runApiV1Handler(async () => {
+      throw new Error('boom');
+    });
+
+    expect(response.status).toBe(500);
+    expect(mockError).toHaveBeenCalled();
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api-v1/errors.ts
+++ b/src/lib/api-v1/errors.ts
@@ -35,6 +35,11 @@ export async function runApiV1Handler(
     return await fn();
   } catch (error) {
     if (error instanceof z.ZodError) {
+      logger.warn('api/v1 handler rejected: {code} {message}', {
+        code: 'VALIDATION_ERROR',
+        message: 'Invalid request body.',
+        status: 400,
+      });
       return apiJsonError(400, 'VALIDATION_ERROR', 'Invalid request body.', {
         issues: error.issues,
       });
@@ -51,6 +56,12 @@ export async function runApiV1Handler(
         message: handled.message,
         // Keep the original error (stack/cause) so a 500 is traceable later.
         err: toErrorPayload(error),
+      });
+    } else {
+      logger.warn('api/v1 handler rejected: {code} {message}', {
+        code: handled.code,
+        message: handled.message,
+        status: handled.statusCode,
       });
     }
     return apiJsonError(handled.statusCode, handled.code, handled.message);

--- a/src/lib/api-v1/resolve.test.ts
+++ b/src/lib/api-v1/resolve.test.ts
@@ -198,6 +198,29 @@ describe('resolveTalentIds', () => {
     );
     expect(ids).toEqual(['t-ada']);
   });
+
+  it('reuses an existing talent by name instead of creating a duplicate', async () => {
+    const talent = [makeTalent({ id: 't-ada', name: 'Ada Lovelace' })];
+    const createTalent = vi.fn();
+    const ids = await resolveTalentIds(
+      { talent: { list: async () => talent }, createTalent },
+      [{ name: 'Ada Lovelace', isHuman: true }]
+    );
+    expect(ids).toEqual(['t-ada']);
+    expect(createTalent).not.toHaveBeenCalled();
+  });
+
+  it('creates only once when the same name is inlined twice', async () => {
+    const createTalent = vi.fn(async (input: { name: string }) => ({
+      id: `new-${input.name}`,
+    }));
+    const ids = await resolveTalentIds(
+      { talent: { list: async () => [] }, createTalent },
+      [{ name: 'Hero' }, { name: 'Hero' }]
+    );
+    expect(ids).toEqual(['new-Hero']);
+    expect(createTalent).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('resolveLocationIds', () => {
@@ -212,6 +235,17 @@ describe('resolveLocationIds', () => {
     );
     expect(ids).toEqual(['l-roof', 'new-Beach']);
     expect(createLocation).toHaveBeenCalledWith({ name: 'Beach' });
+  });
+
+  it('reuses an existing location by name instead of creating a duplicate', async () => {
+    const locations = [makeLocation({ id: 'l-roof', name: 'Rooftop Bar' })];
+    const createLocation = vi.fn();
+    const ids = await resolveLocationIds(
+      { locations: { list: async () => locations }, createLocation },
+      [{ name: 'Rooftop Bar' }]
+    );
+    expect(ids).toEqual(['l-roof']);
+    expect(createLocation).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/api-v1/resolve.ts
+++ b/src/lib/api-v1/resolve.ts
@@ -107,8 +107,8 @@ export async function resolveStyle(
 /**
  * Resolve a mixed list of talent items — reference strings (id|name) and inline
  * create objects — into a deduped list of talent ids for `suggestedTalentIds`.
- * Inline-create is delegated to `deps.createTalent` (which triggers sheet
- * generation); the storyboard workflow's `waitForTalentSheets` gate then waits.
+ * Inline creates matching an existing name (or a name already created in this
+ * list) reuse that id. New names are delegated to `deps.createTalent`.
  */
 export async function resolveTalentIds(
   deps: TalentResolveDeps,
@@ -118,20 +118,31 @@ export async function resolveTalentIds(
   const { refs, creates } = partition(items);
   const ids: string[] = [];
 
-  if (refs.length > 0) {
-    const all = await deps.talent.list();
-    for (const ref of refs) {
-      const match = all.find((t) => matchesRef(ref, t));
-      if (!match) {
-        throw new NotFoundError(`No character/talent found matching "${ref}".`);
-      }
-      ids.push(match.id);
+  const all = await deps.talent.list();
+  const seen = new Map<string, string>();
+  for (const talent of all) {
+    seen.set(talent.id, talent.id);
+    seen.set(slugify(talent.name), talent.id);
+  }
+
+  for (const ref of refs) {
+    const match = all.find((t) => matchesRef(ref, t));
+    if (!match) {
+      throw new NotFoundError(`No character/talent found matching "${ref}".`);
     }
+    ids.push(match.id);
+    seen.set(slugify(match.name), match.id);
   }
 
   for (const create of creates) {
+    const existingId = seen.get(slugify(create.name));
+    if (existingId) {
+      ids.push(existingId);
+      continue;
+    }
     const created = await deps.createTalent(create);
     ids.push(created.id);
+    seen.set(slugify(create.name), created.id);
   }
 
   return [...new Set(ids)];
@@ -150,20 +161,31 @@ export async function resolveLocationIds(
   const { refs, creates } = partition(items);
   const ids: string[] = [];
 
-  if (refs.length > 0) {
-    const all = await deps.locations.list();
-    for (const ref of refs) {
-      const match = all.find((l) => matchesRef(ref, l));
-      if (!match) {
-        throw new NotFoundError(`No location found matching "${ref}".`);
-      }
-      ids.push(match.id);
+  const all = await deps.locations.list();
+  const seen = new Map<string, string>();
+  for (const location of all) {
+    seen.set(location.id, location.id);
+    seen.set(slugify(location.name), location.id);
+  }
+
+  for (const ref of refs) {
+    const match = all.find((l) => matchesRef(ref, l));
+    if (!match) {
+      throw new NotFoundError(`No location found matching "${ref}".`);
     }
+    ids.push(match.id);
+    seen.set(slugify(match.name), match.id);
   }
 
   for (const create of creates) {
+    const existingId = seen.get(slugify(create.name));
+    if (existingId) {
+      ids.push(existingId);
+      continue;
+    }
     const created = await deps.createLocation(create);
     ids.push(created.id);
+    seen.set(slugify(create.name), created.id);
   }
 
   return [...new Set(ids)];
@@ -183,11 +205,16 @@ export async function ingestElements(
   if (!elements || elements.length === 0) return [];
 
   return Promise.all(
-    elements.map(async (el) => {
+    elements.map(async (el, index) => {
       const { tempPath, publicUrl, extension } = await ingestImageToTempBucket(
         el.url,
         STORAGE_BUCKETS.ELEMENTS,
-        teamId
+        teamId,
+        {
+          label: el.token
+            ? `Element "${el.token}"`
+            : `Element image #${index + 1}`,
+        }
       );
       return {
         // promote contract wants the bucket-prefixed `elements/` form.

--- a/src/lib/api-v1/safe-fetch.test.ts
+++ b/src/lib/api-v1/safe-fetch.test.ts
@@ -1,5 +1,19 @@
-import { describe, expect, it } from 'vitest';
-import { assertSafeImageUrl } from './safe-fetch';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ValidationError } from '@/lib/errors';
+import {
+  IMAGE_FETCH_TIMEOUT_MS,
+  MAX_IMAGE_REDIRECTS,
+  assertSafeImageUrl,
+  ingestImageToTempBucket,
+} from './safe-fetch';
+
+const { uploadFileMock } = vi.hoisted(() => ({
+  uploadFileMock: vi.fn(async () => undefined),
+}));
+
+vi.mock('#storage', () => ({
+  uploadFile: uploadFileMock,
+}));
 
 describe('assertSafeImageUrl', () => {
   it('allows ordinary public https/http image URLs', () => {
@@ -34,5 +48,115 @@ describe('assertSafeImageUrl', () => {
 
   it('rejects malformed URLs', () => {
     expect(() => assertSafeImageUrl('not a url')).toThrow(/invalid/i);
+  });
+
+  it('names the supplied label in the error', () => {
+    expect(() =>
+      assertSafeImageUrl('not a url', 'Character "Ada" reference image #2')
+    ).toThrow(/Character "Ada" reference image #2 URL is invalid/);
+  });
+});
+
+function pngResponse(): Response {
+  return new Response(new Uint8Array([1, 2, 3, 4]), {
+    status: 200,
+    headers: { 'content-type': 'image/png' },
+  });
+}
+
+function redirectResponse(location: string, status = 302): Response {
+  return new Response(null, { status, headers: { location } });
+}
+
+describe('ingestImageToTempBucket', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('times out under 20s and names the character plus URL', async () => {
+    expect(IMAGE_FETCH_TIMEOUT_MS).toBeLessThan(20_000);
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: RequestInfo, init?: RequestInit) => {
+        expect(init?.signal).toBeInstanceOf(AbortSignal);
+        return Promise.reject(
+          new DOMException('The operation was aborted.', 'TimeoutError')
+        );
+      })
+    );
+
+    const url = 'https://slow.example/portrait.png';
+    await expect(
+      ingestImageToTempBucket(url, 'talent', 'team-1', {
+        label: 'Character "Ada" reference image #2',
+      })
+    ).rejects.toSatisfy((error: unknown) => {
+      if (!(error instanceof ValidationError)) return false;
+      expect(error.message).toBe(
+        'Character "Ada" reference image #2 could not be fetched (timeout): https://slow.example/portrait.png'
+      );
+      return true;
+    });
+  });
+
+  it('follows a bounded redirect to a still-safe host', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        redirectResponse('https://cdn.example.com/real.png')
+      )
+      .mockResolvedValueOnce(pngResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const ingested = await ingestImageToTempBucket(
+      'https://share.example.com/x',
+      'talent',
+      'team-1',
+      { label: 'Character "Ada" reference image #1' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toBe(
+      'https://cdn.example.com/real.png'
+    );
+    expect(ingested.contentType).toBe('image/png');
+    expect(uploadFileMock).toHaveBeenCalled();
+  });
+
+  it('does not follow a redirect onto a private host and hides the target', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectResponse('http://127.0.0.1/secret'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      ingestImageToTempBucket(
+        'https://share.example.com/x',
+        'talent',
+        'team-1',
+        { label: 'Character "Ada" reference image #2' }
+      )
+    ).rejects.toThrow(
+      'Character "Ada" reference image #2 could not be fetched (redirect blocked): https://share.example.com/x'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops after MAX_IMAGE_REDIRECTS hops', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(redirectResponse('https://cdn.example.com/next.png'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      ingestImageToTempBucket(
+        'https://share.example.com/start',
+        'talent',
+        'team-1'
+      )
+    ).rejects.toThrow(/redirect blocked/);
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_IMAGE_REDIRECTS + 1);
   });
 });

--- a/src/lib/api-v1/safe-fetch.ts
+++ b/src/lib/api-v1/safe-fetch.ts
@@ -6,7 +6,10 @@
  *   - block loopback / private / link-local / reserved IP literals and ambiguous
  *     numeric (decimal/hex/octal) or IPv6 host encodings, plus internal-looking
  *     hostnames (localhost, *.internal, *.local),
- *   - never follow redirects (a public URL can't bounce to an internal one),
+ *   - follow a bounded number of redirects, re-checking `assertSafeImageUrl` on
+ *     every hop so a public URL can't bounce to an internal one,
+ *   - abort after {@link IMAGE_FETCH_TIMEOUT_MS} so a black-holing host cannot
+ *     hang the request until the isolate dies,
  *   - require a real image Content-Type from the *response* (not the URL ext),
  *   - cap the response size.
  *
@@ -15,8 +18,8 @@
  * practice Workers egress through Cloudflare's network (no VPC / no instance
  * metadata endpoint reachable), which blunts the classic cloud-metadata target;
  * the host checks below close the direct-literal and internal-name vectors.
- * Errors are deliberately generic so we don't reflect the URL or upstream
- * status back to the caller.
+ * Fetch failures name the caller-supplied URL (they already know it) and never
+ * the blocked redirect target.
  */
 
 import { uploadFile } from '#storage';
@@ -26,6 +29,16 @@ import { getPublicUrl, type StorageBucket } from '@/lib/storage/buckets';
 
 const MAX_IMAGE_BYTES = 20 * 1024 * 1024; // 20 MB
 
+/** Wall-clock budget for one image fetch, including redirect hops. */
+export const IMAGE_FETCH_TIMEOUT_MS = 15_000;
+
+/** Max 3xx hops; each hop is re-checked by {@link assertSafeImageUrl}. */
+export const MAX_IMAGE_REDIRECTS = 3;
+
+const DEFAULT_IMAGE_LABEL = 'Element image';
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
 /** content-type → file extension for the storage key. */
 const ALLOWED_IMAGE_TYPES: Record<string, string> = {
   'image/jpeg': 'jpg',
@@ -34,6 +47,23 @@ const ALLOWED_IMAGE_TYPES: Record<string, string> = {
   'image/gif': 'gif',
   'image/avif': 'avif',
 };
+
+function isTimeoutError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const name = Reflect.get(error, 'name');
+  return name === 'TimeoutError' || name === 'AbortError';
+}
+
+function fetchFailed(
+  label: string,
+  originalUrl: string,
+  reason?: 'timeout' | 'redirect blocked'
+): ValidationError {
+  const suffix = reason ? ` (${reason})` : '';
+  return new ValidationError(
+    `${label} could not be fetched${suffix}: ${originalUrl}`
+  );
+}
 
 function isPrivateIpv4(host: string): boolean {
   const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
@@ -60,16 +90,19 @@ function isPrivateIpv4(host: string): boolean {
  * IPv4), ambiguous numeric encodings, IPv6, or internal-looking names. Returns
  * the validated URL.
  */
-export function assertSafeImageUrl(rawUrl: string): URL {
+export function assertSafeImageUrl(
+  rawUrl: string,
+  label: string = DEFAULT_IMAGE_LABEL
+): URL {
   let url: URL;
   try {
     url = new URL(rawUrl);
   } catch {
-    throw new ValidationError('Element image URL is invalid.');
+    throw new ValidationError(`${label} URL is invalid.`);
   }
 
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
-    throw new ValidationError('Element image URL must use http or https.');
+    throw new ValidationError(`${label} URL must use http or https.`);
   }
 
   const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, '');
@@ -81,74 +114,108 @@ export function assertSafeImageUrl(rawUrl: string): URL {
     host.endsWith('.internal') ||
     host.endsWith('.local')
   ) {
-    throw new ValidationError('Element image URL is not allowed.');
+    throw new ValidationError(`${label} URL is not allowed.`);
   }
 
   // IPv6 literal (contains a colon) — uncommon for hosted images; reject to
   // avoid ::1 / fc00::/7 / fe80::/10 / ::ffff:v4 mapping bypasses.
   if (host.includes(':')) {
-    throw new ValidationError('Element image URL is not allowed.');
+    throw new ValidationError(`${label} URL is not allowed.`);
   }
 
   // Ambiguous numeric encodings (decimal 2130706433, hex 0x7f000001, octal):
   // these are almost always SSRF probes for hosted-image use, so reject.
   if (/^0x[0-9a-f]+$/i.test(host) || /^\d+$/.test(host)) {
-    throw new ValidationError('Element image URL is not allowed.');
+    throw new ValidationError(`${label} URL is not allowed.`);
   }
 
   // Dotted IPv4 literal in a private/reserved range.
   if (isPrivateIpv4(host)) {
-    throw new ValidationError('Element image URL is not allowed.');
+    throw new ValidationError(`${label} URL is not allowed.`);
   }
 
   return url;
 }
 
 /**
- * Fetch a caller-supplied image URL safely. Validates the host, refuses
- * redirects, enforces an image Content-Type from the response, and caps size.
+ * Fetch a caller-supplied image URL safely. Validates the host, follows a
+ * bounded number of redirects to hosts that still pass {@link assertSafeImageUrl},
+ * enforces an image Content-Type from the response, and caps size.
  * Returns the bytes, the validated content type, and its file extension.
  */
 async function fetchSafeImage(
-  rawUrl: string
+  rawUrl: string,
+  label: string = DEFAULT_IMAGE_LABEL
 ): Promise<{ bytes: Uint8Array; contentType: string; extension: string }> {
-  const url = assertSafeImageUrl(rawUrl);
+  let current = rawUrl;
 
-  let res: Response;
-  try {
-    res = await fetch(url, { redirect: 'manual' });
-  } catch {
-    throw new ValidationError('Element image could not be fetched.');
+  for (let hops = 0; hops <= MAX_IMAGE_REDIRECTS; hops++) {
+    let url: URL;
+    try {
+      url = assertSafeImageUrl(current, label);
+    } catch (error) {
+      if (hops > 0) {
+        throw fetchFailed(label, rawUrl, 'redirect blocked');
+      }
+      throw error;
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        redirect: 'manual',
+        signal: AbortSignal.timeout(IMAGE_FETCH_TIMEOUT_MS),
+      });
+    } catch (error) {
+      throw fetchFailed(
+        label,
+        rawUrl,
+        isTimeoutError(error) ? 'timeout' : undefined
+      );
+    }
+
+    if (REDIRECT_STATUSES.has(res.status)) {
+      const location = res.headers.get('location');
+      void res.body?.cancel();
+      if (!location) throw fetchFailed(label, rawUrl);
+      try {
+        current = new URL(location, url).toString();
+      } catch {
+        throw fetchFailed(label, rawUrl);
+      }
+      continue;
+    }
+
+    if (!res.ok) {
+      throw fetchFailed(label, rawUrl);
+    }
+
+    const contentType =
+      (res.headers.get('content-type') ?? '')
+        .split(';')[0]
+        ?.trim()
+        .toLowerCase() ?? '';
+    const extension = ALLOWED_IMAGE_TYPES[contentType];
+    if (!extension) {
+      throw new ValidationError(
+        `${label} must be a PNG, JPEG, WebP, GIF, or AVIF.`
+      );
+    }
+
+    const declaredLength = Number(res.headers.get('content-length'));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
+      throw new ValidationError(`${label} is too large (max 20 MB).`);
+    }
+
+    const bytes = new Uint8Array(await res.arrayBuffer());
+    if (bytes.byteLength > MAX_IMAGE_BYTES) {
+      throw new ValidationError(`${label} is too large (max 20 MB).`);
+    }
+
+    return { bytes, contentType, extension };
   }
 
-  // redirect: 'manual' surfaces 3xx as a non-ok response — never followed.
-  if (!res.ok) {
-    throw new ValidationError('Element image could not be fetched.');
-  }
-
-  const contentType =
-    (res.headers.get('content-type') ?? '')
-      .split(';')[0]
-      ?.trim()
-      .toLowerCase() ?? '';
-  const extension = ALLOWED_IMAGE_TYPES[contentType];
-  if (!extension) {
-    throw new ValidationError(
-      'Element image must be a PNG, JPEG, WebP, GIF, or AVIF.'
-    );
-  }
-
-  const declaredLength = Number(res.headers.get('content-length'));
-  if (Number.isFinite(declaredLength) && declaredLength > MAX_IMAGE_BYTES) {
-    throw new ValidationError('Element image is too large (max 20 MB).');
-  }
-
-  const bytes = new Uint8Array(await res.arrayBuffer());
-  if (bytes.byteLength > MAX_IMAGE_BYTES) {
-    throw new ValidationError('Element image is too large (max 20 MB).');
-  }
-
-  return { bytes, contentType, extension };
+  throw fetchFailed(label, rawUrl, 'redirect blocked');
 }
 
 export type IngestedImage = {
@@ -160,6 +227,11 @@ export type IngestedImage = {
   contentType: string;
 };
 
+export type ImageFetchSource = {
+  /** e.g. `Character "Ada" reference image #2`. */
+  label: string;
+};
+
 /**
  * SSRF-safely fetch a caller-supplied image URL and store it under the given
  * bucket's `temp/` prefix, returning the temp path + public URL. The temp
@@ -169,9 +241,13 @@ export type IngestedImage = {
 export async function ingestImageToTempBucket(
   url: string,
   bucket: StorageBucket,
-  teamId: string
+  teamId: string,
+  source?: ImageFetchSource
 ): Promise<IngestedImage> {
-  const { bytes, contentType, extension } = await fetchSafeImage(url);
+  const { bytes, contentType, extension } = await fetchSafeImage(
+    url,
+    source?.label ?? DEFAULT_IMAGE_LABEL
+  );
   const tempPath = `${teamId}/temp/${generateId()}.${extension}`;
   await uploadFile(bucket, tempPath, bytes, { contentType });
   return {

--- a/src/lib/locations/create-library-location.ts
+++ b/src/lib/locations/create-library-location.ts
@@ -62,10 +62,39 @@ export type CreateLibraryLocationContext = {
   teamId: string;
 };
 
+export type CreateLibraryLocationOptions = {
+  /**
+   * When false, insert the location but do not trigger the billed sheet
+   * workflow. The caller enqueues {@link CreateLibraryLocationResult.sheetWorkflowInput}
+   * after the sequence exists.
+   * @default true
+   */
+  enqueueSheet?: boolean;
+};
+
+export type CreateLibraryLocationResult = {
+  location: LibraryLocation;
+  sheetWorkflowInput: LibraryLocationSheetWorkflowInput;
+};
+
+export async function enqueueLibraryLocationSheet(
+  workflowInput: LibraryLocationSheetWorkflowInput,
+  locationId: string
+): Promise<void> {
+  try {
+    await triggerWorkflow('/library-location-sheet', workflowInput, {
+      label: buildWorkflowLabel(locationId),
+    });
+  } catch (error) {
+    logger.error('Failed to trigger location sheet workflow:', { err: error });
+  }
+}
+
 export async function createLibraryLocation(
   input: CreateLibraryLocationInput,
-  ctx: CreateLibraryLocationContext
-): Promise<LibraryLocation> {
+  ctx: CreateLibraryLocationContext,
+  options?: CreateLibraryLocationOptions
+): Promise<CreateLibraryLocationResult> {
   const processedImages = await promoteLocationReferenceImages(
     input.referenceImageUrls ?? [],
     ctx.teamId
@@ -93,7 +122,8 @@ export async function createLibraryLocation(
     );
   }
 
-  // Always trigger sheet generation (works with or without reference images).
+  // Sheet generation works with or without reference images. The public API
+  // defers the trigger until the sequence exists (`enqueueSheet: false`).
   const workflowInput: LibraryLocationSheetWorkflowInput = {
     locationDbId: newLocation.id,
     locationName: input.name,
@@ -106,11 +136,10 @@ export async function createLibraryLocation(
   workflowInput.snapshotInputHash =
     await computeLibraryLocationSheetHashFromDto(workflowInput);
 
-  void triggerWorkflow('/library-location-sheet', workflowInput, {
-    label: buildWorkflowLabel(newLocation.id),
-  }).catch((error) => {
-    logger.error('Failed to trigger location sheet workflow:', { err: error });
-  });
+  if (options?.enqueueSheet !== false) {
+    // Dashboard create: fire-and-forget so the dialog can return immediately.
+    void enqueueLibraryLocationSheet(workflowInput, newLocation.id);
+  }
 
-  return newLocation;
+  return { location: newLocation, sheetWorkflowInput: workflowInput };
 }

--- a/src/lib/talent/create-library-talent.test.ts
+++ b/src/lib/talent/create-library-talent.test.ts
@@ -250,6 +250,64 @@ describe('createLibraryTalent', () => {
     );
   });
 
+  it('classifies every uploaded reference in one vision call', async () => {
+    await createLibraryTalent(
+      {
+        name: 'Sam',
+        isHuman: true,
+        referenceImageUrls: [
+          '/r2/talent/team-1/temp/a.png',
+          '/r2/talent/team-1/temp/b.png',
+          '/r2/talent/team-1/temp/c.png',
+        ],
+        portraitAttestation: {
+          statementVersion: 'v1',
+          authorizationBasis: 'self',
+        },
+      },
+      makeCtx()
+    );
+
+    expect(mockAnalyze).toHaveBeenCalledTimes(1);
+    expect(mockAnalyze).toHaveBeenCalledWith(
+      expect.objectContaining({
+        imageUrls: [
+          expect.stringContaining('/r2/talent/'),
+          expect.stringContaining('/r2/talent/'),
+          expect.stringContaining('/r2/talent/'),
+        ],
+      })
+    );
+  });
+
+  it('does not classify or enqueue when enqueueSheet is false', async () => {
+    const result = await createLibraryTalent(
+      {
+        name: 'Sam',
+        isHuman: true,
+        referenceImageUrls: [
+          '/r2/talent/team-1/temp/a.png',
+          '/r2/talent/team-1/temp/b.png',
+          '/r2/talent/team-1/temp/c.png',
+        ],
+        portraitAttestation: {
+          statementVersion: 'v1',
+          authorizationBasis: 'self',
+        },
+        enqueueSheet: false,
+      },
+      makeCtx()
+    );
+
+    expect(mockAnalyze).not.toHaveBeenCalled();
+    expect(mockTriggerWorkflow).not.toHaveBeenCalled();
+    expect(result.sheetWorkflowRunId).toBeNull();
+    expect(result.deferredSheet?.talentId).toBe('tal-1');
+    expect(result.deferredSheet?.workflowInput.referenceImageUrls).toHaveLength(
+      3
+    );
+  });
+
   it('records an asset attestation when the subject is not human', async () => {
     await createLibraryTalent(
       {

--- a/src/lib/talent/create-library-talent.ts
+++ b/src/lib/talent/create-library-talent.ts
@@ -31,7 +31,10 @@ import {
   analyzeTalentMediaForTeam,
   sheetMetadataFromAnalysis,
 } from './analyze-talent-media';
-import { enqueueLibraryTalentSheet } from './enqueue-library-talent-sheet';
+import {
+  enqueueLibraryTalentSheet,
+  type EnqueueLibraryTalentSheetParams,
+} from './enqueue-library-talent-sheet';
 import { libraryTalentGenerateDedupId } from './library-talent-sheet-dedup';
 
 const logger = getLogger(['openstory', 'talent', 'create-library-talent']);
@@ -50,6 +53,13 @@ export type CreateLibraryTalentInput = {
    */
   characterSheetImageUrls?: string[];
   portraitAttestation?: UploadAttestationInput;
+  /**
+   * When false, insert the talent + media and return `deferredSheet` instead
+   * of triggering the billed `/library-talent-sheet` workflow. Used by the
+   * public API so a later failure cannot charge for a sheet with no sequence.
+   * @default true
+   */
+  enqueueSheet?: boolean;
 };
 
 export type CreateLibraryTalentContext = {
@@ -62,6 +72,8 @@ export type CreateLibraryTalentContext = {
 export type CreateLibraryTalentResult = {
   talent: Talent;
   sheetWorkflowRunId: string | null;
+  /** Present when `enqueueSheet` was false so the caller can trigger later. */
+  deferredSheet?: EnqueueLibraryTalentSheetParams;
 };
 
 export async function createLibraryTalent(
@@ -130,33 +142,44 @@ export async function createLibraryTalent(
       uploadedSheetUrl = classifiedTempUrls
         .map((url) => tempToPermanent.get(url))
         .find((url): url is string => Boolean(url));
-    } else {
-      for (const url of permanentUrls) {
-        try {
-          const analysis = await analyzeTalentMediaForTeam({
-            scopedDb: ctx.scopedDb,
-            userId: ctx.user.id,
-            imageUrls: [url],
-            idempotencyKey: `talent-vision:create:${newTalent.id}:${url}`,
-          });
-          if (analysis.isCharacterSheet) {
-            uploadedSheetUrl = url;
-            uploadedSheetMetadata = sheetMetadataFromAnalysis(
-              newTalent.name,
-              analysis
-            );
-            break;
-          }
-        } catch (error) {
-          logger.warn('Talent-sheet classification failed; treating as photo', {
-            err: error,
-            talentId: newTalent.id,
-          });
+    } else if (input.enqueueSheet !== false) {
+      // One call for every reference: N sequential vision round-trips hung
+      // the public-API request (~9s each) and billed before the sequence
+      // existed (#1372). A single multi-image analysis already accepts
+      // `imageUrls: string[]`. If several images are a sheet we generate
+      // rather than pick the wrong URL to promote.
+      try {
+        const analysis = await analyzeTalentMediaForTeam({
+          scopedDb: ctx.scopedDb,
+          userId: ctx.user.id,
+          imageUrls: permanentUrls,
+          idempotencyKey: `talent-vision:create:${newTalent.id}`,
+        });
+        const [onlyUrl] = permanentUrls;
+        if (
+          analysis.isCharacterSheet &&
+          onlyUrl &&
+          permanentUrls.length === 1
+        ) {
+          uploadedSheetUrl = onlyUrl;
+          uploadedSheetMetadata = sheetMetadataFromAnalysis(
+            newTalent.name,
+            analysis
+          );
         }
+      } catch (error) {
+        logger.warn('Talent-sheet classification failed; treating as photo', {
+          err: error,
+          talentId: newTalent.id,
+        });
       }
     }
 
-    if (uploadedSheetUrl && !uploadedSheetMetadata) {
+    if (
+      uploadedSheetUrl &&
+      !uploadedSheetMetadata &&
+      input.enqueueSheet !== false
+    ) {
       try {
         const analysis = await analyzeTalentMediaForTeam({
           scopedDb: ctx.scopedDb,
@@ -177,9 +200,10 @@ export async function createLibraryTalent(
     }
   }
 
-  // Trigger talent sheet generation. Always runs: if the user uploaded a
-  // sheet we store that image; otherwise we generate a 4-panel (from
-  // reference photos and/or the name + description).
+  // Sheet payload: if the user uploaded a sheet we store that image;
+  // otherwise we generate a 4-panel (from reference photos and/or the
+  // name + description). The public API defers the billed trigger until
+  // the sequence exists (`enqueueSheet: false`).
   const workflowInput: LibraryTalentSheetWorkflowInput = {
     userId: ctx.user.id,
     teamId: ctx.teamId,
@@ -194,16 +218,22 @@ export async function createLibraryTalent(
   workflowInput.snapshotInputHash =
     await computeLibraryTalentSheetHashFromDto(workflowInput);
 
+  const deferredSheet: EnqueueLibraryTalentSheetParams = {
+    talentId: newTalent.id,
+    workflowInput,
+    activity: uploadedSheetUrl ? 'portrait' : 'sheet',
+    deduplicationId: libraryTalentGenerateDedupId(newTalent.id),
+  };
+
+  if (input.enqueueSheet === false) {
+    return { talent: newTalent, sheetWorkflowRunId: null, deferredSheet };
+  }
+
   let sheetWorkflowRunId: string | null = null;
   try {
     // Shared with generate-if-missing on later photo drops so parallel
     // finalizes reuse this run instead of billing another 4-panel.
-    sheetWorkflowRunId = await enqueueLibraryTalentSheet({
-      talentId: newTalent.id,
-      workflowInput,
-      activity: uploadedSheetUrl ? 'portrait' : 'sheet',
-      deduplicationId: libraryTalentGenerateDedupId(newTalent.id),
-    });
+    sheetWorkflowRunId = await enqueueLibraryTalentSheet(deferredSheet);
   } catch {
     // Talent row + media already exist; enqueue already emitted `failed`.
     // Return them so the dialog can say "added" without claiming a run started.

--- a/src/lib/talent/enqueue-library-talent-sheet.ts
+++ b/src/lib/talent/enqueue-library-talent-sheet.ts
@@ -19,12 +19,16 @@ const logger = getLogger([
   'enqueue-library-talent-sheet',
 ]);
 
-export async function enqueueLibraryTalentSheet(params: {
+export type EnqueueLibraryTalentSheetParams = {
   talentId: string;
   workflowInput: LibraryTalentSheetWorkflowInput;
   activity: SheetProgressActivity;
   deduplicationId?: string;
-}): Promise<string> {
+};
+
+export async function enqueueLibraryTalentSheet(
+  params: EnqueueLibraryTalentSheetParams
+): Promise<string> {
   try {
     const runId = await triggerWorkflow(
       '/library-talent-sheet',


### PR DESCRIPTION
Fixes #1372.

`POST /api/v1/sequences` with 2+ reference images per inline character hung for 1–3 minutes, billed vision + sheet generation, then died with a generic `Element image could not be fetched` (or a dropped connection) and no sequence.

## What changed

- Hosted image ingest times out at 15s, follows up to 3 redirects that still pass the SSRF host check, and names the character/location/element plus the caller-supplied URL.
- One-shot create ingests every reference **before any DB write**, skips request-path talent-vision, inserts library rows **without** triggering billed sheets, and enqueues sheets only after sequence rows exist.
- If sequence create fails, inline talents/locations are deleted so retries do not leave charged sheets. Inline creates with an existing name are reused.
- Dashboard talent create classifies all references in **one** vision call instead of one sequential call per image.
- v1 4xx responses are logged at `warn` with the error code (they were previously silent).

## Acceptance

- A create with 3 references per character and 2 characters no longer does N sequential vision round-trips on the HTTP path (same order of time as a 1-reference create).
- A failed create does not enqueue billed sheets; inline library rows are rolled back.
- A bad reference URL fails in <20s with a message that names the character and URL.