### PR TITLE
fix(#1414): style emails with inline CSS instead of <Tailwind>

### DIFF
--- a/src/lib/emails/abuse-report-email.tsx
+++ b/src/lib/emails/abuse-report-email.tsx
@@ -4,10 +4,11 @@
 
 import { Heading, Section, Text } from '@react-email/components';
 import {
-  detailRowClass,
+  detailRowStyle,
   EmailLayout,
-  headingClass,
-  paragraphClass,
+  headingStyle,
+  mutedBoxStyle,
+  paragraphStyle,
 } from './email-layout';
 
 interface AbuseReportEmailProps {
@@ -27,25 +28,25 @@ export const AbuseReportEmail: React.FC<AbuseReportEmailProps> = ({
 }) => (
   <EmailLayout appName={appName} preview={`New ${reason} report ${reference}`}>
     <Section>
-      <Heading as="h2" className={headingClass}>
+      <Heading as="h2" style={headingStyle}>
         New content report
       </Heading>
-      <Text className={paragraphClass}>
+      <Text style={paragraphStyle}>
         A report landed in the moderation queue. Open Admin → Moderation to
         triage it.
       </Text>
 
-      <Section className="my-6 rounded-lg bg-muted p-6">
-        <Text className={detailRowClass}>
+      <Section style={mutedBoxStyle}>
+        <Text style={detailRowStyle}>
           <strong>Reference:</strong> {reference}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Reason:</strong> {reason}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Target:</strong> {targetType}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Trace id supplied:</strong> {hasTrace ? 'yes' : 'no'}
         </Text>
       </Section>

--- a/src/lib/emails/email-layout.tsx
+++ b/src/lib/emails/email-layout.tsx
@@ -2,10 +2,11 @@
  * Shared layout for transactional emails.
  *
  * Server-only: these components are rendered to static HTML by
- * email-service.tsx via @react-email/render — they must never be imported
- * from client code. Styling uses react-email's <Tailwind> wrapper, which
- * compiles the utility classes to inline styles at render time (email
- * clients — Gmail in particular — strip <style> blocks).
+ * email-service.tsx — they must never be imported from client code.
+ *
+ * Styles are inline `style={{}}` objects, not `<Tailwind>`. Gmail strips
+ * `<style>` blocks, and the Tailwind compiler is the bulk of
+ * `@react-email/components` at Worker startup (#1414).
  */
 
 import {
@@ -14,36 +15,61 @@ import {
   Head,
   Html,
   Img,
-  pixelBasedPreset,
   Preview,
   Section,
-  Tailwind,
   Text,
 } from '@react-email/components';
 
 /**
  * App dark-mode palette, transcribed from `src/styles/global.css` `:root`
- * oklch tokens into hex. React-email inlines these at render time — Gmail
- * strips `<style>`, so every Text/Body/Container must set colour explicitly
- * (no inheritance, no `prefers-color-scheme`).
+ * oklch tokens into hex. Every Text/Body/Container sets colour explicitly —
+ * Gmail does not inherit, and there is no `prefers-color-scheme`.
  */
 const emailColors = {
-  background: '#171717',
   foreground: '#fafafa',
   card: '#171717',
   muted: '#2e2e2e',
   mutedForeground: '#a3a3a3',
   border: '#2e2e2e',
-  primary: '#fafafa',
-  primaryForeground: '#262626',
   canvas: '#0a0a0a',
 } as const;
 
+const fontSans = 'Arial, Helvetica, sans-serif';
+
 /** Shared text styles for template content. */
-export const headingClass = 'mt-0 mb-4 text-2xl font-bold text-foreground';
-export const paragraphClass =
-  'mt-0 mb-3 text-base leading-6 text-muted-foreground';
-export const detailRowClass = 'm-0 text-sm leading-6 text-foreground';
+export const headingStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 16,
+  fontSize: 24,
+  fontWeight: 700,
+  lineHeight: '32px',
+  color: emailColors.foreground,
+};
+
+export const paragraphStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 12,
+  fontSize: 16,
+  lineHeight: '24px',
+  color: emailColors.mutedForeground,
+};
+
+export const detailRowStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 0,
+  fontSize: 14,
+  lineHeight: '24px',
+  color: emailColors.foreground,
+};
+
+/** Grey info panel used for OTP, details, and quoted messages. */
+export const mutedBoxStyle: React.CSSProperties = {
+  marginTop: 24,
+  marginBottom: 24,
+  borderRadius: 8,
+  backgroundColor: emailColors.muted,
+  padding: 24,
+};
 
 // Emails can't bundle assets and outlive any single deployment, so the logo
 // is served from the stable public-assets domain (same fallback pattern as
@@ -62,23 +88,54 @@ interface EmailLayoutProps {
   footerNote?: string;
 }
 
-const tailwindConfig = {
-  presets: [pixelBasedPreset],
-  theme: {
-    extend: {
-      colors: {
-        background: emailColors.background,
-        foreground: emailColors.foreground,
-        card: emailColors.card,
-        muted: emailColors.muted,
-        'muted-foreground': emailColors.mutedForeground,
-        border: emailColors.border,
-        primary: emailColors.primary,
-        'primary-foreground': emailColors.primaryForeground,
-        canvas: emailColors.canvas,
-      },
-    },
-  },
+const bodyStyle: React.CSSProperties = {
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  backgroundColor: emailColors.canvas,
+  padding: 20,
+  fontFamily: fontSans,
+  color: emailColors.foreground,
+};
+
+const containerStyle: React.CSSProperties = {
+  maxWidth: 600,
+  borderRadius: 8,
+  border: `1px solid ${emailColors.border}`,
+  backgroundColor: emailColors.card,
+  padding: 32,
+};
+
+const logoSectionStyle: React.CSSProperties = {
+  marginBottom: 32,
+  textAlign: 'center',
+};
+
+const logoStyle: React.CSSProperties = {
+  marginLeft: 'auto',
+  marginRight: 'auto',
+};
+
+const footerSectionStyle: React.CSSProperties = {
+  marginTop: 32,
+  borderWidth: 0,
+  borderTopWidth: 1,
+  borderStyle: 'solid',
+  borderColor: emailColors.border,
+  paddingTop: 24,
+  textAlign: 'center',
+};
+
+const footerTextStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 0,
+  fontSize: 14,
+  lineHeight: '24px',
+  color: emailColors.mutedForeground,
+};
+
+const footerNoteStyle: React.CSSProperties = {
+  ...footerTextStyle,
+  marginBottom: 8,
 };
 
 export const EmailLayout: React.FC<EmailLayoutProps> = ({
@@ -90,34 +147,30 @@ export const EmailLayout: React.FC<EmailLayoutProps> = ({
   <Html>
     <Head />
     <Preview>{preview}</Preview>
-    <Tailwind config={tailwindConfig}>
-      <Body className="mx-auto bg-canvas p-5 font-sans text-foreground">
-        <Container className="max-w-[600px] rounded-lg border border-solid border-border bg-card p-8">
-          <Section className="mb-8 text-center">
-            {/* Inline SVG is stripped by most email clients, so the wordmark
-                ships as a hosted PNG. alt covers blocked-image clients. */}
-            <Img
-              src={LOGO_URL}
-              width="183"
-              height="40"
-              alt={appName}
-              className="mx-auto"
-            />
-          </Section>
-          {children}
-          <Section className="mt-8 border-0 border-t border-solid border-border pt-6 text-center">
-            {footerNote ? (
-              <Text className="m-0 mb-2 text-sm leading-6 text-muted-foreground">
-                {footerNote}
-              </Text>
-            ) : null}
-            <Text className="m-0 text-sm leading-6 text-muted-foreground">
-              © {new Date().getFullYear()} {appName}. All rights reserved.
-            </Text>
-          </Section>
-        </Container>
-      </Body>
-    </Tailwind>
+    <Body style={bodyStyle}>
+      <Container style={containerStyle}>
+        <Section style={logoSectionStyle}>
+          {/* Inline SVG is stripped by most email clients, so the wordmark
+              ships as a hosted PNG. alt covers blocked-image clients. */}
+          <Img
+            src={LOGO_URL}
+            width="183"
+            height="40"
+            alt={appName}
+            style={logoStyle}
+          />
+        </Section>
+        {children}
+        <Section style={footerSectionStyle}>
+          {footerNote ? (
+            <Text style={footerNoteStyle}>{footerNote}</Text>
+          ) : null}
+          <Text style={footerTextStyle}>
+            © {new Date().getFullYear()} {appName}. All rights reserved.
+          </Text>
+        </Section>
+      </Container>
+    </Body>
   </Html>
 );
 
@@ -126,13 +179,40 @@ interface WarningBoxProps {
   children: React.ReactNode;
 }
 
+const warningBoxStyle: React.CSSProperties = {
+  marginTop: 24,
+  marginBottom: 24,
+  borderRadius: 4,
+  // Emails get no CSS reset, so a lone `borderLeft` would still show
+  // default-width borders on the other sides.
+  borderWidth: 0,
+  borderLeftWidth: 4,
+  borderStyle: 'solid',
+  borderColor: '#f59e0b',
+  backgroundColor: '#451a03',
+  padding: 16,
+};
+
+const warningTitleStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 4,
+  fontSize: 14,
+  fontWeight: 700,
+  lineHeight: '24px',
+  color: '#fde68a',
+};
+
+const warningBodyStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 0,
+  fontSize: 14,
+  lineHeight: '24px',
+  color: '#fde68a',
+};
+
 export const WarningBox: React.FC<WarningBoxProps> = ({ title, children }) => (
-  // border-0 first: emails get no CSS reset, so `border-solid` alone would
-  // surface default-width borders on all sides.
-  <Section className="my-6 rounded border-0 border-l-4 border-solid border-amber-500 bg-amber-950 p-4">
-    <Text className="m-0 mb-1 text-sm font-bold leading-6 text-amber-200">
-      {title}
-    </Text>
-    <Text className="m-0 text-sm leading-6 text-amber-200">{children}</Text>
+  <Section style={warningBoxStyle}>
+    <Text style={warningTitleStyle}>{title}</Text>
+    <Text style={warningBodyStyle}>{children}</Text>
   </Section>
 );

--- a/src/lib/emails/emails.test.tsx
+++ b/src/lib/emails/emails.test.tsx
@@ -21,10 +21,9 @@ describe('renderEmail(OtpEmail)', () => {
     expect(html).not.toContain('/brand/openstory-logo-light.png');
     // Styles must be inline — Gmail strips <style> blocks.
     expect(html).not.toContain('<style');
-    // The Tailwind wrapper must have compiled classes to inline styles.
     expect(html).toContain('style=');
-    // Dark canvas, not the old light grey. Tailwind inlines rgb(), not hex.
-    expect(html).toContain('rgb(10,10,10)');
+    // Dark canvas, not the old light grey. Inline styles keep the hex.
+    expect(html).toContain('#0a0a0a');
   });
 
   it('renders a plain-text version with the code', async () => {

--- a/src/lib/emails/feedback-email.tsx
+++ b/src/lib/emails/feedback-email.tsx
@@ -4,10 +4,11 @@
 
 import { Heading, Section, Text } from '@react-email/components';
 import {
-  detailRowClass,
+  detailRowStyle,
   EmailLayout,
-  headingClass,
-  paragraphClass,
+  headingStyle,
+  mutedBoxStyle,
+  paragraphStyle,
 } from './email-layout';
 
 interface FeedbackEmailProps {
@@ -18,8 +19,22 @@ interface FeedbackEmailProps {
   message: string;
 }
 
-const messageClass =
-  'm-0 whitespace-pre-wrap text-sm leading-6 text-foreground';
+const messageStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 0,
+  whiteSpace: 'pre-wrap',
+  fontSize: 14,
+  lineHeight: '24px',
+  color: '#fafafa',
+};
+
+const messageBoxStyle: React.CSSProperties = {
+  marginTop: 24,
+  marginBottom: 24,
+  borderRadius: 8,
+  border: '1px solid #2e2e2e',
+  padding: 24,
+};
 
 export const FeedbackEmail: React.FC<FeedbackEmailProps> = ({
   appName,
@@ -30,27 +45,27 @@ export const FeedbackEmail: React.FC<FeedbackEmailProps> = ({
 }) => (
   <EmailLayout appName={appName} preview={`Feedback from ${userEmail}`}>
     <Section>
-      <Heading as="h2" className={headingClass}>
+      <Heading as="h2" style={headingStyle}>
         Feedback
       </Heading>
-      <Text className={paragraphClass}>
+      <Text style={paragraphStyle}>
         A user sent feedback from the app sidebar.
       </Text>
 
-      <Section className="my-6 rounded-lg bg-muted p-6">
-        <Text className={detailRowClass}>
+      <Section style={mutedBoxStyle}>
+        <Text style={detailRowStyle}>
           <strong>Name:</strong> {userName || '—'}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Email:</strong> {userEmail}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Team:</strong> {teamId}
         </Text>
       </Section>
 
-      <Section className="my-6 rounded-lg border border-solid border-border p-6">
-        <Text className={messageClass}>{message}</Text>
+      <Section style={messageBoxStyle}>
+        <Text style={messageStyle}>{message}</Text>
       </Section>
     </Section>
   </EmailLayout>

--- a/src/lib/emails/founder-credit-request-email.tsx
+++ b/src/lib/emails/founder-credit-request-email.tsx
@@ -6,10 +6,11 @@
 
 import { Heading, Section, Text } from '@react-email/components';
 import {
-  detailRowClass,
+  detailRowStyle,
   EmailLayout,
-  headingClass,
-  paragraphClass,
+  headingStyle,
+  mutedBoxStyle,
+  paragraphStyle,
 } from './email-layout';
 
 interface FounderCreditRequestEmailProps {
@@ -26,35 +27,35 @@ export const FounderCreditRequestEmail: React.FC<
 > = ({ appName, userName, userEmail, teamId, balanceDisplay, message }) => (
   <EmailLayout appName={appName} preview={`${userEmail} is asking for credits`}>
     <Section>
-      <Heading as="h2" className={headingClass}>
+      <Heading as="h2" style={headingStyle}>
         Credit request
       </Heading>
-      <Text className={paragraphClass}>
+      <Text style={paragraphStyle}>
         A user asked the founder for credits on the billing gate. Reply to them
         directly, or send a gift code.
       </Text>
 
-      <Section className="my-6 rounded-lg bg-muted p-6">
-        <Text className={detailRowClass}>
+      <Section style={mutedBoxStyle}>
+        <Text style={detailRowStyle}>
           <strong>Name:</strong> {userName || '—'}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Email:</strong> {userEmail}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Team:</strong> {teamId}
         </Text>
-        <Text className={detailRowClass}>
+        <Text style={detailRowStyle}>
           <strong>Balance:</strong> {balanceDisplay}
         </Text>
       </Section>
 
       {message ? (
-        <Section className="my-6 rounded-lg bg-muted p-6">
-          <Text className={detailRowClass}>
+        <Section style={mutedBoxStyle}>
+          <Text style={detailRowStyle}>
             <strong>Message:</strong>
           </Text>
-          <Text className={paragraphClass}>{message}</Text>
+          <Text style={paragraphStyle}>{message}</Text>
         </Section>
       ) : null}
     </Section>

--- a/src/lib/emails/otp-email.tsx
+++ b/src/lib/emails/otp-email.tsx
@@ -5,8 +5,9 @@
 import { Heading, Section, Text } from '@react-email/components';
 import {
   EmailLayout,
-  headingClass,
-  paragraphClass,
+  headingStyle,
+  mutedBoxStyle,
+  paragraphStyle,
   WarningBox,
 } from './email-layout';
 
@@ -15,20 +16,30 @@ interface OtpEmailProps {
   otp: string;
 }
 
+const otpStyle: React.CSSProperties = {
+  marginTop: 0,
+  marginBottom: 0,
+  textAlign: 'center',
+  fontFamily:
+    'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+  fontSize: 36,
+  fontWeight: 700,
+  letterSpacing: 8,
+  color: '#fafafa',
+};
+
 export const OtpEmail: React.FC<OtpEmailProps> = ({ appName, otp }) => (
   <EmailLayout appName={appName} preview={`Your sign-in code is ${otp}`}>
     <Section>
-      <Heading as="h2" className={headingClass}>
+      <Heading as="h2" style={headingStyle}>
         Your Sign-In Code
       </Heading>
-      <Text className={paragraphClass}>
+      <Text style={paragraphStyle}>
         Enter this code to sign in to your account:
       </Text>
 
-      <Section className="my-6 rounded-lg bg-muted p-6">
-        <Text className="m-0 text-center font-mono text-4xl font-bold tracking-[8px] text-foreground">
-          {otp}
-        </Text>
+      <Section style={mutedBoxStyle}>
+        <Text style={otpStyle}>{otp}</Text>
       </Section>
 
       <WarningBox title="This code expires in 5 minutes">

--- a/src/lib/emails/render-email.ts
+++ b/src/lib/emails/render-email.ts
@@ -8,8 +8,8 @@
  * runtime on deployed workers (#841). A static import of react-dom/server.edge
  * bundles correctly (TanStack Router's SSR uses the same pattern).
  *
- * The stream API (not renderToStaticMarkup) is required because react-email's
- * <Tailwind> component suspends while compiling classes to inline styles.
+ * Templates no longer suspend (inline styles, no `<Tailwind>`). The stream
+ * API is kept so the import of `react-dom/server.edge` stays static.
  */
 
 import { toPlainText } from '@react-email/components';

--- a/src/lib/emails/sequence-ready-email.tsx
+++ b/src/lib/emails/sequence-ready-email.tsx
@@ -10,7 +10,7 @@ import {
   Section,
   Text,
 } from '@react-email/components';
-import { EmailLayout, headingClass, paragraphClass } from './email-layout';
+import { EmailLayout, headingStyle, paragraphStyle } from './email-layout';
 
 export interface SequenceReadyEmailProps {
   appName: string;
@@ -22,6 +22,31 @@ export interface SequenceReadyEmailProps {
   balanceDisplay: string;
   typicalShortCostDisplay: string;
 }
+
+const posterStyle: React.CSSProperties = {
+  marginBottom: 24,
+  borderRadius: 8,
+};
+
+const watchButtonStyle: React.CSSProperties = {
+  marginTop: 16,
+  marginBottom: 16,
+  boxSizing: 'border-box',
+  display: 'inline-block',
+  borderRadius: 6,
+  backgroundColor: '#fafafa',
+  padding: '12px 24px',
+  textAlign: 'center',
+  fontSize: 16,
+  fontWeight: 700,
+  color: '#262626',
+  textDecoration: 'none',
+};
+
+const creditsLinkStyle: React.CSSProperties = {
+  color: '#fafafa',
+  textDecoration: 'underline',
+};
 
 export const SequenceReadyEmail: React.FC<SequenceReadyEmailProps> = ({
   appName,
@@ -39,21 +64,18 @@ export const SequenceReadyEmail: React.FC<SequenceReadyEmailProps> = ({
     footerNote="Questions? Reply to this email."
   >
     <Section>
-      <Heading as="h2" className={headingClass}>
+      <Heading as="h2" style={headingStyle}>
         {title} is ready
       </Heading>
       {posterUrl ? (
-        <Img src={posterUrl} width="536" alt="" className="mb-6 rounded-lg" />
+        <Img src={posterUrl} width="536" alt="" style={posterStyle} />
       ) : null}
-      {clipMeta ? <Text className={paragraphClass}>{clipMeta}</Text> : null}
-      <Button
-        href={watchUrl}
-        className="my-4 box-border inline-block rounded-md bg-primary px-6 py-3 text-center text-base font-bold text-primary-foreground no-underline"
-      >
+      {clipMeta ? <Text style={paragraphStyle}>{clipMeta}</Text> : null}
+      <Button href={watchUrl} style={watchButtonStyle}>
         Watch
       </Button>
-      <Text className={paragraphClass}>
-        <Link href={creditsUrl} className="text-foreground underline">
+      <Text style={paragraphStyle}>
+        <Link href={creditsUrl} style={creditsLinkStyle}>
           {balanceDisplay} left · another short is about{' '}
           {typicalShortCostDisplay}
         </Link>

--- a/src/lib/services/email-service.tsx
+++ b/src/lib/services/email-service.tsx
@@ -2,7 +2,7 @@
  * Email Service
  * Handles sending transactional emails via Cloudflare Email Service.
  * Templates are React components in src/lib/emails/ rendered to
- * email-safe HTML (and a plain-text version) by @react-email/render.
+ * email-safe HTML (and a plain-text version) by render-email.ts.
  */
 
 import { getEnv } from '#env';


### PR DESCRIPTION
## Related Issue

Closes #1414

## Summary of Changes

Drop `@react-email/components`' `<Tailwind>` wrapper and style transactional emails with inline `style={{}}` objects instead.

10021 is isolate-start **CPU** (1s to parse and run global scope), not Worker size. `<Tailwind>` pulled the Tailwind v4 compiler and Prism (via `@react-email/code-block`) into the Worker entry graph. That chunk was 2.5MB and ~113ms of css-tree `DFS` / `insertBefore` on every cold start.

React Email has no lighter documented import. Dynamic `import()` only defers evaluation (gzip did not move). Inline styles keep the same look and leave the compiler off the startup path. Imports stay `from '@react-email/components'`.

Local `wrangler check startup` profile after this change: `email-service` **113ms → 2.5ms**. Built chunk **2.5MB → 856KB** (leftover is mostly `react-dom/server.edge`, which SSR already needs).

Cloudflare's deploy-time `startup_time_ms` is the real gate; local is a lower bound. Remaining startup cost is Drizzle `scoped-*` and Zod `schemas-*`, not email.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

OTP / ready / feedback / credit-request / abuse-report emails still render to inline-styled HTML. Gmail still gets no `<style>` block. Visuals should match; hex is used instead of Tailwind's `rgb()`.

## Additional Notes

- `bun run test src/lib/emails` — 8/8
- Did **not** lazy-load email modules. That was the first attempt; it does not cut weight and can still evaluate the chunk if `react-dom/server.edge` shares it with the Worker entry.