### PR TITLE
fix(#1435): name the status and provider body when an image download fails

### DIFF
--- a/src/lib/image/image-storage.test.ts
+++ b/src/lib/image/image-storage.test.ts
@@ -90,9 +90,11 @@ describe('uploadPosterToStorage', () => {
     expect(result.path).toMatch(/\.webp$/);
   });
 
-  it('throws when the provider image cannot be downloaded', async () => {
+  it('names the status, host and provider body when the download fails', async () => {
+    // Providers send no reason phrase, so `statusText` alone said `<none>`
+    // and left the failure undiagnosable (#1435).
     fetchMock.mockResolvedValue(
-      new Response(null, { status: 404, statusText: 'Not Found' })
+      new Response('NoSuchKey', { status: 404, statusText: '' })
     );
 
     await expect(
@@ -101,7 +103,9 @@ describe('uploadPosterToStorage', () => {
         teamId: 'team_1',
         sequenceId: 'seq_1',
       })
-    ).rejects.toThrow('Failed to download image');
+    ).rejects.toThrow(
+      'Failed to download image from v3.fal.media: 404 NoSuchKey'
+    );
     expect(uploadFile).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/image/image-storage.ts
+++ b/src/lib/image/image-storage.ts
@@ -44,7 +44,14 @@ export async function uploadImageFromUrl(
   const response = await fetch(imageUrl);
 
   if (!response.ok) {
-    throw new Error(`Failed to download image: ${response.statusText}`);
+    // `statusText` was the whole error we reported, and it is worthless:
+    // provider CDNs send no reason phrase, so both occurrences to date read
+    // `Failed to download image: <none>` — nothing to act on (#1435). The
+    // status and the provider's error body are what name the cause.
+    const body = (await response.text().catch(() => '')).slice(0, 200).trim();
+    throw new Error(
+      `Failed to download image from ${new URL(imageUrl).host}: ${response.status}${body ? ` ${body}` : ''}`
+    );
   }
 
   // Magic bytes first: fal's upscale endpoints return extension-less URLs


### PR DESCRIPTION
Closes #1435.

## What happened

The failing row is the 3×3 framing grid for one shot in sequence
`01M1EX6SBFSTQ3CCVN2JFYN3Q9`:

```
frame_variants  kind=framing  model=nano_banana_2_lite  status=failed
error: "Failed to download image: <none>"
```

Ten `ShotVariantWorkflow` runs fired within ~20s. Nine uploaded their grid
in 12–110s. The tenth generated its image fine, then failed in
`upload-to-storage` — the fetch of the provider's image URL came back
non-OK, repeatedly, across ~18 minutes of Cloudflare step retries.

Which non-OK? Unknown. We only reported `response.statusText`, and provider
CDNs send no reason phrase, so the message said `<none>` and nothing else.
The same message is the only other occurrence of this failure in the DB
(2026-08-24, a `model` still) — two data points, zero diagnosis.

## The change

`uploadImageFromUrl` is the one helper every image / poster / variant /
upscale upload routes through. It now reports the status code, the host and
a slice of the provider's error body:

```
Failed to download image from v3.fal.media: 404 NoSuchKey
```

Retry semantics are unchanged — classifying which statuses are worth
retrying is a guess until we see a real status code.
