### PR TITLE
fix(#1382): H3 Max estimates 8 units per 5s clip, not duration

### DIFF
--- a/src/lib/ai/__tests__/fal-pricing-fixture.ts
+++ b/src/lib/ai/__tests__/fal-pricing-fixture.ts
@@ -43,8 +43,14 @@ export const TEST_FAL_PRICING: Record<string, EffectiveFalPricing> = {
     typicalUnitsPerCall: 1,
   },
   'minimax/h3-max/image-to-video': {
-    unitPrice: micros(80_000),
+    unitPrice: micros(25_000),
     unit: 'seconds',
+    typicalUnitsPerCall: 8,
+  },
+  'minimax/h3-max/text-to-video': {
+    unitPrice: micros(25_000),
+    unit: 'seconds',
+    typicalUnitsPerCall: 8,
   },
   'bytedance/seedance-2.5/image-to-video': {
     unitPrice: micros(14_000),

--- a/src/lib/ai/fal-cost.test.ts
+++ b/src/lib/ai/fal-cost.test.ts
@@ -117,6 +117,95 @@ describe('estimateFalCost', () => {
     ).toBe(usd(3.2));
   });
 
+  test('per-second still prefers requested duration over fal typical clip length', () => {
+    // fal's historical typical for Veo is an average duration, not a
+    // resolution multiplier. Using it would price a 4s clip as 8s.
+    const live = {
+      'fal-ai/veo3.1/image-to-video': {
+        unitPrice: usd(0.4),
+        unit: 'seconds',
+        typicalUnitsPerCall: 8,
+      },
+    };
+    expect(
+      estimateFalCost(
+        'fal-ai/veo3.1/image-to-video',
+        { durationSeconds: 4 },
+        live
+      )
+    ).toBe(usd(1.6));
+  });
+
+  test('H3 Max 5s clip estimates 8 units at the billed 480p-second rate', () => {
+    // 768P default bills 1.6× the stored $0.025 unit → 8 units × $0.025 = $0.20.
+    // Using duration (5) as units was 37% low (#1382).
+    const live = {
+      'minimax/h3-max/image-to-video': {
+        unitPrice: micros(25_000),
+        unit: 'seconds',
+      },
+    };
+    expect(
+      estimateFalCost(
+        'minimax/h3-max/image-to-video',
+        { durationSeconds: 5 },
+        live
+      )
+    ).toBe(usd(0.2));
+  });
+
+  test('H3 Max scales the 5s typical with requested duration', () => {
+    const live = {
+      'minimax/h3-max/image-to-video': {
+        unitPrice: micros(25_000),
+        unit: 'seconds',
+        typicalUnitsPerCall: 8,
+      },
+    };
+    expect(
+      estimateFalCost(
+        'minimax/h3-max/image-to-video',
+        { durationSeconds: 10 },
+        live
+      )
+    ).toBe(usd(0.4));
+  });
+
+  test('H3 Max observed median outranks duration for seconds-priced video', () => {
+    const live = {
+      'minimax/h3-max/image-to-video': {
+        unitPrice: micros(25_000),
+        unit: 'seconds',
+        observed: { medianUnits: 8, sampleCount: MIN_OBSERVED_SAMPLES },
+      },
+    };
+    expect(
+      estimateFalCost(
+        'minimax/h3-max/image-to-video',
+        { durationSeconds: 5 },
+        live
+      )
+    ).toBe(usd(0.2));
+  });
+
+  test('H3 Max t2v compute-seconds still has a unit-count signal', () => {
+    // Before the sibling alias copies i2v's verified rate, t2v sat on
+    // "compute seconds × $0.00017" and logged "No unit-count signal".
+    const live = {
+      'minimax/h3-max/text-to-video': {
+        unitPrice: micros(170),
+        unit: 'compute seconds',
+      },
+    };
+    expect(
+      estimateFalCost(
+        'minimax/h3-max/text-to-video',
+        { durationSeconds: 5 },
+        live
+      )
+    ).not.toBeNull();
+  });
+
   test('per-minute rounds up', () => {
     expect(
       estimateFalCost(

--- a/src/lib/ai/fal-cost.ts
+++ b/src/lib/ai/fal-cost.ts
@@ -9,9 +9,10 @@
  * `estimateFalCost` predicts a cost BEFORE a generation runs, for the
  * pre-flight credit gate. Preference order for the unit count (#1069):
  * our observed median (`MIN_OBSERVED_SAMPLES`+ generations), then fal's
- * historical estimate, then **null** ("unknown") — never a fabricated
- * default; a fixed one made Grok Imagine read ~98× cheap. Callers gate
- * conservatively / display nothing for null.
+ * historical estimate, then a billed-units fallback for endpoints whose
+ * "seconds" unit is not 1:1 with duration (H3 Max, #1382), then **null**
+ * ("unknown") — never a fabricated default; a fixed one made Grok Imagine
+ * read ~98× cheap. Callers gate conservatively / display nothing for null.
  */
 
 // Type-only static import + dynamic import at the call site: a static value
@@ -20,6 +21,10 @@
 // components via `cost-estimation.ts` (#1253). Client callers always pass
 // `pricingMap`, so the dynamic import only ever executes on the server.
 import type { EffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
+import {
+  FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP,
+  TYPICAL_VIDEO_CLIP_SECONDS,
+} from '@/lib/ai/fal-typical-units';
 import { reportMissingBillingCost } from '@/lib/billing/billing-observability';
 import {
   type Microdollars,
@@ -177,9 +182,31 @@ const isUsableCount = (n: number | undefined | null): n is number =>
 
 /**
  * Predicted unitsBilled for one call: our observed median first (once it has
- * `MIN_OBSERVED_SAMPLES` behind it), then fal's historical estimate.
+ * `MIN_OBSERVED_SAMPLES` behind it), then fal's historical estimate, then a
+ * known billed-units fallback (H3 Max 8 for a 5s clip — #1382).
  */
 export function knownUnitsPerCall(
+  pricing: EffectiveFalPricing,
+  endpointId?: string
+): number | undefined {
+  const { observed } = pricing;
+  if (
+    observed &&
+    observed.sampleCount >= MIN_OBSERVED_SAMPLES &&
+    isUsableCount(observed.medianUnits)
+  ) {
+    return observed.medianUnits;
+  }
+  if (isUsableCount(pricing.typicalUnitsPerCall)) {
+    return pricing.typicalUnitsPerCall;
+  }
+  const fallback = endpointId
+    ? FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP[endpointId]
+    : undefined;
+  return isUsableCount(fallback) ? fallback : undefined;
+}
+
+function trustedObservedUnits(
   pricing: EffectiveFalPricing
 ): number | undefined {
   const { observed } = pricing;
@@ -190,9 +217,41 @@ export function knownUnitsPerCall(
   ) {
     return observed.medianUnits;
   }
-  return isUsableCount(pricing.typicalUnitsPerCall)
-    ? pricing.typicalUnitsPerCall
-    : undefined;
+  return undefined;
+}
+
+/**
+ * Predicted billable units for a seconds-priced video call.
+ *
+ * Wall-clock duration is 1:1 for models like Veo. H3 Max (and any endpoint
+ * in `FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP`) bills more units than seconds —
+ * 768P is 1.6× the stored 480p unit — so observed/typical/fallback outranks
+ * duration and scales from a 5s default clip (#1382).
+ *
+ * Fal's historical `typicalUnitsPerCall` for ordinary per-second models is
+ * an average clip length and must not replace the requested duration.
+ */
+function predictedSecondUnits(
+  endpointId: string,
+  duration: number,
+  pricing: EffectiveFalPricing
+): number {
+  const observedUnits = trustedObservedUnits(pricing);
+  const fallback = FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP[endpointId];
+
+  if (fallback != null) {
+    const known =
+      observedUnits ??
+      (isUsableCount(pricing.typicalUnitsPerCall)
+        ? pricing.typicalUnitsPerCall
+        : fallback);
+    return Math.max(duration, known * (duration / TYPICAL_VIDEO_CLIP_SECONDS));
+  }
+
+  if (observedUnits != null) {
+    return Math.max(duration, observedUnits);
+  }
+  return duration;
 }
 
 /**
@@ -221,7 +280,7 @@ export function estimateFalCost(
       // Covers flat rates, per-image "units" prices (gpt-image-2 bills ~0.22
       // units per image on a $1 unit), and compute-seconds models (~10 to
       // ~294 s/image across models — unknowable from request params).
-      const unitsPerCall = knownUnitsPerCall(pricing);
+      const unitsPerCall = knownUnitsPerCall(pricing, endpointId);
       if (unitsPerCall == null) {
         logger.error(
           `No unit-count signal for ${endpointId} (unit "${pricing.unit}") — ` +
@@ -240,7 +299,10 @@ export function estimateFalCost(
     }
 
     case 'seconds':
-      return multiplyMicros(pricing.unitPrice, duration);
+      return multiplyMicros(
+        pricing.unitPrice,
+        predictedSecondUnits(endpointId, duration, pricing)
+      );
 
     case 'minutes':
       return multiplyMicros(pricing.unitPrice, Math.ceil(duration / 60));

--- a/src/lib/ai/fal-pricing-live.test.ts
+++ b/src/lib/ai/fal-pricing-live.test.ts
@@ -205,3 +205,48 @@ describe('BytePlus route aliasing', () => {
     expect(map['fal-ai/veo3.1/image-to-video']?.unitPrice).toBe(77);
   });
 });
+
+describe('H3 Max t2v sibling rate (#1382)', () => {
+  const I2V = 'minimax/h3-max/image-to-video';
+  const T2V = 'minimax/h3-max/text-to-video';
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('fills typical 8 when the i2v row has no fal history', async () => {
+    const { getEffectiveFalPricing } = await loadWithRows([
+      row({
+        endpointId: I2V,
+        unit: 'seconds',
+        unitPriceMicros: 25_000,
+        typicalUnitsPerCall: null,
+      }),
+    ]);
+    const pricing = (await getEffectiveFalPricing())[I2V];
+    expect(pricing?.typicalUnitsPerCall).toBe(8);
+  });
+
+  it('points t2v at i2v’s billed seconds rate instead of compute seconds', async () => {
+    const { getEffectiveFalPricing } = await loadWithRows([
+      row({
+        endpointId: I2V,
+        unit: 'seconds',
+        unitPriceMicros: 25_000,
+        typicalUnitsPerCall: 8,
+      }),
+      row({
+        endpointId: T2V,
+        unit: 'compute seconds',
+        unitPriceMicros: 170,
+        typicalUnitsPerCall: null,
+      }),
+    ]);
+    const map = await getEffectiveFalPricing();
+    expect(map[T2V]).toEqual({
+      unitPrice: micros(25_000),
+      unit: 'seconds',
+      typicalUnitsPerCall: 8,
+    });
+  });
+});

--- a/src/lib/ai/fal-pricing-live.ts
+++ b/src/lib/ai/fal-pricing-live.ts
@@ -10,6 +10,10 @@ import { getDb } from '#db-client';
 import { isBytePlusConfigured } from '@/lib/ai/byteplus-config';
 import { BYTEPLUS_RATE_CARD } from '@/lib/ai/byteplus-pricing';
 import {
+  FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP,
+  FAL_UNVERIFIED_SIBLINGS,
+} from '@/lib/ai/fal-typical-units';
+import {
   IMAGE_MODELS,
   IMAGE_TO_VIDEO_MODELS,
   MOTION_REFERENCE_ENDPOINTS,
@@ -74,7 +78,9 @@ export function buildFalPricingMap(
     map[row.endpointId] = {
       unitPrice: micros(row.unitPriceMicros),
       unit: row.unit,
-      typicalUnitsPerCall: row.typicalUnitsPerCall ?? undefined,
+      typicalUnitsPerCall:
+        row.typicalUnitsPerCall ??
+        FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP[row.endpointId],
       // The DB CHECK keeps median and count consistent.
       ...(row.observedMedianUnits != null && {
         observed: {
@@ -111,6 +117,7 @@ async function load(): Promise<NonNullable<typeof cache>> {
   // (if the cron ever learns Ark) wins over the hand-maintained rate.
   const map = { ...BYTEPLUS_RATE_CARD, ...buildFalPricingMap(rows) };
   applyBytePlusRouteAliases(map);
+  applyUnverifiedSiblingRates(map);
   cache = { at: Date.now(), map, updatedAt };
   return cache;
 }
@@ -148,6 +155,33 @@ function applyBytePlusRouteAliases(
     // referenced shot silently quotes the fal rate.
     const referenceEndpoint = MOTION_REFERENCE_ENDPOINTS[modelKey];
     if (referenceEndpoint) map[referenceEndpoint.endpointId] = rate;
+  }
+}
+
+/**
+ * Point an unused sibling at the bill-verified source rate (#1382).
+ * MiniMax H3 Max t2v has the same advertised rates as i2v but no usage, so
+ * fal's pricing API still reports "compute seconds × $0.00017". Looking up
+ * the t2v id must yield the i2v billed rate or studio estimates are ~150× low.
+ */
+function applyUnverifiedSiblingRates(
+  map: Record<string, EffectiveFalPricing>
+): void {
+  for (const [target, source] of Object.entries(FAL_UNVERIFIED_SIBLINGS)) {
+    const sourceRate = map[source];
+    if (!sourceRate) continue;
+    const targetRate = map[target];
+    map[target] = {
+      unitPrice: sourceRate.unitPrice,
+      unit: sourceRate.unit,
+      typicalUnitsPerCall:
+        targetRate?.typicalUnitsPerCall ??
+        sourceRate.typicalUnitsPerCall ??
+        FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP[target],
+      ...((targetRate?.observed ?? sourceRate.observed)
+        ? { observed: targetRate?.observed ?? sourceRate.observed }
+        : {}),
+    };
   }
 }
 

--- a/src/lib/ai/fal-typical-units.ts
+++ b/src/lib/ai/fal-typical-units.ts
@@ -1,0 +1,25 @@
+/**
+ * Endpoints whose fal unit is "seconds" but billed units are not 1:1 with
+ * wall-clock duration (#1382). MiniMax H3 Max stores the 480p second as the
+ * unit ($0.025); 768P (our default) is 1.6×, so a 5s clip bills 8 units.
+ *
+ * Values are billed units for a default-length call
+ * (`TYPICAL_VIDEO_CLIP_SECONDS`).
+ */
+export const TYPICAL_VIDEO_CLIP_SECONDS = 5;
+
+export const FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP: Readonly<
+  Record<string, number>
+> = {
+  'minimax/h3-max/image-to-video': 8,
+  'minimax/h3-max/text-to-video': 8,
+};
+
+/**
+ * Sibling endpoints that share advertised (and, so far, billed) rates.
+ * t2v has no usage of its own yet, so it inherits i2v's bill-verified rate
+ * rather than sitting on fal's advertised "compute seconds × $0.00017".
+ */
+export const FAL_UNVERIFIED_SIBLINGS: Readonly<Record<string, string>> = {
+  'minimax/h3-max/text-to-video': 'minimax/h3-max/image-to-video',
+};

--- a/src/lib/billing/cost-estimation.test.ts
+++ b/src/lib/billing/cost-estimation.test.ts
@@ -13,6 +13,7 @@ import {
   estimateLocationSheetCount,
   estimateStoryboardCost,
   estimateStoryboardRenderCost,
+  estimateStudioVideoCost,
   estimateVideoCost,
   gateEstimate,
 } from './cost-estimation';
@@ -399,6 +400,18 @@ describe('estimateVideoCost endpoint routing', () => {
     });
     expect(withRefs).toBe(without);
     expect(withRefs).toBe(micros(5 * 70_000));
+  });
+
+  it('prices a 5s H3 Max clip at $0.20 (8 billed units, not duration)', () => {
+    expect(
+      estimateVideoCost('minimax_h3_max', 5, { pricing: FAL_PRICING })
+    ).toBe(micros(200_000));
+    expect(
+      estimateStudioVideoCost('minimax_h3_max', 5, {
+        pricing: FAL_PRICING,
+        mode: 'text',
+      })
+    ).toBe(micros(200_000));
   });
 });
 

--- a/src/lib/cron/reconcile-fal-billing.test.ts
+++ b/src/lib/cron/reconcile-fal-billing.test.ts
@@ -13,6 +13,7 @@ import {
   teams,
   transactions,
 } from '@/lib/db/schema';
+import { modelUsageObservations } from '@/lib/db/schema/model-pricing';
 import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 
@@ -136,6 +137,7 @@ describe('reconcileFalBilling', () => {
     await db.delete(modelPricing);
     await db.delete(modelPricingHistory);
     await db.delete(transactions);
+    await db.delete(modelUsageObservations);
     vi.unstubAllGlobals();
   });
 
@@ -212,5 +214,65 @@ describe('reconcileFalBilling', () => {
     const summary = await reconcileFalBilling({ billingKey: 'admin' });
     expect(summary?.unmatchedEvents).toBe(1);
     expect(driftReports).toHaveLength(0);
+  });
+
+  test('writes observed_median_units from our own samples the same hour', async () => {
+    await db.insert(modelPricing).values(
+      pricingRow({
+        endpointId: 'minimax/h3-max/image-to-video',
+        unit: 'seconds',
+        unitPriceMicros: 25_000,
+      })
+    );
+    await db.insert(modelUsageObservations).values(
+      Array.from({ length: 6 }, (_, i) => ({
+        provider: 'fal' as const,
+        endpointId: 'minimax/h3-max/image-to-video',
+        unitsBilled: 8,
+        numImages: 1,
+        id: `obs-${i}`,
+      }))
+    );
+    const { reconcileFalBilling } = await load([]);
+
+    const summary = await reconcileFalBilling({ billingKey: 'admin' });
+
+    expect(summary?.observedEndpoints).toBe(1);
+    const [row] = await db.select().from(modelPricing);
+    expect(row?.observedMedianUnits).toBe(8);
+    expect(row?.observedSampleCount).toBe(6);
+    expect(row?.typicalUnitsPerCall).toBe(8);
+  });
+
+  test('t2v inherits i2v’s billed unit price when t2v has no events', async () => {
+    await db.insert(modelPricing).values([
+      pricingRow({
+        endpointId: 'minimax/h3-max/image-to-video',
+        unit: 'seconds',
+        unitPriceMicros: 25_000,
+      }),
+      pricingRow({
+        endpointId: 'minimax/h3-max/text-to-video',
+        unit: 'compute seconds',
+        unitPriceMicros: 170,
+      }),
+    ]);
+    const { reconcileFalBilling } = await load([
+      event({
+        endpoint_id: 'minimax/h3-max/image-to-video',
+        unit_price: 0.025,
+        output_units: 8,
+        cost_total: 0.2,
+        cost_estimate_nano_usd: 200_000_000,
+      }),
+    ]);
+
+    await reconcileFalBilling({ billingKey: 'admin' });
+
+    const t2v = (await db.select().from(modelPricing)).find(
+      (r) => r.endpointId === 'minimax/h3-max/text-to-video'
+    );
+    expect(t2v?.unitPriceMicros).toBe(25_000);
+    expect(t2v?.rateVerifiedAt).not.toBeNull();
   });
 });

--- a/src/lib/cron/reconcile-fal-billing.ts
+++ b/src/lib/cron/reconcile-fal-billing.ts
@@ -25,6 +25,7 @@ import {
   fetchFalBillingEvents,
 } from '@/lib/ai/fal-pricing-fetch';
 import { reportBillingDrift } from '@/lib/billing/billing-observability';
+import { FAL_UNVERIFIED_SIBLINGS } from '@/lib/ai/fal-typical-units';
 import { usdToMicros } from '@/lib/billing/money';
 import {
   modelPricing,
@@ -33,7 +34,10 @@ import {
 } from '@/lib/db/schema';
 import { getLogger } from '@/lib/observability/logger';
 import { and, eq, gte, lte } from 'drizzle-orm';
-import type { PricingRefreshDb } from './refresh-fal-pricing';
+import {
+  type PricingRefreshDb,
+  writeObservedUnits,
+} from './refresh-fal-pricing';
 
 const logger = getLogger(['openstory', 'cron', 'reconcile-fal-billing']);
 
@@ -55,6 +59,8 @@ export type FalBillingReconcileSummary = {
   matchedTransactions: number;
   drifts: number;
   rateCorrections: number;
+  /** Endpoints whose observed_median_units were patched from our samples. */
+  observedEndpoints: number;
   /** Events with no matching transaction (scripts, unpriced $0 charges…). */
   unmatchedEvents: number;
 };
@@ -90,14 +96,17 @@ export async function reconcileFalBilling(
     matchedTransactions: 0,
     drifts: 0,
     rateCorrections: 0,
+    observedEndpoints: 0,
     unmatchedEvents: 0,
   };
+
+  summary.rateCorrections = await correctRates(db, events, now);
+  summary.observedEndpoints = await writeObservedUnits(db, now);
+
   if (events.length === 0) {
     logger.info('fal billing reconcile: no events in window', { ...summary });
     return summary;
   }
-
-  summary.rateCorrections = await correctRates(db, events, now);
 
   // Join events to our usage transactions by the fal request id in metadata.
   // The transaction window is wider than the event window: a transaction is
@@ -221,6 +230,87 @@ async function correctRates(
       endpointId,
       unit: row.unit,
       unitPriceMicros: billedMicros,
+      recordedAt: now,
+    });
+    corrections++;
+  }
+
+  corrections += await copySiblingRates(
+    db,
+    latestByEndpoint,
+    rowsByEndpoint,
+    now
+  );
+  return corrections;
+}
+
+/**
+ * Stamp an unverified sibling (H3 Max t2v) with the source's billed unit
+ * price so it does not sit on fal's advertised compute-seconds lie (#1382).
+ * Unit re-denomination (PK includes unit) is left to the nightly snapshot.
+ */
+async function copySiblingRates(
+  db: PricingRefreshDb,
+  latestByEndpoint: Map<string, FalBillingEvent>,
+  rowsByEndpoint: Map<string, typeof modelPricing.$inferSelect>,
+  now: Date
+): Promise<number> {
+  let corrections = 0;
+  for (const [target, source] of Object.entries(FAL_UNVERIFIED_SIBLINGS)) {
+    if (latestByEndpoint.has(target)) continue;
+    const sourceEvent = latestByEndpoint.get(source);
+    const sourceRow = rowsByEndpoint.get(source);
+    const targetRow = rowsByEndpoint.get(target);
+    if (!targetRow) continue;
+    const sourceMicros = sourceEvent
+      ? usdToMicros(sourceEvent.unitPriceUsd)
+      : sourceRow?.rateVerifiedAt != null
+        ? sourceRow.unitPriceMicros
+        : undefined;
+    if (sourceMicros == null) continue;
+    if (targetRow.unitPriceMicros === sourceMicros) {
+      if (targetRow.rateVerifiedAt == null) {
+        await db
+          .update(modelPricing)
+          .set({ rateVerifiedAt: now, updatedAt: now })
+          .where(
+            and(
+              eq(modelPricing.provider, 'fal'),
+              eq(modelPricing.endpointId, target),
+              eq(modelPricing.unit, targetRow.unit)
+            )
+          );
+      }
+      continue;
+    }
+    logger.warn(
+      'unverified sibling inheriting billed rate from source endpoint',
+      {
+        target,
+        source,
+        storedMicros: targetRow.unitPriceMicros,
+        billedMicros: sourceMicros,
+      }
+    );
+    await db
+      .update(modelPricing)
+      .set({
+        unitPriceMicros: sourceMicros,
+        rateVerifiedAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(modelPricing.provider, 'fal'),
+          eq(modelPricing.endpointId, target),
+          eq(modelPricing.unit, targetRow.unit)
+        )
+      );
+    await db.insert(modelPricingHistory).values({
+      provider: 'fal',
+      endpointId: target,
+      unit: targetRow.unit,
+      unitPriceMicros: sourceMicros,
       recordedAt: now,
     });
     corrections++;

--- a/src/lib/cron/refresh-fal-pricing.test.ts
+++ b/src/lib/cron/refresh-fal-pricing.test.ts
@@ -31,13 +31,20 @@ import { createClient } from '@libsql/client';
 import { readFileSync } from 'node:fs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import {
+  collectObservedUnits,
+  computeLedgerObservedUnits,
   computeObservedUnits,
   FAL_PRICING_CRON,
   HISTORY_CHUNK,
   OBSERVATIONS_PER_ENDPOINT,
   UPSERT_CHUNK,
 } from '@/lib/cron/refresh-fal-pricing';
-import { modelPricing, modelPricingHistory } from '@/lib/db/schema';
+import {
+  modelPricing,
+  modelPricingHistory,
+  teams,
+  transactions,
+} from '@/lib/db/schema';
 import { modelUsageObservations } from '@/lib/db/schema/model-pricing';
 import { eq, getTableColumns } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
@@ -675,5 +682,120 @@ describe('refreshFalPricing', () => {
       'fal-ai/erroring',
       'fal-ai/flux-2',
     ]);
+  });
+
+  test('writes the H3 Max typical-units fallback when fal has no history', async () => {
+    const { refreshFalPricing } = await load({
+      prices: [
+        {
+          endpointId: 'minimax/h3-max/image-to-video',
+          unitPriceUsd: 0.025,
+          unit: 'seconds',
+        },
+      ],
+    });
+
+    await refreshFalPricing();
+
+    const [row] = await db.select().from(modelPricing);
+    expect(row?.typicalUnitsPerCall).toBe(8);
+  });
+
+  test('H3 Max t2v inherits i2v billed rate when t2v has no usage', async () => {
+    const { refreshFalPricing } = await load({
+      prices: [
+        {
+          endpointId: 'minimax/h3-max/image-to-video',
+          unitPriceUsd: 0.00017,
+          unit: 'compute seconds',
+        },
+        {
+          endpointId: 'minimax/h3-max/text-to-video',
+          unitPriceUsd: 0.00017,
+          unit: 'compute seconds',
+        },
+      ],
+      billed: [
+        {
+          endpointId: 'minimax/h3-max/image-to-video',
+          unit: 'seconds',
+          unitPriceUsd: 0.025,
+          costUsd: 1.2,
+        },
+      ],
+    });
+
+    await refreshFalPricing({ billingKey: 'admin-key' });
+
+    const rows = await db.select().from(modelPricing);
+    const t2v = rows.find(
+      (r) => r.endpointId === 'minimax/h3-max/text-to-video'
+    );
+    expect(t2v?.unit).toBe('seconds');
+    expect(t2v?.unitPriceMicros).toBe(25_000);
+    expect(t2v?.rateVerifiedAt).not.toBeNull();
+    expect(t2v?.typicalUnitsPerCall).toBe(8);
+  });
+});
+
+describe('computeLedgerObservedUnits', () => {
+  const client = createClient({ url: ':memory:' });
+  const db = drizzle({ client });
+
+  beforeEach(async () => {
+    await migrate(db, { migrationsFolder: './drizzle/migrations' });
+    await db
+      .insert(teams)
+      .values({ id: 'team-1', name: 't', slug: 'team-1-slug' })
+      .onConflictDoNothing();
+    await db.delete(transactions);
+    await db.delete(modelUsageObservations);
+  });
+
+  test('reads unitsBilled from transaction metadata when observations are empty', async () => {
+    await db.insert(transactions).values({
+      id: 'tx-1',
+      teamId: 'team-1',
+      type: 'credit_usage',
+      amount: -200_000,
+      balanceAfter: 0,
+      metadata: {
+        endpointId: 'minimax/h3-max/image-to-video',
+        unitsBilled: 8,
+      },
+    });
+
+    const { observed, samples } = await computeLedgerObservedUnits(db);
+    expect(samples).toBe(1);
+    expect(observed.get('minimax/h3-max/image-to-video')).toEqual({
+      medianUnits: 8,
+      sampleCount: 1,
+    });
+  });
+
+  test('observations outrank the ledger so a generation is not counted twice', async () => {
+    await db.insert(modelUsageObservations).values({
+      provider: 'fal',
+      endpointId: 'minimax/h3-max/image-to-video',
+      unitsBilled: 8,
+      numImages: 1,
+    });
+    await db.insert(transactions).values({
+      id: 'tx-1',
+      teamId: 'team-1',
+      type: 'credit_usage',
+      amount: -200_000,
+      balanceAfter: 0,
+      metadata: {
+        endpointId: 'minimax/h3-max/image-to-video',
+        unitsBilled: 99,
+      },
+    });
+
+    const { observed } = await collectObservedUnits(db);
+    expect(observed.get('minimax/h3-max/image-to-video')).toEqual({
+      medianUnits: 8,
+      sampleCount: 1,
+    });
   });
 });

