### PR TITLE
fix(#1433): ETA analysis tier follows the analysis model

### DIFF
--- a/e2e/tests/full-sequence.spec.ts
+++ b/e2e/tests/full-sequence.spec.ts
@@ -309,7 +309,7 @@ SUPER:  CORAL.  OUT NOW.
       await page.getByRole('button', { name: /^Generate$/i }).click();
 
       // Generate opens the stop-at alert (#1408) rather than starting the run.
-      // Its default is the full pipeline ("Music & Motion"), which is what this
+      // Its default is the full pipeline ("Motion & Music"), which is what this
       // spec asserts, so confirm without touching the slider. Scoped to the
       // dialog because the confirm button is also called "Generate".
       const stopAtAlert = page.getByRole('alertdialog');

--- a/src/components/generation/generation-progress-banner.tsx
+++ b/src/components/generation/generation-progress-banner.tsx
@@ -17,6 +17,7 @@ type GenerationProgressBannerProps = {
   script?: string;
   /** When set, used instead of the banner's own elapsed-based remaining. */
   remainingSeconds?: number;
+  analysisModel?: string | null;
   imageModel?: string | null;
   videoModel?: string | null;
   musicModel?: string | null;
@@ -32,6 +33,7 @@ export const GenerationProgressBanner: React.FC<
   startedAt,
   script,
   remainingSeconds,
+  analysisModel,
   imageModel,
   videoModel,
   musicModel,
@@ -64,7 +66,7 @@ export const GenerationProgressBanner: React.FC<
         sceneCount,
         estimatedSceneCount,
         generationState.phases.length,
-        { imageModel, videoModel, musicModel }
+        { analysisModel, imageModel, videoModel, musicModel }
       ) - elapsedSeconds
     );
 

--- a/src/components/generation/generation-stop-slider.tsx
+++ b/src/components/generation/generation-stop-slider.tsx
@@ -1,6 +1,7 @@
 import {
   GENERATION_STAGE_META,
   sliderStages,
+  sliderStopLabel,
   sliderThumbIndex,
   stopAfterSentence,
   stopAtFromSliderIndex,
@@ -99,8 +100,11 @@ export const GenerationStopSlider: FC<GenerationStopSliderProps> = ({
               )}
               style={{ left: `${stopLabelPercent(index, lastStop)}%` }}
             >
+              {/* Ticks name the stop; the heading above says what happens
+                  there. The last tick used stopAfterSentence, so it repeated
+                  the heading ("Don't stop") instead of naming the stage. */}
               {index === lastStop
-                ? stopAfterSentence(stage)
+                ? sliderStopLabel(stage)
                 : GENERATION_STAGE_META[stage].shortName}
             </button>
           ))}
