### PR TITLE
fix(#1455): studio generate acknowledges the click at once

### DIFF
--- a/src/components/studio/studio-composer.tsx
+++ b/src/components/studio/studio-composer.tsx
@@ -128,6 +128,7 @@ import {
   AudioLines,
   Film,
   ImagePlus,
+  Loader2,
   RotateCcw,
   Shuffle,
   SlidersHorizontal,
@@ -816,7 +817,7 @@ export function StudioComposer({ activity }: StudioComposerProps) {
   };
 
   const submit = () => {
-    if (!canSubmit) return;
+    if (!canSubmit || create.isPending) return;
     if (trimmed.length === 0) {
       posthog.capture('empty_prompt_generate_clicked', {
         surface: 'studio',
@@ -1245,10 +1246,14 @@ export function StudioComposer({ activity }: StudioComposerProps) {
             type="submit"
             size="icon-lg"
             className="rounded-full"
-            aria-label={submitLabel}
-            disabled={!canSubmit}
+            aria-label={create.isPending ? 'Starting…' : submitLabel}
+            disabled={!canSubmit || create.isPending}
           >
-            <ArrowUp aria-hidden="true" />
+            {create.isPending ? (
+              <Loader2 className="animate-spin" aria-hidden="true" />
+            ) : (
+              <ArrowUp aria-hidden="true" />
+            )}
           </Button>
         </div>
       </div>

--- a/src/components/studio/studio-composer.tsx
+++ b/src/components/studio/studio-composer.tsx
@@ -66,6 +66,7 @@ import { useFalPricing } from '@/hooks/use-fal-pricing';
 import {
   useCreateStudioAssets,
   useDraftStudioPrompt,
+  useStudioPendingCreates,
 } from '@/hooks/use-studio-assets';
 import { useUploadTempMedia } from '@/hooks/use-talent';
 import {
@@ -155,6 +156,8 @@ const REFERENCE_TOKENS = {
 
 type StudioComposerProps = {
   activity: 'image' | 'video';
+  /** Prompts of generations still in flight — the editor pulses while it shows one. */
+  generatingPrompts: string[];
 };
 
 function referenceMentionItem(
@@ -274,13 +277,17 @@ function AddTile({
   );
 }
 
-export function StudioComposer({ activity }: StudioComposerProps) {
+export function StudioComposer({
+  activity,
+  generatingPrompts,
+}: StudioComposerProps) {
   const { requireAuth, isAuthenticated } = useAuthGate();
   const posthog = usePostHog();
   const { showGate } = useFalBillingGate();
   const { pricing } = useFalPricing();
   const create = useCreateStudioAssets();
   const draft = useDraftStudioPrompt();
+  const pendingCreates = useStudioPendingCreates(activity);
   const upload = useUploadTempMedia();
   const library = useStudioLibrary();
 
@@ -399,6 +406,12 @@ export function StudioComposer({ activity }: StudioComposerProps) {
   // cheapest place to open the login dialog or offer a random prompt. Only
   // an unready mode or an in-flight upload actually disables it.
   const canSubmit = modeReady && uploading === 0;
+  // The prompt, not the button, is what pulses while its generation runs
+  // (#1455) — and typing anything else stops it, even mid-generation.
+  const generating =
+    trimmed.length > 0 &&
+    (generatingPrompts.includes(trimmed) ||
+      pendingCreates.some((input) => input.prompt === trimmed));
 
   // --- references -----------------------------------------------------------
 
@@ -991,7 +1004,10 @@ export function StudioComposer({ activity }: StudioComposerProps) {
           placeholder={placeholder}
           aria-label="Prompt"
           data-testid="studio-prompt"
-          className="min-h-24 flex-1 border-0 bg-transparent px-1 py-1 shadow-none focus-within:ring-0 dark:bg-transparent"
+          className={cn(
+            'min-h-24 flex-1 border-0 bg-transparent px-1 py-1 shadow-none focus-within:ring-0 dark:bg-transparent',
+            generating && 'motion-safe:animate-pulse'
+          )}
           mentionItems={refsCapable ? mentionItems : undefined}
           onMentionSelect={onMentionSelect}
           onKeyDown={(event) => {

--- a/src/components/studio/studio-composer.tsx
+++ b/src/components/studio/studio-composer.tsx
@@ -128,7 +128,6 @@ import {
   AudioLines,
   Film,
   ImagePlus,
-  Loader2,
   RotateCcw,
   Shuffle,
   SlidersHorizontal,
@@ -1246,14 +1245,10 @@ export function StudioComposer({ activity }: StudioComposerProps) {
             type="submit"
             size="icon-lg"
             className="rounded-full"
-            aria-label={create.isPending ? 'Starting…' : submitLabel}
-            disabled={!canSubmit || create.isPending}
+            aria-label={submitLabel}
+            disabled={!canSubmit}
           >
-            {create.isPending ? (
-              <Loader2 className="animate-spin" aria-hidden="true" />
-            ) : (
-              <ArrowUp aria-hidden="true" />
-            )}
+            <ArrowUp aria-hidden="true" />
           </Button>
         </div>
       </div>

--- a/src/components/studio/studio-gallery.tsx
+++ b/src/components/studio/studio-gallery.tsx
@@ -22,6 +22,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { AppImage } from '@/components/ui/app-image';
 import {
   useDeleteStudioAsset,
+  useStudioPendingCreates,
   useToggleStudioFavorite,
 } from '@/hooks/use-studio-assets';
 import type { GeneratedAsset } from '@/lib/db/schema';
@@ -131,6 +132,24 @@ function StudioCard({
   );
 }
 
+/** Stand-in for a generation whose rows have not landed in the list yet (#1455). */
+function PendingCard({ aspectRatio }: { aspectRatio: string }) {
+  return (
+    <article className="relative overflow-hidden rounded-lg border bg-muted">
+      <Skeleton
+        className="w-full rounded-none"
+        style={{ aspectRatio: aspectRatio.replace(':', ' / ') }}
+      />
+      <p
+        aria-live="polite"
+        className="absolute inset-x-0 bottom-0 bg-background/80 px-2 py-1 text-xs text-muted-foreground"
+      >
+        Starting…
+      </p>
+    </article>
+  );
+}
+
 /** The opened asset at viewer size: the media fills the dialog, letterboxed. */
 function StudioViewer({ asset }: { asset: GeneratedAsset }) {
   const primary = studioPrimaryOutput(asset);
@@ -191,6 +210,12 @@ export function StudioGallery({
   const [openId, setOpenId] = useState<string | null>(null);
   const remove = useDeleteStudioAsset();
   const openAsset = assets.find((asset) => asset.id === openId);
+  const pending = useStudioPendingCreates(activity).flatMap((input, index) =>
+    Array.from({ length: input.count }, (_, i) => ({
+      key: `pending-${index}-${i}`,
+      aspectRatio: input.aspectRatio,
+    }))
+  );
 
   if (isLoading) {
     return (
@@ -205,7 +230,7 @@ export function StudioGallery({
     );
   }
 
-  if (assets.length === 0) {
+  if (assets.length === 0 && pending.length === 0) {
     return (
       <EmptyState
         icon={<Images className="h-12 w-12" />}
@@ -224,6 +249,11 @@ export function StudioGallery({
   return (
     <>
       <div className="columns-2 gap-4 md:columns-3 lg:columns-4">
+        {pending.map((tile) => (
+          <div key={tile.key} className="mb-4 break-inside-avoid">
+            <PendingCard aspectRatio={tile.aspectRatio} />
+          </div>
+        ))}
         {assets.map((asset) => (
           <div key={asset.id} className="mb-4 break-inside-avoid">
             <StudioCard asset={asset} onOpen={() => setOpenId(asset.id)} />

--- a/src/components/studio/studio-gallery.tsx
+++ b/src/components/studio/studio-gallery.tsx
@@ -32,9 +32,21 @@ import {
   studioPrimaryOutput,
   studioPrompt,
 } from '@/lib/studio/outputs';
+import { estimateStudioProgress } from '@/lib/studio/progress';
 import { cn } from '@/lib/utils';
 import { Download, Images, Star, Trash2 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
+/** Wall clock ticking once a second while `active`; null otherwise. */
+function useNow(active: boolean) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return active ? now : null;
+}
 
 function StudioCard({
   asset,
@@ -49,6 +61,15 @@ function StudioCard({
   const prompt = studioPrompt(asset);
   const inFlight = asset.status === 'queued' || asset.status === 'running';
   const isVideo = primary?.contentType.startsWith('video/');
+  const now = useNow(inFlight);
+  const progress =
+    now === null
+      ? null
+      : estimateStudioProgress(
+          asset.activity === 'video' ? 'video' : 'image',
+          asset.createdAt,
+          now
+        );
 
   return (
     <article className="group relative overflow-hidden rounded-lg border bg-muted">
@@ -123,9 +144,10 @@ function StudioCard({
       {inFlight && (
         <p
           aria-live="polite"
-          className="absolute inset-x-0 bottom-0 bg-background/80 px-2 py-1 text-xs text-muted-foreground"
+          className="absolute inset-x-0 bottom-0 bg-background/80 px-2 py-1 text-xs text-muted-foreground tabular-nums"
         >
           {asset.status === 'queued' ? 'Queued…' : 'Generating…'}
+          <span>{` ${progress ?? 0}%`}</span>
         </p>
       )}
     </article>

--- a/src/components/studio/studio-view.tsx
+++ b/src/components/studio/studio-view.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { PageContainer } from '@/components/layout/page-container';
 import { PageIntro } from '@/components/typography/page-intro';
 import { useStudioAssets } from '@/hooks/use-studio-assets';
+import { studioPrompt } from '@/lib/studio/outputs';
 import type { StudioActivity, StudioSort } from '@/lib/studio/schema';
 import { Link } from '@tanstack/react-router';
 import { Star } from 'lucide-react';
@@ -24,6 +25,9 @@ export function StudioView({ activity, sort, favorites }: StudioViewProps) {
   });
 
   const assets = query.data?.pages.flatMap((page) => page.assets) ?? [];
+  const generatingPrompts = assets
+    .filter((a) => a.status === 'queued' || a.status === 'running')
+    .map(studioPrompt);
   const to = activity === 'video' ? '/videos' : '/images';
 
   return (
@@ -103,7 +107,10 @@ export function StudioView({ activity, sort, favorites }: StudioViewProps) {
 
       <div className="shrink-0 border-t bg-background/80 backdrop-blur-md">
         <PageContainer maxWidth="wide" padding="compact" className="py-4">
-          <StudioComposer activity={activity} />
+          <StudioComposer
+            activity={activity}
+            generatingPrompts={generatingPrompts}
+          />
         </PageContainer>
       </div>
     </div>

--- a/src/hooks/use-studio-assets.ts
+++ b/src/hooks/use-studio-assets.ts
@@ -6,14 +6,16 @@ import {
   listStudioAssetsFn,
   setStudioAssetFavoriteFn,
 } from '@/functions/studio-assets';
-import type {
-  StudioActivity,
-  StudioCreateInput,
-  StudioSort,
+import {
+  studioCreateInputSchema,
+  type StudioActivity,
+  type StudioCreateInput,
+  type StudioSort,
 } from '@/lib/studio/schema';
 import {
   useInfiniteQuery,
   useMutation,
+  useMutationState,
   useQueryClient,
 } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -63,19 +65,40 @@ export function useStudioAssets(filters: StudioAssetFilters) {
   });
 }
 
+// Module-level so pending creates can be found by identity (no `mutationKey`:
+// a keyed mutation would stop the global cache from refreshing the balance).
+const createStudioAssets = (input: StudioCreateInput) =>
+  createStudioAssetsFn({ data: input });
+
 export function useCreateStudioAssets() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (input: StudioCreateInput) =>
-      createStudioAssetsFn({ data: input }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: studioAssetKeys.all });
-    },
+    mutationFn: createStudioAssets,
+    // Awaited so the mutation stays pending until the new rows are in the
+    // list — the composer's spinner and the gallery's placeholder tiles
+    // (#1455) hand off to the real queued tiles with no gap.
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: studioAssetKeys.all }),
     onError: (error) => {
       toast.error(error.message);
     },
   });
+}
+
+/** Inputs of studio generations still being started, newest first (#1455). */
+export function useStudioPendingCreates(activity: StudioActivity) {
+  return useMutationState({
+    filters: {
+      status: 'pending',
+      predicate: (mutation) =>
+        mutation.options.mutationFn === createStudioAssets,
+    },
+    select: (mutation) =>
+      studioCreateInputSchema.parse(mutation.state.variables),
+  })
+    .filter((input) => input.activity === activity)
+    .reverse();
 }
 
 export function useToggleStudioFavorite() {

--- a/src/lib/studio/progress.test.ts
+++ b/src/lib/studio/progress.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { estimateStudioProgress } from './progress';
+
+describe('estimateStudioProgress', () => {
+  const createdAt = new Date(1_000_000);
+  const at = (ms: number) => createdAt.getTime() + ms;
+
+  it('starts at zero and never reports done', () => {
+    expect(estimateStudioProgress('image', createdAt, at(0))).toBe(0);
+    expect(estimateStudioProgress('image', createdAt, at(-5_000))).toBe(0);
+    expect(estimateStudioProgress('video', createdAt, at(60 * 60_000))).toBe(
+      99
+    );
+  });
+
+  it('reaches half at one half-life and three quarters at two', () => {
+    expect(estimateStudioProgress('image', createdAt, at(5_000))).toBe(50);
+    expect(estimateStudioProgress('image', createdAt, at(10_000))).toBe(75);
+    expect(estimateStudioProgress('video', createdAt, at(40_000))).toBe(50);
+  });
+});

--- a/src/lib/studio/progress.ts
+++ b/src/lib/studio/progress.ts
@@ -1,0 +1,22 @@
+/**
+ * Guessed completion for an in-flight studio generation (#1455).
+ *
+ * Nothing upstream reports progress, so this is a half-life curve from the
+ * row's creation: 50% at one half-life, 75% at two, and so on, capped at 99
+ * until the row actually completes. Fast at first, then a crawl — the shape
+ * users read as "still working" rather than "stuck".
+ */
+
+// ponytail: one half-life per activity; swap for per-model observed medians
+// once generations record how long they took.
+const HALF_LIFE_MS = { image: 5_000, video: 40_000 } as const;
+
+export function estimateStudioProgress(
+  activity: 'image' | 'video',
+  createdAt: Date,
+  now: number
+): number {
+  const elapsed = Math.max(0, now - createdAt.getTime());
+  const fraction = 1 - 0.5 ** (elapsed / HALF_LIFE_MS[activity]);
+  return Math.min(99, Math.floor(fraction * 100));
+}


### PR DESCRIPTION
Closes #1455

## Problem
Generate on `/videos` and `/images` started a job (`studio_generation_started`) but the screen looked unchanged until the list refetched. New users clicked again and stacked duplicate jobs.

## Change
- **Grid:** draws "Starting…" placeholder tiles at the top the moment Generate is clicked, one per requested output at the requested aspect ratio, read from the pending mutation's input via `useMutationState`. Shows even when the library is empty.
- **Prompt pulses, not the button** (Grok Imagine pattern): the editor pulses while a generation for its exact text is in flight and stops as soon as the user types anything else, even mid-generation. Honors `prefers-reduced-motion`.
- **Estimated percentage** on in-flight tiles: "Generating… 42%". Nothing upstream reports progress, so it's a half-life curve from `createdAt` (50% at 5s for images, 40s for video; 75% at two half-lives), capped at 99 until the row completes. `src/lib/studio/progress.ts`, unit-tested.
- **Hand-off:** the create mutation awaits its list invalidation, so placeholders stay until the real queued tiles are in the list.
- **Button:** stays live and unchanged. A click while the previous start is still in flight is a no-op.

The mutation stays keyless on purpose: a `mutationKey` would stop the global mutation cache from refreshing the balance and other queries after a generation. Pending creates are matched by `mutationFn` identity instead.

## Follow-up
The half-lives are a static guess per activity. Recording how long generations actually take would let this be per-model medians.

## Files
- `src/lib/studio/progress.ts` (+ test)
- `src/hooks/use-studio-assets.ts`
- `src/components/studio/studio-composer.tsx`
- `src/components/studio/studio-gallery.tsx`
- `src/components/studio/studio-view.tsx`