### PR TITLE
feat(#1427): generation progress as a title-row chip, not a layout-shifting banner

### DIFF
--- a/src/components/generation/generation-progress-banner.stories.tsx
+++ b/src/components/generation/generation-progress-banner.stories.tsx
@@ -4,7 +4,7 @@ import {
   type GenerationStreamState,
 } from '@/lib/realtime/generation-stream.reducer';
 import type { Meta, StoryObj } from '@storybook/react';
-import { CanvasViewToggle } from '@/components/scenes/canvas-view-toggle';
+import { Pencil } from 'lucide-react';
 import { GenerationProgressBanner } from './generation-progress-banner';
 
 function makeState(
@@ -70,14 +70,34 @@ const meta: Meta<typeof GenerationProgressBanner> = {
     layout: 'padded',
   },
   decorators: [
-    // Shown where it actually lives: the Canvas/Script toolbar's leading slot.
+    // Shown where it actually lives: the right of the sequence title row,
+    // which is `shrink-0` and exists with or without a run — hence no layout
+    // shift. Rendered at 1280px and 900px page widths.
     (Story) => (
-      <div className="mx-auto max-w-6xl">
-        <CanvasViewToggle
-          view="canvas"
-          onViewChange={() => {}}
-          leading={<Story />}
-        />
+      <div className="flex flex-col gap-8">
+        {[1280, 900].map((width) => (
+          <div key={width} className="flex flex-col gap-1">
+            <span className="text-[11px] text-muted-foreground">
+              page @ {width}px
+            </span>
+            <div style={{ width }} className="border">
+              <div className="shrink-0 space-y-1 px-6 pt-4">
+                <div className="flex min-w-0 items-center gap-1">
+                  <h1 className="truncate text-sm font-medium">
+                    Golden Hour Surf
+                  </h1>
+                  <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                  <div className="@container flex min-w-0 flex-1 items-center justify-end pl-2">
+                    <Story />
+                  </div>
+                </div>
+              </div>
+              <div className="flex h-20 items-center justify-center text-[11px] text-muted-foreground">
+                scenes
+              </div>
+            </div>
+          </div>
+        ))}
       </div>
     ),
   ],

--- a/src/components/generation/generation-progress-banner.stories.tsx
+++ b/src/components/generation/generation-progress-banner.stories.tsx
@@ -4,6 +4,7 @@ import {
   type GenerationStreamState,
 } from '@/lib/realtime/generation-stream.reducer';
 import type { Meta, StoryObj } from '@storybook/react';
+import { CanvasViewToggle } from '@/components/scenes/canvas-view-toggle';
 import { GenerationProgressBanner } from './generation-progress-banner';
 
 function makeState(
@@ -69,9 +70,14 @@ const meta: Meta<typeof GenerationProgressBanner> = {
     layout: 'padded',
   },
   decorators: [
+    // Shown where it actually lives: the Canvas/Script toolbar's leading slot.
     (Story) => (
       <div className="mx-auto max-w-6xl">
-        <Story />
+        <CanvasViewToggle
+          view="canvas"
+          onViewChange={() => {}}
+          leading={<Story />}
+        />
       </div>
     ),
   ],

--- a/src/components/generation/generation-progress-banner.tsx
+++ b/src/components/generation/generation-progress-banner.tsx
@@ -37,7 +37,7 @@ export const GenerationProgressBanner: React.FC<
   musicModel,
   willEmail = false,
 }) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const startTimeRef = useRef(startedAt?.getTime() ?? Date.now());
 

--- a/src/components/generation/motion-progress-banner.tsx
+++ b/src/components/generation/motion-progress-banner.tsx
@@ -80,7 +80,7 @@ export const MotionProgressBanner: React.FC<MotionProgressBannerProps> = ({
   startedAt,
   onComplete,
 }) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const startTimeRef = useRef(startedAt);
 

--- a/src/components/generation/progress-banner.tsx
+++ b/src/components/generation/progress-banner.tsx
@@ -1,14 +1,21 @@
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent } from '@/components/ui/card';
+/**
+ * Generation progress as a chip, not a banner (#1427).
+ *
+ * The old card sat in the column flow above the scenes view, so every run
+ * pushed the whole layout down and back up again. This lives in the
+ * Canvas/Script toolbar's leading slot — a row that is already there and
+ * already that tall — so it costs zero layout shift and covers nothing. The
+ * phase detail moved into a popover, closed by default.
+ */
+
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
 import { formatTimeRemaining } from '@/lib/generation/time-estimate';
 import { cn } from '@/lib/utils';
