### PR TITLE
fix(#1430): don't cap browser export at 300s

### DIFF
--- a/src/components/theatre/use-sequence-export.ts
+++ b/src/components/theatre/use-sequence-export.ts
@@ -44,8 +44,9 @@ const sequenceExportKeys = {
 };
 
 // Cap the upload PUT so a stalled R2 proxy surfaces an error toast instead of
-// spinning forever. Generous enough for a 5-min export on a slow connection.
-const UPLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+// spinning forever. Generous enough for a 10-min export on a slow connection
+// (browser export's safety valve, matching server — #1430).
+const UPLOAD_TIMEOUT_MS = 10 * 60 * 1000;
 
 export type SequenceExportState = {
   isRunning: boolean;

--- a/src/lib/sequence-player/export-duration.test.ts
+++ b/src/lib/sequence-player/export-duration.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_BROWSER_EXPORT_DURATION_SECONDS,
+  assertBrowserExportDuration,
+} from './export-duration';
+
+describe('assertBrowserExportDuration', () => {
+  it('allows a 5-minute sequence and clip-duration overshoot (#1430)', () => {
+    expect(() => assertBrowserExportDuration(300)).not.toThrow();
+    // Enhancer ±10% on a 5m target, plus models returning slightly long clips.
+    expect(() => assertBrowserExportDuration(330)).not.toThrow();
+  });
+
+  it('allows up to the 10-minute safety valve (matches server export)', () => {
+    expect(MAX_BROWSER_EXPORT_DURATION_SECONDS).toBe(10 * 60);
+    expect(() =>
+      assertBrowserExportDuration(MAX_BROWSER_EXPORT_DURATION_SECONDS)
+    ).not.toThrow();
+  });
+
+  it('rejects beyond the safety valve', () => {
+    expect(() =>
+      assertBrowserExportDuration(MAX_BROWSER_EXPORT_DURATION_SECONDS + 0.1)
+    ).toThrow(/caps at 600s/);
+  });
+});

--- a/src/lib/sequence-player/export-duration.ts
+++ b/src/lib/sequence-player/export-duration.ts
@@ -1,0 +1,22 @@
+/**
+ * Browser-export duration policy (#1430).
+ *
+ * The product targets 5-minute films (`targetSeconds` max 300, composer 5m
+ * chip). Encoded clip durations overshoot that — enhancer labels are allowed
+ * ±10%, and motion models return slightly longer than requested — so a 300s
+ * gate rejected real 5-minute sequences. This cap is only a memory/time
+ * safety valve for the in-memory MP4 + OfflineAudioContext path; it matches
+ * the server-export cap in `containers/video-export`.
+ */
+
+export const MAX_BROWSER_EXPORT_DURATION_SECONDS = 10 * 60;
+
+export function assertBrowserExportDuration(
+  totalDurationSeconds: number
+): void {
+  if (totalDurationSeconds > MAX_BROWSER_EXPORT_DURATION_SECONDS) {
+    throw new Error(
+      `Sequence is ${totalDurationSeconds.toFixed(1)}s long; browser export currently caps at ${MAX_BROWSER_EXPORT_DURATION_SECONDS}s.`
+    );
+  }
+}

--- a/src/lib/sequence-player/export.ts
+++ b/src/lib/sequence-player/export.ts
@@ -37,12 +37,12 @@ import {
 } from './concatenated-video-source';
 import { decodeAudioTrack } from './decode-audio-track';
 import { assertEncoderSupport } from './encoder-support';
+import { assertBrowserExportDuration } from './export-duration';
 
 import { getLogger } from '@/lib/observability/logger';
 
 const logger = getLogger(['openstory', 'sequence-player', 'export']);
 
-const MAX_TOTAL_DURATION_SECONDS = 5 * 60;
 const TARGET_SAMPLE_RATE = 48_000;
 const TARGET_CHANNELS = 2;
 const AAC_BITRATE = 192_000;
@@ -112,11 +112,7 @@ export async function exportSequence(
     const meta = await videoSource.prepare();
     onProgress?.({ phase: 'prepare', completed: 1, total: 1 });
 
-    if (meta.totalDurationSeconds > MAX_TOTAL_DURATION_SECONDS) {
-      throw new Error(
-        `Sequence is ${meta.totalDurationSeconds.toFixed(1)}s long; browser export currently caps at ${MAX_TOTAL_DURATION_SECONDS}s.`
-      );
-    }
+    assertBrowserExportDuration(meta.totalDurationSeconds);
 
     const sceneAudioTracks = videoSource.getSceneAudioTracks();
     const hasAudio = Boolean(musicUrl) || sceneAudioTracks.length > 0;


### PR DESCRIPTION
## Related Issue

Closes #1430

## Summary of Changes

Theatre "Export MP4" refused any sequence longer than 300s. We advertise 5-minute films (`targetSeconds` max 300, composer 5m chip from #1423), but encoded clip durations overshoot that — enhancer labels are allowed ±10%, and motion models return slightly longer than requested — so a real 5-minute sequence could not export.

- Raise the browser-export safety valve from 5 minutes to 10 minutes, matching server export.
- Bump the R2 upload PUT timeout to 10 minutes so a longer export does not stall-fail after encode.
- Unit-test that 300s and 330s (5m + overshoot) are allowed.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Cap only; encode path unchanged. Sequences between 300s and 600s now export in-browser instead of throwing.

## Additional Notes

Server export already capped at 10 minutes (`containers/video-export`). Browser keeps a cap as a memory/time valve for the in-memory MP4 + `OfflineAudioContext` path — just not at the 5-minute product target.

## Screenshots (if applicable)

n/a — duration guard, no UI change.