### PR TITLE
fix(#1447): drop the leaked type name from the Add Character button

### DIFF
--- a/src/components/scenes/add-character-dialog.tsx
+++ b/src/components/scenes/add-character-dialog.tsx
@@ -64,7 +64,7 @@ export const AddCharacterDialog: React.FC<{ sequenceId: string }> = ({
       <DialogTrigger asChild>
         <Button variant="outline" size="sm">
           <Plus className="mr-2 h-4 w-4" />
-          Add CharacterWithSheet
+          Add Character
         </Button>
       </DialogTrigger>
       <DialogContent>


### PR DESCRIPTION
Closes #1447

The "Add character" trigger in the scene cast panel read **Add CharacterWithSheet** — the DB row type name leaked into the user-facing label. Now reads "Add Character", matching the sibling add-location dialog.

One-line change; no other occurrence of a leaked type name in `src/components` or `src/routes`.