-import { Check, ChevronDown, ChevronUp, Loader2 } from 'lucide-react';
+import { Check, Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 export type BannerPhase = {
@@ -80,125 +87,104 @@ export const ProgressBanner: React.FC<ProgressBannerProps> = ({
   const activePhase = phases.find((p) => p.status === 'active');
   const completedCount = phases.filter((p) => p.status === 'completed').length;
   const progressValue = activePhase ? completedCount + 1 : completedCount;
+  const percent = Math.round((progressValue / phases.length) * 100);
 
   const showCompleted = isComplete && completedLabel;
+  const label = showCompleted
+    ? completedLabel
+    : (activePhase?.name ?? defaultLabel);
 
   return (
-    <Collapsible open={isOpen} onOpenChange={onOpenChange}>
-      <Card
+    <Popover open={isOpen} onOpenChange={onOpenChange}>
+      {/* Progress fills the chip's own background — a determinate cue that
+          costs no extra height. The <progress> carries the semantics. */}
+      <progress
+        value={progressValue}
+        max={phases.length}
+        aria-label={
+          activePhase
+            ? `${ariaPrefix} progress: ${activePhase.name}`
+            : `${ariaPrefix} progress`
+        }
+        className="sr-only"
+      />
+      <PopoverTrigger
         className={cn(
-          'gap-0 py-0 transition-all duration-500',
-          isExiting && !prefersReducedMotion && 'translate-y-[-100%] opacity-0',
-          isExiting && prefersReducedMotion && 'opacity-0'
+          'relative flex h-8 min-w-0 items-center gap-1.5 overflow-hidden rounded-full border bg-background px-2.5 text-xs text-muted-foreground transition-opacity duration-500 hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50 outline-none',
+          isExiting && 'opacity-0'
         )}
       >
-        <CardContent className="flex flex-col gap-2 py-3">
-          {/* Header row */}
-          <div className="flex items-center gap-3">
-            {showCompleted ? (
-              <Check className="h-4 w-4 shrink-0 text-primary" />
-            ) : (
-              <Loader2 className="h-4 w-4 shrink-0 animate-spin text-primary" />
+        <span
+          aria-hidden="true"
+          className="absolute inset-y-0 left-0 bg-primary/10 transition-[width] duration-500"
+          style={{ width: `${percent}%` }}
+        />
+        {showCompleted ? (
+          <Check className="relative h-3.5 w-3.5 shrink-0 text-primary" />
+        ) : (
+          <Loader2
+            className={cn(
+              'relative h-3.5 w-3.5 shrink-0 text-primary',
+              !prefersReducedMotion && 'animate-spin'
             )}
-            <span className="text-sm font-medium truncate">
-              {showCompleted
-                ? completedLabel
-                : activePhase
-                  ? activePhase.name
-                  : defaultLabel}
-            </span>
-
-            <Badge
-              variant="secondary"
-              className="ml-auto tabular-nums"
-              aria-live="polite"
-            >
-              {showCompleted && completedBadge
-                ? completedBadge
-                : formatTimeRemaining(remaining)}
-            </Badge>
-
-            <CollapsibleTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-7 w-7">
-                {isOpen ? (
-                  <ChevronUp className="h-4 w-4" />
-                ) : (
-                  <ChevronDown className="h-4 w-4" />
-                )}
-                <span className="sr-only">
-                  {isOpen ? 'Collapse' : 'Expand'} progress
-                </span>
-              </Button>
-            </CollapsibleTrigger>
-          </div>
-
-          {/* Segmented progress bar: visual is N phase divs (decorative); the real <progress> below is sr-only and carries the semantics. */}
-          <progress
-            value={progressValue}
-            max={phases.length}
-            aria-label={
-              activePhase
-                ? `${ariaPrefix} progress: ${activePhase.name}`
-                : `${ariaPrefix} progress`
-            }
-            className="sr-only"
           />
-          <div className="flex gap-0.5" aria-hidden="true">
-            {phases.map((phase) => (
-              <div
-                key={phase.key}
+        )}
+        <span className="relative hidden truncate sm:inline">{label}</span>
+        <span className="relative tabular-nums" aria-live="polite">
+          {showCompleted && completedBadge ? (
+            completedBadge
+          ) : (
+            <>
+              {formatTimeRemaining(remaining)}
+              <span className="sr-only"> remaining</span>
+            </>
+          )}
+        </span>
+        <span className="sr-only">Show {ariaPrefix.toLowerCase()} detail</span>
+      </PopoverTrigger>
+
+      <PopoverContent align="start" className="gap-3">
+        <p className="font-medium text-foreground sm:hidden">{label}</p>
+        <ol className="flex flex-col gap-1.5">
+          {phases.map((phase) => (
+            <li
+              key={phase.key}
+              className={cn(
+                'flex items-center gap-2 text-xs',
+                phase.status === 'completed' && 'text-muted-foreground',
+                phase.status === 'active' && 'font-medium text-foreground',
+                phase.status === 'pending' && 'text-muted-foreground/40'
+              )}
+            >
+              <span
+                aria-hidden="true"
                 className={cn(
-                  'h-1 flex-1 rounded-full transition-colors duration-500',
+                  'h-1.5 w-1.5 shrink-0 rounded-full',
                   phase.status === 'completed' && 'bg-primary',
                   phase.status === 'active' &&
-                    'bg-primary/60' +
-                      (!prefersReducedMotion ? ' animate-pulse' : ''),
+                    cn('bg-primary', !prefersReducedMotion && 'animate-pulse'),
                   phase.status === 'pending' && 'bg-border'
                 )}
               />
-            ))}
-          </div>
-        </CardContent>
+              <span className="truncate">{phase.shortName}</span>
+            </li>
+          ))}
+        </ol>
 
-        {/* Expanded content */}
-        <CollapsibleContent>
-          <CardContent className="flex flex-col gap-3 border-t py-3">
-            {/* Phase labels aligned to segments — hidden on mobile */}
-            <div className="hidden gap-4 sm:flex">
-              {phases.map((phase) => (
-                <span
-                  key={phase.key}
-                  className={cn(
-                    'flex-1 text-center text-[11px] tracking-wide',
-                    phase.status === 'completed' && 'text-muted-foreground',
-                    phase.status === 'active' && 'font-medium text-foreground',
-                    phase.status === 'pending' && 'text-muted-foreground/40'
-                  )}
-                >
-                  {phase.shortName}
-                </span>
-              ))}
-            </div>
+        {activePhase?.description && (
+          <p className="text-xs text-muted-foreground">
+            {activePhase.description}
+          </p>
+        )}
 
-            {/* Active phase description */}
-            {activePhase?.description && (
-              <p className="text-sm text-muted-foreground">
-                {activePhase.description}
-              </p>
-            )}
-
-            {/* "You can leave" message */}
-            <p className="text-xs text-muted-foreground/50">
-              {leaveHint ?? (
-                <>
-                  Click around or create something else while you&rsquo;re
-                  waiting
-                </>
-              )}
-            </p>
-          </CardContent>
-        </CollapsibleContent>
-      </Card>
-    </Collapsible>
+        <p className="text-xs text-muted-foreground/50">
+          {leaveHint ?? (
+            <>
+              Click around or create something else while you&rsquo;re waiting
+            </>
+          )}
+        </p>
+      </PopoverContent>
+    </Popover>
   );
 };

--- a/src/components/generation/progress-banner.tsx
+++ b/src/components/generation/progress-banner.tsx
@@ -129,7 +129,13 @@ export const ProgressBanner: React.FC<ProgressBannerProps> = ({
             )}
           />
         )}
-        <span className="relative hidden truncate sm:inline">{label}</span>
+        {/* Container query, not a breakpoint: the toolbar cell this sits in
+            narrows with the spine and inspector, not with the viewport. Below
+            ~15rem the name drops and the chip is spinner + ETA (~4rem), which
+            fits the tightest real cell. The name is always in the popover. */}
+        <span className="relative hidden truncate @[15rem]:inline">
+          {label}
+        </span>
         <span className="relative tabular-nums" aria-live="polite">
           {showCompleted && completedBadge ? (
             completedBadge
@@ -143,8 +149,9 @@ export const ProgressBanner: React.FC<ProgressBannerProps> = ({
         <span className="sr-only">Show {ariaPrefix.toLowerCase()} detail</span>
       </PopoverTrigger>
 
-      <PopoverContent align="start" className="gap-3">
-        <p className="font-medium text-foreground sm:hidden">{label}</p>
+      {/* Right-anchored trigger, so open leftwards from its right edge. */}
+      <PopoverContent align="end" className="gap-3">
+        <p className="font-medium text-foreground">{label}</p>
         <ol className="flex flex-col gap-1.5">
           {phases.map((phase) => (
             <li

--- a/src/components/scenes/canvas-view-toggle.tsx
+++ b/src/components/scenes/canvas-view-toggle.tsx
@@ -20,6 +20,9 @@ type CanvasViewToggleProps = {
   /** View-scoped action in the right column. The 1fr / auto / 1fr grid keeps
    *  the toggle centred without overlapping this control on a narrow screen. */
   trailing?: React.ReactNode;
+  /** Left column — generation progress lives here so it costs no layout
+   *  shift: this row is already this tall whether or not it renders (#1427). */
+  leading?: React.ReactNode;
 };
 
 export const CanvasViewToggle: React.FC<CanvasViewToggleProps> = ({
@@ -27,9 +30,10 @@ export const CanvasViewToggle: React.FC<CanvasViewToggleProps> = ({
   onViewChange,
   canvasDisabled,
   trailing,
+  leading,
 }) => (
   <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-2 pt-4 md:px-4">
-    <div />
+    <div className="flex min-w-0 justify-start">{leading}</div>
     <ToggleGroup
       type="single"
       value={view}

--- a/src/components/scenes/canvas-view-toggle.tsx
+++ b/src/components/scenes/canvas-view-toggle.tsx
@@ -20,9 +20,6 @@ type CanvasViewToggleProps = {
   /** View-scoped action in the right column. The 1fr / auto / 1fr grid keeps
    *  the toggle centred without overlapping this control on a narrow screen. */
   trailing?: React.ReactNode;
-  /** Left column — generation progress lives here so it costs no layout
-   *  shift: this row is already this tall whether or not it renders (#1427). */
-  leading?: React.ReactNode;
 };
 
 export const CanvasViewToggle: React.FC<CanvasViewToggleProps> = ({
@@ -30,10 +27,9 @@ export const CanvasViewToggle: React.FC<CanvasViewToggleProps> = ({
   onViewChange,
   canvasDisabled,
   trailing,
-  leading,
 }) => (
   <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 px-2 pt-4 md:px-4">
-    <div className="flex min-w-0 justify-start">{leading}</div>
+    <div />
     <ToggleGroup
       type="single"
       value={view}

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -17,6 +17,7 @@ import {
   type TabValue,
 } from '@/components/scenes/scene-script-prompts';
 import { FailureSummaryBanner } from '@/components/sequence/failure-summary-banner';
+import { SequenceHeaderPortal } from '@/components/sequence/sequence-header-slot';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { batchGenerateMotionFn } from '@/functions/motion-functions';
 import { getDivergentVariantPromptDiffFn } from '@/functions/prompt-variants';
@@ -1438,6 +1439,10 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
 
   return (
     <div className="flex h-full flex-col">
+      {/* Progress rides in the sequence title row (#1427) — no layout shift,
+          and it never sits on top of anything you might want to click. */}
+      <SequenceHeaderPortal>{progressChip}</SequenceHeaderPortal>
+
       {/* Failure summary with smart retry — wait until the run finishes so a
           single in-flight miss doesn't headline the first result (#1286). */}
       {failureSummary?.hasFailed && !isGenerationActive && (
@@ -1464,7 +1469,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
               view={effectiveView}
               onViewChange={setView}
               canvasDisabled={!canvasReady}
-              leading={progressChip}
               trailing={
                 effectiveView === 'script' ? (
                   <CopyScriptButton sequenceId={sequenceId} />

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -1382,6 +1382,30 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
   remainingRef.current = remainingSeconds;
   const etaMinutes = Math.max(1, Math.round(remainingSeconds / 60));
 
+  // Progress rides in the view-toggle row (#1427) — no layout shift, and it
+  // never sits on top of anything you might want to click.
+  const progressChip = isGenerationActive ? (
+    <GenerationProgressBanner
+      generationState={generationState}
+      isProcessing={isProcessing}
+      startedAt={sequence.updatedAt}
+      script={sequence.script ?? undefined}
+      remainingSeconds={remainingSeconds}
+      imageModel={sequence.imageModel}
+      videoModel={sequence.videoModel}
+      musicModel={sequence.musicModel}
+      willEmail={willEmail}
+    />
+  ) : motionBannerState !== null && sequence && shots ? (
+    <MotionProgressBanner
+      shots={shots}
+      sequence={sequence}
+      includeMusic={motionBannerState.includeMusic}
+      startedAt={motionBannerState.startedAt}
+      onComplete={resetGenerationStream}
+    />
+  ) : null;
+
   // One prop bag for the desktop sidebar and the phone sheet — same list.
   const sceneListProps: SceneListProps = {
     sequenceId,
@@ -1414,39 +1438,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
 
   return (
     <div className="flex h-full flex-col">
-      {/* Generation progress banner */}
-      {isGenerationActive && (
-        <div className="pl-4 pr-4 pt-4 md:pr-8">
-          <GenerationProgressBanner
-            generationState={generationState}
-            isProcessing={isProcessing}
-            startedAt={sequence.updatedAt}
-            script={sequence.script ?? undefined}
-            remainingSeconds={remainingSeconds}
-            imageModel={sequence.imageModel}
-            videoModel={sequence.videoModel}
-            musicModel={sequence.musicModel}
-            willEmail={willEmail}
-          />
-        </div>
-      )}
-
-      {/* Motion generation progress banner */}
-      {!isGenerationActive &&
-        motionBannerState !== null &&
-        sequence &&
-        shots && (
-          <div className="pl-4 pr-4 pt-4 md:pr-8">
-            <MotionProgressBanner
-              shots={shots}
-              sequence={sequence}
-              includeMusic={motionBannerState.includeMusic}
-              startedAt={motionBannerState.startedAt}
-              onComplete={resetGenerationStream}
-            />
-          </div>
-        )}
-
       {/* Failure summary with smart retry — wait until the run finishes so a
           single in-flight miss doesn't headline the first result (#1286). */}
       {failureSummary?.hasFailed && !isGenerationActive && (
@@ -1473,6 +1464,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
               view={effectiveView}
               onViewChange={setView}
               canvasDisabled={!canvasReady}
+              leading={progressChip}
               trailing={
                 effectiveView === 'script' ? (
                   <CopyScriptButton sequenceId={sequenceId} />

--- a/src/components/sequence/sequence-header-slot.tsx
+++ b/src/components/sequence/sequence-header-slot.tsx
@@ -1,0 +1,32 @@
+/**
+ * Right-hand slot in the sequence title row (#1427).
+ *
+ * Generation progress used to be a card in the scenes column flow, so every
+ * run pushed the whole layout down and popped it back up. The title row is
+ * already there, already that tall, and everything to the right of the title
+ * is dead space — so progress rendered into it costs zero layout shift and
+ * covers nothing.
+ *
+ * The row lives in the sequence layout route while the progress state lives
+ * in `ScenesView`, hence the portal rather than prop drilling through
+ * `<Outlet />`.
+ */
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export const SEQUENCE_HEADER_SLOT_ID = 'sequence-header-slot';
+
+export const SequenceHeaderPortal: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  // The slot is rendered by an ancestor route, so it exists by the time
+  // effects run — but not during SSR, which is fine: live progress is
+  // client-only anyway, and a missing slot simply renders nothing.
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setNode(document.getElementById(SEQUENCE_HEADER_SLOT_ID));
+  }, []);
+
+  return node ? createPortal(children, node) : null;
+};

--- a/src/lib/generation/time-estimate.test.ts
+++ b/src/lib/generation/time-estimate.test.ts
@@ -195,14 +195,14 @@ describe('formatTimeRemaining', () => {
   });
 
   test('shows seconds for < 60', () => {
-    expect(formatTimeRemaining(30)).toBe('30s remaining');
+    expect(formatTimeRemaining(30)).toBe('30s');
   });
 
   test('shows minutes:seconds for 60', () => {
-    expect(formatTimeRemaining(60)).toBe('1:00 remaining');
+    expect(formatTimeRemaining(60)).toBe('1:00');
   });
 
   test('shows minutes:seconds for 150', () => {
-    expect(formatTimeRemaining(150)).toBe('2:30 remaining');
+    expect(formatTimeRemaining(150)).toBe('2:30');
   });
 });

--- a/src/lib/generation/time-estimate.ts
+++ b/src/lib/generation/time-estimate.ts
@@ -232,9 +232,9 @@ export function estimateRemainingSeconds(opts: {
 
 export function formatTimeRemaining(seconds: number): string {
   if (seconds <= 0) return 'Finishing up\u2026';
-  if (seconds < 60) return `${seconds}s remaining`;
+  if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   const secs = seconds % 60;
   const paddedSecs = secs.toString().padStart(2, '0');
-  return `${minutes}:${paddedSecs} remaining`;
+  return `${minutes}:${paddedSecs}`;
 }

--- a/src/routes/_app/sequences/$id/route.tsx
+++ b/src/routes/_app/sequences/$id/route.tsx
@@ -1,6 +1,7 @@
 import { RouteErrorFallback } from '@/components/error/route-error-fallback';
 import { routeParams } from '@/components/layout/breadcrumbs';
 import { RenameSequenceButton } from '@/components/sequence/rename-sequence-button';
+import { SEQUENCE_HEADER_SLOT_ID } from '@/components/sequence/sequence-header-slot';
 import { getDefaultSequenceTabPath } from '@/components/sequence/sequence-tabs';
 import { getSequenceFn } from '@/functions/sequences';
 import { sequenceKeys, useSequence } from '@/hooks/use-sequences';
@@ -69,6 +70,16 @@ function SequenceLayout() {
               title={sequence.title}
             />
           )}
+          {/* Generation progress portals in here (#1427). The row is already
+              this tall with just the title in it, so progress costs no layout
+              shift and sits over nothing. `@container` so the chip can size
+              its label against the space it actually has, which requires the
+              slot be `flex-1` — a container sized by its own content could
+              never satisfy the query. */}
+          <div
+            id={SEQUENCE_HEADER_SLOT_ID}
+            className="@container flex min-w-0 flex-1 items-center justify-end pl-2"
+          />
         </div>
         {/* No Script | Scenes tab strip — those are lifecycle destinations,
             not peer pages. Pre-analysis lives at /script; analysed work at


### PR DESCRIPTION
Closes #1427.

The 5-phase progress card sat in the column flow above the scenes view, so
every run pushed the whole layout down and popped it back up on completion.
It was also expanded by default, which made it the loudest thing on screen.

It is now a small chip on the right of the sequence title row. That row is
already there and already that tall with just the title in it, so the chip
costs no layout shift, reserves no space, and sits on top of nothing - the
canvas, the scene list and the inspector all stay clickable while a run is
in flight.

- Chip: spinner, phase name, countdown. Progress shows as a fill of the
  chip's own background, so it needs no extra height. The phase name drops
  when the row is too narrow to hold it, which is measured with a container
  query on the slot rather than a screen-width breakpoint.
- Detail moved into a popover, closed by default: the phase list, what the
  current phase is doing, and the "click around while you wait" hint.
- The scenes view portals into a slot in the sequence layout route, because
  the title row sits above the `<Outlet />`.
- Same change covers the 5-phase generation banner and the motion banner -
  they share `ProgressBanner`, whose props are unchanged.
- `formatTimeRemaining` drops the " remaining" suffix (the chip is its only
  caller and the spinner already gives the context). It is still read out to
  screen readers.
- Stories render the chip in a real title row at 1280px and 900px, so the
  preview does not flatter it with space it will not have.

Checked in Storybook: chip sits right, full label at 1280 and truncated at
900, popover opens from the right edge with the correct phase states, and
the screen-reader `<progress>` is intact.