--- a/src/lib/cron/refresh-fal-pricing.ts
+++ b/src/lib/cron/refresh-fal-pricing.ts
@@ -32,11 +32,16 @@ import {
   fetchFalTypicalUnits,
   fetchFalUnitPrices,
 } from '@/lib/ai/fal-pricing-fetch';
+import {
+  FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP,
+  FAL_UNVERIFIED_SIBLINGS,
+} from '@/lib/ai/fal-typical-units';
 import { usdToMicros } from '@/lib/billing/money';
 import {
   modelPricing,
   modelPricingHistory,
   modelUsageObservations,
+  transactions,
 } from '@/lib/db/schema';
 import type { ObservedUnits } from '@/lib/db/schema/model-pricing';
 import { getLogger } from '@/lib/observability/logger';
@@ -185,6 +190,200 @@ export async function computeObservedUnits(
     samples += units.length;
   }
   return { observed, samples };
+}
+
+/**
+ * Median unitsBilled from credit transactions, for endpoints whose
+ * observations table is empty. Same window as `computeObservedUnits`.
+ * Skips samples that already have an observation so we do not double-count.
+ */
+export async function computeLedgerObservedUnits(
+  db: ObservationReader
+): Promise<{ observed: ObservedUnitsByEndpoint; samples: number }> {
+  const cutoff = observationCutoff();
+  const rows = await db.all<{
+    endpoint_id: string;
+    units_billed: number;
+    num_images: number;
+  }>(sql`
+    SELECT endpoint_id, units_billed, num_images FROM (
+      SELECT
+        json_extract(${transactions.metadata}, '$.endpointId') AS endpoint_id,
+        json_extract(${transactions.metadata}, '$.unitsBilled') AS units_billed,
+        COALESCE(json_extract(${transactions.metadata}, '$.numImages'), 1)
+          AS num_images,
+        ROW_NUMBER() OVER (
+          PARTITION BY json_extract(${transactions.metadata}, '$.endpointId')
+          ORDER BY ${transactions.createdAt} DESC
+        ) AS rn
+      FROM ${transactions}
+      WHERE ${transactions.type} = 'credit_usage'
+        AND ${transactions.createdAt} > ${toEpochSeconds(cutoff)}
+        AND json_extract(${transactions.metadata}, '$.unitsBilled') IS NOT NULL
+        AND json_extract(${transactions.metadata}, '$.endpointId') IS NOT NULL
+        AND (
+          json_extract(${transactions.metadata}, '$.billingProvider') IS NULL
+          OR json_extract(${transactions.metadata}, '$.billingProvider') = 'fal'
+        )
+    ) WHERE rn <= ${OBSERVATIONS_PER_ENDPOINT}
+  `);
+
+  const byEndpoint = new Map<string, number[]>();
+  for (const row of rows) {
+    if (typeof row.endpoint_id !== 'string' || row.endpoint_id.length === 0) {
+      continue;
+    }
+    if (!Number.isFinite(row.units_billed) || row.units_billed <= 0) continue;
+    const images =
+      Number.isFinite(row.num_images) && row.num_images > 0
+        ? row.num_images
+        : 1;
+    const perImage = row.units_billed / images;
+    const list = byEndpoint.get(row.endpoint_id);
+    if (list) list.push(perImage);
+    else byEndpoint.set(row.endpoint_id, [perImage]);
+  }
+
+  const observed: ObservedUnitsByEndpoint = new Map();
+  let samples = 0;
+  for (const [endpointId, units] of byEndpoint) {
+    observed.set(endpointId, {
+      medianUnits: median(units),
+      sampleCount: units.length,
+    });
+    samples += units.length;
+  }
+  return { observed, samples };
+}
+
+/**
+ * Observed median: our usage samples first, then transaction metadata for
+ * endpoints that somehow missed an observation write (#1382).
+ */
+export async function collectObservedUnits(
+  db: ObservationReader
+): Promise<{ observed: ObservedUnitsByEndpoint; samples: number }> {
+  const fromObs = await computeObservedUnits(db);
+  const fromLedger = await computeLedgerObservedUnits(db);
+  for (const [endpointId, ledger] of fromLedger.observed) {
+    if (fromObs.observed.has(endpointId)) continue;
+    fromObs.observed.set(endpointId, ledger);
+    fromObs.samples += ledger.sampleCount;
+  }
+  return fromObs;
+}
+
+/**
+ * Patch `observed_median_units` (and a missing H3 Max typical) onto existing
+ * `model_pricing` rows. Used by the hourly reconcile so a day's samples do
+ * not wait until 03:17 UTC to feed the estimator.
+ */
+export async function writeObservedUnits(
+  db: PricingRefreshDb,
+  now: Date = new Date()
+): Promise<number> {
+  const { observed } = await collectObservedUnits(db);
+  const rows = await db
+    .select()
+    .from(modelPricing)
+    .where(eq(modelPricing.provider, 'fal'));
+  const rowsByEndpoint = new Map(rows.map((r) => [r.endpointId, r]));
+
+  let written = 0;
+  for (const [endpointId, obs] of observed) {
+    const row = rowsByEndpoint.get(endpointId);
+    if (!row) continue;
+    const fallbackTypical =
+      FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP[endpointId] ?? null;
+    await db
+      .update(modelPricing)
+      .set({
+        observedMedianUnits: obs.medianUnits,
+        observedSampleCount: obs.sampleCount,
+        ...(row.typicalUnitsPerCall == null && fallbackTypical != null
+          ? { typicalUnitsPerCall: fallbackTypical }
+          : {}),
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(modelPricing.provider, 'fal'),
+          eq(modelPricing.endpointId, endpointId),
+          eq(modelPricing.unit, row.unit)
+        )
+      );
+    written++;
+  }
+
+  for (const [endpointId, typical] of Object.entries(
+    FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP
+  )) {
+    const row = rowsByEndpoint.get(endpointId);
+    if (!row || row.typicalUnitsPerCall != null) continue;
+    if (observed.has(endpointId)) continue;
+    await db
+      .update(modelPricing)
+      .set({ typicalUnitsPerCall: typical, updatedAt: now })
+      .where(
+        and(
+          eq(modelPricing.provider, 'fal'),
+          eq(modelPricing.endpointId, endpointId),
+          eq(modelPricing.unit, row.unit)
+        )
+      );
+  }
+  return written;
+}
+
+/**
+ * Copy a bill-verified rate onto a sibling with no usage of its own
+ * (H3 Max t2v ← i2v, #1382). Stamps the target as verified so the advertised
+ * "compute seconds" lie cannot overwrite it on the next advertised fetch.
+ */
+function overlaySiblingBilledRates(
+  prices: FalUnitPrice[],
+  verifiedNow: Set<string>,
+  verifiedExisting: ReadonlySet<string> = new Set()
+): void {
+  const priceByEndpoint = new Map(prices.map((p) => [p.endpointId, p]));
+  for (const [target, source] of Object.entries(FAL_UNVERIFIED_SIBLINGS)) {
+    if (verifiedNow.has(target)) continue;
+    if (!verifiedNow.has(source) && !verifiedExisting.has(source)) continue;
+    const sourcePrice = priceByEndpoint.get(source);
+    if (!sourcePrice) continue;
+    const targetPrice = priceByEndpoint.get(target);
+    if (targetPrice) {
+      if (
+        targetPrice.unit !== sourcePrice.unit ||
+        targetPrice.unitPriceUsd !== sourcePrice.unitPriceUsd
+      ) {
+        logger.warn(
+          'unverified sibling inheriting billed rate from source endpoint',
+          {
+            target,
+            source,
+            from: {
+              unit: targetPrice.unit,
+              unitPriceUsd: targetPrice.unitPriceUsd,
+            },
+            to: {
+              unit: sourcePrice.unit,
+              unitPriceUsd: sourcePrice.unitPriceUsd,
+            },
+          }
+        );
+      }
+      targetPrice.unit = sourcePrice.unit;
+      targetPrice.unitPriceUsd = sourcePrice.unitPriceUsd;
+    } else {
+      prices.push({
+        endpointId: target,
+        unit: sourcePrice.unit,
+        unitPriceUsd: sourcePrice.unitPriceUsd,
+      });
+    }
+    verifiedNow.add(target);
+  }
 }
 
 function chunk<T>(items: T[], size: number): T[][] {
@@ -367,6 +566,14 @@ export async function refreshFalPricing(
     p.unitPriceUsd = verified.unitPriceMicros / 1_000_000;
   }
 
+  // Sibling copy after verified-existing preservation so t2v inherits i2v's
+  // bill-verified rate even when i2v's usage aged out of this run's overlay.
+  overlaySiblingBilledRates(
+    prices,
+    verifiedNow,
+    new Set(verifiedExisting.keys())
+  );
+
   // A used endpoint without a price would bill $0 after the sweep dropped its
   // row. Abort the whole run so yesterday's snapshot survives.
   const pricedIds = new Set(prices.map((p) => p.endpointId));
@@ -401,19 +608,22 @@ export async function refreshFalPricing(
   );
 
   await discardObservationsForRedenominatedEndpoints(db, existing, prices);
-  const { observed, samples } = await computeObservedUnits(db);
+  const { observed, samples } = await collectObservedUnits(db);
 
   const now = new Date();
   const snapshotRows = prices.map((p) => {
     const obs = observed.get(p.endpointId);
     const key = pricingKey(p);
     // A failed typical fetch carries the stored value forward — absence of an
-    // answer is not an answer of "none". A genuine no-history reply nulls it.
+    // answer is not an answer of "none". A genuine no-history reply uses the
+    // billed-units fallback (H3 Max 8/5s) when we have one, else nulls.
+    const fallbackTypical =
+      FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP[p.endpointId] ?? null;
     const typical =
       typicalUnits.get(p.endpointId) ??
       (typicalDegraded || failedEndpoints.has(p.endpointId)
-        ? (existingTypicalByKey.get(key) ?? null)
-        : null);
+        ? (existingTypicalByKey.get(key) ?? fallbackTypical)
+        : fallbackTypical);
     return {
       provider: 'fal' as const,
       endpointId: p.endpointId,

--- a/src/lib/db/seed-model-pricing.ts
+++ b/src/lib/db/seed-model-pricing.ts
@@ -9,6 +9,7 @@
  */
 
 import { getFalEndpointIds } from '@/lib/ai/fal-endpoints';
+import { FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP } from '@/lib/ai/fal-typical-units';
 import { usdToMicros } from '@/lib/billing/money';
 import { modelPricing } from '@/lib/db/schema';
 import { eq } from 'drizzle-orm';
@@ -97,9 +98,20 @@ export const LOCAL_FAL_PRICING_SEED: Record<string, SeedPrice> = {
   },
   'fal-ai/minimax/hailuo-2.3/pro/image-to-video': units(0.49),
   'fal-ai/minimax/hailuo-2.3/pro/text-to-video': units(0.49),
-  // 768P list rate; fal's launch promo (0.04) ends 2026-09-01.
-  'minimax/h3-max/image-to-video': { unit: 'seconds', unitPriceUsd: 0.08 },
-  'minimax/h3-max/text-to-video': { unit: 'seconds', unitPriceUsd: 0.08 },
+  // Bill-verified unit is the 480p second ($0.025). 768P (our default) bills
+  // 8 units for a 5s clip — not 5 (#1382). Same advertised rates on t2v.
+  'minimax/h3-max/image-to-video': {
+    unit: 'seconds',
+    unitPriceUsd: 0.025,
+    typicalUnitsPerCall:
+      FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP['minimax/h3-max/image-to-video'] ?? 8,
+  },
+  'minimax/h3-max/text-to-video': {
+    unit: 'seconds',
+    unitPriceUsd: 0.025,
+    typicalUnitsPerCall:
+      FAL_TYPICAL_UNITS_PER_DEFAULT_CLIP['minimax/h3-max/text-to-video'] ?? 8,
+  },
   // Seedance 2.5 (sequences + studio). Advertised fal unit is ~$0.014–0.021
   // per 1000 tokens; local seed is a floor until the pricing cron runs.
   'bytedance/seedance-2.5/image-to-video': units(0.014),


### PR DESCRIPTION
Fixes #1382

## Problem

MiniMax H3 Max estimates were ~$0.13 for a 5s clip; fal bills **$0.20**. The estimator treated fal's `seconds` unit as wall-clock duration. fal stores the **480p** second as the unit ($0.025); our default is **768P**, which bills 1.6× — **8 units for a 5s clip**.

`minimax/h3-max/text-to-video` was still on advertised `compute seconds × $0.00017` with no billed usage of its own.

## Fix

- Video estimator prefers observed / typical billed units over duration for H3 Max, scaled from a 5s default (10s → 16 units / $0.40). Ordinary per-second models (Veo) still use requested duration.
- Hardcoded typical of **8 units per 5s clip** so estimates are right before the next cron.
- Nightly refresh and hourly reconcile write `observed_median_units` from `model_usage_observations`, falling back to `transactions.metadata.unitsBilled`.
- t2v inherits i2v's bill-verified rate (same advertised pricing; t2v has no usage yet) instead of being hidden.

## Acceptance

- 5s H3 Max estimate is $0.20 (`8 × $0.025`).
- No `No unit-count signal for minimax/h3-max` once typical/observed exist.
- t2v studio estimates use the i2v billed rate, not compute-seconds.