### PR TITLE
fix(#1406): write sourceShotsHash on server exports so theatre cache hits

### DIFF
--- a/src/components/theatre/use-sequence-export.ts
+++ b/src/components/theatre/use-sequence-export.ts
@@ -6,13 +6,14 @@
  *   3. PUT the resulting Blob to the reserved URL.
  *   4. Commit via `commitSequenceExportFn` (writes a new `sequence_exports` row).
  *
- * Every commit records `sourceShotsHash` — a SHA-256 of the scene video URLs
- * + the music choice — so `sequence_exports` is a content-addressed cache of
- * what the user is looking at (#1253). `freshExportUrl` is the cached MP4 for
- * the CURRENT state (or null), and both user actions go through the cache:
- * `download()` and `copyLink()` reuse a matching export, else export first and
- * then act. There is no "export" verb in the UI and no way to share a stale
- * cut.
+ * Every commit records `sourceShotsHash` — SHA-256 of `{sceneUrls, musicUrl}`
+ * via `hashSequenceExportInputs` — so `sequence_exports` is a content-
+ * addressed cache of what the user is looking at (#1253, #1406). The server
+ * export route writes the same hash, so an API-produced MP4 is reused here.
+ * `freshExportUrl` is the cached MP4 for the CURRENT state (or null), and
+ * both user actions go through the cache: `download()` and `copyLink()` reuse
+ * a matching export, else export first and then act. There is no "export"
+ * verb in the UI and no way to share a stale cut.
  */
 
 import {
@@ -21,7 +22,11 @@ import {
   requestSequenceExportUploadUrlFn,
 } from '@/functions/sequence-exports';
 import { useShotsBySequence } from '@/hooks/use-shots';
-import { sha256Hex } from '@/lib/compliance/hash';
+import {
+  effectiveExportMusicUrl,
+  hashSequenceExportInputs,
+  sequenceExportInputsKey,
+} from '@/lib/sequence-player/source-shots-hash';
 import { putToR2 } from '@/lib/utils/upload';
 import {
   exportSequence,
@@ -75,23 +80,37 @@ export function useSequenceExport(
     enabled: Boolean(sequence),
   });
 
-  const inputsKey = useMemo(() => {
+  const exportInputs = useMemo(() => {
     if (!sequence || !shots) return null;
-    const sceneUrls = shots.map((f) => f.video?.url ?? null);
-    if (sceneUrls.length === 0 || sceneUrls.some((u) => !u)) return null;
-    return JSON.stringify({
+    const sceneUrls: string[] = [];
+    for (const shot of shots) {
+      const url = shot.video?.url;
+      if (!url) return null;
+      sceneUrls.push(url);
+    }
+    if (sceneUrls.length === 0) return null;
+    return {
       sceneUrls,
-      musicUrl: sequence.includeMusic ? (sequence.musicUrl ?? null) : null,
-    });
+      musicUrl: effectiveExportMusicUrl(
+        sequence.includeMusic,
+        sequence.musicUrl
+      ),
+    };
   }, [sequence, shots]);
+  const inputsKey = exportInputs ? sequenceExportInputsKey(exportInputs) : null;
   const {
     data: inputsHash,
     error: inputsHashError,
     isLoading: hashLoading,
   } = useQuery({
     queryKey: ['sequence-export-inputs-hash', inputsKey],
-    queryFn: () => sha256Hex(inputsKey ?? ''),
-    enabled: inputsKey !== null,
+    queryFn: () => {
+      if (!exportInputs) {
+        throw new Error('Could not fingerprint the scenes for export.');
+      }
+      return hashSequenceExportInputs(exportInputs);
+    },
+    enabled: exportInputs !== null,
     staleTime: Infinity,
     retry: false,
   });

--- a/src/lib/db/schema/sequence-exports.ts
+++ b/src/lib/db/schema/sequence-exports.ts
@@ -8,13 +8,13 @@
  *    which commits a finished `ready` row directly; and
  *  - the server-side (API) export workflow, which reserves a `processing` row
  *    up front and later flips it to `ready`/`failed`.
- * The "Download" UI surfaces the newest *ready* row (per sequence); the API
- * lists every status so a caller can poll progress.
+ * Theatre Download/Share reuse a row only when `sourceShotsHash` matches the
+ * current cut (`freshExportUrl` in `useSequenceExport`). The API lists every
+ * status so a caller can poll progress.
  *
- * `sourceShotsHash` is a SHA-256 of the scene video URLs + effective music
- * URL, computed by `useSequenceExport` (#1253). The latest `ready` row is
- * reused as a cache — for direct download and native playback in
- * `SequencePlayer` — only when it matches the current inputs.
+ * `sourceShotsHash` is SHA-256 of `{sceneUrls, musicUrl}`, computed by
+ * `hashSequenceExportInputs` and written by both producers (#1253, #1406).
+ * There is no "latest ready" fallback.
  * `sourceMusicVariantId` is reserved but currently never written.
  */
 
@@ -61,7 +61,7 @@ export const sequenceExports = snakeCase.table(
     // row. Null for browser exports.
     workflowRunId: text(),
 
-    // Inputs that produced this snapshot (cache key, see useSequenceExport)
+    // Inputs that produced this snapshot (cache key, see hashSequenceExportInputs)
     sourceShotsHash: text(),
     sourceMusicVariantId: text(),
 

--- a/src/lib/db/scoped/sequence-exports.ts
+++ b/src/lib/db/scoped/sequence-exports.ts
@@ -1,7 +1,7 @@
 /**
  * Scoped sequence_exports CRUD. Exports are flat — no primary/divergent
- * split — and rows accumulate. The newest row per sequence is what the UI
- * surfaces as "your latest download".
+ * split — and rows accumulate. Theatre reuse is hash-matched on
+ * `sourceShotsHash`, not "newest ready".
  *
  * Two producers write here:
  * - the browser export pipeline (see `src/lib/sequence-player/export.ts`),
@@ -9,8 +9,8 @@
  * - the server-side (API) export workflow, which `createProcessing()`s a row
  *   up front and later flips it to `ready`/`failed`.
  *
- * `listBySequence`/`getLatest` are `ready`-only so the download UI never offers
- * an in-flight or failed server export; the API uses `listAllBySequence` to
+ * `listBySequence` is `ready`-only so the download UI never offers an
+ * in-flight or failed server export; the API uses `listAllBySequence` to
  * surface progress.
  */
 
@@ -50,21 +50,6 @@ export function createSequenceExportsMethods(db: Database) {
         .orderBy(desc(sequenceExports.createdAt));
     },
 
-    getLatest: async (sequenceId: string): Promise<SequenceExport | null> => {
-      const rows = await db
-        .select()
-        .from(sequenceExports)
-        .where(
-          and(
-            eq(sequenceExports.sequenceId, sequenceId),
-            eq(sequenceExports.status, 'ready')
-          )
-        )
-        .orderBy(desc(sequenceExports.createdAt))
-        .limit(1);
-      return rows[0] ?? null;
-    },
-
     getById: async (id: string): Promise<SequenceExport | null> => {
       const rows = await db
         .select()
@@ -95,6 +80,7 @@ export function createSequenceExportsMethods(db: Database) {
       sequenceId: string;
       url: string;
       storagePath: string;
+      sourceShotsHash: string;
       workflowRunId?: string | null;
     }): Promise<{ row: SequenceExport; created: boolean }> => {
       try {

--- a/src/lib/sequence-player/source-shots-hash.test.ts
+++ b/src/lib/sequence-player/source-shots-hash.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Pins the export cache key so browser and server producers cannot drift
+ * onto different hashes for the same cut (#1406).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { sha256Hex } from '@/lib/compliance/hash';
+import {
+  effectiveExportMusicUrl,
+  hashSequenceExportInputs,
+  sequenceExportInputsKey,
+} from './source-shots-hash';
+
+const cut = {
+  sceneUrls: ['/r2/a.mp4', '/r2/b.mp4'],
+  musicUrl: '/r2/music.mp3',
+} as const;
+
+describe('sequenceExportInputsKey', () => {
+  it('serializes {sceneUrls, musicUrl} in that key order', () => {
+    expect(sequenceExportInputsKey(cut)).toBe(
+      '{"sceneUrls":["/r2/a.mp4","/r2/b.mp4"],"musicUrl":"/r2/music.mp3"}'
+    );
+  });
+
+  it('treats a muted cut as musicUrl null, not omitted', () => {
+    expect(
+      sequenceExportInputsKey({ sceneUrls: cut.sceneUrls, musicUrl: null })
+    ).toBe('{"sceneUrls":["/r2/a.mp4","/r2/b.mp4"],"musicUrl":null}');
+  });
+});
+
+describe('hashSequenceExportInputs', () => {
+  it('is SHA-256 of the canonical JSON (byte-identical across producers)', async () => {
+    const hash = await hashSequenceExportInputs(cut);
+    expect(hash).toBe(await sha256Hex(sequenceExportInputsKey(cut)));
+    expect(hash).toBe(await hashSequenceExportInputs({ ...cut }));
+  });
+
+  it('changes when scene order, a url, or the music choice changes', async () => {
+    const base = await hashSequenceExportInputs(cut);
+    expect(
+      await hashSequenceExportInputs({
+        sceneUrls: [...cut.sceneUrls].reverse(),
+        musicUrl: cut.musicUrl,
+      })
+    ).not.toBe(base);
+    expect(
+      await hashSequenceExportInputs({
+        sceneUrls: ['/r2/a-v2.mp4', '/r2/b.mp4'],
+        musicUrl: cut.musicUrl,
+      })
+    ).not.toBe(base);
+    expect(
+      await hashSequenceExportInputs({
+        sceneUrls: cut.sceneUrls,
+        musicUrl: null,
+      })
+    ).not.toBe(base);
+  });
+});
+
+describe('effectiveExportMusicUrl', () => {
+  it('is the music URL when the toggle is on, else null', () => {
+    expect(effectiveExportMusicUrl(true, '/r2/m.mp3')).toBe('/r2/m.mp3');
+    expect(effectiveExportMusicUrl(true, null)).toBeNull();
+    expect(effectiveExportMusicUrl(true, undefined)).toBeNull();
+    expect(effectiveExportMusicUrl(false, '/r2/m.mp3')).toBeNull();
+  });
+});

--- a/src/lib/sequence-player/source-shots-hash.ts
+++ b/src/lib/sequence-player/source-shots-hash.ts
@@ -1,0 +1,40 @@
+/**
+ * Canonical `sourceShotsHash` for `sequence_exports` (#1253, #1406).
+ *
+ * Theatre lookup is strict equality on this hash, so both producers — the
+ * browser hook and the v1 export route — must emit the same bytes for the
+ * same cut. The stored digest is SHA-256 of
+ * `JSON.stringify({ sceneUrls, musicUrl })`; key order is load-bearing.
+ */
+
+import { sha256Hex } from '@/lib/compliance/hash';
+
+export type SequenceExportInputs = {
+  sceneUrls: readonly string[];
+  musicUrl: string | null;
+};
+
+/** Music URL that actually goes into the stitched MP4 (and therefore the hash). */
+export function effectiveExportMusicUrl(
+  includeMusic: boolean,
+  musicUrl: string | null | undefined
+): string | null {
+  return includeMusic ? (musicUrl ?? null) : null;
+}
+
+/**
+ * Canonical JSON payload. Do not reorder or rename fields — existing rows
+ * were hashed against this exact shape.
+ */
+export function sequenceExportInputsKey(inputs: SequenceExportInputs): string {
+  return JSON.stringify({
+    sceneUrls: inputs.sceneUrls,
+    musicUrl: inputs.musicUrl,
+  });
+}
+
+export async function hashSequenceExportInputs(
+  inputs: SequenceExportInputs
+): Promise<string> {
+  return sha256Hex(sequenceExportInputsKey(inputs));
+}

--- a/src/routes/api/v1/sequences.$id.exports.ts
+++ b/src/routes/api/v1/sequences.$id.exports.ts
@@ -9,8 +9,9 @@
  *          the `ready` URL.
  *
  * Team-scoped via `authWithTeamRequestMiddleware`; a key only sees its own
- * team's sequences. The browser-side export (`use-sequence-export`) is
- * untouched — both producers write the same `sequence_exports` table.
+ * team's sequences. Both producers write the same `sequence_exports` table
+ * and the same `sourceShotsHash` (via `hashSequenceExportInputs`) so a
+ * server-rendered MP4 is reused by the theatre cache (#1406).
  */
 
 import { authWithTeamRequestMiddleware } from '@/functions/middleware';
@@ -30,6 +31,10 @@ import {
   getPublicUrl,
   toShareableUrl,
 } from '@/lib/storage/buckets';
+import {
+  effectiveExportMusicUrl,
+  hashSequenceExportInputs,
+} from '@/lib/sequence-player/source-shots-hash';
 import { triggerWorkflow } from '@/lib/workflow/client';
 import type { SequenceExportWorkflowInput } from '@/lib/workflow/types';
 import { createFileRoute } from '@tanstack/react-router';
@@ -168,12 +173,24 @@ export const Route = createFileRoute('/api/v1/sequences/$id/exports')({
           // leaves a row the stale sweep above can reconcile. `created: false`
           // means a concurrent POST won the one-processing-row race — coalesce
           // onto its row rather than starting a second workflow.
+          //
+          // Hash is computed here, not accepted from the client — a wrong
+          // client cache key would mark a stale MP4 as current (#1253 / #1406).
+          const musicUrl = effectiveExportMusicUrl(
+            sequence.includeMusic,
+            sequence.musicUrl
+          );
+          const sourceShotsHash = await hashSequenceExportInputs({
+            sceneUrls: scenes.map((s) => s.videoUrl),
+            musicUrl,
+          });
           const path = buildExportPath(context.teamId, params.id);
           const { row, created } =
             await context.scopedDb.sequenceExports.createProcessing({
               sequenceId: params.id,
               url: getPublicUrl(STORAGE_BUCKETS.VIDEOS, path),
               storagePath: path,
+              sourceShotsHash,
             });
           if (!created) {
             return Response.json(
@@ -195,10 +212,7 @@ export const Route = createFileRoute('/api/v1/sequences/$id/exports')({
                 exportId: row.id,
                 storagePath: path,
                 scenes,
-                musicUrl:
-                  sequence.includeMusic && sequence.musicUrl
-                    ? sequence.musicUrl
-                    : null,
+                musicUrl,
               }
             );
           await context.scopedDb.sequenceExports.setWorkflowRunId(


### PR DESCRIPTION
## Related Issue

Closes #1406

## Summary of Changes

Server-side sequence exports now write `sourceShotsHash` at reserve time so an API-produced MP4 is reused by theatre Download/Share instead of forcing a browser re-export.

- Extracted `hashSequenceExportInputs` (`JSON.stringify({ sceneUrls, musicUrl })` then SHA-256) into a shared module used by both `use-sequence-export` and `POST /api/v1/sequences/$id/exports`.
- `createProcessing` requires `sourceShotsHash` and stamps it on the processing row. Hash is computed on the server from the same cut the workflow renders — not accepted from the client.
- Deleted unused `sequenceExports.getLatest` (newest-ready, no hash) so it cannot be wired as a stale-cut fallback.
- Schema comment now matches reality: reuse is hash equality, not "latest ready".

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Hash is additive on a nullable column. Failed rows keep the hash (harmless: `listBySequence` is ready-only). Existing browser hashes stay byte-identical because the JSON shape is unchanged.

## Additional Notes

Prerequisite for #1402 (route UI traffic to the server path for browsers with no AAC encoder). Found while scoping #1397 / PR #1403.