### PR TITLE
feat(#1423): add 5m target duration to Enhance

### DIFF
--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -160,6 +160,7 @@ const DURATION_PRESETS = [
   { value: '60', label: '1m', seconds: 60 },
   { value: '120', label: '2m', seconds: 120 },
   { value: '180', label: '3m', seconds: 180 },
+  { value: '300', label: '5m', seconds: 300 },
 ] as const;
 
 /** Empty-composer copy (#1255): visible until the user types or shuffles.

--- a/src/functions/ai.ts
+++ b/src/functions/ai.ts
@@ -250,7 +250,7 @@ const enhanceScriptInputSchema = z
     // the style is Match script) instead of expanding one — which is why the
     // 10-character floor below lifts only for this flag.
     invent: z.boolean().optional(),
-    targetDuration: z.number().min(5).max(180).optional(),
+    targetDuration: z.number().min(5).max(300).optional(),
     // Catalog key of the selected video model — clip-grid constraint for labels
     // (#1374). Optional; the enhancer defaults to DEFAULT_VIDEO_MODEL.
     videoModel: z

--- a/src/lib/api-v1/enhance-input-schema.ts
+++ b/src/lib/api-v1/enhance-input-schema.ts
@@ -46,11 +46,11 @@ export const apiEnhanceScriptSchema = z
     targetSeconds: z
       .int()
       .min(5)
-      .max(180)
+      .max(300)
       .optional()
       .meta({
         description:
-          'Target video length in seconds (max 3 minutes); guides scene count and length of the enhanced script.',
+          'Target video length in seconds (max 5 minutes); guides scene count and length of the enhanced script.',
         examples: [30],
       }),
     videoModel: z

--- a/src/lib/api-v1/input-schema.test.ts
+++ b/src/lib/api-v1/input-schema.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { apiEnhanceScriptSchema } from './enhance-input-schema';
 import { apiCreateSequenceSchema } from './input-schema';
 
 describe('apiCreateSequenceSchema', () => {
@@ -116,5 +117,17 @@ describe('apiCreateSequenceSchema', () => {
     expect(
       apiCreateSequenceSchema.safeParse({ ...base, targetSeconds: 300 }).success
     ).toBe(true);
+  });
+});
+
+describe('apiEnhanceScriptSchema', () => {
+  it('bounds targetSeconds to 5–300, matching the 5m composer chip (#1423)', () => {
+    const base = { script: 'A lighthouse keeper befriends a stranded whale.' };
+    expect(
+      apiEnhanceScriptSchema.safeParse({ ...base, targetSeconds: 300 }).success
+    ).toBe(true);
+    expect(
+      apiEnhanceScriptSchema.safeParse({ ...base, targetSeconds: 301 }).success
+    ).toBe(false);
   });
 });

--- a/src/lib/billing/film-cost-examples.test.ts
+++ b/src/lib/billing/film-cost-examples.test.ts
@@ -26,7 +26,7 @@ describe('buildFilmCostExamples', () => {
     expect(result).not.toBeNull();
     if (!result) return;
 
-    // Align with composer duration chips (15 / 30 / 60 / 180) and default 30s.
+    // Align with composer duration chips (15 / 30 / 60 / 120 / 180 / 300) and default 30s.
     expect(result.targetDurationSeconds).toBe(30);
     expect(result.sceneCount * result.shotDurationSeconds).toBe(
       result.targetDurationSeconds

--- a/src/lib/billing/film-cost-examples.ts
+++ b/src/lib/billing/film-cost-examples.ts
@@ -35,7 +35,7 @@ import { microsToDisplayUsd, type Microdollars } from '@/lib/billing/money';
 import { SIGNUP_GRANT_MICROS } from '@/lib/billing/constants';
 
 /**
- * Composer default target duration (`script-view` duration chip: 15 / 30 / 60 / 180).
+ * Composer default target duration (`script-view` duration chip: 15 / 30 / 60 / 120 / 180 / 300).
  * Showcase totals use this runtime so pricing matches what users pick on Enhance.
  */
 const TARGET_DURATION_S = 30;

--- a/src/lib/billing/storyboard-preflight-cost.ts
+++ b/src/lib/billing/storyboard-preflight-cost.ts
@@ -30,7 +30,7 @@ export type StoryboardPreflightInput = {
   autoGenerateMusic?: boolean;
   audioModels?: AudioModel[];
   /**
-   * Enhance / Generate duration chip (15 / 30 / 60 / 180). Used for scene-count
+   * Enhance / Generate duration chip (15 / 30 / 60 / 120 / 180 / 300). Used for scene-count
    * pre-Enhance and for per-shot / music duration when motion or music is on.
    */
   targetDurationSeconds?: number;

--- a/src/lib/generation/time-estimate.ts
+++ b/src/lib/generation/time-estimate.ts
@@ -116,7 +116,8 @@ export function estimateSceneCountFromDuration(
   if (targetDurationSeconds <= 30) return 5;
   if (targetDurationSeconds <= 60) return 10;
   if (targetDurationSeconds <= 120) return 18;
-  return 25;
+  if (targetDurationSeconds <= 180) return 25;
+  return 30;
 }
 
 function estimateSceneCountFromWords(script: string): number {

--- a/src/lib/schemas/sequence.schemas.ts
+++ b/src/lib/schemas/sequence.schemas.ts
@@ -131,10 +131,10 @@ export const createSequenceSchema = createInsertSchema(sequences, {
       )
       .min(1, 'At least one audio model must be selected')
       .optional(),
-    // Enhance / Generate duration chip (15 / 30 / 60 / 180). Pre-flight scene
+    // Enhance / Generate duration chip (15 / 30 / 60 / 120 / 180 / 300). Pre-flight scene
     // count + per-shot duration use this so client ActionCost and server
     // requireCredits stay aligned before Scene N headings exist (#1140).
-    targetDurationSeconds: z.number().min(5).max(180).optional(),
+    targetDurationSeconds: z.number().min(5).max(300).optional(),
     // Suggested talent IDs for AI-assisted casting during generation
     suggestedTalentIds: z.array(z.string()).optional(),
     // Suggested location IDs for visual consistency during generation


### PR DESCRIPTION
Closes #1423.

We say "create 5 min films" but the Enhance duration chip stopped at 3m.

- `script-view` duration chips gain **5m** (300s) — both the Enhance popover and the short-script nudge dialog read the same `DURATION_PRESETS`.
- Lifts the `max(180)` cap on every schema behind that chip: `enhanceScriptFn` (`functions/ai.ts`), `createSequenceSchema.targetDurationSeconds`, and the v1 `POST /scripts/enhance` body (`apiCreateSequenceSchema` already allowed 300).
- `estimateSceneCountFromDuration` gains a >180s rung (30 scenes) so pre-Enhance cost/time preflight doesn't estimate a 5m board like a 3m one.

The enhancer prompt already handles >120s targets (20–30 scenes, intersected with the model clip grid), so no prompt change was needed.

Test: `apiEnhanceScriptSchema` bound check for 300/301 in `input-schema.test.ts`.