### PR TITLE
fix(#1432): Update all checkboxes + character refs on start frames

### DIFF
--- a/src/components/staleness/update-all-dialog.test.ts
+++ b/src/components/staleness/update-all-dialog.test.ts
@@ -1,6 +1,11 @@
 import type { ShotStaleness } from '@/hooks/use-shot-staleness';
 import { describe, expect, it } from 'vitest';
-import { describeCauses, previewLevels, shotsLabel } from './update-all-dialog';
+import {
+  describeCauses,
+  levelsFromStaleShots,
+  previewLevels,
+  shotsLabel,
+} from './update-all-dialog';
 
 const shot = (causes: string[]): ShotStaleness => ({
   thumbnail: 'stale',
@@ -35,6 +40,43 @@ describe('shotsLabel', () => {
   });
   it('falls back to a count without numbering', () => {
     expect(shotsLabel(['x', 'y'], undefined, false)).toBe('2 shots');
+  });
+});
+
+describe('levelsFromStaleShots', () => {
+  it('shows prompts + images from client staleness so checkboxes render before the preview (#1432)', () => {
+    expect(
+      levelsFromStaleShots([
+        {
+          thumbnail: 'stale',
+          visualPrompt: 'stale',
+          motionPrompt: 'fresh',
+          causes: ['Script'],
+        },
+      ])
+    ).toEqual([
+      { depth: 'prompts', label: 'Prompts' },
+      { depth: 'images', label: 'Images' },
+    ]);
+  });
+
+  it('shows images only when the still is stale and prompts are fresh', () => {
+    expect(levelsFromStaleShots([shot(['Character "Woman"'])])).toEqual([
+      { depth: 'images', label: 'Images' },
+    ]);
+  });
+
+  it('shows prompts only when motion is stale and the still is not', () => {
+    expect(
+      levelsFromStaleShots([
+        {
+          thumbnail: 'fresh',
+          visualPrompt: 'fresh',
+          motionPrompt: 'stale',
+          causes: ['Script'],
+        },
+      ])
+    ).toEqual([{ depth: 'prompts', label: 'Prompts' }]);
   });
 });
 

--- a/src/components/staleness/update-all-dialog.tsx
+++ b/src/components/staleness/update-all-dialog.tsx
@@ -67,6 +67,28 @@ export const shotsLabel = (
   return `shots ${numbers.slice(0, -1).join(', ')} & ${numbers[numbers.length - 1]}`;
 };
 
+/**
+ * Immediate checkbox levels from the client staleness map (#1432). The dry-run
+ * preview is a server `computePlan` at max depth — on a remote D1 that can
+ * take long enough that the dialog used to render "…" with no checkboxes.
+ * These two levels are what the client already knows; video/music arrive
+ * when the preview does.
+ */
+export const levelsFromStaleShots = (
+  staleShots: ShotStaleness[]
+): Array<{ depth: UpdateStaleDepth; label: string }> => {
+  const prompts = staleShots.some(
+    (s) => s.visualPrompt === 'stale' || s.motionPrompt === 'stale'
+  );
+  const images = staleShots.some(
+    (s) => s.thumbnail === 'stale' || s.visualPrompt === 'stale'
+  );
+  const levels: Array<{ depth: UpdateStaleDepth; label: string }> = [];
+  if (prompts) levels.push({ depth: 'prompts', label: 'Prompts' });
+  if (images) levels.push({ depth: 'images', label: 'Images' });
+  return levels;
+};
+
 /** Levels with something to do, in cascade order, with their own additions. */
 export const previewLevels = (
   preview: UpdateStalePreview,
@@ -111,12 +133,13 @@ const RANK: Record<UpdateStaleDepth, number> = {
 };
 
 /**
- * "Update all" confirmation (#1085/#1194). Leads with WHAT changed, then the
- * computed cascade from a server dry-run of the same plan the workflow
- * freezes: one checkbox per level that has work, with its shots and cost.
- * Levels cascade (images need prompts, videos need images), so ticking a
- * level locks every shallower one on. Only the deepest tick is sent — the
- * run's `depth`. Native inputs for keyboard/AT semantics.
+ * "Update all" confirmation (#1085/#1194/#1432). Leads with WHAT changed,
+ * then one checkbox per level that has work. Checkboxes render immediately
+ * from the client staleness map; the server dry-run refines labels, costs,
+ * and video/music when it lands. Levels cascade (images need prompts,
+ * videos need images), so ticking a level locks every shallower one on.
+ * Only the deepest tick is sent — the run's `depth`. Native inputs for
+ * keyboard/AT semantics.
  */
 export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   open,
@@ -132,7 +155,11 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   const { showCosts } = useShowCosts();
   const singleShotScope = scope.shotId != null;
 
-  const { data: preview, isError } = useQuery({
+  const {
+    data: preview,
+    isError,
+    isPending,
+  } = useQuery({
     queryKey: [
       'update-stale-preview',
       scope.sequenceId,
@@ -144,14 +171,13 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
     staleTime: 30_000,
   });
 
+  const clientLevels = levelsFromStaleShots(staleShots);
   const levels = preview
     ? previewLevels(preview, shotNumberById, singleShotScope)
-    : null;
+    : clientLevels;
   // Snap the default to a level that exists: the deepest at or above it.
   const available =
-    depth == null
-      ? []
-      : (levels?.filter((l) => RANK[l.depth] <= RANK[depth]) ?? []);
+    depth == null ? [] : levels.filter((l) => RANK[l.depth] <= RANK[depth]);
   // Preview failed: fall back to the pre-preview behaviour — a plain confirm
   // at the old default depth — rather than blocking the update on a preview.
   const selectedDepth =
@@ -160,13 +186,11 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
   const checked = (d: UpdateStaleDepth) =>
     selectedDepth != null && RANK[d] <= RANK[selectedDepth];
   const total = levels
-    ? levels
-        .filter((l) => checked(l.depth))
-        .reduce<Microdollars | null>((acc, l) => {
-          const c = preview?.costByLevel[l.depth] ?? null;
-          return acc == null || c == null ? null : addMicros(acc, c);
-        }, ZERO_MICROS)
-    : null;
+    .filter((l) => checked(l.depth))
+    .reduce<Microdollars | null>((acc, l) => {
+      const c = preview?.costByLevel[l.depth] ?? null;
+      return acc == null || c == null ? null : addMicros(acc, c);
+    }, ZERO_MICROS);
 
   const toggle = (d: UpdateStaleDepth, on: boolean) => {
     if (on) {
@@ -174,7 +198,7 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
       return;
     }
     // Unticking a level drops it and everything deeper.
-    const shallower = levels?.filter((l) => RANK[l.depth] < RANK[d]) ?? [];
+    const shallower = levels.filter((l) => RANK[l.depth] < RANK[d]);
     setDepth(shallower[shallower.length - 1]?.depth ?? null);
   };
 
@@ -193,16 +217,15 @@ export const UpdateAllDialog: React.FC<UpdateAllDialogProps> = ({
         </AlertDialogHeader>
         <fieldset className="flex flex-col gap-2">
           <legend className="sr-only">What to regenerate</legend>
-          {isError ? (
+          {isError && (
             <span className="text-xs text-muted-foreground">
-              Couldn’t compute the plan — Update regenerates out-of-date prompts
-              and images.
+              Couldn’t compute the exact plan — showing out-of-date prompts and
+              images.
             </span>
-          ) : levels == null ? (
-            <span className="text-xs text-muted-foreground">…</span>
-          ) : levels.length === 0 ? (
+          )}
+          {levels.length === 0 ? (
             <span className="text-xs text-muted-foreground">
-              Nothing to regenerate.
+              {isPending ? '…' : 'Nothing to regenerate.'}
             </span>
           ) : (
             levels.map((level, index) => {

--- a/src/functions/shot-image.ts
+++ b/src/functions/shot-image.ts
@@ -39,7 +39,7 @@ import type {
   ShotVariantWorkflowInput,
   UpscaleShotVariantWorkflowInput,
 } from '@/lib/workflow/types';
-import { matchCharactersToScene } from '@/lib/workflows/scene-matching';
+import { matchCharactersToShotImage } from '@/lib/workflows/scene-matching';
 import { createServerFn } from '@tanstack/react-start';
 import { zodValidator } from '@tanstack/zod-adapter';
 import { z } from 'zod';
@@ -249,22 +249,6 @@ export const generateShotVariantsFn = createServerFn({ method: 'POST' })
       throw new Error('Shot must have a still image to generate variants');
     }
 
-    const allCharacters = await context.scopedDb.characters.listWithSheets(
-      sequence.id
-    );
-    const characterTags = scene?.continuity?.characterTags ?? [];
-    const characterReferences = buildCharacterReferenceImages(
-      matchCharactersToScene(allCharacters, characterTags)
-    );
-
-    const allLocations =
-      await context.scopedDb.sequenceLocations.listWithReferences(sequence.id);
-    const locationReferences = getSceneLocationReferenceImages(
-      allLocations,
-      scene?.continuity?.environmentTag ?? '',
-      scene?.metadata?.location ?? ''
-    );
-
     const numImages = data.numImages ?? 1;
     await requireCredits(
       context.scopedDb,
@@ -286,8 +270,22 @@ export const generateShotVariantsFn = createServerFn({ method: 'POST' })
 
     const gridConfig = getVariantGridConfig(sequence.aspectRatio);
 
-    const selectedPrompt =
-      await context.scopedDb.framePromptVersions.getSelected(frame.id);
+    const [allCharacters, allLocations, selectedPrompt] = await Promise.all([
+      context.scopedDb.characters.listWithSheets(sequence.id),
+      context.scopedDb.sequenceLocations.listWithReferences(sequence.id),
+      context.scopedDb.framePromptVersions.getSelected(frame.id),
+    ]);
+    const characterReferences = buildCharacterReferenceImages(
+      matchCharactersToShotImage(allCharacters, {
+        characterTags: scene?.continuity?.characterTags,
+        visualPrompt: selectedPrompt?.text,
+      })
+    );
+    const locationReferences = getSceneLocationReferenceImages(
+      allLocations,
+      scene?.continuity?.environmentTag ?? '',
+      scene?.metadata?.location ?? ''
+    );
 
     const workflowInput: ShotVariantWorkflowInput = {
       userId: user.id,
@@ -385,9 +383,13 @@ export const selectShotVariantFn = createServerFn({ method: 'POST' })
     const allCharacters = await context.scopedDb.characters.listWithSheets(
       sequence.id
     );
-    const characterTags = scene?.continuity?.characterTags ?? [];
+    const selectedPrompt =
+      await context.scopedDb.framePromptVersions.getSelected(frame.id);
     const characterReferences = buildCharacterReferenceImages(
-      matchCharactersToScene(allCharacters, characterTags)
+      matchCharactersToShotImage(allCharacters, {
+        characterTags: scene?.continuity?.characterTags,
+        visualPrompt: selectedPrompt?.text,
+      })
     );
 
     const allLocations =

--- a/src/lib/image/build-shot-image-input.test.ts
+++ b/src/lib/image/build-shot-image-input.test.ts
@@ -229,4 +229,38 @@ describe('buildShotImageWorkflowInput — reference images', () => {
       role: 'character',
     });
   });
+
+  it('attaches a character named in the visual prompt even when continuity tags are empty (#1432)', async () => {
+    const shot = makeShot();
+    const character: CharacterMinimal = {
+      id: 'c1',
+      characterId: 'char_001',
+      name: 'Scarlett',
+      sheetImageUrl: 'https://cdn/scarlett-sheet.png',
+      sheetStatus: 'completed',
+      sheetInputHash: 'hash-scarlett',
+      selectedSheetVersionId: null,
+      physicalDescription: 'red coat',
+      consistencyTag: null,
+    };
+    const input = await buildShotImageWorkflowInput({
+      ...baseOpts,
+      shot,
+      imagePrompt: 'SCARLETT stands in the doorway.',
+      characters: [character],
+      continuity: {
+        characterTags: [],
+        environmentTag: '',
+        elementTags: [],
+        colorPalette: '',
+        lightingSetup: '',
+        styleTag: '',
+      },
+    });
+    expect(input?.referenceImages?.[0]).toMatchObject({
+      referenceImageUrl: 'https://cdn/scarlett-sheet.png',
+      role: 'character',
+      token: 'Scarlett',
+    });
+  });
 });

--- a/src/lib/image/build-shot-image-input.ts
+++ b/src/lib/image/build-shot-image-input.ts
@@ -26,7 +26,7 @@ import type {
   ImageWorkflowInput,
 } from '@/lib/workflow/types';
 import {
-  matchCharactersToScene,
+  matchCharactersToShotImage,
   matchElementsToShotImage,
   matchLocationsToScene,
 } from '@/lib/workflows/scene-matching';
@@ -107,10 +107,10 @@ export async function buildShotImageWorkflowInput(opts: {
 
   const continuity = opts.continuity ?? opts.scene?.continuity;
 
-  const matchedCharacters = matchCharactersToScene(
-    characters,
-    continuity?.characterTags ?? []
-  );
+  const matchedCharacters = matchCharactersToShotImage(characters, {
+    characterTags: continuity?.characterTags,
+    visualPrompt: prompt,
+  });
   const characterReferences = buildCharacterReferenceImages(matchedCharacters);
 
   const environmentTag = continuity?.environmentTag ?? '';

--- a/src/lib/motion/build-motion-references.test.ts
+++ b/src/lib/motion/build-motion-references.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import type { CharacterMinimal, SequenceElementMinimal } from '@/lib/db/schema';
-import { buildMotionReferenceImages } from './build-motion-references';
+import {
+  buildMotionReferenceImages,
+  buildShotImageReferenceImages,
+} from './build-motion-references';
 
 const character = (
   name: string,
@@ -91,5 +94,47 @@ describe('buildMotionReferenceImages', () => {
       elements: [element('LOGO', 'https://example.com/logo.png')],
     });
     expect(refs).toEqual([]);
+  });
+});
+
+describe('buildShotImageReferenceImages', () => {
+  it('attaches a character named in the visual prompt even with empty tags (#1432)', () => {
+    const refs = buildShotImageReferenceImages({
+      scene: {
+        continuity: { characterTags: [], elementTags: [], environmentTag: '' },
+        originalScript: { extract: '' },
+      },
+      visualPrompt: 'ALICE waits at the window.',
+      characters: [
+        character('Alice', 'https://example.com/alice.png'),
+        character('Bob', 'https://example.com/bob.png'),
+      ],
+      locations: [],
+      elements: [],
+    });
+    expect(refs.map((r) => r.referenceImageUrl)).toEqual([
+      'https://example.com/alice.png',
+    ]);
+    expect(refs[0]).toMatchObject({ role: 'character', token: 'Alice' });
+  });
+
+  it('still matches continuity tags when the prompt does not name the character', () => {
+    const refs = buildShotImageReferenceImages({
+      scene: {
+        continuity: {
+          characterTags: ['Alice'],
+          elementTags: [],
+          environmentTag: '',
+        },
+        originalScript: { extract: '' },
+      },
+      visualPrompt: 'A woman in a red coat waits at the window.',
+      characters: [character('Alice', 'https://example.com/alice.png')],
+      locations: [],
+      elements: [],
+    });
+    expect(refs.map((r) => r.referenceImageUrl)).toEqual([
+      'https://example.com/alice.png',
+    ]);
   });
 });

--- a/src/lib/motion/build-motion-references.ts
+++ b/src/lib/motion/build-motion-references.ts
@@ -26,6 +26,7 @@ import { buildLocationReferenceImages } from '@/lib/prompts/location-prompt';
 import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
 import {
   matchCharactersToScene,
+  matchCharactersToShotImage,
   matchElementsToScene,
   matchElementsToShotImage,
   matchLocationsToScene,
@@ -73,8 +74,8 @@ export function buildMotionReferenceImages(params: {
 export function buildShotImageReferenceImages(params: {
   scene: SceneReferenceInput;
   /**
-   * The still's visual prompt. When present, element refs follow the
-   * prompt (same matcher as `/image` stamp + staleness verify).
+   * The still's visual prompt. Character and element refs follow the
+   * prompt (same matcher as `/image` stamp + staleness verify) (#1432).
    */
   visualPrompt?: string | null;
   characters: CharacterMinimal[];
@@ -83,10 +84,10 @@ export function buildShotImageReferenceImages(params: {
 }): ReferenceImageDescription[] {
   const { scene, visualPrompt, characters, locations, elements } = params;
 
-  const matchedCharacters = matchCharactersToScene(
-    characters,
-    scene?.continuity?.characterTags ?? []
-  );
+  const matchedCharacters = matchCharactersToShotImage(characters, {
+    characterTags: scene?.continuity?.characterTags,
+    visualPrompt,
+  });
   const matchedLocations = matchLocationsToScene(
     locations,
     scene?.continuity?.environmentTag ?? '',

--- a/src/lib/shots/shot-image-input.ts
+++ b/src/lib/shots/shot-image-input.ts
@@ -35,7 +35,7 @@ import type {
 } from '@/lib/workflow/types';
 import { shouldRecordUserEdit } from '@/lib/workflows/user-edit-predicate';
 import {
-  matchCharactersToScene,
+  matchCharactersToShotImage,
   matchElementsToShotImage,
   matchLocationsToScene,
 } from '@/lib/workflows/scene-matching';
@@ -173,10 +173,10 @@ export async function prepareShotImageWorkflowInput(args: {
         scopedDb.sequenceElements.list(sequence.id),
       ]);
 
-  const matchedCharacters = matchCharactersToScene(
-    allCharacters,
-    continuity?.characterTags ?? []
-  );
+  const matchedCharacters = matchCharactersToShotImage(allCharacters, {
+    characterTags: continuity?.characterTags,
+    visualPrompt: prompt,
+  });
   const characterReferences = buildCharacterReferenceImages(matchedCharacters);
 
   const matchedLocations = matchLocationsToScene(

--- a/src/lib/workflows/scene-matching.test.ts
+++ b/src/lib/workflows/scene-matching.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { CharacterMinimal, SequenceElementMinimal } from '@/lib/db/schema';
 import {
+  characterMentionedInPrompt,
   matchCharacterToShotTags,
   matchCharactersToScene,
+  matchCharactersToShotImage,
   matchElementsToScene,
   matchElementsToShotImage,
 } from './scene-matching';
@@ -151,6 +153,79 @@ describe('matchCharactersToScene', () => {
       makeCharacter({ name: 'GIRL ONE', characterId: 'char_girl_one' }),
     ];
     expect(matchCharactersToScene(cast, [])).toEqual([]);
+  });
+});
+
+describe('matchCharactersToShotImage', () => {
+  const scarlett = makeCharacter({
+    name: 'Scarlett',
+    characterId: 'char_001',
+    consistencyTag: 'char_001: scarlett-red-coat',
+  });
+  const jack = makeCharacter({ name: 'Jack', characterId: 'char_002' });
+
+  it('attaches a character named in ALL-CAPS in the visual prompt even with empty tags (#1432)', () => {
+    const result = matchCharactersToShotImage([scarlett, jack], {
+      characterTags: [],
+      visualPrompt: 'SCARLETT stands in the doorway, coat dripping.',
+    });
+    expect(result.map((c) => c.name)).toEqual(['Scarlett']);
+  });
+
+  it('does not treat a lowercase prose mention as a cast reference', () => {
+    expect(
+      matchCharactersToShotImage([scarlett], {
+        characterTags: [],
+        visualPrompt: 'scarlett stands in the doorway.',
+      })
+    ).toEqual([]);
+  });
+
+  it('unions prompt mentions with continuity tags', () => {
+    const result = matchCharactersToShotImage([scarlett, jack], {
+      characterTags: ['Jack'],
+      visualPrompt: 'SCARLETT enters. The room is empty.',
+    });
+    expect(result.map((c) => c.name).sort()).toEqual(['Jack', 'Scarlett']);
+  });
+
+  it('falls back to tags when the visual prompt is empty', () => {
+    expect(
+      matchCharactersToShotImage([jack], {
+        characterTags: ['Jack'],
+        visualPrompt: '   ',
+      }).map((c) => c.name)
+    ).toEqual(['Jack']);
+  });
+
+  it('matches characterId and consistencyTag slug in the prompt', () => {
+    expect(
+      matchCharactersToShotImage([scarlett], {
+        characterTags: [],
+        visualPrompt: 'char_001 waits by the window.',
+      }).map((c) => c.name)
+    ).toEqual(['Scarlett']);
+    expect(
+      matchCharactersToShotImage([scarlett], {
+        characterTags: [],
+        visualPrompt: 'scarlett-red-coat in silhouette.',
+      }).map((c) => c.name)
+    ).toEqual(['Scarlett']);
+  });
+});
+
+describe('characterMentionedInPrompt', () => {
+  it('requires the ALL-CAPS name, not title case', () => {
+    const scarlett = makeCharacter({
+      name: 'Scarlett',
+      characterId: 'char_001',
+    });
+    expect(characterMentionedInPrompt(scarlett, 'SCARLETT walks in.')).toBe(
+      true
+    );
+    expect(characterMentionedInPrompt(scarlett, 'Scarlett walks in.')).toBe(
+      false
+    );
   });
 });
 

--- a/src/lib/workflows/scene-matching.ts
+++ b/src/lib/workflows/scene-matching.ts
@@ -93,6 +93,90 @@ export function matchCharactersToScene<T extends CharacterMatchInput>(
   );
 }
 
+/**
+ * Strip `"char_001: jack-denim-jacket"` down to the slug half. Same split
+ * `extract-continuity-from-prompt` uses — kept local to avoid a cycle.
+ */
+function consistencyTagSlug(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const idx = raw.indexOf(':');
+  const slug = (idx >= 0 ? raw.slice(idx + 1) : raw).trim();
+  return slug.length > 0 ? slug : null;
+}
+
+function escapeForRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Whole-word match. Hyphen/underscore stay inside the token so
+ * `jack-denim-jacket` is one term. `caseSensitive` is for ALL-CAPS cast
+ * names (the deliberate `SCARLETT` mention, not lowercase prose).
+ */
+function tagMatchesText(
+  tag: string,
+  text: string,
+  caseSensitive = false
+): boolean {
+  if (!tag) return false;
+  const escaped = escapeForRegex(tag);
+  const re = new RegExp(
+    `(?:^|[^A-Za-z0-9_-])${escaped}(?:[^A-Za-z0-9_-]|$)`,
+    caseSensitive ? '' : 'i'
+  );
+  return re.test(text);
+}
+
+/**
+ * Did this visual prompt name the character the way prompts actually do
+ * (#1432)? ALL-CAPS name is case-sensitive (mirrors tagify / the continuity
+ * rescan); `characterId` and the consistencyTag slug are case-insensitive.
+ */
+export function characterMentionedInPrompt(
+  character: CharacterMatchInput,
+  prompt: string
+): boolean {
+  if (!prompt.trim()) return false;
+  const nameUpper = character.name.toUpperCase();
+  if (nameUpper.length > 0 && tagMatchesText(nameUpper, prompt, true)) {
+    return true;
+  }
+  if (tagMatchesText(character.characterId, prompt)) return true;
+  const slug = consistencyTagSlug(character.consistencyTag);
+  return slug != null && tagMatchesText(slug, prompt);
+}
+
+/**
+ * Characters whose sheets should attach to a still (#1432).
+ *
+ * Continuity tags stay the primary match (a tagged character may be described
+ * without an ALL-CAPS name). The visual prompt is additive: a regenerated
+ * prompt that names `SCARLETT` still attaches her sheet when tags are empty
+ * or stale — the same fallback `matchElementsToShotImage` already has for
+ * tokens. Update all's chained stills skip `rescanContinuityFromPrompt`, so
+ * this is the path that actually sends the refs.
+ */
+export function matchCharactersToShotImage<T extends CharacterMatchInput>(
+  allCharacters: T[],
+  args: {
+    characterTags?: string[] | null;
+    visualPrompt?: string | null;
+  }
+): T[] {
+  const tagged = matchCharactersToScene(
+    allCharacters,
+    args.characterTags ?? []
+  );
+  const prompt = (args.visualPrompt ?? '').trim();
+  if (!prompt) return tagged;
+
+  const seen = new Set(tagged.map((c) => c.characterId));
+  const extra = allCharacters.filter(
+    (c) => !seen.has(c.characterId) && characterMentionedInPrompt(c, prompt)
+  );
+  return extra.length === 0 ? tagged : [...tagged, ...extra];
+}
+
 type LocationMatchInput = Pick<
   SequenceLocationMinimal,
   'locationId' | 'name' | 'consistencyTag'

--- a/src/lib/workflows/sheet-snapshots.ts
+++ b/src/lib/workflows/sheet-snapshots.ts
@@ -41,7 +41,7 @@ import type {
   LocationSheetWorkflowInput,
 } from '@/lib/workflow/types';
 import {
-  matchCharactersToScene,
+  matchCharactersToShotImage,
   matchElementsToShotImage,
   matchLocationsToScene,
 } from './scene-matching';
@@ -360,9 +360,11 @@ function sortedRefHashes(values: Array<string | null | undefined>): string[] {
  * image re-stales stills even with identical bible inputs), else the parent
  * `sheetInputHash` / `referenceInputHash`; plus element `imageUrl`.
  *
- * Element matching uses the still's visual prompt when `visualPrompt` is
- * passed (the same text the image model generated from). Scene extract /
- * `elementTags` are the fallback only when no prompt exists.
+ * Character and element matching use the still's visual prompt when
+ * `visualPrompt` is passed (the same text the image model generated from)
+ * so a regenerated prompt that names `SCARLETT` still attaches her sheet
+ * when continuity tags are empty (#1432). Scene extract / `elementTags`
+ * are the element fallback only when no prompt exists.
  *
  * Single source of truth so the image-generation trigger **stamp**
  * (`computeShotImageInputHash` via `prepareShotImageWorkflowInput`) and the staleness **verify**
@@ -401,10 +403,10 @@ export function resolveSceneShotImageReferences(params: {
   elementReferenceHashes: string[];
 } {
   const { scene, visualPrompt, characters, locations, elements } = params;
-  const matchedCharacters = matchCharactersToScene(
-    characters,
-    scene?.continuity?.characterTags ?? []
-  );
+  const matchedCharacters = matchCharactersToShotImage(characters, {
+    characterTags: scene?.continuity?.characterTags,
+    visualPrompt,
+  });
   const matchedLocations = matchLocationsToScene(
     locations,
     scene?.continuity?.environmentTag ?? '',

--- a/src/lib/workflows/shot-images-workflow.ts
+++ b/src/lib/workflows/shot-images-workflow.ts
@@ -45,7 +45,7 @@ import type {
   ShotVariantWorkflowInput,
 } from '@/lib/workflow/types';
 import {
-  matchCharactersToScene,
+  matchCharactersToShotImage,
   matchElementsToShotImage,
   matchLocationsToScene,
 } from '@/lib/workflows/scene-matching';
@@ -170,10 +170,10 @@ export class ShotImagesWorkflow extends OpenStoryWorkflowEntrypoint<ShotImagesWo
           sceneCharacterMap: Object.fromEntries(
             scenesWithVisualPrompts.map((scene) => [
               scene.sceneId,
-              matchCharactersToScene(
-                charactersWithSheets,
-                scene.continuity?.characterTags || []
-              ),
+              matchCharactersToShotImage(charactersWithSheets, {
+                characterTags: scene.continuity?.characterTags,
+                visualPrompt: visualPromptBySceneId[scene.sceneId] ?? '',
+              }),
             ])
           ),
           sceneLocationMap: Object.fromEntries(


### PR DESCRIPTION
Fixes #1432.

Reproduced on a PR preview (not local `bun dev`): the Update all dialog took a long time to populate, showed no checkboxes, and the regenerated start frames did not use character sheets.

## Dialog

The depth checkboxes were gated on `getUpdateStalePreviewFn`, which runs a max-depth `computePlan` against D1. Until that returned — or if it failed — the fieldset rendered `…` and the user could not see what would regenerate.

Checkboxes now render immediately from the client staleness map (prompts / images). The dry-run still runs and replaces labels, costs, and video/music when it lands. A failed preview keeps the client levels instead of hiding the form.

## Character refs

Start-frame regeneration matched characters from `continuity.characterTags` only. Elements already fall back to the visual prompt; characters did not. Update all's chained stills also skip `rescanContinuityFromPrompt` (that helper is the single-shot Generate Image path).

`matchCharactersToShotImage` unions tags with ALL-CAPS prompt mentions (`SCARLETT`), plus `characterId` / consistencyTag slug. Wired through the image stamp (`prepareShotImageWorkflowInput`, `buildShotImageWorkflowInput`), the client preview (`buildShotImageReferenceImages`), staleness verify (`resolveSceneShotImageReferences`), first-generation `shot-images-workflow`, and variant/upscale triggers.

A regenerated prompt that names a character now attaches her sheet even when tags are empty or stale.

## Tests

- `levelsFromStaleShots` — checkboxes exist before the preview
- `matchCharactersToShotImage` — ALL-CAPS prompt mention, no lowercase prose false-positive, union with tags
- `buildShotImageWorkflowInput` / `buildShotImageReferenceImages` — sheet URL lands on the payload