### PR TITLE
fix(#1388): client pricing map covers studio/edit endpoints; prune alarm at TTL, not hourly

### DIFF
--- a/src/lib/billing/catalog-endpoints.test.ts
+++ b/src/lib/billing/catalog-endpoints.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  EDIT_ENDPOINTS,
   IMAGE_TO_VIDEO_MODELS,
   MOTION_REFERENCE_ENDPOINTS,
 } from '@/lib/ai/models';
 import { catalogFalEndpointIds } from '@/lib/billing/catalog-endpoints';
+import { studioVideoEndpointId } from '@/lib/studio/text-to-video';
 
 describe('catalogFalEndpointIds', () => {
   it('includes Seedance image-to-video and reference-to-video endpoints', () => {
@@ -12,5 +14,14 @@ describe('catalogFalEndpointIds', () => {
     expect(ids).toContain(MOTION_REFERENCE_ENDPOINTS.seedance_v2?.endpointId);
     expect(ids).toContain(IMAGE_TO_VIDEO_MODELS.seedance_v2_5.id);
     expect(ids).toContain(MOTION_REFERENCE_ENDPOINTS.seedance_v2_5?.endpointId);
+  });
+
+  it('includes studio text/reference endpoints and edit siblings (#1388)', () => {
+    const ids = catalogFalEndpointIds();
+    expect(ids).toContain(studioVideoEndpointId('seedance_v2', 'text'));
+    expect(ids).toContain(studioVideoEndpointId('kling_v3_pro', 'reference'));
+    for (const endpointId of Object.values(EDIT_ENDPOINTS)) {
+      expect(ids).toContain(endpointId);
+    }
   });
 });

--- a/src/lib/billing/catalog-endpoints.ts
+++ b/src/lib/billing/catalog-endpoints.ts
@@ -4,15 +4,14 @@
  * instead of the full ~1,350-row fal catalog.
  */
 
-import {
-  AUDIO_MODELS,
-  IMAGE_MODELS,
-  IMAGE_TO_VIDEO_MODELS,
-  MOTION_REFERENCE_ENDPOINTS,
-} from '@/lib/ai/models';
+import { getFalEndpointIds } from '@/lib/ai/fal-endpoints';
+import { IMAGE_MODELS, IMAGE_TO_VIDEO_MODELS } from '@/lib/ai/models';
 
 /**
- * Unique pricing ids for every image / video / audio model we offer.
+ * Unique pricing ids for every endpoint a client-side estimate can price:
+ * image / video / audio models, edit + motion-reference siblings, and the
+ * studio text-to-video / reference-to-video endpoints (#1388 — those were
+ * missing, so the studio cost label logged "No fal pricing data").
  *
  * BytePlus ids ride along unconditionally (#1157) rather than gated on
  * `ARK_API_KEY`: this map is cached by the client, the route can flip when a
@@ -20,21 +19,12 @@ import {
  * The extra rows are a handful of entries off a static card.
  */
 export function catalogFalEndpointIds(): string[] {
-  const ids = new Set<string>();
-  for (const model of Object.values(IMAGE_MODELS)) {
-    ids.add(model.id);
+  const ids = new Set(getFalEndpointIds());
+  for (const model of [
+    ...Object.values(IMAGE_MODELS),
+    ...Object.values(IMAGE_TO_VIDEO_MODELS),
+  ]) {
     if ('byteplusId' in model) ids.add(model.byteplusId);
-  }
-  for (const model of Object.values(IMAGE_TO_VIDEO_MODELS)) {
-    ids.add(model.id);
-    if ('byteplusId' in model) ids.add(model.byteplusId);
-  }
-  // Seedance (etc.) motion with cast/element refs bills on a separate endpoint.
-  for (const config of Object.values(MOTION_REFERENCE_ENDPOINTS)) {
-    ids.add(config.endpointId);
-  }
-  for (const model of Object.values(AUDIO_MODELS)) {
-    ids.add(model.id);
   }
   return [...ids];
 }

--- a/src/lib/realtime/realtime-channel.do.test.ts
+++ b/src/lib/realtime/realtime-channel.do.test.ts
@@ -433,11 +433,33 @@ describe('RealtimeChannel history cap (#1332)', () => {
     expect(numberField(seqs, 'min')).toBe(mountain - HISTORY_MAX_ROWS + 1);
   });
 
-  it('schedules a prune alarm on first emit', async () => {
-    const { channel, getAlarm } = createHarness();
-    expect(getAlarm()).toBeNull();
-    await emit(channel, { n: 1 });
-    expect(getAlarm()).toBeGreaterThan(Date.now());
+  it('schedules the prune alarm at the oldest row expiry, not hourly (#1388)', async () => {
+    const t0 = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(t0);
+    const harness = createHarness();
+    expect(harness.getAlarm()).toBeNull();
+    await emit(harness.channel, { n: 1 });
+    expect(harness.getAlarm()).toBe(t0 + THIRTY_DAYS_MS);
+
+    // A later emit never pulls the alarm earlier; an idle alarm tick with
+    // nothing expired re-arms at the same expiry.
+    vi.spyOn(Date, 'now').mockReturnValue(t0 + 60_000);
+    await emit(harness.channel, { n: 2 });
+    expect(harness.getAlarm()).toBe(t0 + THIRTY_DAYS_MS);
+    await triggerAlarm(harness);
+    expect(eventCount(harness.db)).toBe(2);
+    expect(harness.getAlarm()).toBe(t0 + THIRTY_DAYS_MS);
+  });
+
+  it('does not re-arm the alarm once the table is empty', async () => {
+    const t0 = 1_700_000_000_000;
+    vi.spyOn(Date, 'now').mockReturnValue(t0);
+    const harness = createHarness();
+    await emit(harness.channel, { n: 1 });
+    vi.spyOn(Date, 'now').mockReturnValue(t0 + THIRTY_DAYS_MS + 1);
+    await triggerAlarm(harness);
+    expect(eventCount(harness.db)).toBe(0);
+    expect(harness.getAlarm()).toBeNull();
   });
 
   it('reschedules a catch-up alarm when a cap batch leaves the table over the cap', async () => {

--- a/src/lib/realtime/realtime-channel.do.ts
+++ b/src/lib/realtime/realtime-channel.do.ts
@@ -26,7 +26,7 @@ import { getLogger } from '@/lib/observability/logger';
  * - **History replay**: events are persisted in the DO's own SQLite storage so a
  *   page refresh mid-generation can replay progress (`/history`). `/emit` deletes
  *   a PK prefix of at most `PRUNE_BATCH_ROWS` so one-row emits stay at the cap.
- *   A periodic alarm TTL-deletes up to `PRUNE_BATCH_ROWS` expired rows and the
+ *   An alarm set for the oldest row's expiry TTL-deletes up to `PRUNE_BATCH_ROWS` expired rows and the
  *   same PK-prefix cap batch; leftovers reschedule in `PRUNE_CATCHUP_MS`.
  *   Every statement is a bounded PK-range op: `ts` is monotonic with `seq`, so
  *   expired rows are a PK prefix and no index is needed (#1332).
@@ -49,8 +49,6 @@ export const HISTORY_MAX_ROWS = 2000;
  * subscriber rather than grow it.
  */
 export const SSE_MAX_BUFFERED_CHUNKS = 32;
-/** How often the prune alarm runs while a channel still has stored events. */
-const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 /** Catch-up cadence when a leftover mountain still exceeds the cap / TTL. */
 export const PRUNE_CATCHUP_MS = 5_000;
 /** Rows deleted per prune statement so one storage op cannot exceed the timeout. */
@@ -302,10 +300,14 @@ export class RealtimeChannel extends DurableObject {
     );
   }
 
-  private stillOverCap(newestSeq: number): boolean {
-    const min = this.ctx.storage.sql
+  private minSeq(): number | null {
+    return this.ctx.storage.sql
       .exec<{ m: number | null }>('SELECT MIN(seq) AS m FROM events')
       .one().m;
+  }
+
+  private stillOverCap(newestSeq: number): boolean {
+    const min = this.minSeq();
     return min !== null && min <= this.capCutoff(newestSeq);
   }
 
@@ -319,17 +321,31 @@ export class RealtimeChannel extends DurableObject {
     );
   }
 
-  private hasExpired(cutoffTs: number): boolean {
-    const oldest = this.ctx.storage.sql
+  private oldestTs(): number | undefined {
+    return this.ctx.storage.sql
       .exec<{ ts: number }>('SELECT ts FROM events ORDER BY seq LIMIT 1')
-      .toArray()[0];
-    return oldest !== undefined && oldest.ts < cutoffTs;
+      .toArray()[0]?.ts;
   }
 
+  /**
+   * Next prune: `PRUNE_CATCHUP_MS` while a leftover still exceeds the cap /
+   * TTL, otherwise when the oldest row expires. Not hourly for 30 days on
+   * every channel that ever emitted (#1388) — those idle alarms were most of
+   * the DO storage-timeout noise. Nothing stored → nothing to schedule.
+   */
   private async schedulePrune(asap: boolean): Promise<void> {
     const existing = await this.ctx.storage.getAlarm();
-    const when = Date.now() + (asap ? PRUNE_CATCHUP_MS : PRUNE_INTERVAL_MS);
-    if (existing === null || (asap && existing > when)) {
+    // An existing alarm is already at or before the oldest row's expiry.
+    if (existing !== null && !asap) return;
+    let when: number;
+    if (asap) {
+      when = Date.now() + PRUNE_CATCHUP_MS;
+    } else {
+      const oldest = this.oldestTs();
+      if (oldest === undefined) return;
+      when = oldest + HISTORY_EXPIRE_SECS * 1000;
+    }
+    if (existing === null || existing > when) {
       await this.ctx.storage.setAlarm(when);
     }
   }
@@ -345,7 +361,19 @@ export class RealtimeChannel extends DurableObject {
 
     this.pruneCapBatch(newest);
 
-    const more = this.hasExpired(cutoffTs) || this.stillOverCap(newest);
-    await this.schedulePrune(more);
+    const oldest = this.oldestTs();
+    const min = this.minSeq();
+    const expired = oldest !== undefined && oldest < cutoffTs;
+    const overCap = min !== null && min <= this.capCutoff(newest);
+    // Only prefix deletes happen, so MAX - MIN + 1 is the row count without a
+    // COUNT(*) scan. `databaseSize` sizes the objects that hit the storage
+    // timeout (#1388).
+    logger.info('prune', {
+      rows: min === null ? 0 : newest - min + 1,
+      bytes: this.ctx.storage.sql.databaseSize,
+      expired,
+      overCap,
+    });
+    await this.schedulePrune(expired || overCap);
   }
 }


### PR DESCRIPTION
Closes #1388

## Why
PostHog showed ~50/day browser errors `No fal pricing data for endpoint: bytedance/seedance-2.0/enterprise/v2/text-to-video` (plus Kling o3 ref, Kling v3 t2v, gpt-image-2/edit, nano-banana-pro/edit). Prod `model_pricing` has every one of those rows and the server reads the full map, so **billing was never affected** — only the client ActionCost label, which rendered nothing.

Separately, `Durable Object storage operation exceeded timeout` runs ~12/day after #1357, all from `RealtimeChannel`'s prune `alarm()` (retried successfully), concentrated on a few objects.

## What
- `catalogFalEndpointIds()` builds from `getFalEndpointIds()` (the same list the pricing refresh uses) plus BytePlus ids, instead of a hand-picked subset that missed the studio and edit siblings.
- `RealtimeChannel.schedulePrune` sets the next alarm at `oldest.ts + TTL` (catch-up cadence unchanged while over cap/TTL) rather than hourly for 30 days on every channel that ever emitted. Empty table → no alarm.
- Each alarm logs `rows` (MAX−MIN+1, no COUNT scan) and `sql.databaseSize` so the objects that hit the storage timeout can be sized from the logs.

## Tests
- `catalog-endpoints.test.ts`: studio text/reference + all `EDIT_ENDPOINTS` present.
- `realtime-channel.do.test.ts`: alarm lands at oldest-row expiry, a later emit never pulls it earlier, idle tick re-arms at the same expiry, empty table leaves no alarm. Existing cap/TTL batch tests unchanged.