@@ -115,7 +119,7 @@ export const GenerationStopSlider: FC<GenerationStopSliderProps> = ({
               onCheckedChange={(next) => {
                 onGenerateStartFramesChange(next);
                 // Off drops the Images stop; a thumb sitting on it moves up to
-                // Music & Motion so the parent's value matches the slider.
+                // Motion & Music so the parent's value matches the slider.
                 const nextStages = sliderStages(!next);
                 const moved = stopAtFromSliderIndex(
                   sliderThumbIndex(value, nextStages),

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -1454,6 +1454,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         sequence?.script ? estimateSceneCount(sequence.script) : undefined,
         generationState.phases.length,
         {
+          analysisModel: sequence?.analysisModel,
           imageModel: sequence?.imageModel,
           videoModel: sequence?.videoModel,
           musicModel: sequence?.musicModel,
@@ -1465,6 +1466,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
     generationState.phases,
     generationState.scenes.length,
     sequence?.script,
+    sequence?.analysisModel,
     sequence?.imageModel,
     sequence?.videoModel,
     sequence?.musicModel,
@@ -1481,6 +1483,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
       startedAt={sequence.updatedAt}
       script={sequence.script ?? undefined}
       remainingSeconds={remainingSeconds}
+      analysisModel={sequence.analysisModel}
       imageModel={sequence.imageModel}
       videoModel={sequence.videoModel}
       musicModel={sequence.musicModel}

--- a/src/components/settings/generation-settings-trigger.tsx
+++ b/src/components/settings/generation-settings-trigger.tsx
@@ -4,21 +4,15 @@ import {
   ASPECT_RATIOS,
   type AspectRatio,
 } from '@/shared/constants/aspect-ratios';
-import {
-  RESOLUTION_OPTIONS,
-  type Resolution,
-} from '@/shared/constants/resolutions';
 import { ChevronDown, SlidersHorizontal } from 'lucide-react';
 import type { FC, ComponentProps } from 'react';
 
 type GenerationSettingsTriggerProps = {
   aspectRatio: AspectRatio;
-  resolution: Resolution;
 } & ComponentProps<typeof Button>;
 
 export const GenerationSettingsTrigger: FC<GenerationSettingsTriggerProps> = ({
   aspectRatio,
-  resolution,
   ...props
 }) => {
   const aspectRatioData = ASPECT_RATIOS.find((r) => r.value === aspectRatio);
@@ -38,9 +32,6 @@ export const GenerationSettingsTrigger: FC<GenerationSettingsTriggerProps> = ({
         />
       )}
       <span className="font-mono text-sm">{aspectRatio}</span>
-      <span className="font-mono text-xs text-muted-foreground">
-        {RESOLUTION_OPTIONS.find((r) => r.value === resolution)?.label}
-      </span>
       <SlidersHorizontal className="size-3.5 text-muted-foreground" />
       <ChevronDown className="size-3.5 text-muted-foreground" />
     </Button>

--- a/src/components/settings/generation-settings.tsx
+++ b/src/components/settings/generation-settings.tsx
@@ -133,10 +133,7 @@ export const GenerationSettings: FC<GenerationSettingsProps> = ({
     <Popover open={open} onOpenChange={setOpen}>
       <div className="flex items-center gap-2 flex-wrap">
         <PopoverTrigger asChild disabled={disabled}>
-          <GenerationSettingsTrigger
-            aspectRatio={aspectRatio}
-            resolution={resolution}
-          />
+          <GenerationSettingsTrigger aspectRatio={aspectRatio} />
         </PopoverTrigger>
         {appliedFromStyle && onResetStyleDefaults && (
           <span className="inline-flex items-center gap-1.5 rounded-full bg-primary/10 text-primary px-2 py-0.5 text-xs">

--- a/src/lib/ai/generation-mode.test.ts
+++ b/src/lib/ai/generation-mode.test.ts
@@ -24,6 +24,7 @@ import {
   QUALITY_DEFAULT_VIDEO,
   selectorGroup,
   TURBO_ANALYSIS_MODELS,
+  isTurboAnalysisModel,
   TURBO_AUDIO_MODELS,
   TURBO_DEFAULT_ANALYSIS,
   TURBO_DEFAULT_AUDIO,
@@ -142,12 +143,17 @@ describe('styleMayApplyImage / styleMayApplyVideo', () => {
   });
 });
 
-describe('isTurboImageModel / isTurboVideoModel', () => {
+describe('isTurboAnalysisModel / isTurboImageModel / isTurboVideoModel', () => {
   it('flags Lite and H3 Max, not GPT Image 2 or Seedance', () => {
     expect(isTurboImageModel('nano_banana_2_lite')).toBe(true);
     expect(isTurboImageModel('gpt_image_2')).toBe(false);
     expect(isTurboVideoModel('minimax_h3_max')).toBe(true);
     expect(isTurboVideoModel('seedance_v2')).toBe(false);
+  });
+
+  it('flags Luna, not Fable', () => {
+    expect(isTurboAnalysisModel('openai/gpt-5.6-luna')).toBe(true);
+    expect(isTurboAnalysisModel('anthropic/claude-fable-5')).toBe(false);
   });
 });
 

--- a/src/lib/ai/generation-mode.ts
+++ b/src/lib/ai/generation-mode.ts
@@ -69,8 +69,13 @@ export const QUALITY_DEFAULT_IMAGE = 'gpt_image_2' as const;
 export const QUALITY_DEFAULT_VIDEO = 'seedance_v2' as const;
 export const QUALITY_DEFAULT_AUDIO = 'elevenlabs_music' as const;
 
+const TURBO_ANALYSIS_MODEL_SET = new Set<string>(TURBO_ANALYSIS_MODELS);
 const TURBO_IMAGE_MODEL_SET = new Set<string>(TURBO_IMAGE_MODELS);
 const TURBO_VIDEO_MODEL_SET = new Set<string>(TURBO_VIDEO_MODELS);
+
+export function isTurboAnalysisModel(model: string): boolean {
+  return TURBO_ANALYSIS_MODEL_SET.has(model);
+}
 
 export function isTurboImageModel(model: string): boolean {
   return TURBO_IMAGE_MODEL_SET.has(model);

--- a/src/lib/realtime/generation-stream.reducer.test.ts
+++ b/src/lib/realtime/generation-stream.reducer.test.ts
@@ -193,7 +193,7 @@ describe('generationStreamReducer — stop-at banner (#1408)', () => {
     expect(next.phases.map((p) => p.shortName)).toEqual([
       'Casting',
       'References',
-      'Music & Motion',
+      'Motion & Music',
     ]);
     expect(next.phases.map((p) => p.status)).toEqual([
       'completed',
@@ -216,7 +216,7 @@ describe('progress phases in reference-only', () => {
     expect(shortNames({ stopAt: 'music', referenceOnly: true })).toEqual([
       'Casting',
       'References',
-      'Music & Motion',
+      'Motion & Music',
     ]);
 
     expect(
@@ -231,7 +231,7 @@ describe('progress phases in reference-only', () => {
       'Casting',
       'References',
       'Images',
-      'Music & Motion',
+      'Motion & Music',
     ]);
   });
 

--- a/src/lib/realtime/generation-stream.reducer.ts
+++ b/src/lib/realtime/generation-stream.reducer.ts
@@ -218,7 +218,7 @@ export function createInitialState(
       return {
         phase: meta.phase,
         phaseName: isCombinedLast ? 'Generating motion & music…' : meta.name,
-        shortName: isCombinedLast ? 'Music & Motion' : meta.shortName,
+        shortName: isCombinedLast ? 'Motion & Music' : meta.shortName,
         status: 'pending' as const,
       };
     });

--- a/src/lib/workflows/analyze-script-workflow.ts
+++ b/src/lib/workflows/analyze-script-workflow.ts
@@ -913,7 +913,7 @@ export class AnalyzeScriptWorkflow extends OpenStoryWorkflowEntrypoint<AnalyzeSc
     // ----------------------------------------------------------------------
     // Reference-only has no phase 4: the stills are skipped and the prompts
     // finished in phase 3, so it emits nothing and the progress rail runs
-    // Script → References → Music & Motion.
+    // Script → References → Motion & Music.
     if (!referenceOnly) {
       await step.do('phase-4-start', async () => {
         await getGenerationChannel(sequenceId).emit('generation.phase:start', {

--- a/src/shared/generation/pipeline.test.ts
+++ b/src/shared/generation/pipeline.test.ts
@@ -260,13 +260,13 @@ describe('completedStageFromArtifacts / nextActionFromArtifacts', () => {
     ]);
   });
 
-  it('slider folds music into the last stop (Music & Motion)', () => {
+  it('slider folds music into the last stop (Motion & Music)', () => {
     const stages = sliderStages(false);
     expect(stages).toEqual(['script', 'references', 'images', 'motion']);
     expect(stopAtFromSliderIndex(3, stages)).toBe('music');
     expect(sliderThumbIndex('music', stages)).toBe(3);
     expect(sliderThumbIndex('motion', stages)).toBe(3);
-    expect(sliderStopLabel('music')).toBe('Music & Motion');
+    expect(sliderStopLabel('music')).toBe('Motion & Music');
     expect(sliderStopLabel('references')).toBe('References & Prompts');
     expect(sliderStopLabel('images')).toBe('Images');
     expect(stopAfterSentence('motion')).toBe('Don’t stop');
@@ -275,7 +275,7 @@ describe('completedStageFromArtifacts / nextActionFromArtifacts', () => {
   it('slider has no Images stop in reference-only', () => {
     const stages = sliderStages(true);
     expect(stages).toEqual(['script', 'references', 'motion']);
-    // A remembered Images stop lands on the next stop up, Music & Motion.
+    // A remembered Images stop lands on the next stop up, Motion & Music.
     expect(sliderThumbIndex('images', stages)).toBe(2);
     expect(stopAtFromSliderIndex(2, stages)).toBe('music');
     expect(sliderThumbIndex('references', stages)).toBe(1);

--- a/src/shared/generation/pipeline.ts
+++ b/src/shared/generation/pipeline.ts
@@ -102,7 +102,7 @@ export const GENERATION_STAGE_META: Record<
     shortName: 'Music',
     description: 'Generating the sequence music track',
     // The `music` stop runs motion AND music in one workflow child, which is
-    // why the slider calls it "Music & Motion". The button has to promise the
+    // why the slider calls it "Motion & Music". The button has to promise the
     // same thing — "Generate Music" under-sold the whole motion pass (#1408).
     actionLabel: 'Generate Motion & Music',
   },
@@ -335,7 +335,7 @@ export type GenerationCheckpoint = {
 /**
  * Progress-banner phases for a run that stops at `stopAt`. Music rides with
  * motion in one workflow child, so a music stop still has four banner
- * segments — the last one labelled "Music & Motion".
+ * segments — the last one labelled "Motion & Music".
  */
 export function bannerStagesForStopAt(
   stopAt: GenerationStage
@@ -348,7 +348,7 @@ export function bannerStagesForStopAt(
 
 /**
  * Generate-dialog / continue-slider stops. Same as a full-run banner — the
- * last thumb is Music & Motion (`stopAt: 'music'`). Reference-only has no
+ * last thumb is Motion & Music (`stopAt: 'music'`). Reference-only has no
  * Images stop: nothing renders there, so the thumb goes References → Motion.
  */
 export function sliderStages(referenceOnly: boolean): GenerationStage[] {
@@ -383,7 +383,7 @@ export function stopAtFromSliderIndex(
 }
 
 export function sliderStopLabel(stopAt: GenerationStage): string {
-  if (stopAt === 'music' || stopAt === 'motion') return 'Music & Motion';
+  if (stopAt === 'music' || stopAt === 'motion') return 'Motion & Music';
   if (stopAt === 'references') return 'References & Prompts';
   return GENERATION_STAGE_META[stopAt].shortName;
 }

--- a/src/shared/generation/time-estimate.test.ts
+++ b/src/shared/generation/time-estimate.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from 'vitest';
 import {
   countScriptSceneHeadings,
   estimateMotionSeconds,
-  estimateRemainingSeconds,
   estimateSceneCount,
   estimateSceneCountFromDuration,
   estimateTotalSeconds,
@@ -104,9 +103,11 @@ describe('estimateSceneCountFromDuration', () => {
 });
 
 describe('estimateTotalSeconds', () => {
-  test('quality GPT Image 2 + Seedance is one parallel video wave', () => {
-    // 109+18+126+143+288 from PostHog p90s (30d ending 2026-09-01)
-    expect(estimateTotalSeconds(6)).toBe(684);
+  test('defaults are GPT Image 2 + Seedance stills/motion, Luna analysis', () => {
+    // Image/video p90s from PostHog (30d ending 2026-09-01). Analysis falls
+    // back to DEFAULT_ANALYSIS_MODEL (Luna, fast) like the other wall clocks,
+    // so the default pair is deliberately mixed-tier.
+    expect(estimateTotalSeconds(6)).toBe(641);
   });
 
   test('uses default scene count for 0', () => {
@@ -122,14 +123,55 @@ describe('estimateTotalSeconds', () => {
   });
 
   test('turbo Lite + H3 Max is ~2.5 min, not a Seedance-class 11 min', () => {
-    const quality = estimateTotalSeconds(5);
+    const defaults = estimateTotalSeconds(5);
     const turbo = estimateTotalSeconds(5, undefined, undefined, {
+      analysisModel: 'openai/gpt-5.6-luna',
       imageModel: 'nano_banana_2_lite',
       videoModel: 'minimax_h3_max',
     });
-    expect(quality).toBe(674);
+    expect(defaults).toBe(635);
     expect(turbo).toBe(151);
-    expect(turbo).toBeLessThan(quality / 2);
+    expect(turbo).toBeLessThan(defaults / 2);
+  });
+
+  test('analysis tier follows the analysis model, not the image model', () => {
+    // Both mixed pairs named in #1433.
+    const liteFable = estimateTotalSeconds(5, undefined, undefined, {
+      analysisModel: 'anthropic/claude-fable-5',
+      imageModel: 'nano_banana_2_lite',
+    });
+    const liteLuna = estimateTotalSeconds(5, undefined, undefined, {
+      analysisModel: 'openai/gpt-5.6-luna',
+      imageModel: 'nano_banana_2_lite',
+    });
+    expect(liteFable).toBeGreaterThan(liteLuna);
+
+    const gptImageLuna = estimateTotalSeconds(5, undefined, undefined, {
+      analysisModel: 'openai/gpt-5.6-luna',
+      imageModel: 'gpt_image_2',
+    });
+    const gptImageFable = estimateTotalSeconds(5, undefined, undefined, {
+      analysisModel: 'anthropic/claude-fable-5',
+      imageModel: 'gpt_image_2',
+    });
+    expect(gptImageLuna).toBeLessThan(gptImageFable);
+
+    // Same image model, so the whole gap is the analysis tier.
+    expect(liteFable - liteLuna).toBe(gptImageFable - gptImageLuna);
+  });
+
+  test('a retired analysis id scores the app default, not quality', () => {
+    // The `sequences.analysisModel` SQL default is a pinned legacy literal
+    // that is no longer in the registry (#612 blocks changing it).
+    const legacy = estimateTotalSeconds(5, undefined, undefined, {
+      analysisModel: 'anthropic/claude-haiku-4.5',
+      imageModel: 'gpt_image_2',
+    });
+    expect(legacy).toBe(
+      estimateTotalSeconds(5, undefined, undefined, {
+        imageModel: 'gpt_image_2',
+      })
+    );
   });
 });
 
@@ -148,44 +190,6 @@ describe('estimateMotionSeconds', () => {
 
   test('Hailuo stays Seedance-class even though it is in the turbo picker', () => {
     expect(estimateMotionSeconds('minimax_hailuo_02', 5)).toBe(228);
-  });
-});
-
-describe('estimateRemainingSeconds', () => {
-  test('decreases as phases complete', () => {
-    const full = estimateRemainingSeconds({
-      sceneCount: 6,
-      completedPhases: [],
-      elapsedSeconds: 0,
-    });
-
-    const partial = estimateRemainingSeconds({
-      sceneCount: 6,
-      completedPhases: [1, 2, 3],
-      elapsedSeconds: 30,
-    });
-
-    expect(partial).toBeLessThan(full);
-  });
-
-  test('never returns negative', () => {
-    const result = estimateRemainingSeconds({
-      sceneCount: 6,
-      completedPhases: [1, 2, 3, 4, 5],
-      elapsedSeconds: 9999,
-    });
-
-    expect(result).toBe(0);
-  });
-
-  test('returns 0 when all phases completed', () => {
-    const result = estimateRemainingSeconds({
-      sceneCount: 1,
-      completedPhases: [1, 2, 3, 4, 5],
-      elapsedSeconds: 0,
-    });
-
-    expect(result).toBe(0);
   });
 });
 

--- a/src/shared/generation/time-estimate.ts
+++ b/src/shared/generation/time-estimate.ts
@@ -8,7 +8,11 @@
  * badly undercounts (e.g. 29 labeled scenes → ~8 by words → ~⅓ the real cost).
  */
 
-import { isTurboImageModel } from '@/lib/ai/generation-mode';
+import { isTurboAnalysisModel } from '@/lib/ai/generation-mode';
+import {
+  DEFAULT_ANALYSIS_MODEL,
+  isValidAnalysisModelId,
+} from '@/lib/ai/models.config';
 import {
   ANALYSIS_FAST,
   ANALYSIS_QUALITY,
@@ -25,6 +29,7 @@ import {
 type PhaseBudget = { base: number; perScene: number };
 
 export type TimeEstimateModels = {
+  analysisModel?: string | null;
   imageModel?: string | null;
   videoModel?: string | null;
   musicModel?: string | null;
@@ -51,9 +56,16 @@ export function estimateMusicSeconds(musicModel?: string | null): number {
 
 function phaseBudgets(models?: TimeEstimateModels): readonly PhaseBudget[] {
   const image = imageWallClock(models?.imageModel);
-  const fastAnalysis = Boolean(
-    models?.imageModel && isTurboImageModel(models.imageModel)
-  );
+  // Analysis + casting are LLM phases: their tier follows the analysis model,
+  // which is picked independently of the image model. Absent or retired ids
+  // (e.g. the legacy `analysisModel` column default) fall back to the app
+  // default, matching imageWallClock / videoWallClock / audioWallClock —
+  // defaulting to quality instead would re-create this bug for those rows.
+  const analysisModel =
+    models?.analysisModel && isValidAnalysisModelId(models.analysisModel)
+      ? models.analysisModel
+      : DEFAULT_ANALYSIS_MODEL;
+  const fastAnalysis = isTurboAnalysisModel(analysisModel);
   const analysis = fastAnalysis ? ANALYSIS_FAST : ANALYSIS_QUALITY;
   const casting = fastAnalysis ? CASTING_FAST : CASTING_QUALITY;
   const sheets = Math.max(VISUAL_PROMPT_P90_SECONDS, image.p90);
@@ -203,34 +215,6 @@ export function estimateTotalSeconds(
     total += phaseBudget(i, scenes, models);
   }
   return total;
-}
-
-export function estimateRemainingSeconds(opts: {
-  sceneCount: number;
-  completedPhases: number[];
-  elapsedSeconds: number;
-  estimatedSceneCount?: number;
-  imageModel?: string | null;
-  videoModel?: string | null;
-  musicModel?: string | null;
-}): number {
-  const models = {
-    imageModel: opts.imageModel,
-    videoModel: opts.videoModel,
-    musicModel: opts.musicModel,
-  };
-  const fallback = opts.estimatedSceneCount ?? DEFAULT_SCENE_COUNT;
-  const scenes = opts.sceneCount > 0 ? opts.sceneCount : fallback;
-  const completedSet = new Set(opts.completedPhases);
-
-  let remaining = 0;
-  for (let i = 0; i < PIPELINE_PHASE_COUNT; i++) {
-    if (!completedSet.has(i + 1)) {
-      remaining += phaseBudget(i, scenes, models);
-    }
-  }
-
-  return Math.max(0, remaining);
 }
 
 export function formatTimeRemaining(seconds: number): string {


### PR DESCRIPTION
Closes #1433.

`phaseBudgets` picked the fast/quality budget for the Script phase (analysis + casting) from `isTurboImageModel(models.imageModel)`. Those are LLM phases and the analysis model is selected independently of the image model, so mixed pairs got the wrong ETA — Lite + Fable underestimated, GPT Image 2 + Luna overestimated.

- New `isTurboAnalysisModel` next to the existing image/video predicates.
- `TimeEstimateModels` gains `analysisModel`; analysis/casting tier reads it, image latency still comes from the image model.
- `GenerationProgressBanner` and the `ScenesView` estimate pass `sequence.analysisModel`.
- Test covers both mixed pairs.
