### PR TITLE
fix(#1479): wording changes

### DIFF
--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -37,7 +37,7 @@ baseTest.describe('Route Protection', () => {
       const editor = page.locator('[data-slot="markdown-editor"]');
       await expect(
         page.getByText(
-          'Paste a screenplay, or a one-liner we can expand — not a prompt.'
+          'Paste a screenplay, or a one-liner we can expand - not a prompt.'
         )
       ).toBeVisible();
       const height = await editor.evaluate(

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -36,7 +36,9 @@ baseTest.describe('Route Protection', () => {
       await waitForScriptEditor(page);
       const editor = page.locator('[data-slot="markdown-editor"]');
       await expect(
-        page.getByText('Paste a screenplay, or a one-liner we can expand.')
+        page.getByText(
+          'Paste a screenplay, or a one-liner we can expand — not a prompt.'
+        )
       ).toBeVisible();
       const height = await editor.evaluate(
         (el) => el.getBoundingClientRect().height

--- a/e2e/tests/sequences.spec.ts
+++ b/e2e/tests/sequences.spec.ts
@@ -145,7 +145,7 @@ test.describe('Sequences', () => {
     );
     await expect(
       page.getByText(
-        'Paste a screenplay, or a one-liner we can expand — not a prompt.'
+        'Paste a screenplay, or a one-liner we can expand - not a prompt.'
       )
     ).toBeVisible();
     const automatic = page.getByRole('button', {

--- a/e2e/tests/sequences.spec.ts
+++ b/e2e/tests/sequences.spec.ts
@@ -144,7 +144,9 @@ test.describe('Sequences', () => {
       ''
     );
     await expect(
-      page.getByText('Paste a screenplay, or a one-liner we can expand.')
+      page.getByText(
+        'Paste a screenplay, or a one-liner we can expand — not a prompt.'
+      )
     ).toBeVisible();
     const automatic = page.getByRole('button', {
       name: 'Match script: derive a style from the script',

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -176,7 +176,7 @@ const DURATION_PRESETS = [
 /** Empty-composer copy (#1255): visible until the user types or shuffles.
  *  Keep this to ~1–2 lines so it fits the phone editor floor. */
 const COMPOSER_SCRIPT_PLACEHOLDER =
-  'Paste a screenplay, or a one-liner we can expand — not a prompt.';
+  'Paste a screenplay, or a one-liner we can expand - not a prompt.';
 
 function DurationFitHint({
   targetDuration,

--- a/src/components/script/script-view.tsx
+++ b/src/components/script/script-view.tsx
@@ -176,7 +176,7 @@ const DURATION_PRESETS = [
 /** Empty-composer copy (#1255): visible until the user types or shuffles.
  *  Keep this to ~1–2 lines so it fits the phone editor floor. */
 const COMPOSER_SCRIPT_PLACEHOLDER =
-  'Paste a screenplay, or a one-liner we can expand.';
+  'Paste a screenplay, or a one-liner we can expand — not a prompt.';
 
 function DurationFitHint({
   targetDuration,

--- a/src/lib/generation/pipeline.test.ts
+++ b/src/lib/generation/pipeline.test.ts
@@ -269,7 +269,7 @@ describe('completedStageFromArtifacts / nextActionFromArtifacts', () => {
     expect(sliderStopLabel('music')).toBe('Music & Motion');
     expect(sliderStopLabel('references')).toBe('References & Prompts');
     expect(sliderStopLabel('images')).toBe('Images');
-    expect(stopAfterSentence('motion')).toBe('Stop after motion & music');
+    expect(stopAfterSentence('motion')).toBe('Continue to the end');
   });
 
   it('slider has no Images stop in reference-only', () => {

--- a/src/lib/generation/pipeline.test.ts
+++ b/src/lib/generation/pipeline.test.ts
@@ -269,7 +269,7 @@ describe('completedStageFromArtifacts / nextActionFromArtifacts', () => {
     expect(sliderStopLabel('music')).toBe('Music & Motion');
     expect(sliderStopLabel('references')).toBe('References & Prompts');
     expect(sliderStopLabel('images')).toBe('Images');
-    expect(stopAfterSentence('motion')).toBe('Continue to the end');
+    expect(stopAfterSentence('motion')).toBe('Don’t stop');
   });
 
   it('slider has no Images stop in reference-only', () => {

--- a/src/lib/generation/pipeline.ts
+++ b/src/lib/generation/pipeline.ts
@@ -396,8 +396,8 @@ const STOP_AFTER_SENTENCE: Record<GenerationStage, string> = {
   script: 'Stop after casting',
   references: 'Stop after references & prompts',
   images: 'Stop after images',
-  motion: 'Continue to the end',
-  music: 'Continue to the end',
+  motion: 'Don’t stop',
+  music: 'Don’t stop',
 };
 
 export function stopAfterSentence(stopAt: GenerationStage): string {

--- a/src/lib/generation/pipeline.ts
+++ b/src/lib/generation/pipeline.ts
@@ -396,8 +396,8 @@ const STOP_AFTER_SENTENCE: Record<GenerationStage, string> = {
   script: 'Stop after casting',
   references: 'Stop after references & prompts',
   images: 'Stop after images',
-  motion: 'Stop after motion & music',
-  music: 'Stop after motion & music',
+  motion: 'Continue to the end',
+  music: 'Continue to the end',
 };
 
 export function stopAfterSentence(stopAt: GenerationStage): string {


### PR DESCRIPTION
Closes #1479

- Generate dialog's final slider stop now reads **Continue to the end** instead of "Stop after motion & music" (it isn't a stop).
- Sequence composer placeholder: "Paste a screenplay, or a one-liner we can expand — not a prompt."

E2E text assertions updated to match.