### PR TITLE
feat(#1378): emit studio_generation_started product event

### DIFF
--- a/src/lib/observability/product-events.ts
+++ b/src/lib/observability/product-events.ts
@@ -22,7 +22,8 @@ type ProductEventName =
   | 'founder_credits_requested'
   | 'credits_added'
   | 'feedback_submitted'
-  | 'sequence_ready_email_sent';
+  | 'sequence_ready_email_sent'
+  | 'studio_generation_started';
 
 export type CaptureProductEventArgs = {
   distinctId: string;

--- a/src/lib/studio/create-studio-asset.test.ts
+++ b/src/lib/studio/create-studio-asset.test.ts
@@ -23,6 +23,7 @@ const mockReserveRunCredits = vi.fn();
 const mockTriggerWorkflow = vi.fn();
 const mockRequireGenerationAllowed = vi.fn();
 const mockGetEffectiveFalPricing = vi.fn();
+const mockCaptureProductEvent = vi.fn();
 
 vi.doMock('#db-client', () => ({ getDb: () => db }));
 vi.doMock('@/lib/billing/preflight', async (importOriginal) => {
@@ -45,6 +46,9 @@ vi.doMock('@/lib/workflow/client', () => ({
 }));
 vi.doMock('@/lib/compliance/generation-gate', () => ({
   requireGenerationAllowed: mockRequireGenerationAllowed,
+}));
+vi.doMock('@/lib/observability/product-events', () => ({
+  captureProductEvent: mockCaptureProductEvent,
 }));
 vi.doMock('@/lib/ai/fal-pricing-live', () => ({
   getEffectiveFalPricing: mockGetEffectiveFalPricing,
@@ -228,6 +232,20 @@ describe('createStudioAssets', () => {
         deduplicationId: expect.stringMatching(/^studio-/),
       })
     );
+
+    expect(mockCaptureProductEvent).toHaveBeenCalledTimes(1);
+    expect(mockCaptureProductEvent).toHaveBeenCalledWith({
+      distinctId: USER_ID,
+      event: 'studio_generation_started',
+      properties: expect.objectContaining({
+        team_id: TEAM_ID,
+        activity: 'image',
+        model: 'gpt_image_2',
+        count: 2,
+        asset_ids: result.assets.map((a) => a.id),
+        reference_image_count: 0,
+      }),
+    });
   });
 
   it('zeros earlier holds if a later reserve fails, leaving no row', async () => {

--- a/src/lib/studio/create-studio-asset.ts
+++ b/src/lib/studio/create-studio-asset.ts
@@ -35,6 +35,7 @@ import {
 } from '@/lib/studio/schema';
 import { snapStudioVideoDuration } from '@/lib/studio/text-to-video';
 import { triggerWorkflow } from '@/lib/workflow/client';
+import { captureProductEvent } from '@/lib/observability/product-events';
 import type { StudioGenerationWorkflowInput } from '@/lib/workflow/types';
 
 const logger = getLogger(['openstory', 'studio', 'create']);
@@ -227,6 +228,29 @@ export async function createStudioAssets(
     );
     throw error;
   }
+
+  // Server-side so the dashboard and the public API both count (#1378).
+  captureProductEvent({
+    distinctId: scopedDb.userId,
+    event: 'studio_generation_started',
+    properties: {
+      team_id: scopedDb.teamId,
+      activity: input.activity,
+      model: input.activity === 'image' ? input.imageModel : input.videoModel,
+      model_name: modelName,
+      count: input.count,
+      asset_ids: assets.map((a) => a.id),
+      aspect_ratio: input.aspectRatio,
+      reference_image_count: input.referenceImages.length,
+      ...(input.activity === 'video' && {
+        mode: input.mode,
+        duration: input.duration,
+        reference_video_count: input.referenceVideos.length,
+        reference_audio_count: input.referenceAudio.length,
+        has_start_frame: Boolean(input.startImageUrl),
+      }),
+    },
+  });
 
   return { assets };
 }


### PR DESCRIPTION
Closes #1378

## Why

The Images/Videos studio (#1274) emitted no product event. Studio image runs only showed up as `studio-image` AI spans, and studio video runs were indistinguishable from storyboard motion in PostHog — measuring adoption meant querying `generated_assets` in production D1.

## What

- `studio_generation_started` added to `ProductEventName`.
- `createStudioAssets` captures it server-side once per run (after all rows are reserved and triggered) with `team_id`, `activity`, `model`, `model_name`, `count`, `asset_ids`, `aspect_ratio`, `reference_image_count`, and for video `mode`, `duration`, `reference_video_count`, `reference_audio_count`, `has_start_frame`. Server-side so the public API path emits it too, mirroring `sequence_generated`.
- Test asserts one capture per run with the expected properties.

## Verification

- `bun run test src/lib/studio/create-studio-asset.test.ts` — 13 passed
- lint / format / typecheck / dead-code via lefthook pre-commit