### PR TITLE
fix(#1395): reload once when a lazy chunk 404s after a deploy

### DIFF
--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -2,6 +2,7 @@ import { PostHogIdentify } from '@/components/observability/posthog-identify';
 import { sessionQueryOptions } from '@/lib/auth/session-query';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
+import { installChunkReload } from '@/lib/chunk-reload';
 import { configureLogging } from '@/lib/observability/logger';
 import { flushReactErrors } from '@/lib/observability/react-errors';
 import { PostHogProvider } from '@posthog/react';
@@ -11,6 +12,7 @@ import { RealtimeContext, RealtimeProvider } from '@/lib/realtime/client';
 import { lazy, useEffect, useState, type FC } from 'react';
 
 configureLogging();
+installChunkReload();
 
 // Wrap the entire lazy() in import.meta.env.DEV so Vite dead-code-eliminates
 // the dynamic imports before rollup tries to resolve them. This prevents

--- a/src/lib/chunk-reload.test.ts
+++ b/src/lib/chunk-reload.test.ts
@@ -1,49 +1,66 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { reloadOnceForChunkError } from './chunk-reload';
+
+type PreloadHandler = (event: {
+  payload: unknown;
+  preventDefault: () => void;
+}) => void;
 
 const store = new Map<string, string>();
 const reload = vi.fn();
+let handler: PreloadHandler | undefined;
 
-beforeEach(() => {
+/** Dispatch what Vite's preload helper dispatches. */
+function firePreloadError() {
+  const preventDefault = vi.fn();
+  handler?.({ payload: new Error('boom'), preventDefault });
+  return preventDefault;
+}
+
+beforeEach(async () => {
   store.clear();
   reload.mockClear();
+  handler = undefined;
+  vi.stubGlobal('window', {
+    addEventListener: (_type: string, fn: PreloadHandler) => {
+      handler = fn;
+    },
+  });
   vi.stubGlobal('sessionStorage', {
     getItem: (k: string) => store.get(k) ?? null,
     setItem: (k: string, v: string) => void store.set(k, v),
   });
   vi.stubGlobal('location', { reload });
+  vi.resetModules();
+  const { installChunkReload } = await import('./chunk-reload');
+  installChunkReload();
 });
 
-describe('reloadOnceForChunkError', () => {
-  it('reloads once for a stale chunk, not twice', () => {
-    const error = new Error(
-      'Failed to fetch dynamically imported module: /assets/route-a1b2.js'
-    );
-    expect(reloadOnceForChunkError(error)).toBe(true);
-    expect(reloadOnceForChunkError(error)).toBe(false);
+describe('installChunkReload', () => {
+  it('reloads on the first preload error and suppresses the throw', () => {
+    const preventDefault = firePreloadError();
     expect(reload).toHaveBeenCalledTimes(1);
+    expect(preventDefault).toHaveBeenCalled();
   });
 
-  it('reloads again once the cooldown has passed', () => {
-    const error = new Error('Importing a module script failed.');
-    expect(reloadOnceForChunkError(error)).toBe(true);
+  it('does not reload twice for the same page load', () => {
+    firePreloadError();
+    const preventDefault = firePreloadError();
+    expect(reload).toHaveBeenCalledTimes(1);
+    // Second time we let the error through to the boundary.
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('reloads again once the retry window has passed', () => {
+    firePreloadError();
     store.set('os:chunk-reloaded-at', String(Date.now() - 60_000));
-    expect(reloadOnceForChunkError(error)).toBe(true);
+    firePreloadError();
     expect(reload).toHaveBeenCalledTimes(2);
-  });
-
-  it('ignores unrelated errors', () => {
-    expect(reloadOnceForChunkError(new Error('insertBefore'))).toBe(false);
-    expect(reload).not.toHaveBeenCalled();
   });
 
   it('does not reload without sessionStorage (no loop guard)', () => {
     vi.stubGlobal('sessionStorage', undefined);
-    expect(
-      reloadOnceForChunkError(
-        new Error('Failed to fetch dynamically imported module')
-      )
-    ).toBe(false);
+    const preventDefault = firePreloadError();
     expect(reload).not.toHaveBeenCalled();
+    expect(preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/chunk-reload.test.ts
+++ b/src/lib/chunk-reload.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reloadOnceForChunkError } from './chunk-reload';
+
+const store = new Map<string, string>();
+const reload = vi.fn();
+
+beforeEach(() => {
+  store.clear();
+  reload.mockClear();
+  vi.stubGlobal('sessionStorage', {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+  });
+  vi.stubGlobal('location', { reload });
+});
+
+describe('reloadOnceForChunkError', () => {
+  it('reloads once for a stale chunk, not twice', () => {
+    const error = new Error(
+      'Failed to fetch dynamically imported module: /assets/route-a1b2.js'
+    );
+    expect(reloadOnceForChunkError(error)).toBe(true);
+    expect(reloadOnceForChunkError(error)).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('reloads again once the cooldown has passed', () => {
+    const error = new Error('Importing a module script failed.');
+    expect(reloadOnceForChunkError(error)).toBe(true);
+    store.set('os:chunk-reloaded-at', String(Date.now() - 60_000));
+    expect(reloadOnceForChunkError(error)).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores unrelated errors', () => {
+    expect(reloadOnceForChunkError(new Error('insertBefore'))).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('does not reload without sessionStorage (no loop guard)', () => {
+    vi.stubGlobal('sessionStorage', undefined);
+    expect(
+      reloadOnceForChunkError(
+        new Error('Failed to fetch dynamically imported module')
+      )
+    ).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -1,0 +1,59 @@
+/**
+ * Reload once when a lazy chunk fails to import after a deploy (#1395).
+ *
+ * A deploy replaces every hashed chunk filename, but an already-loaded tab
+ * still points at the old ones. The next lazy import — a route chunk on
+ * navigation, a `React.lazy` component — 404s, and the user sits on
+ * "Something went wrong" until they refresh by hand.
+ *
+ * Vite's preload helper wraps every dynamic import and dispatches a
+ * cancelable `vite:preloadError` when one fails, so a single window listener
+ * covers all of them. Reloading fetches fresh HTML, which points at chunks
+ * that exist.
+ */
+
+import { getLogger } from '@/lib/observability/logger';
+
+const logger = getLogger(['openstory', 'ui', 'chunk-reload']);
+
+const KEY = 'os:chunk-reloaded-at';
+
+// Long enough that a genuinely broken deploy can't reload-loop, short enough
+// that a long-lived tab still gets its one reload on the *next* deploy.
+const COOLDOWN_MS = 10_000;
+
+const CHUNK_ERROR = /dynamically imported module|module script failed/i;
+
+function isChunkLoadError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'string'
+        ? error
+        : '';
+  return CHUNK_ERROR.test(message);
+}
+
+/** Returns true when it triggered a reload. */
+export function reloadOnceForChunkError(error: unknown): boolean {
+  if (!isChunkLoadError(error)) return false;
+  const now = Date.now();
+  try {
+    if (now - Number(globalThis.sessionStorage.getItem(KEY) ?? 0) < COOLDOWN_MS)
+      return false;
+    globalThis.sessionStorage.setItem(KEY, String(now));
+  } catch {
+    // No sessionStorage means no loop guard — show the error instead.
+    return false;
+  }
+  logger.warn('stale chunk after deploy, reloading', { err: error });
+  globalThis.location.reload();
+  return true;
+}
+
+export function installChunkReload(): void {
+  if (typeof window === 'undefined') return;
+  window.addEventListener('vite:preloadError', (event) => {
+    if (reloadOnceForChunkError(event.payload)) event.preventDefault();
+  });
+}

--- a/src/lib/chunk-reload.ts
+++ b/src/lib/chunk-reload.ts
@@ -4,12 +4,17 @@
  * A deploy replaces every hashed chunk filename, but an already-loaded tab
  * still points at the old ones. The next lazy import — a route chunk on
  * navigation, a `React.lazy` component — 404s, and the user sits on
- * "Something went wrong" until they refresh by hand.
+ * "Something went wrong" until they refresh by hand. Reloading fetches fresh
+ * HTML, which points at chunks that exist; there is no lighter repair, since
+ * the missing chunk is what the render needed.
  *
- * Vite's preload helper wraps every dynamic import and dispatches a
- * cancelable `vite:preloadError` when one fails, so a single window listener
- * covers all of them. Reloading fetches fresh HTML, which points at chunks
- * that exist.
+ * Vite's preload helper wraps every dynamic import and dispatches a cancelable
+ * `vite:preloadError` when either the dep preload or the module import
+ * rejects — so the event already *means* "a chunk failed to load". We
+ * deliberately don't sniff the error message on top of it: the wording is
+ * browser-specific ("Failed to fetch dynamically imported module" /
+ * "Importing a module script failed"), so a matcher can only ever go stale
+ * and silently stop firing.
  */
 
 import { getLogger } from '@/lib/observability/logger';
@@ -18,42 +23,26 @@ const logger = getLogger(['openstory', 'ui', 'chunk-reload']);
 
 const KEY = 'os:chunk-reloaded-at';
 
-// Long enough that a genuinely broken deploy can't reload-loop, short enough
-// that a long-lived tab still gets its one reload on the *next* deploy.
-const COOLDOWN_MS = 10_000;
-
-const CHUNK_ERROR = /dynamically imported module|module script failed/i;
-
-function isChunkLoadError(error: unknown): boolean {
-  const message =
-    error instanceof Error
-      ? error.message
-      : typeof error === 'string'
-        ? error
-        : '';
-  return CHUNK_ERROR.test(message);
-}
-
-/** Returns true when it triggered a reload. */
-export function reloadOnceForChunkError(error: unknown): boolean {
-  if (!isChunkLoadError(error)) return false;
-  const now = Date.now();
-  try {
-    if (now - Number(globalThis.sessionStorage.getItem(KEY) ?? 0) < COOLDOWN_MS)
-      return false;
-    globalThis.sessionStorage.setItem(KEY, String(now));
-  } catch {
-    // No sessionStorage means no loop guard — show the error instead.
-    return false;
-  }
-  logger.warn('stale chunk after deploy, reloading', { err: error });
-  globalThis.location.reload();
-  return true;
-}
+// Not a guess about deploy timing: a successful reload *removes* the stale
+// URLs, so staleness cannot recur. This only asks "did I already try this
+// remedy on this page?" — bounding a broken deploy to one wasted reload
+// instead of a loop. Anything longer than a page load would do.
+const RETRY_WINDOW_MS = 10_000;
 
 export function installChunkReload(): void {
   if (typeof window === 'undefined') return;
   window.addEventListener('vite:preloadError', (event) => {
-    if (reloadOnceForChunkError(event.payload)) event.preventDefault();
+    const now = Date.now();
+    try {
+      if (now - Number(sessionStorage.getItem(KEY) ?? 0) < RETRY_WINDOW_MS)
+        return;
+      sessionStorage.setItem(KEY, String(now));
+    } catch {
+      // No sessionStorage means no loop guard — surface the error instead.
+      return;
+    }
+    logger.warn('stale chunk after deploy, reloading', { err: event.payload });
+    event.preventDefault(); // Suppress the throw; we're leaving the page.
+    location.reload();
   });
 }


### PR DESCRIPTION
Closes #1395

## Cause

TanStack Router code-splits every route, and Workers Static Assets deploys assets **per Worker version** — the live version serves only its own manifest. A deploy therefore invalidates every hashed chunk URL an already-loaded tab is still holding. The next lazy import fails, the route boundary renders "Something went wrong", and the tab stays broken until the user refreshes by hand.

Confirmed in production — the failing URLs are exactly our split route/vendor chunks:

```
Failed to fetch dynamically imported module: https://openstory.so/assets/route-Diq7Pz0I.js
Failed to fetch dynamically imported module: https://openstory.so/assets/_app-D4igK_TR.js
Failed to fetch dynamically imported module: https://openstory.so/assets/sequences-Ceid7PZb.js
```

Deploy cadence is what makes it bite: 66 merges to `main` in the last 14 days (5–16/day). Every one opens the window.

## How common

Over 2026-08-25 → 08-31: **67 occurrences, 28 users, 36 sessions** — ~2.9% of users and ~2.9% of sessions in that window (baseline 977 users / 1243 sessions).

**Caveat: that's a floor over 7 days, not a 90-day total.** Boundary-caught errors only started reaching PostHog when #1283 landed on 2026-08-25; before that a chunk failure hit the router boundary and never reached `window.onerror`, so it was invisible. Weekly `$exception` volume jumps from ~20–70 to 610 that same week — that's instrumentation, not a regression.

Users do **not** reliably self-rescue. Errors per session:

| errors in session | sessions |
|---|---|
| 1 | 30 |
| 2 | 4 |
| 3 | 1 |
| 26 | 1 |

Safari is the bad case: 31 occurrences across 4 sessions (~8 per session).

## Fix

Vite's preload helper wraps every dynamic import and dispatches a cancelable `vite:preloadError` when the dep preload or the module import rejects — so the event already *means* "a chunk failed to load". One listener in `src/lib/chunk-reload.ts` (installed alongside `configureLogging()` in `providers.tsx`) reloads once. Fresh HTML → chunks that exist.

Deliberately **no** error-message matching on top of the event. The wording is browser-specific and the production data shows why: Safari says `Importing a module script failed.` with no URL, Chrome says `Failed to fetch dynamically imported module: <url>`. A matcher could only go stale and silently stop firing.

Loop guard is a `sessionStorage` timestamp with a 10s window. Not a guess about deploy timing: a successful reload *removes* the stale URLs, so staleness can't recur — it only asks "did I already try this remedy on this page?", bounding a broken deploy to one wasted reload. No `sessionStorage` means no loop guard, so we surface the error instead.

Unit test covers reload-once, no-double-reload, reload-again-after-window, and the no-`sessionStorage` path.