### PR TITLE
feat(#1419): resolve character/location sheet reads from version rows (PR B)

### DIFF
--- a/src/lib/db/scoped/characters.ts
+++ b/src/lib/db/scoped/characters.ts
@@ -3,7 +3,7 @@
  * Character CRUD, sheet generation, talent assignment, and shot-character matching.
  */
 
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, eq, getTableColumns, inArray, isNull, sql } from 'drizzle-orm';
 import type { Database } from '@/lib/db/client';
 import type {
   Character,
@@ -12,7 +12,12 @@ import type {
   NewCharacter,
   SheetStatus,
 } from '@/lib/db/schema';
-import { characters, shots, talent } from '@/lib/db/schema';
+import {
+  characterSheetVariants,
+  characters,
+  shots,
+  talent,
+} from '@/lib/db/schema';
 import {
   loadSceneContextBySequenceFromDb,
   resolveSceneForShot,
@@ -42,7 +47,56 @@ export type CharacterBibleUpdate = Partial<
   >
 >;
 
+/**
+ * The character's live sheet version (#1419 PR B).
+ *
+ * The explicit selection when there is one, else the row the #1419 backfill
+ * keyed to the character's own id — the snapshot of the pre-versioning sheet
+ * that used to live in the mirror columns. Both branches are a primary-key
+ * lookup on `character_sheet_variants`.
+ *
+ * The pointer stays NULL on those legacy rows on purpose. It feeds the shot
+ * thumbnail hash as `selectedSheetVersionId ?? sheetInputHash`
+ * (`workflows/sheet-snapshots.ts`), so filling it would move the ingredient
+ * for ~1,600 characters and read every shot referencing one as stale. It gets
+ * set the first time anyone re-rolls or selects a version, through
+ * `applyConvergent` / `select` — so the NULL drains as characters are touched
+ * rather than being a permanent second class.
+ */
+const liveSheetVersionId = sql`COALESCE(${characters.selectedSheetVersionId}, ${characters.id})`;
+
+/**
+ * Character columns with the four sheet mirrors resolved from that live
+ * version instead of read off the row (#1419). Same field names, so callers
+ * are unchanged and PR C can drop the physical columns — at which point any
+ * call site still reading them off a raw `Character` fails to compile, which
+ * is how we find the ones that never came through here.
+ *
+ * `sheetStatus` and `sheetError` are NOT in this list. They are character-level
+ * generation lifecycle, not version mirrors: `generating` is stamped at trigger
+ * time and `failed` on workflow failure, both when no variant row exists to
+ * carry them. #1067 kept `frames.imageStatus` / `imageError` for the same
+ * reason.
+ */
+const charactersWithLiveSheet = {
+  ...getTableColumns(characters),
+  sheetImageUrl: characterSheetVariants.url,
+  sheetImagePath: characterSheetVariants.storagePath,
+  sheetGeneratedAt: characterSheetVariants.generatedAt,
+  sheetInputHash: characterSheetVariants.inputHash,
+};
+
 export function createCharactersMethods(db: Database) {
+  /** `select(charactersWithLiveSheet)` + the join it depends on. */
+  const selectWithLiveSheet = () =>
+    db
+      .select(charactersWithLiveSheet)
+      .from(characters)
+      .leftJoin(
+        characterSheetVariants,
+        eq(characterSheetVariants.id, liveSheetVersionId)
+      );
+
   // Private update helper used by updateSheetStatus and updateSheet
   const update = async (
     id: string,
@@ -63,10 +117,7 @@ export function createCharactersMethods(db: Database) {
 
   return {
     getById: async (id: string): Promise<Character | null> => {
-      const result = await db
-        .select()
-        .from(characters)
-        .where(eq(characters.id, id));
+      const result = await selectWithLiveSheet().where(eq(characters.id, id));
       return result[0] ?? null;
     },
 
@@ -74,15 +125,12 @@ export function createCharactersMethods(db: Database) {
       sequenceId: string,
       characterId: string
     ): Promise<Character | null> => {
-      const result = await db
-        .select()
-        .from(characters)
-        .where(
-          and(
-            eq(characters.sequenceId, sequenceId),
-            eq(characters.characterId, characterId)
-          )
-        );
+      const result = await selectWithLiveSheet().where(
+        and(
+          eq(characters.sequenceId, sequenceId),
+          eq(characters.characterId, characterId)
+        )
+      );
       return result[0] ?? null;
     },
 
@@ -91,15 +139,9 @@ export function createCharactersMethods(db: Database) {
     // staleness verifies — all of which read through these methods. Restore
     // (or an id-addressed getById) is the only way back.
     list: async (sequenceId: string): Promise<Character[]> => {
-      return await db
-        .select()
-        .from(characters)
-        .where(
-          and(
-            eq(characters.sequenceId, sequenceId),
-            isNull(characters.deletedAt)
-          )
-        );
+      return await selectWithLiveSheet().where(
+        and(eq(characters.sequenceId, sequenceId), isNull(characters.deletedAt))
+      );
     },
 
     listWithTalent: async (
@@ -107,7 +149,7 @@ export function createCharactersMethods(db: Database) {
     ): Promise<CharacterWithTalent[]> => {
       const results = await db
         .select({
-          character: characters,
+          character: charactersWithLiveSheet,
           talent: {
             id: talent.id,
             name: talent.name,
@@ -116,6 +158,10 @@ export function createCharactersMethods(db: Database) {
         })
         .from(characters)
         .leftJoin(talent, eq(characters.talentId, talent.id))
+        .leftJoin(
+          characterSheetVariants,
+          eq(characterSheetVariants.id, liveSheetVersionId)
+        )
         .where(
           and(
             eq(characters.sequenceId, sequenceId),
@@ -131,23 +177,17 @@ export function createCharactersMethods(db: Database) {
 
     getByIds: async (ids: string[]): Promise<Character[]> => {
       if (ids.length === 0) return [];
-      return await db
-        .select()
-        .from(characters)
-        .where(inArray(characters.id, ids));
+      return await selectWithLiveSheet().where(inArray(characters.id, ids));
     },
 
     listWithSheets: async (sequenceId: string): Promise<Character[]> => {
-      return await db
-        .select()
-        .from(characters)
-        .where(
-          and(
-            eq(characters.sequenceId, sequenceId),
-            eq(characters.sheetStatus, 'completed'),
-            isNull(characters.deletedAt)
-          )
-        );
+      return await selectWithLiveSheet().where(
+        and(
+          eq(characters.sequenceId, sequenceId),
+          eq(characters.sheetStatus, 'completed'),
+          isNull(characters.deletedAt)
+        )
+      );
     },
 
     create: async (data: NewCharacter): Promise<Character> => {
@@ -256,16 +296,13 @@ export function createCharactersMethods(db: Database) {
     },
 
     getNeedingSheets: async (sequenceId: string): Promise<Character[]> => {
-      return await db
-        .select()
-        .from(characters)
-        .where(
-          and(
-            eq(characters.sequenceId, sequenceId),
-            inArray(characters.sheetStatus, ['pending', 'failed']),
-            isNull(characters.deletedAt)
-          )
-        );
+      return await selectWithLiveSheet().where(
+        and(
+          eq(characters.sequenceId, sequenceId),
+          inArray(characters.sheetStatus, ['pending', 'failed']),
+          isNull(characters.deletedAt)
+        )
+      );
     },
 
     /**

--- a/src/lib/db/scoped/media-upload.test.ts
+++ b/src/lib/db/scoped/media-upload.test.ts
@@ -17,6 +17,7 @@ import type { Scene } from '@/lib/ai/scene-analysis.schema';
 import type { Database } from '@/lib/db/client';
 import { generateId } from '@/lib/db/id';
 import {
+  characterSheetVariants,
   characters,
   framePromptVersions,
   frameVariants,
@@ -252,6 +253,16 @@ async function seedCharacterWithSheet(sheetInputHash: string) {
     })
     .returning();
   if (!row) throw new Error('test setup: character insert returned nothing');
+  // The live sheet is read from the version row, not the mirror (#1419) —
+  // keyed to the character's own id, the shape the backfill produced.
+  await db.insert(characterSheetVariants).values({
+    id: row.id,
+    characterId: row.id,
+    model: 'prior',
+    url: '/r2/characters/jack.png',
+    status: 'completed',
+    inputHash: sheetInputHash,
+  });
   return row;
 }
 
@@ -547,9 +558,9 @@ describe('§4.3 B — image-only upload (appendUploadedVersion + select)', () =>
     // "fresh" above is a real comparison and not a hash that ignores its
     // reference inputs.
     await db
-      .update(characters)
-      .set({ sheetInputHash: 'sheet-hash-2' })
-      .where(eq(characters.id, character.id));
+      .update(characterSheetVariants)
+      .set({ inputHash: 'sheet-hash-2' })
+      .where(eq(characterSheetVariants.id, character.id));
     expect(await verifyThumbnailStaleness(SCENE_WITH_REFS)).toBe('stale');
   });
 

--- a/src/lib/db/scoped/sequence-locations.ts
+++ b/src/lib/db/scoped/sequence-locations.ts
@@ -3,7 +3,7 @@
  * Location CRUD, reference images, and shot-location matching.
  */
 
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, eq, getTableColumns, inArray, isNull, sql } from 'drizzle-orm';
 import type { Database } from '@/lib/db/client';
 import type {
   Shot,
@@ -11,7 +11,12 @@ import type {
   ReferenceStatus,
   SequenceLocation,
 } from '@/lib/db/schema';
-import { shots, sequenceLocations, sequences } from '@/lib/db/schema';
+import {
+  locationSheetVariants,
+  shots,
+  sequenceLocations,
+  sequences,
+} from '@/lib/db/schema';
 import {
   loadSceneContextBySequenceFromDb,
   resolveSceneForShot,
@@ -75,6 +80,29 @@ export function locationMatchesTag(
 // Factory function
 // ============================================================================
 
+/**
+ * The location's live reference version (#1419 PR B) — the sequence-location
+ * twin of `characters.ts`'s `liveSheetVersionId`; see that file for why the
+ * pointer is deliberately left NULL on backfilled rows.
+ *
+ * Scoped to `parent_type = 'sequence_location'` because
+ * `location_sheet_variants` also services team-level `location_library` rows.
+ */
+const liveReferenceVersionId = sql`COALESCE(${sequenceLocations.selectedReferenceVersionId}, ${sequenceLocations.id})`;
+
+/**
+ * Location columns with the four reference mirrors resolved from that live
+ * version. `referenceStatus` / `referenceError` stay on the row — they are
+ * generation lifecycle, not version mirrors (see the characters twin).
+ */
+const locationsWithLiveReference = {
+  ...getTableColumns(sequenceLocations),
+  referenceImageUrl: locationSheetVariants.url,
+  referenceImagePath: locationSheetVariants.storagePath,
+  referenceGeneratedAt: locationSheetVariants.generatedAt,
+  referenceInputHash: locationSheetVariants.inputHash,
+};
+
 export function createSequenceLocationsMethods(db: Database) {
   // Private update helper
   const update = async (
@@ -95,12 +123,24 @@ export function createSequenceLocationsMethods(db: Database) {
     return location;
   };
 
+  /** `select(locationsWithLiveReference)` + the join it depends on. */
+  const selectWithLiveReference = () =>
+    db
+      .select(locationsWithLiveReference)
+      .from(sequenceLocations)
+      .leftJoin(
+        locationSheetVariants,
+        and(
+          eq(locationSheetVariants.parentType, 'sequence_location'),
+          eq(locationSheetVariants.id, liveReferenceVersionId)
+        )
+      );
+
   return {
     getById: async (id: string): Promise<SequenceLocation | null> => {
-      const result = await db
-        .select()
-        .from(sequenceLocations)
-        .where(eq(sequenceLocations.id, id));
+      const result = await selectWithLiveReference().where(
+        eq(sequenceLocations.id, id)
+      );
       return result[0] ?? null;
     },
 
@@ -108,15 +148,12 @@ export function createSequenceLocationsMethods(db: Database) {
       sequenceId: string,
       locationId: string
     ): Promise<SequenceLocation | null> => {
-      const result = await db
-        .select()
-        .from(sequenceLocations)
-        .where(
-          and(
-            eq(sequenceLocations.sequenceId, sequenceId),
-            eq(sequenceLocations.locationId, locationId)
-          )
-        );
+      const result = await selectWithLiveReference().where(
+        and(
+          eq(sequenceLocations.sequenceId, sequenceId),
+          eq(sequenceLocations.locationId, locationId)
+        )
+      );
       return result[0] ?? null;
     },
 
@@ -124,38 +161,31 @@ export function createSequenceLocationsMethods(db: Database) {
     // twin for rationale. Id-addressed reads (getById/getByIds) still return
     // deleted rows so restore can reach them.
     list: async (sequenceId: string): Promise<SequenceLocation[]> => {
-      return await db
-        .select()
-        .from(sequenceLocations)
-        .where(
-          and(
-            eq(sequenceLocations.sequenceId, sequenceId),
-            isNull(sequenceLocations.deletedAt)
-          )
-        );
+      return await selectWithLiveReference().where(
+        and(
+          eq(sequenceLocations.sequenceId, sequenceId),
+          isNull(sequenceLocations.deletedAt)
+        )
+      );
     },
 
     listWithReferences: async (
       sequenceId: string
     ): Promise<SequenceLocation[]> => {
-      return await db
-        .select()
-        .from(sequenceLocations)
-        .where(
-          and(
-            eq(sequenceLocations.sequenceId, sequenceId),
-            eq(sequenceLocations.referenceStatus, 'completed'),
-            isNull(sequenceLocations.deletedAt)
-          )
-        );
+      return await selectWithLiveReference().where(
+        and(
+          eq(sequenceLocations.sequenceId, sequenceId),
+          eq(sequenceLocations.referenceStatus, 'completed'),
+          isNull(sequenceLocations.deletedAt)
+        )
+      );
     },
 
     getByIds: async (ids: string[]): Promise<SequenceLocation[]> => {
       if (ids.length === 0) return [];
-      return await db
-        .select()
-        .from(sequenceLocations)
-        .where(inArray(sequenceLocations.id, ids));
+      return await selectWithLiveReference().where(
+        inArray(sequenceLocations.id, ids)
+      );
     },
 
     create: async (data: NewSequenceLocation): Promise<SequenceLocation> => {
@@ -322,16 +352,13 @@ export function createSequenceLocationsMethods(db: Database) {
     getNeedingReferences: async (
       sequenceId: string
     ): Promise<SequenceLocation[]> => {
-      return await db
-        .select()
-        .from(sequenceLocations)
-        .where(
-          and(
-            eq(sequenceLocations.sequenceId, sequenceId),
-            inArray(sequenceLocations.referenceStatus, ['pending', 'failed']),
-            isNull(sequenceLocations.deletedAt)
-          )
-        );
+      return await selectWithLiveReference().where(
+        and(
+          eq(sequenceLocations.sequenceId, sequenceId),
+          inArray(sequenceLocations.referenceStatus, ['pending', 'failed']),
+          isNull(sequenceLocations.deletedAt)
+        )
+      );
     },
 
     /**

--- a/src/lib/test/seed.ts
+++ b/src/lib/test/seed.ts
@@ -10,6 +10,7 @@
 
 import { generateId } from '@/lib/db/id';
 import {
+  characterSheetVariants,
   characters,
   credits,
   frameVariants,
@@ -534,6 +535,22 @@ export async function createTestCharacter(
     createdAt: now,
     updatedAt: now,
   });
+
+  // The live sheet is read from the version row, not the mirror (#1419).
+  // Keyed to the character's own id — the shape the backfill produced and the
+  // one `applyConvergent` snapshots a pre-versioning image under.
+  if (sheetImageUrl) {
+    await db.insert(characterSheetVariants).values({
+      id,
+      characterId: id,
+      model: 'prior',
+      url: sheetImageUrl,
+      status: 'completed',
+      generatedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
 
   return { id, sequenceId, characterId, name };
 }


### PR DESCRIPTION
PR B of #1419. Follows #1420 (backfill), which is deployed and verified.

## What

Every scoped read of a character or sequence location now sources the four sheet/reference mirrors from the live version row instead of the column on the parent, so PR C can drop the columns.

The live version is `COALESCE(selected_..._version_id, <parent>.id)` — the explicit selection when there is one, else the row PR A keyed to the parent's own id. Both branches are a primary-key lookup on the variants table.

Field names are unchanged, so call sites are untouched. The resolved fields are re-added on top of `getTableColumns()`, so when PR C drops the physical columns **any call site still reading them off a raw row stops compiling** — which is how we find reads that never came through the scoped layer.

## Four columns, not six

`sheetStatus` / `sheetError` and their location twins stay. They are character-level generation lifecycle, not version mirrors:

- `functions/sequence-characters.ts:245` stamps `generating` at trigger time, before any variant row exists
- `workflows/character-sheet-workflow.ts:534` stamps `failed` on workflow failure, with no variant to carry it

There is no pending-claim row for sheets, so nothing in `character_sheet_variants` can hold in-flight state. #1067 kept `frames.imageStatus` / `imageError` (`frames.ts:70,72`) for exactly this reason while dropping the five true mirrors — same call here.

That removes ~58 call sites from the sweep the issue estimated.

## The pointer stays NULL on backfilled rows

`selectedSheetVersionId` feeds the shot thumbnail hash as `selectedSheetVersionId ?? sheetInputHash` (`workflows/sheet-snapshots.ts:423`), and `computeShotStaleness` compares that live hash against the one stamped at generation. Filling the pointer moves the ingredient for ~1,600 characters and ~2,300 locations, so every shot referencing one would read stale — #867 again.

Resolving `sheetInputHash` from the variant row keeps that expression **byte-identical**, because PR A copied the mirror's value into it. The version-id branch is untouched, so re-roll cascade still works: selecting a different version still re-stales the shots that used the old one.

The NULL is transitional. `applyConvergent` / `select` set the pointer the first time anyone re-rolls or selects a version, so legacy rows convert to explicit pointers as they are touched.

## Verification

Against production D1, across every row (not just backfilled ones):

| check | result |
| --- | --- |
| characters resolving a different url than the mirror holds | **0** |
| sequence locations resolving a different url | **0** |
| characters resolving a different input hash | **0** |
| sequence locations resolving a different input hash | **0** |

So this deploy changes no rendered image and no staleness verdict. Full unit suite green (3,495 tests).

## Also

Test and e2e seeds that inserted a sheet url with no version row now insert the version row too — the shape production has had since PR A. `media-upload.test.ts`'s counterfactual moves the variant's `inputHash` rather than the mirror's, which is where the value now lives.

## Next

PR C — drop the four columns from each table, remove them from `characters.create`'s conflict set, and stop the workflows writing them.