### PR TITLE
fix(#1397): probe WebCodecs encoder support before browser export

### DIFF
--- a/src/lib/sequence-player/encoder-support.test.ts
+++ b/src/lib/sequence-player/encoder-support.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Mediabunny's `canEncode*` hit real WebCodecs, which jsdom doesn't have — mock
+ * the two helpers and assert the branching + message (#1397).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const canEncodeAudio = vi.fn<() => Promise<boolean>>();
+const canEncodeVideo = vi.fn<() => Promise<boolean>>();
+vi.doMock('mediabunny', () => ({ canEncodeAudio, canEncodeVideo }));
+
+const { assertEncoderSupport } = await import('./encoder-support');
+
+const needs = {
+  audio: true,
+  video: true,
+  width: 1920,
+  height: 1080,
+  sampleRate: 48_000,
+  numberOfChannels: 2,
+  audioBitrate: 192_000,
+};
+
+beforeEach(() => {
+  canEncodeAudio.mockReset().mockResolvedValue(true);
+  canEncodeVideo.mockReset().mockResolvedValue(true);
+});
+
+describe('assertEncoderSupport', () => {
+  it('resolves when both encoders are available', async () => {
+    await expect(assertEncoderSupport(needs)).resolves.toBeUndefined();
+  });
+
+  it('names AAC when the audio encoder is missing (the Firefox case)', async () => {
+    canEncodeAudio.mockResolvedValue(false);
+    await expect(assertEncoderSupport(needs)).rejects.toThrow(/AAC audio/);
+  });
+
+  it('names H.264 when the video encoder is missing', async () => {
+    canEncodeVideo.mockResolvedValue(false);
+    await expect(assertEncoderSupport(needs)).rejects.toThrow(/H\.264 video/);
+  });
+
+  it('names both when neither is available', async () => {
+    canEncodeAudio.mockResolvedValue(false);
+    canEncodeVideo.mockResolvedValue(false);
+    await expect(assertEncoderSupport(needs)).rejects.toThrow(
+      /AAC audio or H\.264 video/
+    );
+  });
+
+  // A silent, transmux-compatible sequence encodes nothing, so an absent
+  // encoder must not block it.
+  it('probes nothing when neither encoder is needed', async () => {
+    await expect(
+      assertEncoderSupport({ ...needs, audio: false, video: false })
+    ).resolves.toBeUndefined();
+    expect(canEncodeAudio).not.toHaveBeenCalled();
+    expect(canEncodeVideo).not.toHaveBeenCalled();
+  });
+
+  it('probes with the export pipeline parameters', async () => {
+    await assertEncoderSupport(needs);
+    expect(canEncodeAudio).toHaveBeenCalledWith('aac', {
+      numberOfChannels: 2,
+      sampleRate: 48_000,
+      bitrate: 192_000,
+    });
+    expect(canEncodeVideo).toHaveBeenCalledWith('avc', {
+      width: 1920,
+      height: 1080,
+    });
+  });
+});

--- a/src/lib/sequence-player/encoder-support.ts
+++ b/src/lib/sequence-player/encoder-support.ts
@@ -1,0 +1,60 @@
+/**
+ * Encoder-support probe for browser export (#1397).
+ *
+ * `exportSequence` needs two WebCodecs encoders, and neither is universal:
+ *
+ * - **AAC** whenever the sequence has music or scene dialogue. Firefox ships
+ *   no AAC encoder at all, so this is the common failure.
+ * - **AVC** only on the re-encode path (mixed resolutions / differing decoder
+ *   configs). Missing on some Linux Chromium builds.
+ *
+ * Without this probe the export runs its full decode pass first and dies
+ * minutes later with a raw `DOMException` from the encoder error callback.
+ *
+ * The server-side container export (#968) covers the AAC case — it renders
+ * exactly the uniform-AVC-plus-audio-mix shape — but explicitly rejects mixed
+ * resolutions, so it can't stand in for the AVC case. Routing there is a
+ * follow-up; this module is the prerequisite either way.
+ */
+
+import { canEncodeAudio, canEncodeVideo } from 'mediabunny';
+
+export type EncoderNeeds = {
+  /** Sequence has music or dialogue, so the AAC encoder is required. */
+  audio: boolean;
+  /** Transmux unavailable, so a video encoder is required to re-encode. */
+  video: boolean;
+  width: number;
+  height: number;
+  sampleRate: number;
+  numberOfChannels: number;
+  audioBitrate: number;
+};
+
+/**
+ * Throws a message naming the missing codec(s) when the browser can't encode
+ * what this export needs. Resolves silently otherwise.
+ */
+export async function assertEncoderSupport(needs: EncoderNeeds): Promise<void> {
+  const [audioOk, videoOk] = await Promise.all([
+    needs.audio
+      ? canEncodeAudio('aac', {
+          numberOfChannels: needs.numberOfChannels,
+          sampleRate: needs.sampleRate,
+          bitrate: needs.audioBitrate,
+        })
+      : Promise.resolve(true),
+    needs.video
+      ? canEncodeVideo('avc', { width: needs.width, height: needs.height })
+      : Promise.resolve(true),
+  ]);
+
+  const missing: string[] = [];
+  if (!audioOk) missing.push('AAC audio');
+  if (!videoOk) missing.push('H.264 video');
+  if (missing.length === 0) return;
+
+  throw new Error(
+    `This browser can't encode ${missing.join(' or ')}, which this export needs. Try Chrome, Edge, or Safari.`
+  );
+}

--- a/src/lib/sequence-player/export.ts
+++ b/src/lib/sequence-player/export.ts
@@ -36,6 +36,7 @@ import {
   type SceneInput,
 } from './concatenated-video-source';
 import { decodeAudioTrack } from './decode-audio-track';
+import { assertEncoderSupport } from './encoder-support';
 
 import { getLogger } from '@/lib/observability/logger';
 
@@ -119,6 +120,18 @@ export async function exportSequence(
 
     const sceneAudioTracks = videoSource.getSceneAudioTracks();
     const hasAudio = Boolean(musicUrl) || sceneAudioTracks.length > 0;
+
+    // Earliest point at which both encoder needs are known, and still before
+    // any decode work — fail in a second rather than after a full pass (#1397).
+    await assertEncoderSupport({
+      audio: hasAudio,
+      video: !meta.canTransmux,
+      width: meta.displayWidth,
+      height: meta.displayHeight,
+      sampleRate: TARGET_SAMPLE_RATE,
+      numberOfChannels: TARGET_CHANNELS,
+      audioBitrate: AAC_BITRATE,
+    });
 
     const output = new Output({
       format: new Mp4OutputFormat({ fastStart: 'in-memory' }),


### PR DESCRIPTION
Closes #1397.

## Problem

`exportSequence` assumed two WebCodecs encoders that aren't universal:

- **AAC** (`mp4a.40.2`) whenever the sequence has music or scene dialogue — Firefox ships no AAC encoder at all, so this is the common failure.
- **AVC** only on the re-encode path (`!meta.canTransmux`: mixed resolutions or differing decoder configs) — missing on some Linux Chromium builds.

Neither was checked. An unsupported browser fetched and decoded every scene first and only then died, minutes later, with a raw `DOMException` from the encoder error callback — an unactionable toast after a long wait.

## Change

New `src/lib/sequence-player/encoder-support.ts` probes with mediabunny's `canEncodeAudio` / `canEncodeVideo` (already a dependency — no hand-rolled `isConfigSupported`) and throws a message naming the missing codec.

Called from `exportSequence` immediately after `videoSource.prepare()`: the earliest point at which both needs are known (`hasAudio`, `meta.canTransmux`) and still before `output.start()` or any decode work. `useSequenceExport`'s existing `toExportErrorMessage` surfaces it as the export error toast, so there's no new UI.

A silent, transmux-compatible sequence encodes nothing and probes nothing — it stays unaffected.

## Why not just fall back to the server export

The container path (#968) and the two failures line up exactly, and inversely:

| Missing encoder | Server container |
|---|---|
| AAC (transmux-compatible + audio) | ✅ precisely its v1 scope |
| AVC (mixed resolutions) | ❌ `containers/video-export/src/export.ts:171` rejects it outright |

So a fallback can't replace the probe — the probe is what decides the route, and the AVC case needs a clear failure regardless. Wiring the fallback is #1402; the blockers there are `sourceShotsHash` never being written on the server path (which would silently break the #1253 export cache), the 202+poll shape vs. the hook's synchronous progress model, and the container being production-only.

## Tests

`encoder-support.test.ts` — 6 cases: both available, AAC missing, AVC missing, both missing, neither needed (asserts no probe fires), and the exact probe parameters. mediabunny's `canEncode*` hit real WebCodecs, so they're mocked per the repo's `vi.doMock` + dynamic-import pattern.

`bun run test src/lib/sequence-player/` — 62 passing. `bun typecheck` and `bun lint` clean on the changed files.
