### PR TITLE
fix(#1380): pin still and motion-prompt version ids on storyboard auto-motion

### DIFF
--- a/src/lib/ai/input-hash.test.ts
+++ b/src/lib/ai/input-hash.test.ts
@@ -40,6 +40,19 @@ describe('computeVideoManifestInputHash', () => {
     expect(newPrompt).not.toBe(base);
   });
 
+  it('returns null when every entry lacks pinned version ids (#1380)', async () => {
+    // A hash over null/null immediately diverges from a live hash built
+    // from the selected still + prompt — that's how storyboard clips were
+    // born Stale. Unknown provenance is a null hash (never stale), matching
+    // `videoVariants.isStale` for legacy rows.
+    expect(
+      await computeVideoManifestInputHash(
+        [entry({ motionPromptVersionId: null, frameVersionId: null })],
+        'veo3_1'
+      )
+    ).toBeNull();
+  });
+
   it('changes with the model and with shot order (ordered manifest)', async () => {
     const base = await computeVideoManifestInputHash([entry()], 'veo3_1');
     expect(

--- a/src/lib/ai/input-hash.ts
+++ b/src/lib/ai/input-hash.ts
@@ -162,7 +162,20 @@ export function computeShotVideoInputHash(
 export function computeVideoManifestInputHash(
   manifest: readonly VideoManifestEntry[],
   model: string
-): Promise<string> {
+): Promise<string | null> {
+  // A hash over null/null immediately diverges from a live hash built from
+  // the selected still + prompt — that's how storyboard clips were born
+  // Stale (#1380). Unknown provenance is a null hash, matching
+  // `videoVariants.isStale` for legacy rows (never stale).
+  if (
+    manifest.length > 0 &&
+    manifest.every(
+      (entry) =>
+        entry.motionPromptVersionId == null && entry.frameVersionId == null
+    )
+  ) {
+    return Promise.resolve(null);
+  }
   return sha256Hex({ artifact: 'video:manifest', model, manifest });
 }
 

--- a/src/lib/db/scoped/video-variants.test.ts
+++ b/src/lib/db/scoped/video-variants.test.ts
@@ -594,4 +594,11 @@ describe('isStale', () => {
     );
     expect(await methods.isStale(legacy.id, 'anything')).toBe(false);
   });
+
+  it('treats a null live hash as unknown-not-stale (#1380)', async () => {
+    const hashed = await methods.appendVersion(
+      versionInput({ inputHash: 'h1' })
+    );
+    expect(await methods.isStale(hashed.id, null)).toBe(false);
+  });
 });

--- a/src/lib/db/scoped/video-variants.ts
+++ b/src/lib/db/scoped/video-variants.ts
@@ -766,12 +766,14 @@ export function createVideoVariantsMethods(db: Database) {
 
     /**
      * Staleness of a single version: stored `inputHash` vs a fresh hash. Null
-     * stored hash (legacy / in-flight) is "unknown, not stale". Throws when the
-     * version is missing. Mirrors `frameVariants.isStale`.
+     * stored hash (legacy / in-flight) is "unknown, not stale". A null live
+     * hash (unpinned manifest, #1380) is the same: refuse to mark Stale when
+     * provenance was never recorded. Throws when the version is missing.
+     * Mirrors `frameVariants.isStale`.
      */
     isStale: async (
       versionId: string,
-      currentHash: string
+      currentHash: string | null
     ): Promise<boolean> => {
       const result = await db
         .select({ hash: videoVariants.inputHash })
@@ -782,7 +784,7 @@ export function createVideoVariantsMethods(db: Database) {
         throw new Error(`VideoVariant ${versionId} not found`);
       }
       const stored = row.hash;
-      if (stored === null) return false;
+      if (stored === null || currentHash === null) return false;
       return currentHash !== stored;
     },
 

--- a/src/lib/scenes/scene-segments.test.ts
+++ b/src/lib/scenes/scene-segments.test.ts
@@ -142,6 +142,20 @@ describe('isSelectedVersionStale', () => {
     ]);
     expect(isSelectedVersionStale(v, motion, frame)).toBe(true);
   });
+
+  it('treats a null-null manifest as unknown-not-stale, not born-stale (#1380)', () => {
+    // Storyboard auto-motion used to stamp both ids as null. Comparing that
+    // to the live selected still + prompt always diverged, so every clip
+    // showed Stale the moment it landed. Same contract as a legacy null hash.
+    const v = version('v1', 'seg', 'kling', [
+      {
+        shotId: 'shot-1',
+        motionPromptVersionId: null,
+        frameVersionId: null,
+      },
+    ]);
+    expect(isSelectedVersionStale(v, motion, frame)).toBe(false);
+  });
 });
 
 describe('assembleSequenceSegments', () => {

--- a/src/lib/scenes/scene-segments.ts
+++ b/src/lib/scenes/scene-segments.ts
@@ -146,7 +146,9 @@ function toVersion(v: SegmentVersionInput): SegmentVideoVersion {
  * stored references against the shots' *current* pointers (rather than rehashing)
  * is the derivation the schema doc calls out, and it sidesteps false positives
  * from non-referenced inputs like a re-snapped duration. A manifest entry whose
- * shot no longer exists (deleted/re-tiled) reads as stale, not fresh.
+ * shot no longer exists (deleted/re-tiled) reads as stale, not fresh. An entry
+ * with both version ids null is unknown provenance (legacy / unpinned trigger)
+ * and is not stale — same contract as a null `inputHash`.
  */
 export function isSelectedVersionStale(
   selected: SegmentVersionInput | undefined,
@@ -155,6 +157,12 @@ export function isSelectedVersionStale(
 ): boolean {
   if (!selected) return false;
   return selected.manifest.some((entry) => {
+    // Both ids null = unknown provenance (pre-#1380 storyboard clips, or a
+    // trigger that forgot to pin). Same contract as a legacy null hash:
+    // unknown is not stale, so a regression cannot mark every clip Stale.
+    if (entry.motionPromptVersionId == null && entry.frameVersionId == null) {
+      return false;
+    }
     const currentMotion = currentMotionByShot.get(entry.shotId) ?? null;
     const currentFrame = currentFrameByShot.get(entry.shotId) ?? null;
     return (

--- a/src/lib/shots/staleness-matrix.test.ts
+++ b/src/lib/shots/staleness-matrix.test.ts
@@ -75,7 +75,7 @@ function imageHash(state: PipelineState): Promise<string> {
   );
 }
 
-function videoHash(state: PipelineState): Promise<string> {
+function videoHash(state: PipelineState): Promise<string | null> {
   const manifest: VideoManifest = [
     {
       shotId: 'shot-1',

--- a/src/lib/workflow/types.ts
+++ b/src/lib/workflow/types.ts
@@ -1354,6 +1354,15 @@ export interface ShotImagesWorkflowResult {
    * wrong scene.
    */
   imageUrls: (string | null)[];
+  /**
+   * Primary `frame_variants` version id per scene, ALIGNED to `imageUrls`.
+   * Null slot = that scene's image failed. Threaded into the motion-batch
+   * payload so the clip's manifest names the still it actually rendered from
+   * (#1380). Optional only so an in-flight child from a pre-#1380 build
+   * (URLs only) still type-checks at the parent; treat a missing array as
+   * all-null.
+   */
+  frameVersionIds?: (string | null)[];
 }
 
 /**
@@ -1405,6 +1414,15 @@ export interface MotionMusicPromptsWorkflowResult {
    * by the per-scene child.
    */
   motionPromptsBySceneId: Record<string, MotionPrompt>;
+  /**
+   * The `shot_prompt_versions` id each per-scene child left live, keyed by
+   * `sceneId`. Analyze-script pins this onto the motion-batch payload so the
+   * clip's manifest names the prompt it rendered from (#1380). Null when the
+   * child persisted nothing (no shot, or the claim was cancelled). Optional
+   * only so an in-flight child from a pre-#1380 build still type-checks;
+   * treat a missing map as all-null.
+   */
+  motionPromptVersionIdsBySceneId?: Record<string, string | null>;
   musicPrompt: string;
   musicTags: string;
 }

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -35,8 +35,6 @@ import { microsToUsd } from '@/lib/billing/money';
 import { gateStoryboardRenders } from '@/lib/billing/storyboard-render-gate';
 import { generateId } from '@/lib/db/id';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
-import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
-import { buildMotionReferenceImages } from '@/lib/motion/build-motion-references';
 import { buildCastCharacterBible } from '@/lib/prompts/character-prompt';
 import { getGenerationChannel } from '@/lib/realtime';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
@@ -66,6 +64,7 @@ import type {
   FramePromptBatchWorkflowResult,
 } from '@/lib/workflow/types';
 import { findMissingElementEntries } from '@/lib/workflows/element-sheet-workflow';
+import { buildStoryboardMotionBatchShots } from '@/lib/workflows/storyboard-motion-batch-shots';
 import {
   computeShotImagesHashFromDto,
   type ShotImageSceneSnapshot,
@@ -718,8 +717,14 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
     }
 
     const imageUrls = shotImagesSettled.value.imageUrls;
-    const { completeScenes, motionPromptsBySceneId, musicPrompt, musicTags } =
-      motionMusicSettled.value;
+    const frameVersionIds = shotImagesSettled.value.frameVersionIds ?? [];
+    const {
+      completeScenes,
+      motionPromptsBySceneId,
+      motionPromptVersionIdsBySceneId,
+      musicPrompt,
+      musicTags,
+    } = motionMusicSettled.value;
 
     // ----------------------------------------------------------------------
     // PHASE 5: motion (+ optional music + merge) batch — single child
@@ -742,59 +747,17 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
         totalDuration += scene.metadata?.durationSeconds || 5;
       }
 
-      const batchShots = completeScenes.flatMap((scene, index) => {
-        const matchedShot = shotMapping.find(
-          (f) => f.analysisSceneId === scene.sceneId
-        );
-        // The structured motion prompt is threaded in from the motion-prompt
-        // phase's return (#713/#991) — NOT re-read from the DB, which would be
-        // racy against concurrent append-only version writes.
-        // `imageUrls` is aligned to scene order; a null slot means that
-        // scene's image generation failed (the shot is already marked
-        // failed by the image workflow). Motion-prompt batch also skips
-        // those scenes (no starting frame). Skip rather than throwing —
-        // a missing still used to fail the whole storyboard.
-        const imageUrl = imageUrls[index];
-        if (!imageUrl) {
-          logger.warn(
-            `[AnalyzeScriptWorkflow:cf] Scene ${scene.sceneId} has no generated image (index ${index}); skipping its motion`
-          );
-          return [];
-        }
-
-        const motionPromptData = motionPromptsBySceneId[scene.sceneId];
-        if (!motionPromptData?.fullPrompt) {
-          throw new WorkflowValidationError(
-            `Scene ${scene.sceneId} has no motion prompt`
-          );
-        }
-
-        const characterTags = scene.continuity?.characterTags;
-
-        return {
-          shotId: matchedShot?.shotId ?? '',
-          imageUrl,
-          // Primary-model prompt (fallback / single-model). `motion-batch`
-          // re-assembles per model from `motionPrompt` for the alternates.
-          prompt: assembleMotionPrompt({
-            motionPrompt: motionPromptData,
-            model: primaryVideoModel,
-            characterTags,
-          }),
-          model: primaryVideoModel,
-          motionPrompt: motionPromptData,
-          characterTags,
-          duration: scene.metadata?.durationSeconds || 3,
-          aspectRatio,
-          // Cast/element refs so motion preserves identity across the clip
-          // (#873) — only Kling v3 Pro emits them. Same library + matcher the
-          // image step uses, so motion attaches the same references.
-          referenceImages: buildMotionReferenceImages({
-            scene,
-            characters: charactersWithSheets,
-            elements: allElements,
-          }),
-        };
+      const batchShots = buildStoryboardMotionBatchShots({
+        scenes: completeScenes,
+        shotMapping,
+        imageUrls,
+        frameVersionIds,
+        motionPromptsBySceneId,
+        motionPromptVersionIdsBySceneId: motionPromptVersionIdsBySceneId ?? {},
+        videoModel: primaryVideoModel,
+        aspectRatio,
+        characters: charactersWithSheets,
+        elements: allElements,
       });
 
       await step.do('phase-5-start', async () => {

--- a/src/lib/workflows/image-workflow.ts
+++ b/src/lib/workflows/image-workflow.ts
@@ -51,6 +51,13 @@ type ImageWorkflowResult = {
   shotId?: string;
   sequenceId?: string;
   /**
+   * The `frame_variants` version this still completed as. Parents pin the
+   * motion-batch payload off THIS id rather than re-reading the frame's
+   * selection pointer (#1380). Null when nothing was persisted (preview,
+   * cancelled claim, or a shotless ad-hoc run).
+   */
+  frameVersionId?: string | null;
+  /**
    * The render's claim was cancelled by the user (before or during the
    * render) and its result was discarded (#1085). Parents must treat this as
    * a stand-down, not a success (nothing landed) and not a failure (the user
@@ -297,6 +304,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
         imageUrl: '',
         shotId: input.shotId,
         sequenceId: input.sequenceId,
+        frameVersionId: null,
         cancelled: true,
       };
     }
@@ -352,6 +360,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
       throw new Error('Image generation did not return any image URLs');
     }
     let imageUrl: string = generatedImageUrl;
+    let frameVersionId: string | null = prep.versionId || null;
 
     if (imageUrl && shotId && sequenceId && teamId && !input.skipStorage) {
       const upload = await step.do('upload-image', async () => {
@@ -360,7 +369,11 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
 
       const writeResult = await step.do(
         'persist-result',
-        async (): Promise<{ imageUrl: string; cancelled?: boolean }> => {
+        async (): Promise<{
+          imageUrl: string;
+          cancelled?: boolean;
+          frameVersionId: string | null;
+        }> => {
           const promptHash = generation.prompt
             ? simpleHash(generation.prompt)
             : null;
@@ -374,7 +387,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
             logger.info(
               `[ImageWorkflow] Shot ${shotId} lost its anchor frame before select; skipping`
             );
-            return { imageUrl: upload.url };
+            return { imageUrl: upload.url, frameVersionId: null };
           }
 
           // Complete the in-flight version — status-guarded, so a user cancel
@@ -417,7 +430,11 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
                 versionId
               );
             }
-            return { imageUrl: upload.url, cancelled: true };
+            return {
+              imageUrl: upload.url,
+              cancelled: true,
+              frameVersionId: null,
+            };
           }
 
           await scopedDb.sequenceEvents.record({
@@ -441,7 +458,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
               model,
               variantOnly: true,
             });
-            return { imageUrl: upload.url };
+            return { imageUrl: upload.url, frameVersionId: versionId };
           }
 
           // Claim the promote in ONE conditional write: last kickoff / explicit
@@ -465,7 +482,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
               model,
             });
             logger.info(`[ImageWorkflow] Uploaded + selected: ${upload.path}`);
-            return { imageUrl: upload.url };
+            return { imageUrl: upload.url, frameVersionId: versionId };
           }
 
           // Not the promote target — finalize into history only. Reset in-flight
@@ -497,10 +514,11 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
           logger.info(
             `[ImageWorkflow] Uploaded unselected (pending promote moved): ${upload.path}`
           );
-          return { imageUrl: upload.url };
+          return { imageUrl: upload.url, frameVersionId: versionId };
         }
       );
       imageUrl = writeResult.imageUrl;
+      frameVersionId = writeResult.frameVersionId;
 
       // Provenance (#1180) — recorded before the cancel check on purpose: a
       // cancelled render still uploaded bytes to R2, so the object exists and
@@ -528,7 +546,13 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
       });
 
       if (writeResult.cancelled) {
-        return { imageUrl, shotId, sequenceId, cancelled: true };
+        return {
+          imageUrl,
+          shotId,
+          sequenceId,
+          frameVersionId: null,
+          cancelled: true,
+        };
       }
     } else if (imageUrl && shotId && input.skipStorage) {
       await step.do('record-preview-variant', async () => {
@@ -570,7 +594,7 @@ export class ImageWorkflow extends OpenStoryWorkflowEntrypoint<ImageWorkflowInpu
       });
     }
 
-    return { imageUrl, shotId, sequenceId };
+    return { imageUrl, shotId, sequenceId, frameVersionId };
   }
 
   protected override async onFailure({

--- a/src/lib/workflows/motion-music-prompts-workflow.ts
+++ b/src/lib/workflows/motion-music-prompts-workflow.ts
@@ -18,7 +18,7 @@
  * */
 
 import { DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
-import type { MotionPrompt, Scene } from '@/lib/ai/scene-analysis.schema';
+import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import { snapDuration } from '@/lib/motion/snap-duration';
 import { reinforceInstrumentalTags } from '@/lib/prompts/music-prompt';
@@ -31,6 +31,7 @@ import type {
   MusicPromptWorkflowInput,
   MusicPromptWorkflowResult,
 } from '@/lib/workflow/types';
+import type { MotionPromptWorkflowResult } from '@/lib/workflows/motion-prompt-workflow';
 import {
   buildMusicSceneSummaries,
   joinMusicDesignByIndex,
@@ -40,7 +41,7 @@ import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'motion-music-prompts']);
 
-type MotionPromptsResult = { sceneId: string; motionPrompt: MotionPrompt }[];
+type MotionPromptsResult = MotionPromptWorkflowResult[];
 
 export class MotionMusicPromptsWorkflow extends OpenStoryWorkflowEntrypoint<MotionMusicPromptsWorkflowInput> {
   protected override async runImpl(
@@ -185,12 +186,17 @@ export class MotionMusicPromptsWorkflow extends OpenStoryWorkflowEntrypoint<Moti
     // render batch rather than re-reading the racy `shot.motionPrompt` mirror /
     // selected-version pointer from the DB (#713/#991). The per-scene child has
     // already persisted them to `shot_prompt_versions`.
-    const motionPromptsBySceneId: Record<string, MotionPrompt> =
-      Object.fromEntries(motionPrompts.map((m) => [m.sceneId, m.motionPrompt]));
+    const motionPromptsBySceneId = Object.fromEntries(
+      motionPrompts.map((m) => [m.sceneId, m.motionPrompt])
+    );
+    const motionPromptVersionIdsBySceneId = Object.fromEntries(
+      motionPrompts.map((m) => [m.sceneId, m.finalVersionId ?? null])
+    );
 
     return {
       completeScenes,
       motionPromptsBySceneId,
+      motionPromptVersionIdsBySceneId,
       musicPrompt: musicDesign.prompt,
       musicTags: reinforceInstrumentalTags(musicDesign.tags),
     };

--- a/src/lib/workflows/motion-prompt-batch-workflow.test.ts
+++ b/src/lib/workflows/motion-prompt-batch-workflow.test.ts
@@ -100,7 +100,11 @@ function makeWorkflow(): Probe {
 const SCOPED_DB = {} as unknown as WorkflowScopedDb;
 
 const succeed = (sceneId: string) =>
-  Promise.resolve({ sceneId, motionPrompt: { fullPrompt: `move ${sceneId}` } });
+  Promise.resolve({
+    sceneId,
+    motionPrompt: { fullPrompt: `move ${sceneId}` },
+    finalVersionId: `mpv-${sceneId}`,
+  });
 
 describe('MotionPromptBatchWorkflow partial failures', () => {
   test('returns every prompt when all scenes succeed', async () => {
@@ -117,6 +121,13 @@ describe('MotionPromptBatchWorkflow partial failures', () => {
     );
 
     expect(result.map((r) => r.sceneId)).toEqual(SCENE_IDS);
+    // Parents pin the render off THIS id — stripping it is how storyboard
+    // clips were born with a null motionPromptVersionId (#1380).
+    expect(result.map((r) => r.finalVersionId)).toEqual([
+      'mpv-scene_1',
+      'mpv-scene_2',
+      'mpv-scene_3',
+    ]);
   });
 
   test('keeps the survivors when one scene fails', async () => {

--- a/src/lib/workflows/motion-prompt-batch-workflow.ts
+++ b/src/lib/workflows/motion-prompt-batch-workflow.ts
@@ -12,7 +12,6 @@
  * parent still surfaces a terminal error, but only after every other sibling has
  * resolved one way or the other. */
 
-import type { MotionPrompt } from '@/lib/ai/scene-analysis.schema';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import { spawnAndAwaitChild } from '@/lib/workflow/await-child';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
@@ -21,16 +20,12 @@ import type {
   MotionPromptWorkflowInput,
   MotionPromptBatchWorkflowInput,
 } from '@/lib/workflow/types';
+import type { MotionPromptWorkflowResult } from '@/lib/workflows/motion-prompt-workflow';
 import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
 import { NonRetryableError } from 'cloudflare:workflows';
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'workflow', 'motion-prompt-batch']);
-
-type MotionPromptWorkflowResult = {
-  sceneId: string;
-  motionPrompt: MotionPrompt;
-};
 
 type MotionPromptBatchWorkflowResult = MotionPromptWorkflowResult[];
 
@@ -180,6 +175,9 @@ export class MotionPromptBatchWorkflow extends OpenStoryWorkflowEntrypoint<Motio
     return results.map((result) => ({
       sceneId: result.sceneId,
       motionPrompt: result.motionPrompt,
+      // Threaded so analyze-script can pin the render off THIS id rather
+      // than re-reading the shot's selection pointer (#1380).
+      finalVersionId: result.finalVersionId ?? null,
     }));
   }
 

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -292,12 +292,21 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
               durationMs: duration * 1000,
             },
           ]);
+          const inputHash = await computeVideoManifestInputHash(
+            manifest,
+            model
+          );
+          if (inputHash == null && !input.variantOnly) {
+            logger.warn(
+              `[MotionWorkflow:cf] Shot ${input.shotId} primary render is missing pinned frameVersionId/motionPromptVersionId; storing a null hash so the clip is unknown-not-stale rather than born Stale (#1380)`
+            );
+          }
           const version = await scopedDb.videoVariants.appendVersion({
             renderSegmentId,
             sequenceId: input.sequenceId,
             model,
             manifest,
-            inputHash: await computeVideoManifestInputHash(manifest, model),
+            inputHash,
             status: 'generating',
             workflowRunId,
             isPrimary: !input.variantOnly,

--- a/src/lib/workflows/shot-images-workflow.ts
+++ b/src/lib/workflows/shot-images-workflow.ts
@@ -79,6 +79,13 @@ type ImageChildResult = {
   imageUrl: string;
   shotId?: string;
   sequenceId?: string;
+  /** The `frame_variants` version this still completed as. Null when none. */
+  frameVersionId?: string | null;
+};
+
+type ShotImageJobResult = {
+  imageUrl: string;
+  frameVersionId: string | null;
 };
 
 /**
@@ -298,7 +305,7 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
     const runImageJob = async (
       { scene, model }: (typeof jobs)[number],
       attempt: 'first' | 'retry'
-    ): Promise<string> => {
+    ): Promise<ShotImageJobResult> => {
       const context = sceneContexts.get(scene.sceneId);
       if (context === undefined) {
         throw new WorkflowValidationError(
@@ -418,12 +425,14 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
         }
       );
 
-      return childOutput.imageUrl;
+      return {
+        imageUrl: childOutput.imageUrl,
+        frameVersionId: childOutput.frameVersionId ?? null,
+      };
     };
 
-    const jobResults: PromiseSettledResult<string>[] = await Promise.allSettled(
-      jobs.map((job) => runImageJob(job, 'first'))
-    );
+    const jobResults: PromiseSettledResult<ShotImageJobResult>[] =
+      await Promise.allSettled(jobs.map((job) => runImageJob(job, 'first')));
 
     // One failed primary of many is usually a transient content-flag or
     // timeout — retry it once silently so the scenes page doesn't open on
@@ -440,10 +449,10 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
           `[ShotImagesWorkflow:cf] Silently retrying lone failed primary for scene ${retryJob.scene.sceneId} model ${retryJob.model}`
         );
         try {
-          const retriedUrl = await runImageJob(retryJob, 'retry');
+          const retried = await runImageJob(retryJob, 'retry');
           jobResults[retryIndex] = {
             status: 'fulfilled',
-            value: retriedUrl,
+            value: retried,
           };
         } catch (err) {
           jobResults[retryIndex] = { status: 'rejected', reason: err };
@@ -458,7 +467,7 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
     // each scene's model sequence exactly.
     const modelResultsByScene = new Map<
       number,
-      PromiseSettledResult<string>[]
+      PromiseSettledResult<ShotImageJobResult>[]
     >();
     jobs.forEach((job, jobIndex) => {
       const result = jobResults[jobIndex];
@@ -473,7 +482,7 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
     // for parity with the QStash original's `result.isFailed` check.
     // Sibling-model failures are logged but don't block — they're
     // alternates that enrich `shot_variants`, not the primary.
-    const sceneResults: PromiseSettledResult<string>[] =
+    const sceneResults: PromiseSettledResult<ShotImageJobResult>[] =
       scenesWithVisualPrompts.map((scene, sceneIndex) => {
         const modelResults = modelResultsByScene.get(sceneIndex) ?? [];
         const primary = modelResults[0];
@@ -517,7 +526,7 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
     // with no visual prompt (or a deleted shot mid-flight) can't poison the
     // rest of the batch.
     const imageUrls: (string | null)[] = sceneResults.map((r, i) => {
-      if (r.status === 'fulfilled') return r.value;
+      if (r.status === 'fulfilled') return r.value.imageUrl;
       const scene = scenesWithVisualPrompts[i];
       logger.error(
         `[ShotImagesWorkflow:cf] Scene ${scene?.sceneId ?? '(unknown)'} failed: ${String(r.reason)}`,
@@ -527,8 +536,11 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
       );
       return null;
     });
+    const frameVersionIds: (string | null)[] = sceneResults.map((r) =>
+      r.status === 'fulfilled' ? r.value.frameVersionId : null
+    );
 
-    return { imageUrls };
+    return { imageUrls, frameVersionIds };
   }
 
   protected override onFailure({

--- a/src/lib/workflows/storyboard-motion-batch-shots.test.ts
+++ b/src/lib/workflows/storyboard-motion-batch-shots.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Storyboard auto-motion batch shots must pin the still + motion-prompt
+ * version ids the render actually consumed (#1380). Omitting them stamps
+ * `video_variants.manifest` with nulls, so every clip is born Stale.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_VIDEO_MODEL } from '@/lib/ai/models';
+import type { MotionPrompt, Scene } from '@/lib/ai/scene-analysis.schema';
+import { WorkflowValidationError } from '@/lib/workflow/errors';
+import { buildStoryboardMotionBatchShots } from './storyboard-motion-batch-shots';
+
+function scene(sceneId: string, durationSeconds = 5): Scene {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- helper only reads sceneId, metadata.durationSeconds, continuity.characterTags
+  return {
+    sceneId,
+    sceneNumber: 1,
+    originalScript: { extract: 'a beat', lineNumber: 1 },
+    metadata: { title: sceneId, durationSeconds },
+    continuity: { characterTags: [] },
+  } as unknown as Scene;
+}
+
+const prompt = (fullPrompt: string): MotionPrompt => ({ fullPrompt });
+
+describe('buildStoryboardMotionBatchShots', () => {
+  it('pins frameVersionId and motionPromptVersionId on each shot', () => {
+    const shots = buildStoryboardMotionBatchShots({
+      scenes: [scene('sc-1'), scene('sc-2')],
+      shotMapping: [
+        { analysisSceneId: 'sc-1', shotId: 'shot-1', frameId: 'fr-1' },
+        { analysisSceneId: 'sc-2', shotId: 'shot-2', frameId: 'fr-2' },
+      ],
+      imageUrls: ['https://cdn/a.png', 'https://cdn/b.png'],
+      frameVersionIds: ['fv-1', 'fv-2'],
+      motionPromptsBySceneId: {
+        'sc-1': prompt('pan across the dock'),
+        'sc-2': prompt('push in on the door'),
+      },
+      motionPromptVersionIdsBySceneId: {
+        'sc-1': 'mpv-1',
+        'sc-2': 'mpv-2',
+      },
+      videoModel: DEFAULT_VIDEO_MODEL,
+      aspectRatio: '16:9',
+      characters: [],
+      elements: [],
+    });
+
+    expect(shots).toHaveLength(2);
+    expect(shots[0]).toMatchObject({
+      shotId: 'shot-1',
+      imageUrl: 'https://cdn/a.png',
+      frameVersionId: 'fv-1',
+      motionPromptVersionId: 'mpv-1',
+    });
+    expect(shots[1]).toMatchObject({
+      shotId: 'shot-2',
+      imageUrl: 'https://cdn/b.png',
+      frameVersionId: 'fv-2',
+      motionPromptVersionId: 'mpv-2',
+    });
+  });
+
+  it('skips a scene whose still failed rather than throwing', () => {
+    const shots = buildStoryboardMotionBatchShots({
+      scenes: [scene('sc-1'), scene('sc-2')],
+      shotMapping: [
+        { analysisSceneId: 'sc-1', shotId: 'shot-1', frameId: 'fr-1' },
+        { analysisSceneId: 'sc-2', shotId: 'shot-2', frameId: 'fr-2' },
+      ],
+      imageUrls: [null, 'https://cdn/b.png'],
+      frameVersionIds: [null, 'fv-2'],
+      motionPromptsBySceneId: {
+        'sc-2': prompt('push in on the door'),
+      },
+      motionPromptVersionIdsBySceneId: { 'sc-2': 'mpv-2' },
+      videoModel: DEFAULT_VIDEO_MODEL,
+      aspectRatio: '16:9',
+      characters: [],
+      elements: [],
+    });
+
+    expect(shots).toHaveLength(1);
+    expect(shots[0]?.shotId).toBe('shot-2');
+    expect(shots[0]?.frameVersionId).toBe('fv-2');
+    expect(shots[0]?.motionPromptVersionId).toBe('mpv-2');
+  });
+
+  it('throws when a still exists but the motion prompt does not', () => {
+    expect(() =>
+      buildStoryboardMotionBatchShots({
+        scenes: [scene('sc-1')],
+        shotMapping: [
+          { analysisSceneId: 'sc-1', shotId: 'shot-1', frameId: 'fr-1' },
+        ],
+        imageUrls: ['https://cdn/a.png'],
+        frameVersionIds: ['fv-1'],
+        motionPromptsBySceneId: {},
+        motionPromptVersionIdsBySceneId: {},
+        videoModel: DEFAULT_VIDEO_MODEL,
+        aspectRatio: '16:9',
+        characters: [],
+        elements: [],
+      })
+    ).toThrow(WorkflowValidationError);
+  });
+});

--- a/src/lib/workflows/storyboard-motion-batch-shots.ts
+++ b/src/lib/workflows/storyboard-motion-batch-shots.ts
@@ -1,0 +1,97 @@
+/**
+ * Build the per-shot payload analyze-script hands to motion-batch.
+ *
+ * The still URL, the `frame_variants` version that produced it, and the
+ * `shot_prompt_versions` row the motion-prompt child just wrote are all
+ * snapshotted here — the motion child never re-derives them (#1380). Omitting
+ * the version ids stamps `video_variants.manifest` with nulls, so every
+ * auto-motion clip is born Stale.
+ */
+
+import type { ImageToVideoModel } from '@/lib/ai/models';
+import type { MotionPrompt, Scene } from '@/lib/ai/scene-analysis.schema';
+import type { AspectRatio } from '@/lib/constants/aspect-ratios';
+import type { CharacterMinimal, SequenceElementMinimal } from '@/lib/db/schema';
+import { assembleMotionPrompt } from '@/lib/motion/assemble-motion-prompt';
+import { buildMotionReferenceImages } from '@/lib/motion/build-motion-references';
+import { getLogger } from '@/lib/observability/logger';
+import { WorkflowValidationError } from '@/lib/workflow/errors';
+import type { BatchMotionMusicWorkflowInput } from '@/lib/workflow/types';
+
+const logger = getLogger(['openstory', 'workflow', 'analyze-script']);
+
+type ShotMapping = Array<{
+  analysisSceneId: string;
+  shotId: string;
+  frameId?: string | null;
+}>;
+
+export function buildStoryboardMotionBatchShots(input: {
+  scenes: readonly Scene[];
+  shotMapping: ShotMapping;
+  /** Aligned to `scenes`; a null slot means that scene's still failed. */
+  imageUrls: readonly (string | null)[];
+  /** Aligned to `scenes` / `imageUrls`. */
+  frameVersionIds: readonly (string | null)[];
+  motionPromptsBySceneId: Record<string, MotionPrompt | undefined>;
+  motionPromptVersionIdsBySceneId: Record<string, string | null | undefined>;
+  videoModel: ImageToVideoModel;
+  aspectRatio: AspectRatio;
+  characters: CharacterMinimal[];
+  elements: SequenceElementMinimal[];
+}): BatchMotionMusicWorkflowInput['shots'] {
+  return input.scenes.flatMap((scene, index) => {
+    const matchedShot = input.shotMapping.find(
+      (f) => f.analysisSceneId === scene.sceneId
+    );
+    // `imageUrls` is aligned to scene order; a null slot means that
+    // scene's image generation failed (the shot is already marked
+    // failed by the image workflow). Motion-prompt batch also skips
+    // those scenes (no starting frame). Skip rather than throwing —
+    // a missing still used to fail the whole storyboard.
+    const imageUrl = input.imageUrls[index];
+    if (!imageUrl) {
+      logger.warn(
+        `[AnalyzeScriptWorkflow:cf] Scene ${scene.sceneId} has no generated image (index ${index}); skipping its motion`
+      );
+      return [];
+    }
+
+    const motionPromptData = input.motionPromptsBySceneId[scene.sceneId];
+    if (!motionPromptData?.fullPrompt) {
+      throw new WorkflowValidationError(
+        `Scene ${scene.sceneId} has no motion prompt`
+      );
+    }
+
+    const characterTags = scene.continuity?.characterTags;
+
+    return {
+      shotId: matchedShot?.shotId ?? '',
+      imageUrl,
+      frameVersionId: input.frameVersionIds[index] ?? null,
+      motionPromptVersionId:
+        input.motionPromptVersionIdsBySceneId[scene.sceneId] ?? null,
+      // Primary-model prompt (fallback / single-model). `motion-batch`
+      // re-assembles per model from `motionPrompt` for the alternates.
+      prompt: assembleMotionPrompt({
+        motionPrompt: motionPromptData,
+        model: input.videoModel,
+        characterTags,
+      }),
+      model: input.videoModel,
+      motionPrompt: motionPromptData,
+      characterTags,
+      duration: scene.metadata?.durationSeconds || 3,
+      aspectRatio: input.aspectRatio,
+      // Cast/element refs so motion preserves identity across the clip
+      // (#873) — only Kling v3 Pro emits them. Same library + matcher the
+      // image step uses, so motion attaches the same references.
+      referenceImages: buildMotionReferenceImages({
+        scene,
+        characters: input.characters,
+        elements: input.elements,
+      }),
+    };
+  });
+}


### PR DESCRIPTION
Closes #1380

## Why

Every clip from the storyboard automatic motion pass showed **Stale** in the shot strip and Video tab as soon as it completed, before anyone changed a still or prompt.

The storyboard motion-batch payload sent `shotId`, `imageUrl`, `prompt`, … but not `frameVersionId` or `motionPromptVersionId`. Motion-batch passes those through untouched, so the clip's `video_variants.manifest` landed as:

```json
[{"shotId":"…","motionPromptVersionId":null,"frameVersionId":null,"durationMs":5000}]
```

Staleness compares that to the *current* selected still + prompt versions → always different → born Stale.

## What

Snapshot both ids onto each batch shot at spawn, same "pinned at the trigger" contract as the server-fn paths:

- `frameVersionId` — the `frame_variants` version shot-images just promoted
- `motionPromptVersionId` — the `shot_prompt_versions` id the motion-prompt child returned as `finalVersionId` (the batch used to strip it)

Defense in depth: a null-null manifest now stores a null `inputHash` and `isSelectedVersionStale` treats it as unknown-not-stale (same as a legacy null hash), so a regression cannot silently mark every clip Stale again. Existing wrongly-stale clips from this bug also stop showing Stale until a still or prompt actually changes.

## Verification

- `bun run test src/lib/workflows/storyboard-motion-batch-shots.test.ts src/lib/workflows/motion-prompt-batch-workflow.test.ts src/lib/scenes/scene-segments.test.ts src/lib/ai/input-hash.test.ts src/lib/db/scoped/video-variants.test.ts` — passed
- Related: media-upload, backfill, motion-workflow, staleness-matrix — passed
- lint / format / typecheck / dead-code via lefthook pre-commit