### PR TITLE
feat(#1419): stop writing the sheet/reference mirror columns (PR C1)

### DIFF
--- a/src/lib/db/scoped/character-sheet-variants.ts
+++ b/src/lib/db/scoped/character-sheet-variants.ts
@@ -124,9 +124,13 @@ export function createCharacterSheetVariantsMethods(db: Database) {
     },
 
     /**
-     * Append a completed version and make it the live primary. If the parent
-     * still holds a pre-versioning image (no selection pointer), that image is
-     * snapshotted first so History can revert to it. Does not discard anything.
+     * Append a completed version and make it the live primary. Does not
+     * discard anything, and no longer mirrors url / path / hash onto the
+     * parent — reads resolve those from the pointer (#1419).
+     *
+     * The old pre-versioning snapshot branch is gone with them: it existed to
+     * capture an image that lived only in the mirror columns, and the #1419
+     * backfill gave every such row a version of its own.
      */
     applyConvergent: async (args: {
       characterId: string;
@@ -145,25 +149,6 @@ export function createCharacterSheetVariantsMethods(db: Database) {
         .where(eq(characters.id, characterId));
       if (!existing) {
         throw new Error(`Character ${characterId} not found`);
-      }
-
-      if (existing.sheetImageUrl && !existing.selectedSheetVersionId) {
-        // Keyed by the character's own ULID, matching the #1419 bulk backfill
-        // (20260901073033) — so whichever path snapshots the pre-versioning
-        // image first wins and History never shows the same sheet twice.
-        await db
-          .insert(characterSheetVariants)
-          .values({
-            id: characterId,
-            characterId,
-            model: 'prior',
-            url: existing.sheetImageUrl,
-            storagePath: existing.sheetImagePath,
-            status: 'completed',
-            generatedAt: existing.sheetGeneratedAt ?? existing.updatedAt,
-            inputHash: existing.sheetInputHash,
-          })
-          .onConflictDoNothing();
       }
 
       const now = new Date();
@@ -188,12 +173,8 @@ export function createCharacterSheetVariantsMethods(db: Database) {
       const [character] = await db
         .update(characters)
         .set({
-          sheetImageUrl: url,
-          sheetImagePath: storagePath,
           sheetStatus: 'completed',
-          sheetGeneratedAt: now,
           sheetError: null,
-          sheetInputHash: inputHash,
           selectedSheetVersionId: version.id,
           updatedAt: now,
         })
@@ -206,9 +187,10 @@ export function createCharacterSheetVariantsMethods(db: Database) {
     },
 
     /**
-     * Repoint the live sheet at an existing completed version. Mirrors url /
-     * path / hash onto the parent. A divergent row is unmarked so the banner
-     * clears. Previous pointer is recorded on the event for undo.
+     * Repoint the live sheet at an existing completed version. Only moves the
+     * pointer — reads resolve url / path / hash from the version it names
+     * (#1419). A divergent row is unmarked so the banner clears. Previous
+     * pointer is recorded on the event for undo.
      */
     select: async (
       characterId: string,
@@ -253,12 +235,8 @@ export function createCharacterSheetVariantsMethods(db: Database) {
         db
           .update(characters)
           .set({
-            sheetImageUrl: version.url,
-            sheetImagePath: version.storagePath,
             sheetStatus: 'completed',
-            sheetGeneratedAt: version.generatedAt ?? now,
             sheetError: null,
-            sheetInputHash: version.inputHash,
             selectedSheetVersionId: version.id,
             updatedAt: now,
           })
@@ -277,8 +255,6 @@ export function createCharacterSheetVariantsMethods(db: Database) {
           data: {
             prevState: {
               selectedSheetVersionId: existing.selectedSheetVersionId,
-              sheetImageUrl: existing.sheetImageUrl,
-              sheetInputHash: existing.sheetInputHash,
             },
             versionId,
           },

--- a/src/lib/db/scoped/characters.ts
+++ b/src/lib/db/scoped/characters.ts
@@ -205,10 +205,12 @@ export function createCharactersMethods(db: Database) {
             standardClothing: data.standardClothing,
             distinguishingFeatures: data.distinguishingFeatures,
             consistencyTag: data.consistencyTag,
-            sheetImageUrl: data.sheetImageUrl,
-            sheetImagePath: data.sheetImagePath,
+            // Sheet OUTPUT is not re-written here (#1419). A re-analysis used
+            // to blank `sheetImageUrl` while leaving the version rows intact,
+            // so the character rendered sheet-less until it regenerated.
+            // `sheetStatus` stays: both callers pass an explicit lifecycle
+            // value ('generating' for re-analysis, 'pending' for a manual add).
             sheetStatus: data.sheetStatus,
-            sheetGeneratedAt: data.sheetGeneratedAt,
             talentId: data.talentId,
             // A re-analysis re-extracting a soft-deleted character revives it —
             // the script says the character exists again (#1108).
@@ -266,7 +268,6 @@ export function createCharactersMethods(db: Database) {
       return await update(id, {
         sheetStatus: status,
         sheetError: error ?? null,
-        ...(status === 'completed' && { sheetGeneratedAt: new Date() }),
       });
     },
 
@@ -442,23 +443,6 @@ export function createCharactersMethods(db: Database) {
       }
 
       return character;
-    },
-
-    isStale: async (
-      characterId: string,
-      currentHash: string
-    ): Promise<boolean> => {
-      const result = await db
-        .select({ hash: characters.sheetInputHash })
-        .from(characters)
-        .where(eq(characters.id, characterId));
-      const row = result[0];
-      if (!row) {
-        throw new Error(`Character ${characterId} not found`);
-      }
-      const stored = row.hash;
-      if (stored === null) return false;
-      return currentHash !== stored;
     },
 
     getShotsForCharacter: async (

--- a/src/lib/db/scoped/location-sheet-variants.ts
+++ b/src/lib/db/scoped/location-sheet-variants.ts
@@ -141,6 +141,11 @@ export function createLocationSheetVariantsMethods(db: Database) {
      * Sequence-location only: append a completed version and select it.
      * Library locations keep the overwrite `locationLibrary.updateReference`
      * path — they are not in this versioning surface.
+     *
+     * No longer mirrors url / path / generatedAt / inputHash onto the parent —
+     * reads resolve those from the pointer (#1419). The old pre-versioning
+     * snapshot branch went with them: it captured an image that lived only in
+     * the mirror columns, and the #1419 backfill gave every such row a version.
      */
     applyConvergent: async (args: {
       locationDbId: string;
@@ -169,26 +174,6 @@ export function createLocationSheetVariantsMethods(db: Database) {
         throw new Error(`SequenceLocation ${locationDbId} not found`);
       }
 
-      if (existing.referenceImageUrl && !existing.selectedReferenceVersionId) {
-        // Keyed by the location's own ULID, matching the #1419 bulk backfill
-        // (20260901073039) — so whichever path snapshots the pre-versioning
-        // image first wins and History never shows the same reference twice.
-        await db
-          .insert(locationSheetVariants)
-          .values({
-            id: locationDbId,
-            parentType: 'sequence_location',
-            parentId: locationDbId,
-            model: 'prior',
-            url: existing.referenceImageUrl,
-            storagePath: existing.referenceImagePath,
-            status: 'completed',
-            generatedAt: existing.referenceGeneratedAt ?? existing.updatedAt,
-            inputHash: existing.referenceInputHash,
-          })
-          .onConflictDoNothing();
-      }
-
       const now = new Date();
       const [version] = await db
         .insert(locationSheetVariants)
@@ -212,12 +197,8 @@ export function createLocationSheetVariantsMethods(db: Database) {
       const [location] = await db
         .update(sequenceLocations)
         .set({
-          referenceImageUrl: url,
-          referenceImagePath: storagePath,
           referenceStatus: 'completed',
-          referenceGeneratedAt: now,
           referenceError: null,
-          referenceInputHash: inputHash,
           selectedReferenceVersionId: version.id,
           updatedAt: now,
         })
@@ -231,6 +212,12 @@ export function createLocationSheetVariantsMethods(db: Database) {
       return { location, version };
     },
 
+    /**
+     * Repoint the live reference at an existing completed version. Only moves
+     * the pointer — reads resolve url / path / hash from the version it names
+     * (#1419). A divergent row is unmarked so the banner clears. Previous
+     * pointer is recorded on the event for undo.
+     */
     select: async (
       locationDbId: string,
       versionId: string,
@@ -275,12 +262,8 @@ export function createLocationSheetVariantsMethods(db: Database) {
         db
           .update(sequenceLocations)
           .set({
-            referenceImageUrl: version.url,
-            referenceImagePath: version.storagePath,
             referenceStatus: 'completed',
-            referenceGeneratedAt: version.generatedAt ?? now,
             referenceError: null,
-            referenceInputHash: version.inputHash,
             selectedReferenceVersionId: version.id,
             updatedAt: now,
           })
@@ -299,8 +282,6 @@ export function createLocationSheetVariantsMethods(db: Database) {
           data: {
             prevState: {
               selectedReferenceVersionId: existing.selectedReferenceVersionId,
-              referenceImageUrl: existing.referenceImageUrl,
-              referenceInputHash: existing.referenceInputHash,
             },
             versionId,
           },

--- a/src/lib/db/scoped/sequence-locations.ts
+++ b/src/lib/db/scoped/sequence-locations.ts
@@ -206,10 +206,9 @@ export function createSequenceLocationsMethods(db: Database) {
             lightingSetup: data.lightingSetup,
             ambiance: data.ambiance,
             consistencyTag: data.consistencyTag,
-            referenceImageUrl: data.referenceImageUrl,
-            referenceImagePath: data.referenceImagePath,
+            // Reference OUTPUT is not re-written here — see the characters
+            // twin (#1419).
             referenceStatus: data.referenceStatus,
-            referenceGeneratedAt: data.referenceGeneratedAt,
             // A re-analysis re-extracting a soft-deleted location revives it
             // (#1108) — mirrors the characters upsert.
             deletedAt: null,
@@ -303,7 +302,6 @@ export function createSequenceLocationsMethods(db: Database) {
       return await update(id, {
         referenceStatus: status,
         referenceError: error ?? null,
-        ...(status === 'completed' && { referenceGeneratedAt: new Date() }),
       });
     },
 
@@ -325,28 +323,6 @@ export function createSequenceLocationsMethods(db: Database) {
         workflowRunId: opts?.workflowRunId,
       });
       return location;
-    },
-
-    /**
-     * True iff `currentHash` differs from the stored `referenceInputHash`.
-     * Returns false when no hash has been recorded yet (legacy artifact, no
-     * opinion). Mirrors `characters.isStale` and `locationLibrary.isStale`.
-     */
-    isStale: async (
-      locationId: string,
-      currentHash: string
-    ): Promise<boolean> => {
-      const result = await db
-        .select({ hash: sequenceLocations.referenceInputHash })
-        .from(sequenceLocations)
-        .where(eq(sequenceLocations.id, locationId));
-      const row = result[0];
-      if (!row) {
-        throw new Error(`SequenceLocation ${locationId} not found`);
-      }
-      const stored = row.hash;
-      if (stored === null) return false;
-      return currentHash !== stored;
     },
 
     getNeedingReferences: async (

--- a/src/lib/db/scoped/sheet-variants.test.ts
+++ b/src/lib/db/scoped/sheet-variants.test.ts
@@ -36,6 +36,7 @@ import {
 import { relations } from '@/lib/db/schema/relations';
 import type { Database } from '@/lib/db/client';
 import { createCharacterSheetVariantsMethods } from './character-sheet-variants';
+import { createCharactersMethods } from './characters';
 import { createLocationSheetVariantsMethods } from './location-sheet-variants';
 import { createTalentSheetVariantsMethods } from './talent-sheet-variants';
 
@@ -819,17 +820,19 @@ describe('talent-sheet-variants promoteAtomically negative cases', () => {
 });
 
 describe('character sheet versions (append + select)', () => {
-  it('applyConvergent snapshots the unversioned primary then selects the new row', async () => {
+  it('applyConvergent appends a version and points at it, keeping history', async () => {
     const methods = createCharacterSheetVariantsMethods(db);
-    await db
-      .update(characters)
-      .set({
-        sheetImageUrl: 'https://example.com/old.png',
-        sheetImagePath: '/old.png',
-        sheetInputHash: 'hash-old',
-        sheetStatus: 'completed',
-      })
-      .where(eq(characters.id, characterId));
+    // The pre-versioning sheet, as the #1419 backfill left it: a 'prior'
+    // version keyed to the character's own id, with the pointer still null.
+    await db.insert(characterSheetVariants).values({
+      id: characterId,
+      characterId,
+      model: 'prior',
+      url: 'https://example.com/old.png',
+      storagePath: '/old.png',
+      status: 'completed',
+      inputHash: 'hash-old',
+    });
 
     const { character, version } = await methods.applyConvergent({
       characterId,
@@ -839,9 +842,12 @@ describe('character sheet versions (append + select)', () => {
       model: 'nano_banana_2',
     });
 
-    expect(character.sheetImageUrl).toBe('https://example.com/new.png');
-    expect(character.sheetInputHash).toBe('hash-new');
     expect(character.selectedSheetVersionId).toBe(version.id);
+    // The parent's mirror columns are no longer written (#1419) — the live
+    // sheet is whatever the pointer names.
+    const live = await createCharactersMethods(db).getById(characterId);
+    expect(live?.sheetImageUrl).toBe('https://example.com/new.png');
+    expect(live?.sheetInputHash).toBe('hash-new');
 
     const history = await methods.listHistoryByCharacter(characterId);
     expect(history).toHaveLength(2);
@@ -876,8 +882,10 @@ describe('character sheet versions (append + select)', () => {
       .from(characters)
       .where(eq(characters.id, characterId));
     expect(after?.selectedSheetVersionId).toBe(first.version.id);
-    expect(after?.sheetImageUrl).toBe('https://example.com/a.png');
-    expect(after?.sheetInputHash).toBe('hash-a');
+    // Reads follow the pointer, not a mirror column (#1419).
+    const live = await createCharactersMethods(db).getById(characterId);
+    expect(live?.sheetImageUrl).toBe('https://example.com/a.png');
+    expect(live?.sheetInputHash).toBe('hash-a');
 
     const history = await methods.listHistoryByCharacter(characterId);
     expect(history).toHaveLength(2);

--- a/src/lib/workflows/character-bible-workflow.ts
+++ b/src/lib/workflows/character-bible-workflow.ts
@@ -90,8 +90,6 @@ export class CharacterBibleWorkflow extends OpenStoryWorkflowEntrypoint<Characte
             firstMentionSceneId: null,
             firstMentionText: null,
             firstMentionLine: null,
-            sheetImageUrl: null,
-            sheetImagePath: null,
             sheetStatus: 'generating' as const,
             talentId: talentMatch?.talentId ?? null,
           } satisfies NewCharacter);


### PR DESCRIPTION
PR C1 of #1419 — the expand half of the drop. Follows #1420 (backfill) and #1421 (resolved reads), both deployed.

Nothing writes the four mirror columns on `characters` / `sequence_locations` any more. PR C2 removes them from the schema.

## Why this is split from the drop

Migrations apply **before** the worker deploys (`deploy:production` = `wrangler d1 migrations apply` → `wrangler deploy`). A single PR that both dropped the columns and stopped writing them would leave the old worker live against a table with no `sheet_image_url`, and every sheet write 500s for the length of the deploy. Expand, then contract.

## What stopped writing

- **`applyConvergent` / `select`** no longer mirror url, path, generatedAt or inputHash onto the parent. They still write `selectedSheetVersionId` — the only field the callers read back — plus `sheetStatus` / `sheetError`, which are generation lifecycle and stay.
- **`characters.create` / `sequenceLocations.create`** no longer re-write sheet output in their conflict sets. This is the bug the issue opens with: a re-analysis blanked `sheetImageUrl` while leaving the version rows and the pointer intact, so the character rendered sheet-less while still claiming a selected version. `sheetStatus` stays in the set — both callers pass an explicit lifecycle value (`generating` for re-analysis, `pending` for a manual add), so re-analysis still correctly reads as regenerating.
- **`updateReferenceStatus`** no longer stamps `referenceGeneratedAt`. The version row already carries it.
- **The pre-versioning snapshot branch** in both `applyConvergent`s. It existed to capture an image that lived only in the mirror columns; PR A gave every such row a version of its own, and with the columns unwritten it can never fire again.
- **`sheet.selected` event `prevState`** keeps only the pointer. url and hash are derivable from it, and nothing reads that payload back — the only prevState anything restores from is `sequence.archived` (`functions/sequences.ts:458`).

## Checks

- No consumer reads a mirror off the returned row: `character-sheet-workflow.ts:135,444` and `location-sheet-workflow.ts:293` take only `selected*VersionId`.
- Full unit suite green (3,495).
- Two tests in `sheet-variants.test.ts` asserted the mirror writes. They now assert the pointer moved and read the live values back through `characters.getById`, which is the resolution PR B added — so they cover the new contract end to end. The first also seeds the `prior` version the way PR A's backfill left it, instead of the mirror columns the lazy snapshot used to read.

## Next

PR C2 — remove the four fields from each schema, `bun db:generate` for the 8 `ALTER TABLE … DROP COLUMN`s (needs `check-migrations.ts --allow-destructive`; native DROP COLUMN, so no table rebuild and no #612 cascade trap). Anything still reading a mirror off a raw row stops compiling there — including the `sequence_location` branch of `locationSheetVariants.promoteAtomically`, which has no caller today.
