### PR TITLE
Fix dictated prompts not saving and a live take getting stuck

### DIFF
--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1763,6 +1763,12 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   size="icon-xs"
                   disabled={isAwaitingVisualPrompt}
                   {...imageVoice}
+                  onStart={() => {
+                    // Treat dictation as a user edit even though the mic
+                    // never focuses the editor (so Escape still hits the button).
+                    imageFocusedRef.current = true;
+                    return imageVoice.onStart();
+                  }}
                 />
               </div>
             </div>
@@ -2064,6 +2070,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   size="icon-xs"
                   disabled={isAwaitingMotionPrompt}
                   {...motionVoice}
+                  onStart={() => {
+                    motionFocusedRef.current = true;
+                    return motionVoice.onStart();
+                  }}
                 />
               </div>
             </div>

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -400,6 +400,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   const { ref: imagePromptRef, voice: imageVoice } = useEditorDictation();
   const { ref: motionPromptRef, voice: motionVoice } = useEditorDictation();
 
+  // Drop a live take when the shot changes so the previous shot's document
+  // cannot land in the new shot's draft. The buttons remount via `key`.
+  useEffect(() => {
+    imagePromptRef.current?.endDictation();
+    motionPromptRef.current?.endDictation();
+    // Refs are stable; the take must end when the shot id changes, not when
+    // the handle object identity does.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [shot?.id]);
+
   const queryClient = useQueryClient();
   const setImageFromVariant = useSetImageFromVariant();
   const setVideoFromVariant = useSetVideoFromVariant();
@@ -1759,6 +1769,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   label="Copy image prompt"
                 />
                 <VoiceInputButton
+                  key={shot?.id}
                   label="image prompt"
                   size="icon-xs"
                   disabled={isAwaitingVisualPrompt}
@@ -1766,8 +1777,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   onStart={() => {
                     // Treat dictation as a user edit even though the mic
                     // never focuses the editor (so Escape still hits the button).
-                    imageFocusedRef.current = true;
-                    return imageVoice.onStart();
+                    const started = imageVoice.onStart();
+                    if (started) imageFocusedRef.current = true;
+                    return started;
                   }}
                 />
               </div>
@@ -2066,13 +2078,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   label="Copy motion prompt"
                 />
                 <VoiceInputButton
+                  key={shot?.id}
                   label="motion prompt"
                   size="icon-xs"
                   disabled={isAwaitingMotionPrompt}
                   {...motionVoice}
                   onStart={() => {
-                    motionFocusedRef.current = true;
-                    return motionVoice.onStart();
+                    // Same as the image mic: Focused means dirty, not DOM focus.
+                    const started = motionVoice.onStart();
+                    if (started) motionFocusedRef.current = true;
+                    return started;
                   }}
                 />
               </div>

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -17,7 +17,13 @@ import {
 import { cn } from '@/lib/utils';
 import { spaceTranscript } from '@/lib/voice/transcript-insert';
 import * as React from 'react';
-import { useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import {
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import type { MentionOptions } from '@tiptap/extension-mention';
 import type { MentionItem } from '@/components/scenes/prompt-mention/mention-items';
 import { PromptMention } from './mention/mention-extension';
@@ -174,8 +180,11 @@ type MarkdownEditorProps = {
  * update, so revised words replace themselves instead of stacking up.
  */
 export type MarkdownEditorHandle = {
-  /** Anchor a take at the caret — or the end of the document if none is placed. */
-  beginDictation: () => void;
+  /**
+   * Anchor a take at the caret — or the end of the document if none is placed.
+   * Returns false when the editor is missing or not editable.
+   */
+  beginDictation: () => boolean;
   /** Rewrite the live take as `text`. */
   setDictation: (text: string) => void;
   /** Release the take's range; the text stays. */
@@ -332,6 +341,12 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   // because the user has never clicked in — it goes to the end instead.
   const caretPlacedRef = useRef(false);
 
+  // The range the live dictation take occupies, or null between takes.
+  // `dictationActive` is the React-visible twin so value-sync / mention
+  // tagify skip setContent for the duration and re-run when the take ends.
+  const dictationRef = useRef<{ from: number; to: number } | null>(null);
+  const [dictationActive, setDictationActive] = useState(false);
+
   // Canonical Tiptap external-value sync (mirrors the Vue v-model example in
   // their docs): only setContent if the editor's current markdown differs
   // from the incoming value. When mentions are on, we tagify the value first
@@ -341,21 +356,28 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   // streaming the script chunk-by-chunk) collapses to one setContent with
   // the latest value. Each setContent is a full markdown re-parse + doc
   // rebuild and freezes the renderer if applied per-chunk at ~30Hz+.
+  //
+  // Skip the rebuild while a take is live — mapping cannot survive a
+  // full-doc replace, and the next setDictation would append instead of
+  // rewrite. `dictationActive` dropping retriggers this so enhance output
+  // that arrived mid-take still lands.
   useEffect(() => {
-    if (!editor) return;
+    if (!editor || dictationActive) return;
     if (editor.storage.markdown.getMarkdown() === value) return;
     const rafId = requestAnimationFrame(() => {
+      if (dictationRef.current) return;
       if (editor.storage.markdown.getMarkdown() === value) return;
       const content = hasMentions
         ? tagifyMarkdown(value, mentionItemsRef.current).content
         : value;
       editor.commands.setContent(content, { emitUpdate: false });
-      // A replaced document (enhance output, a loaded sample) leaves any old
-      // caret position meaningless; dictation appends until the user clicks.
+      // Unfocused setContent forgets the old caret so the next take anchors
+      // at end; a focused replace keeps caretPlacedRef and uses whatever
+      // selection TipTap left.
       if (!editor.isFocused) caretPlacedRef.current = false;
     });
     return () => cancelAnimationFrame(rafId);
-  }, [editor, value, hasMentions]);
+  }, [editor, value, hasMentions, dictationActive]);
 
   // When the items list changes (e.g. characters/elements load async after
   // mount, or the user adds a new one to the sequence), re-tagify the current
@@ -363,16 +385,17 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   // value-sync effect above won't catch this on its own — the stored value
   // hasn't changed, so its `getMarkdown() === value` guard returns true.
   useEffect(() => {
-    if (!editor || !hasMentions) return;
+    if (!editor || !hasMentions || dictationActive) return;
     const { content, matched } = tagifyMarkdown(value, mentionItemsRef.current);
     if (!matched) return;
     const rafId = requestAnimationFrame(() => {
+      if (dictationRef.current) return;
       editor.commands.setContent(content, { emitUpdate: false });
     });
     return () => cancelAnimationFrame(rafId);
     // value intentionally omitted — the sibling effect handles value changes.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [editor, mentionItemsKey, hasMentions]);
+  }, [editor, mentionItemsKey, hasMentions, dictationActive]);
 
   useEffect(() => {
     if (!editor) return;
@@ -387,12 +410,11 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     };
   }, [editor]);
 
-  // The range the live dictation take occupies, or null between takes.
-  const dictationRef = useRef<{ from: number; to: number } | null>(null);
-
-  // The user may keep typing (or an enhance may stream in) mid-take, so carry
-  // the take's range through everyone else's transactions. Our own already
-  // set the range explicitly.
+  // The user may keep typing mid-take, so carry the take's range through
+  // everyone else's transactions. Our own already set the range explicitly.
+  // Full-doc `setContent` (enhance / mention tagify) is skipped while the
+  // take is live rather than mapped — mapping a replace-all collapses the
+  // range.
   useEffect(() => {
     if (!editor) return;
     const remap = ({ transaction }: { transaction: Transaction }) => {
@@ -414,7 +436,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     ref,
     (): MarkdownEditorHandle => ({
       beginDictation: () => {
-        if (!editor?.isEditable) return;
+        if (!editor?.isEditable) return false;
         const { view } = editor;
         const { tr } = view.state;
         // The caret survives the blur that clicking the mic causes, so the
@@ -425,6 +447,8 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         view.dispatch(tr.setMeta(DICTATION_META, true));
         const { from } = view.state.selection;
         dictationRef.current = { from, to: from };
+        setDictationActive(true);
+        return true;
       },
       setDictation: (text: string) => {
         const range = dictationRef.current;
@@ -450,6 +474,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
       },
       endDictation: () => {
         dictationRef.current = null;
+        setDictationActive(false);
       },
     }),
     [editor]

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -335,10 +335,10 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     onFocus: () => onFocusRef.current?.(),
   });
 
-  // Whether the user has put a caret in this editor since its content was
-  // last replaced from outside. ProseMirror's initial selection sits at the
-  // start of the document, so a dictated take must not land there just
-  // because the user has never clicked in — it goes to the end instead.
+  // Whether the user has put a caret in this editor since the last unfocused
+  // external replace. ProseMirror's initial selection sits at the start of
+  // the document, so a dictated take must not land there just because the
+  // user has never clicked in — it goes to the end instead.
   const caretPlacedRef = useRef(false);
 
   // The range the live dictation take occupies, or null between takes.
@@ -357,10 +357,10 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   // the latest value. Each setContent is a full markdown re-parse + doc
   // rebuild and freezes the renderer if applied per-chunk at ~30Hz+.
   //
-  // Skip the rebuild while a take is live — mapping cannot survive a
-  // full-doc replace, and the next setDictation would append instead of
-  // rewrite. `dictationActive` dropping retriggers this so enhance output
-  // that arrived mid-take still lands.
+  // Skip the rebuild while a take is live — mapping a replace-all collapses
+  // the range, so the next setDictation inserts instead of rewriting.
+  // `dictationActive` dropping retriggers this so enhance output that
+  // arrived mid-take still lands.
   useEffect(() => {
     if (!editor || dictationActive) return;
     if (editor.storage.markdown.getMarkdown() === value) return;

--- a/src/components/voice/voice-input-button.tsx
+++ b/src/components/voice/voice-input-button.tsx
@@ -28,7 +28,10 @@ import { toast } from 'sonner';
 type VoiceInputButtonProps = {
   /** The take so far, on every interim update — replaces the previous emission. */
   onTranscript: (text: string) => void;
-  /** A take is starting: anchor wherever the next `onTranscript` should land. */
+  /**
+   * A take is starting: anchor wherever the next `onTranscript` should land.
+   * Return `false` to abort before the recogniser starts (editor not ready).
+   */
   onStart?: () => boolean | void;
   /** The take ended; the last `onTranscript` text stands. */
   onEnd?: () => void;
@@ -81,22 +84,23 @@ export const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   className,
   language,
 }) => {
-  const { status, isSupported, startedAt, toggle, stop } = useSpeechDictation({
-    onTranscript,
-    onStart,
-    onEnd,
-    onError: reportDictationError,
-    language,
-  });
+  const { status, isSupported, startedAt, toggle, stop, abort } =
+    useSpeechDictation({
+      onTranscript,
+      onStart,
+      onEnd,
+      onError: reportDictationError,
+      language,
+    });
   const hydrated = useHydrated();
   const listening = status === 'listening';
 
   // Parent disable (save / enhance / prompt stream) must not leave a live
-  // take with no stop control — end the take, and keep the button clickable
-  // until it actually goes idle.
+  // take with no stop control. Abort + finish immediately so the editor's
+  // setContent skip drops; keep the button clickable until it goes idle.
   useEffect(() => {
-    if (disabled && listening) stop();
-  }, [disabled, listening, stop]);
+    if (disabled && listening) abort();
+  }, [disabled, listening, abort]);
 
   // Pre-hydration the button renders disabled so the row does not reflow when
   // it becomes live; only a browser that cannot dictate hides it.

--- a/src/components/voice/voice-input-button.tsx
+++ b/src/components/voice/voice-input-button.tsx
@@ -1,11 +1,12 @@
 /**
  * Mic button for dictating into a script or prompt field. Click to start, click
- * again (or press Escape) to stop. Words stream into the target as they are
- * spoken: `onTranscript` fires on every interim update with the take so far,
- * and the target replaces what it rendered for the previous update.
+ * again (or press Escape while the mic is focused) to stop. Words stream into
+ * the target as they are spoken: `onTranscript` fires on every interim update
+ * with the take so far, and the target replaces what it rendered last time.
  *
- * Recognition is the browser's own — nothing is recorded or uploaded by us —
- * so the button hides itself where the Web Speech API is missing (Firefox).
+ * OpenStory never records or POSTs audio; the browser vendor's recogniser
+ * typically does. The button hides itself when `SpeechRecognition` /
+ * `webkitSpeechRecognition` is missing (default Firefox today).
  */
 
 import { Button } from '@/components/ui/button';
@@ -28,7 +29,7 @@ type VoiceInputButtonProps = {
   /** The take so far, on every interim update — replaces the previous emission. */
   onTranscript: (text: string) => void;
   /** A take is starting: anchor wherever the next `onTranscript` should land. */
-  onStart?: () => void;
+  onStart?: () => boolean | void;
   /** The take ended; the last `onTranscript` text stands. */
   onEnd?: () => void;
   /** What is being dictated, for the tooltip and screen readers ("script", "prompt"). */
@@ -88,12 +89,19 @@ export const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
     language,
   });
   const hydrated = useHydrated();
+  const listening = status === 'listening';
+
+  // Parent disable (save / enhance / prompt stream) must not leave a live
+  // take with no stop control — end the take, and keep the button clickable
+  // until it actually goes idle.
+  useEffect(() => {
+    if (disabled && listening) stop();
+  }, [disabled, listening, stop]);
 
   // Pre-hydration the button renders disabled so the row does not reflow when
   // it becomes live; only a browser that cannot dictate hides it.
   if (hydrated && !isSupported) return null;
 
-  const listening = status === 'listening';
   const actionLabel = listening ? 'Stop dictating' : `Dictate ${label}`;
 
   return (
@@ -114,7 +122,7 @@ export const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
             className={className}
             aria-label={actionLabel}
             aria-pressed={listening}
-            disabled={disabled || !hydrated}
+            disabled={(disabled && !listening) || !hydrated}
             data-testid="voice-input-button"
             onClick={toggle}
             onKeyDown={(event) => {

--- a/src/hooks/use-dictation.ts
+++ b/src/hooks/use-dictation.ts
@@ -1,9 +1,10 @@
 /**
  * Wiring between a toolbar `VoiceInputButton` and the field it dictates into.
  *
- * Both bindings work the same way: the mic re-emits the whole take on every
- * interim update, so each one rewrites the take's text in place rather than
- * appending — that is what lets the recogniser revise words as they settle.
+ * Shared contract is take-rewrite: the mic re-emits the whole take on every
+ * interim update. The editor inserts at a live ProseMirror range (other
+ * keystrokes are remapped); a textarea freezes a prefix on start and rebuilds
+ * `prefix + take` (keystrokes during the take are overwritten).
  */
 
 import type { MarkdownEditorHandle } from '@/components/text-editor/markdown-editor';
@@ -13,13 +14,15 @@ import { useAsRef } from './use-as-ref';
 
 /**
  * Dictate into a `MarkdownEditor`. Spread `voice` onto the button and put
- * `ref` on the editor; the take lands at the caret the user last placed.
+ * `ref` on the editor; the take lands at the caret if one was placed, else
+ * at the end of the document. Returns `false` from `onStart` when the editor
+ * is not ready so the mic does not open.
  */
 export function useEditorDictation() {
   const ref = useRef<MarkdownEditorHandle>(null);
   const voice = useMemo(
     () => ({
-      onStart: () => ref.current?.beginDictation(),
+      onStart: () => ref.current?.beginDictation() ?? false,
       onTranscript: (text: string) => ref.current?.setDictation(text),
       onEnd: () => ref.current?.endDictation(),
     }),

--- a/src/hooks/use-speech-dictation.ts
+++ b/src/hooks/use-speech-dictation.ts
@@ -1,20 +1,22 @@
 /**
- * Live dictation for the script and prompt editors.
+ * Live dictation for script, prompt, and other text fields.
  *
  * Wraps the browser's `SpeechRecognition` so text streams in while the user
  * speaks: `onTranscript` fires on every interim update with the take *so far*,
- * and the caller replaces whatever it rendered last time. Nothing is recorded
- * and nothing is uploaded by us — the browser owns the mic and the recogniser.
+ * and the caller replaces whatever it rendered last time. OpenStory never
+ * records or POSTs audio; the browser vendor's recogniser typically does.
  *
  * Chromium ends a recognition session on its own after a stretch of silence,
- * so a take spans several sessions: finals are folded into `committedRef` as
- * each one ends and the recogniser is restarted until the user stops.
+ * so a take spans several sessions — see `createDictationSession`.
  */
 
 import {
+  createDictationSession,
+  DictationError,
+  type DictationSession,
+} from '@/lib/voice/dictation-session';
+import {
   getSpeechRecognition,
-  joinSpeech,
-  splitResults,
   type SpeechRecognition,
 } from '@/lib/voice/speech-recognition';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -22,29 +24,12 @@ import { useAsRef } from './use-as-ref';
 import { useHydrated } from './use-hydrated';
 
 export type DictationStatus = 'idle' | 'listening';
-
-/** A recogniser failure the caller should surface. `no-speech` never gets here. */
-export class DictationError extends Error {
-  constructor(readonly code: SpeechRecognitionErrorCode) {
-    super(DICTATION_ERROR_MESSAGES[code]);
-    this.name = 'DictationError';
-  }
-}
-
-const DICTATION_ERROR_MESSAGES: Record<SpeechRecognitionErrorCode, string> = {
-  aborted: 'Dictation stopped.',
-  'audio-capture': 'No microphone was found.',
-  'language-not-supported': 'Dictation is not available in this language.',
-  network: 'Dictation needs a network connection.',
-  'no-speech': 'No speech detected.',
-  'not-allowed': 'Microphone access is blocked.',
-  'phrases-not-supported': 'Dictation is not available in this browser.',
-  'service-not-allowed': 'Microphone access is blocked.',
-};
+export { DictationError };
 
 /**
  * A silent recogniser restarts indefinitely, so a forgotten open mic would
- * hold the browser's recording indicator forever. Bound one take.
+ * hold the browser's recording indicator forever. Bound one take to five
+ * minutes.
  */
 const MAX_DICTATION_MS = 5 * 60 * 1000;
 
@@ -54,8 +39,11 @@ export type UseSpeechDictationOptions = {
    * rather than appending to it — interim words are revised as they settle.
    */
   onTranscript: (text: string) => void;
-  /** A take is starting; no transcript has been emitted for it yet. */
-  onStart?: () => void;
+  /**
+   * A take is starting; no transcript has been emitted for it yet.
+   * Return `false` to abort before the recogniser starts (editor not ready).
+   */
+  onStart?: () => boolean | void;
   /** The take ended. The last `onTranscript` text stands. */
   onEnd?: () => void;
   onError?: (error: DictationError) => void;
@@ -82,16 +70,12 @@ export function useSpeechDictation({
   const onErrorRef = useAsRef(onError);
   const languageRef = useAsRef(language);
 
-  const recognitionRef = useRef<SpeechRecognition | null>(null);
-  /** Finals from earlier recognition sessions within the current take. */
-  const committedRef = useRef('');
-  /** Finals from the session that is running now, folded in when it ends. */
-  const sessionFinalRef = useRef('');
-  /** The user wants to keep dictating — drives the restart in `end`. */
+  const sessionRef = useRef<DictationSession | null>(null);
   const listeningRef = useRef(false);
 
   const finish = useCallback(() => {
     listeningRef.current = false;
+    sessionRef.current = null;
     setStatus('idle');
     setStartedAt(null);
     onEndRef.current?.();
@@ -100,67 +84,56 @@ export function useSpeechDictation({
   const stop = useCallback(() => {
     if (!listeningRef.current) return;
     listeningRef.current = false;
-    // `stop` keeps the phrase in flight; `end` then runs `finish`.
-    recognitionRef.current?.stop();
+    // `stop` keeps the phrase in flight; `onend` then runs `finish`.
+    sessionRef.current?.stop();
   }, []);
 
   const start = useCallback(() => {
     const SpeechRecognitionCtor = getSpeechRecognition();
     if (!SpeechRecognitionCtor || listeningRef.current) return;
 
-    const recognition = new SpeechRecognitionCtor();
+    // Anchor the target before opening the mic so a missing editor does not
+    // leave the recording indicator on with nowhere to put the words.
+    if (onStartRef.current?.() === false) return;
+
+    const recognition: SpeechRecognition = new SpeechRecognitionCtor();
     recognition.continuous = true;
     recognition.interimResults = true;
     recognition.maxAlternatives = 1;
     const lang = languageRef.current;
     if (lang) recognition.lang = lang;
 
-    recognition.onresult = (event) => {
-      const { final, interim } = splitResults(event.results);
-      sessionFinalRef.current = final;
-      onTranscriptRef.current(joinSpeech(committedRef.current, final, interim));
-    };
-
-    recognition.onerror = (event) => {
-      // Silence is not a failure: `end` restarts the recogniser after it.
-      if (event.error === 'no-speech') return;
-      listeningRef.current = false;
-      // 'aborted' is our own `abort()` from cancel/unmount.
-      if (event.error !== 'aborted') {
-        onErrorRef.current?.(new DictationError(event.error));
+    const session = createDictationSession(
+      {
+        start: () => recognition.start(),
+        stop: () => recognition.stop(),
+        abort: () => recognition.abort(),
+      },
+      {
+        onTranscript: (text) => onTranscriptRef.current(text),
+        onError: (error) => onErrorRef.current?.(error),
+        onEnd: finish,
       }
-    };
+    );
+    recognition.onresult = (event) => session.feedResults(event.results);
+    recognition.onerror = (event) => session.feedError(event.error);
+    recognition.onend = () => session.feedEnd();
 
-    recognition.onend = () => {
-      committedRef.current = joinSpeech(
-        committedRef.current,
-        sessionFinalRef.current
-      );
-      sessionFinalRef.current = '';
-      if (!listeningRef.current) {
-        recognitionRef.current = null;
-        finish();
-        return;
-      }
-      // Chromium ends the session after a stretch of silence — pick it back up.
-      recognition.start();
-    };
-
-    recognitionRef.current = recognition;
-    committedRef.current = '';
-    sessionFinalRef.current = '';
+    sessionRef.current = session;
+    if (!session.start()) {
+      // failStart already ran `finish` (toast + endDictation).
+      return;
+    }
     listeningRef.current = true;
-    recognition.start();
     setStatus('listening');
     setStartedAt(Date.now());
-    onStartRef.current?.();
   }, [finish, languageRef, onErrorRef, onStartRef, onTranscriptRef]);
 
   // Release the mic if the surface unmounts mid-take.
   useEffect(
     () => () => {
       listeningRef.current = false;
-      recognitionRef.current?.abort();
+      sessionRef.current?.abort();
     },
     []
   );

--- a/src/hooks/use-speech-dictation.ts
+++ b/src/hooks/use-speech-dictation.ts
@@ -74,19 +74,29 @@ export function useSpeechDictation({
   const listeningRef = useRef(false);
 
   const finish = useCallback(() => {
+    const wasLive = listeningRef.current || sessionRef.current !== null;
     listeningRef.current = false;
     sessionRef.current = null;
     setStatus('idle');
     setStartedAt(null);
-    onEndRef.current?.();
+    if (wasLive) onEndRef.current?.();
   }, [onEndRef]);
 
   const stop = useCallback(() => {
     if (!listeningRef.current) return;
-    listeningRef.current = false;
-    // `stop` keeps the phrase in flight; `onend` then runs `finish`.
+    // Keep the phrase in flight; `onend` then runs `finish`. If `stop()`
+    // throws (engine already inactive), the session calls `onEnd` itself.
     sessionRef.current?.stop();
   }, []);
+
+  const abort = useCallback(() => {
+    if (!listeningRef.current) return;
+    const session = sessionRef.current;
+    // Drop `dictationActive` now — do not wait for `onend`, or enhance /
+    // a shot switch stays locked behind the setContent skip.
+    finish();
+    session?.abort();
+  }, [finish]);
 
   const start = useCallback(() => {
     const SpeechRecognitionCtor = getSpeechRecognition();
@@ -94,7 +104,10 @@ export function useSpeechDictation({
 
     // Anchor the target before opening the mic so a missing editor does not
     // leave the recording indicator on with nowhere to put the words.
-    if (onStartRef.current?.() === false) return;
+    if (onStartRef.current?.() === false) {
+      onErrorRef.current?.(new DictationError('start-failed'));
+      return;
+    }
 
     const recognition: SpeechRecognition = new SpeechRecognitionCtor();
     recognition.continuous = true;
@@ -121,7 +134,7 @@ export function useSpeechDictation({
 
     sessionRef.current = session;
     if (!session.start()) {
-      // failStart already ran `finish` (toast + endDictation).
+      // failStart already fired `onError` and `onEnd` (`finish`).
       return;
     }
     listeningRef.current = true;
@@ -157,6 +170,7 @@ export function useSpeechDictation({
     startedAt,
     start,
     stop,
+    abort,
     toggle,
   };
 }

--- a/src/lib/voice/dictation-session.test.ts
+++ b/src/lib/voice/dictation-session.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDictationSession, DictationError } from './dictation-session';
+import type { RecognitionResults } from './speech-recognition';
+
+const resultList = (
+  entries: Array<{ transcript: string; isFinal: boolean }>
+): RecognitionResults =>
+  entries.map((entry) => ({
+    length: 1,
+    isFinal: entry.isFinal,
+    0: { transcript: entry.transcript },
+  }));
+
+const bind = (throwOnStart?: { current: boolean }) => {
+  const start = vi.fn(() => {
+    if (throwOnStart?.current) throw new Error('InvalidStateError');
+  });
+  const stop = vi.fn();
+  const abort = vi.fn();
+  const onTranscript = vi.fn();
+  const onError = vi.fn();
+  const onEnd = vi.fn();
+  const session = createDictationSession(
+    { start, stop, abort },
+    { onTranscript, onError, onEnd },
+    (fn) => fn()
+  );
+  return { session, start, stop, abort, onTranscript, onError, onEnd };
+};
+
+describe('createDictationSession', () => {
+  it('folds finals from a silence-restarted session into the next interim', () => {
+    const { session, start, onTranscript, onError } = bind();
+
+    expect(session.start()).toBe(true);
+    session.feedResults(
+      resultList([{ transcript: 'INT. KITCHEN', isFinal: true }])
+    );
+    session.feedError('no-speech');
+    session.feedEnd();
+    session.feedResults(resultList([{ transcript: 'night', isFinal: false }]));
+
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onTranscript).toHaveBeenLastCalledWith('INT. KITCHEN night');
+  });
+
+  it('toasts a real error and does not restart', () => {
+    const { session, start, onError, onEnd } = bind();
+
+    session.start();
+    session.feedError('not-allowed');
+    session.feedEnd();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const error = onError.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(DictationError);
+    expect(error).toMatchObject({ code: 'not-allowed' });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toast aborted from our own abort()', () => {
+    const { session, abort, onError, onEnd, start } = bind();
+
+    session.start();
+    session.abort();
+    session.feedError('aborted');
+    session.feedEnd();
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it('toasts an aborted the UA fired on its own', () => {
+    const { session, onError, onEnd } = bind();
+
+    session.start();
+    session.feedError('aborted');
+    session.feedEnd();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: 'aborted' });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when start() throws, without leaving the take running', () => {
+    const throwOnStart = { current: true };
+    const { session, start, onError, onEnd } = bind(throwOnStart);
+
+    expect(session.start()).toBe(false);
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: 'start-failed' });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+
+    throwOnStart.current = false;
+    expect(session.start()).toBe(true);
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when the silence-restart start() throws', () => {
+    const throwOnStart = { current: false };
+    const { session, start, onError, onEnd } = bind(throwOnStart);
+
+    session.start();
+    throwOnStart.current = true;
+    session.feedEnd();
+
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: 'start-failed' });
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/voice/dictation-session.test.ts
+++ b/src/lib/voice/dictation-session.test.ts
@@ -11,26 +11,40 @@ const resultList = (
     0: { transcript: entry.transcript },
   }));
 
-const bind = (throwOnStart?: { current: boolean }) => {
+const bind = ({
+  throwOnStart,
+  throwOnStop,
+  throwOnAbort,
+  scheduleRestart = (fn) => fn(),
+}: {
+  throwOnStart?: { current: boolean };
+  throwOnStop?: { current: boolean };
+  throwOnAbort?: { current: boolean };
+  scheduleRestart?: (fn: () => void) => void;
+} = {}) => {
   const start = vi.fn(() => {
     if (throwOnStart?.current) throw new Error('InvalidStateError');
   });
-  const stop = vi.fn();
-  const abort = vi.fn();
+  const stop = vi.fn(() => {
+    if (throwOnStop?.current) throw new Error('InvalidStateError');
+  });
+  const abort = vi.fn(() => {
+    if (throwOnAbort?.current) throw new Error('InvalidStateError');
+  });
   const onTranscript = vi.fn();
   const onError = vi.fn();
   const onEnd = vi.fn();
   const session = createDictationSession(
     { start, stop, abort },
     { onTranscript, onError, onEnd },
-    (fn) => fn()
+    scheduleRestart
   );
   return { session, start, stop, abort, onTranscript, onError, onEnd };
 };
 
 describe('createDictationSession', () => {
   it('folds finals from a silence-restarted session into the next interim', () => {
-    const { session, start, onTranscript, onError } = bind();
+    const { session, start, onTranscript, onError, onEnd } = bind();
 
     expect(session.start()).toBe(true);
     session.feedResults(
@@ -42,6 +56,7 @@ describe('createDictationSession', () => {
 
     expect(start).toHaveBeenCalledTimes(2);
     expect(onError).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
     expect(onTranscript).toHaveBeenLastCalledWith('INT. KITCHEN night');
   });
 
@@ -75,7 +90,7 @@ describe('createDictationSession', () => {
   });
 
   it('toasts an aborted the UA fired on its own', () => {
-    const { session, onError, onEnd } = bind();
+    const { session, start, onError, onEnd } = bind();
 
     session.start();
     session.feedError('aborted');
@@ -84,11 +99,12 @@ describe('createDictationSession', () => {
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: 'aborted' });
     expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed when start() throws, without leaving the take running', () => {
     const throwOnStart = { current: true };
-    const { session, start, onError, onEnd } = bind(throwOnStart);
+    const { session, start, onError, onEnd } = bind({ throwOnStart });
 
     expect(session.start()).toBe(false);
     expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: 'start-failed' });
@@ -101,7 +117,7 @@ describe('createDictationSession', () => {
 
   it('fails closed when the silence-restart start() throws', () => {
     const throwOnStart = { current: false };
-    const { session, start, onError, onEnd } = bind(throwOnStart);
+    const { session, start, onError, onEnd } = bind({ throwOnStart });
 
     session.start();
     throwOnStart.current = true;
@@ -110,5 +126,70 @@ describe('createDictationSession', () => {
     expect(onError.mock.calls[0]?.[0]).toMatchObject({ code: 'start-failed' });
     expect(onEnd).toHaveBeenCalledTimes(1);
     expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not restart after stop()', () => {
+    const { session, start, stop, onEnd, onError } = bind();
+
+    session.start();
+    session.stop();
+    session.feedEnd();
+
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('ends the take when stop() throws', () => {
+    const { session, onEnd, onError } = bind({
+      throwOnStop: { current: true },
+    });
+
+    session.start();
+    session.stop();
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('ends the take when abort() throws', () => {
+    const { session, onEnd, onError } = bind({
+      throwOnAbort: { current: true },
+    });
+
+    session.start();
+    session.abort();
+
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('skips recognition.abort() when the take is already idle', () => {
+    const { session, abort, onEnd } = bind();
+
+    session.abort();
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(onEnd).not.toHaveBeenCalled();
+  });
+
+  it('cancels a scheduled silence-restart if stop() wins the later turn', () => {
+    let pending: (() => void) | undefined;
+    const { session, start, onEnd, onError } = bind({
+      scheduleRestart: (fn) => {
+        pending = fn;
+      },
+    });
+
+    session.start();
+    session.feedEnd();
+    session.stop();
+    pending?.();
+    session.feedEnd();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/voice/dictation-session.ts
+++ b/src/lib/voice/dictation-session.ts
@@ -1,0 +1,150 @@
+/**
+ * One SpeechRecognition take: fold finals across Chromium silence-restarts,
+ * surface real errors, and restart until the user stops.
+ *
+ * OpenStory never records or POSTs audio. The browser vendor's recogniser
+ * typically does (Chromium → Google, Safari → Apple), which is why a
+ * `network` error exists and why `start()` can throw.
+ */
+
+import {
+  joinSpeech,
+  splitResults,
+  type RecognitionResults,
+} from './speech-recognition';
+
+type DictationErrorCode =
+  | Exclude<SpeechRecognitionErrorCode, 'no-speech'>
+  | 'start-failed';
+
+/** A recogniser failure the caller should surface. `no-speech` never gets here. */
+export class DictationError extends Error {
+  constructor(readonly code: DictationErrorCode) {
+    super(DICTATION_ERROR_MESSAGES[code]);
+    this.name = 'DictationError';
+  }
+}
+
+const DICTATION_ERROR_MESSAGES: Record<DictationErrorCode, string> = {
+  aborted: 'Dictation stopped.',
+  'audio-capture': 'No microphone was found.',
+  'language-not-supported': 'Dictation is not available in this language.',
+  network: 'Dictation needs a network connection.',
+  'not-allowed': 'Microphone access is blocked.',
+  'phrases-not-supported': 'Dictation is not available in this browser.',
+  'service-not-allowed': 'Microphone access is blocked.',
+  'start-failed': 'Dictation could not start. Try again.',
+};
+
+type DictationSessionCallbacks = {
+  onTranscript: (text: string) => void;
+  onError: (error: DictationError) => void;
+  onEnd: () => void;
+};
+
+type RecognitionControls = {
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+};
+
+export type DictationSession = {
+  /** Feed a `result` event. */
+  feedResults: (results: RecognitionResults) => void;
+  /** Feed an `error` event. */
+  feedError: (error: SpeechRecognitionErrorCode) => void;
+  /** Feed an `end` event. */
+  feedEnd: () => void;
+  start: () => boolean;
+  stop: () => void;
+  abort: () => void;
+};
+
+/**
+ * Drive one take from recogniser events. `scheduleRestart` defaults to
+ * `queueMicrotask` so Chromium's `end` → `start()` race (InvalidStateError)
+ * is not hit on the same turn.
+ */
+export function createDictationSession(
+  recognition: RecognitionControls,
+  callbacks: DictationSessionCallbacks,
+  scheduleRestart: (restart: () => void) => void = queueMicrotask
+): DictationSession {
+  let listening = false;
+  let aborting = false;
+  let committed = '';
+  let sessionFinal = '';
+
+  const tryStart = (): boolean => {
+    try {
+      recognition.start();
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const failStart = (): false => {
+    listening = false;
+    callbacks.onError(new DictationError('start-failed'));
+    callbacks.onEnd();
+    return false;
+  };
+
+  const feedResults = (results: RecognitionResults) => {
+    const { final, interim } = splitResults(results);
+    sessionFinal = final;
+    callbacks.onTranscript(joinSpeech(committed, final, interim));
+  };
+
+  const feedError = (error: SpeechRecognitionErrorCode) => {
+    // Silence is not a failure: `feedEnd` restarts the recogniser after it.
+    if (error === 'no-speech') return;
+    listening = false;
+    // `aborted` from our own `abort()` (unmount) is not a user-facing error.
+    // The UA also fires `aborted` when another recogniser starts or the tab
+    // is backgrounded — those we toast.
+    if (error === 'aborted' && aborting) return;
+    callbacks.onError(new DictationError(error));
+  };
+
+  const feedEnd = () => {
+    committed = joinSpeech(committed, sessionFinal);
+    sessionFinal = '';
+    if (!listening) {
+      callbacks.onEnd();
+      return;
+    }
+    // Chromium ends the session after a stretch of silence — pick it back up
+    // on a later turn so `start()` is not called while the engine is stopping.
+    scheduleRestart(() => {
+      if (!listening) return;
+      if (!tryStart()) failStart();
+    });
+  };
+
+  return {
+    feedResults,
+    feedError,
+    feedEnd,
+    start: () => {
+      if (listening) return true;
+      committed = '';
+      sessionFinal = '';
+      aborting = false;
+      listening = true;
+      if (!tryStart()) return failStart();
+      return true;
+    },
+    stop: () => {
+      if (!listening) return;
+      listening = false;
+      recognition.stop();
+    },
+    abort: () => {
+      listening = false;
+      aborting = true;
+      recognition.abort();
+    },
+  };
+}

--- a/src/lib/voice/dictation-session.ts
+++ b/src/lib/voice/dictation-session.ts
@@ -4,7 +4,8 @@
  *
  * OpenStory never records or POSTs audio. The browser vendor's recogniser
  * typically does (Chromium → Google, Safari → Apple), which is why a
- * `network` error exists and why `start()` can throw.
+ * `network` error exists. `start()` throws on Chromium's same-turn
+ * `end` → `start()` race, not because of that upload.
  */
 
 import {
@@ -17,7 +18,7 @@ type DictationErrorCode =
   | Exclude<SpeechRecognitionErrorCode, 'no-speech'>
   | 'start-failed';
 
-/** A recogniser failure the caller should surface. `no-speech` never gets here. */
+/** A failure the caller should surface. `no-speech` never gets here. */
 export class DictationError extends Error {
   constructor(readonly code: DictationErrorCode) {
     super(DICTATION_ERROR_MESSAGES[code]);
@@ -49,11 +50,8 @@ type RecognitionControls = {
 };
 
 export type DictationSession = {
-  /** Feed a `result` event. */
   feedResults: (results: RecognitionResults) => void;
-  /** Feed an `error` event. */
   feedError: (error: SpeechRecognitionErrorCode) => void;
-  /** Feed an `end` event. */
   feedEnd: () => void;
   start: () => boolean;
   stop: () => void;
@@ -101,9 +99,9 @@ export function createDictationSession(
     // Silence is not a failure: `feedEnd` restarts the recogniser after it.
     if (error === 'no-speech') return;
     listening = false;
-    // `aborted` from our own `abort()` (unmount) is not a user-facing error.
-    // The UA also fires `aborted` when another recogniser starts or the tab
-    // is backgrounded — those we toast.
+    // `aborted` from our own `abort()` (unmount / parent disable) is not a
+    // user-facing error. The UA also fires `aborted` when another recogniser
+    // starts — those we surface.
     if (error === 'aborted' && aborting) return;
     callbacks.onError(new DictationError(error));
   };
@@ -139,12 +137,22 @@ export function createDictationSession(
     stop: () => {
       if (!listening) return;
       listening = false;
-      recognition.stop();
+      try {
+        recognition.stop();
+      } catch {
+        // Engine already inactive — no `end` is coming.
+        callbacks.onEnd();
+      }
     },
     abort: () => {
-      listening = false;
       aborting = true;
-      recognition.abort();
+      if (!listening) return;
+      listening = false;
+      try {
+        recognition.abort();
+      } catch {
+        callbacks.onEnd();
+      }
     },
   };
 }

--- a/src/lib/voice/speech-recognition.ts
+++ b/src/lib/voice/speech-recognition.ts
@@ -2,9 +2,9 @@
  * Typed access to the Web Speech API's `SpeechRecognition`.
  *
  * `lib.dom` ships the event and result types but not the constructor — it is
- * still vendor-prefixed in Chromium (`webkitSpeechRecognition`) and absent in
- * Firefox — so the interface and the two globals are declared here rather
- * than reached through a cast.
+ * still vendor-prefixed in Chromium (`webkitSpeechRecognition`) and missing
+ * when the constructor is absent (default Firefox today) — so the interface
+ * and the two globals are declared here rather than reached through a cast.
  */
 
 export interface SpeechRecognition extends EventTarget {


### PR DESCRIPTION
## Related Issue

Follow-up to #1443 (no new issue).

## Summary of Changes

Dictation into image/motion prompts never counted as a user edit because the mic does not focus the editor, so Save stayed hidden and switching shots discarded the take.

Also:

- Keep the stop control enabled while a take is live. Parent disable (save / enhance / prompt stream) **aborts and finishes immediately** so TipTap `setContent` is no longer skipped waiting on `onend`.
- Skip TipTap `setContent` while a take is live so enhance/mention tagify cannot collapse the dictation range. Switching shots remounts the mic (`key={shot.id}`) and calls `endDictation` so the previous shot's document cannot land in the new draft.
- Extract `createDictationSession` so `start()` / `stop()` / `abort()` throwing `InvalidStateError` ends the take instead of wedging the mic. Chromium silence-restarts on a later turn; UA `aborted` is distinguished from our own abort.
- Toast when `onStart` returns `false` (editor not ready).

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Client-only dictation lifecycle. Session orchestration is unit-tested.

## Test plan

- [x] `bun run test src/lib/voice/` — silence restart + committed buffer, `not-allowed` vs own `aborted`, `start()`/`stop()`/`abort()` throw, stop does not restart, deferred restart cancelled
- [ ] Chrome: open a shot, click the image-prompt mic *without* clicking the editor, dictate, confirm Save appears
- [ ] Switch shots mid-take — previous prompt must not appear on the new shot; mic returns to idle
- [ ] Start dictating a script, click Enhance — take should stop immediately and enhance output should land
- [ ] Firefox: mic still hidden