### PR TITLE
fix(#1299): low-balance toast carries the offer, not "Options"

### DIFF
--- a/src/components/billing/add-credits-dialog.tsx
+++ b/src/components/billing/add-credits-dialog.tsx
@@ -62,6 +62,9 @@ import { ulid } from 'ulid';
 /** Sentinel Select value for "pay with a new card at checkout". */
 const NEW_CARD = 'new-card';
 
+/** Amount the dialog opens on — matches the low-balance toast's "Add $10". */
+const DEFAULT_TOPUP_AMOUNT = String(MIN_TOPUP_AMOUNT_USD);
+
 function formatBrand(brand: string): string {
   return brand.charAt(0).toUpperCase() + brand.slice(1);
 }
@@ -72,17 +75,7 @@ export function AddCreditsDialog() {
   const queryClient = useQueryClient();
   const posthog = usePostHog();
 
-  // Every "Add credits" button routes through openAddCreditsDialog(surface),
-  // so one capture here covers them all (#1301).
-  useEffect(() => {
-    if (open) {
-      posthog.capture('add_credits_clicked', {
-        surface: getAddCreditsSurface(),
-      });
-    }
-  }, [open, posthog]);
-
-  const [amount, setAmount] = useState('10');
+  const [amount, setAmount] = useState(DEFAULT_TOPUP_AMOUNT);
   const [selectedPm, setSelectedPm] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   /**
@@ -91,6 +84,19 @@ export function AddCreditsDialog() {
    * whose charge actually landed can never charge or credit a second time.
    */
   const [requestId, setRequestId] = useState(() => ulid());
+
+  // Every "Add credits" button routes through openAddCreditsDialog(surface),
+  // so one capture here covers them all (#1301).
+  useEffect(() => {
+    if (open) {
+      posthog.capture('add_credits_clicked', {
+        surface: getAddCreditsSurface(),
+      });
+      // The dialog is mounted once, so a previously typed amount would still
+      // be sitting there — and the low-balance toast promises "Add $10" (#1299).
+      setAmount(DEFAULT_TOPUP_AMOUNT);
+    }
+  }, [open, posthog]);
 
   const {
     data: pmData,

--- a/src/components/billing/low-balance-toast.stories.tsx
+++ b/src/components/billing/low-balance-toast.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useCallback, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Toaster } from '@/components/ui/sonner';
+import { TYPICAL_SHORT_COST_USD } from '@/lib/billing/constants';
+import {
+  showLowBalanceToast,
+  type LowBalanceToastProps,
+} from './low-balance-toast';
+
+/**
+ * The hook only fires this on a real balance *decrease* across the threshold,
+ * so the story calls it directly. Sonner needs a mounted <Toaster/> — the app
+ * has one in Providers, the Storybook preview does not.
+ */
+function ToastHarness({
+  balanceUsd,
+  isZeroBalance,
+  runCostUsd,
+}: Omit<LowBalanceToastProps, 'onAddCredits' | 'onOtherOptions'>) {
+  const show = useCallback(
+    () =>
+      showLowBalanceToast({
+        balanceUsd,
+        isZeroBalance,
+        runCostUsd,
+        onAddCredits: () => console.log('Add credits'),
+        onOtherOptions: () => console.log('Other options'),
+      }),
+    [balanceUsd, isZeroBalance, runCostUsd]
+  );
+
+  useEffect(() => {
+    show();
+  }, [show]);
+
+  return (
+    <div className="flex min-h-40 items-start p-4">
+      <Button variant="secondary" onClick={show}>
+        Show toast again
+      </Button>
+      <Toaster />
+    </div>
+  );
+}
+
+const meta: Meta<typeof ToastHarness> = {
+  title: 'Billing/LowBalanceToast',
+  component: ToastHarness,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ToastHarness>;
+
+export const LowBalance: Story = {
+  render: () => (
+    <ToastHarness
+      balanceUsd={4.21}
+      isZeroBalance={false}
+      runCostUsd={TYPICAL_SHORT_COST_USD}
+    />
+  ),
+};
+
+export const ZeroBalance: Story = {
+  render: () => (
+    <ToastHarness
+      balanceUsd={0}
+      isZeroBalance
+      runCostUsd={TYPICAL_SHORT_COST_USD}
+    />
+  ),
+};

--- a/src/components/billing/low-balance-toast.ts
+++ b/src/components/billing/low-balance-toast.ts
@@ -1,0 +1,60 @@
+/**
+ * Low-balance toast (#1299).
+ *
+ * The toast carries the offer — "Add $10" as the primary action, with the
+ * gate's other paths (BYOK, gift codes, founder credits) on Sonner's `cancel`
+ * slot. Separated from `useLowBalanceWarning` so the copy and both buttons
+ * are viewable in Storybook without a real balance drop; the hook owns when
+ * it fires, the analytics, and what the buttons open.
+ */
+
+import { MIN_TOPUP_AMOUNT_USD } from '@/lib/billing/constants';
+import type { CSSProperties } from 'react';
+import { toast } from 'sonner';
+
+export type LowBalanceToastProps = {
+  balanceUsd: number;
+  isZeroBalance: boolean;
+  /** Live estimate for another default short — see `typicalShortCostUsd`. */
+  runCostUsd: number;
+  onAddCredits: () => void;
+  onOtherOptions: () => void;
+};
+
+export function showLowBalanceToast({
+  balanceUsd,
+  isZeroBalance,
+  runCostUsd,
+  onAddCredits,
+  onOtherOptions,
+}: LowBalanceToastProps) {
+  const action = {
+    label: `Add $${MIN_TOPUP_AMOUNT_USD}`,
+    onClick: onAddCredits,
+  };
+  const cancel = { label: 'Other options', onClick: onOtherOptions };
+  // Two buttons on one toast squeeze the text column to ~4 wrapped lines at
+  // Sonner's default 356px. Widened here rather than on the Toaster — every
+  // other toast in the app has at most one action. Sonner reads `--width`;
+  // setting `width` directly would beat its <600px "fill the screen" rule.
+  const style: CSSProperties & { '--width': string } = { '--width': '440px' };
+
+  if (isZeroBalance) {
+    toast.error('Your credit balance is $0', {
+      description: 'Generation is off until you add credits.',
+      action,
+      cancel,
+      style,
+      duration: 10_000,
+    });
+    return;
+  }
+
+  toast.warning(`Balance is $${balanceUsd.toFixed(2)}`, {
+    description: `Another short is about $${Math.round(runCostUsd)}.`,
+    action,
+    cancel,
+    style,
+    duration: 8_000,
+  });
+}

--- a/src/hooks/use-low-balance-warning.ts
+++ b/src/hooks/use-low-balance-warning.ts
@@ -6,12 +6,17 @@
 import { usePostHog } from '@posthog/react';
 import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
+import { openAddCreditsDialog } from './use-add-credits-dialog';
 import { openBillingGate } from './use-billing-gate-dialog';
 import { useBillingBalance } from './use-billing-balance';
+import { useFalPricing } from './use-fal-pricing';
+import { MIN_TOPUP_AMOUNT_USD } from '@/lib/billing/constants';
+import { typicalShortCostUsd } from '@/lib/billing/typical-short-cost';
 
 export function useLowBalanceWarning() {
   const { balance, isLowBalance, isZeroBalance, lowBalanceThreshold } =
     useBillingBalance();
+  const { pricing } = useFalPricing();
   const posthog = usePostHog();
   const prevBalanceRef = useRef<number | null>(null);
   const hasWarnedRef = useRef(false);
@@ -36,30 +41,55 @@ export function useLowBalanceWarning() {
     if (hasWarnedRef.current) return;
     if (!isZeroBalance && !isLowBalance) return;
 
-    // "Options" opens the billing gate — buying credits, asking the founder,
-    // fal.ai BYOK, and gift codes all live there (#1099).
     hasWarnedRef.current = true;
-    const props = { balance_usd: balance };
+    const props = { balance_usd: balance, is_zero: isZeroBalance };
     posthog.capture('low_balance_toast_shown', props);
+
+    // The offer itself is the primary action (#1299) — the toast was the most
+    // reacted-to billing moment and sent people to pricing to find it. The
+    // gate (BYOK, gift codes, founder credits) stays one tap away.
     const action = {
-      label: 'Options',
+      label: `Add $${MIN_TOPUP_AMOUNT_USD}`,
       onClick: () => {
-        posthog.capture('low_balance_toast_clicked', props);
+        posthog.capture('low_balance_toast_clicked', {
+          ...props,
+          choice: 'add_credits',
+        });
+        openAddCreditsDialog('low_balance_toast');
+      },
+    };
+    const cancel = {
+      label: 'Other options',
+      onClick: () => {
+        posthog.capture('low_balance_toast_clicked', {
+          ...props,
+          choice: 'other_options',
+        });
         openBillingGate(isZeroBalance ? 'zero' : 'manual');
       },
     };
+
     if (isZeroBalance) {
       toast.error('Your credit balance is $0', {
-        description: 'Generation is disabled until you add credits.',
+        description: 'Generation is off until you add credits.',
         action,
+        cancel,
         duration: 10_000,
       });
     } else {
-      toast.warning(`Balance is below $${lowBalanceThreshold}`, {
-        description: `Your balance is $${balance.toFixed(2)}.`,
+      toast.warning(`Balance is $${balance.toFixed(2)}`, {
+        description: `Another short is about $${Math.round(typicalShortCostUsd(pricing))}.`,
         action,
+        cancel,
         duration: 8_000,
       });
     }
-  }, [balance, isLowBalance, isZeroBalance, lowBalanceThreshold, posthog]);
+  }, [
+    balance,
+    isLowBalance,
+    isZeroBalance,
+    lowBalanceThreshold,
+    posthog,
+    pricing,
+  ]);
 }

--- a/src/hooks/use-low-balance-warning.ts
+++ b/src/hooks/use-low-balance-warning.ts
@@ -5,12 +5,11 @@
 
 import { usePostHog } from '@posthog/react';
 import { useEffect, useRef } from 'react';
-import { toast } from 'sonner';
+import { showLowBalanceToast } from '@/components/billing/low-balance-toast';
 import { openAddCreditsDialog } from './use-add-credits-dialog';
 import { openBillingGate } from './use-billing-gate-dialog';
 import { useBillingBalance } from './use-billing-balance';
 import { useFalPricing } from './use-fal-pricing';
-import { MIN_TOPUP_AMOUNT_USD } from '@/lib/billing/constants';
 import { typicalShortCostUsd } from '@/lib/billing/typical-short-cost';
 
 export function useLowBalanceWarning() {
@@ -45,45 +44,22 @@ export function useLowBalanceWarning() {
     const props = { balance_usd: balance, is_zero: isZeroBalance };
     posthog.capture('low_balance_toast_shown', props);
 
-    // The offer itself is the primary action (#1299) — the toast was the most
-    // reacted-to billing moment and sent people to pricing to find it. The
-    // gate (BYOK, gift codes, founder credits) stays one tap away.
-    const action = {
-      label: `Add $${MIN_TOPUP_AMOUNT_USD}`,
-      onClick: () => {
-        posthog.capture('low_balance_toast_clicked', {
-          ...props,
-          choice: 'add_credits',
-        });
+    const clicked = (choice: 'add_credits' | 'other_options') =>
+      posthog.capture('low_balance_toast_clicked', { ...props, choice });
+
+    showLowBalanceToast({
+      balanceUsd: balance,
+      isZeroBalance,
+      runCostUsd: typicalShortCostUsd(pricing),
+      onAddCredits: () => {
+        clicked('add_credits');
         openAddCreditsDialog('low_balance_toast');
       },
-    };
-    const cancel = {
-      label: 'Other options',
-      onClick: () => {
-        posthog.capture('low_balance_toast_clicked', {
-          ...props,
-          choice: 'other_options',
-        });
+      onOtherOptions: () => {
+        clicked('other_options');
         openBillingGate(isZeroBalance ? 'zero' : 'manual');
       },
-    };
-
-    if (isZeroBalance) {
-      toast.error('Your credit balance is $0', {
-        description: 'Generation is off until you add credits.',
-        action,
-        cancel,
-        duration: 10_000,
-      });
-    } else {
-      toast.warning(`Balance is $${balance.toFixed(2)}`, {
-        description: `Another short is about $${Math.round(typicalShortCostUsd(pricing))}.`,
-        action,
-        cancel,
-        duration: 8_000,
-      });
-    }
+    });
   }, [
     balance,
     isLowBalance,

--- a/src/lib/billing/__tests__/typical-short-cost.test.ts
+++ b/src/lib/billing/__tests__/typical-short-cost.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { TEST_FAL_PRICING } from '@/lib/ai/__tests__/fal-pricing-fixture';
+import { TYPICAL_SHORT_COST_USD } from '../constants';
+import { typicalShortCostUsd } from '../typical-short-cost';
+
+describe('typicalShortCostUsd', () => {
+  it('prices a default short from live pricing', () => {
+    // Fixture rates are cheaper than production, so assert the shape, not the
+    // number: a real quote that differs from the static literal.
+    const usd = typicalShortCostUsd(TEST_FAL_PRICING);
+    expect(usd).toBeGreaterThan(1);
+    expect(usd).not.toBe(TYPICAL_SHORT_COST_USD);
+  });
+
+  it('falls back to the static estimate with no priced endpoints', () => {
+    expect(typicalShortCostUsd(null)).toBe(TYPICAL_SHORT_COST_USD);
+    // Empty table = every endpoint at its gate floor (~$1), not a real quote.
+    expect(typicalShortCostUsd({})).toBe(TYPICAL_SHORT_COST_USD);
+  });
+});

--- a/src/lib/billing/typical-short-cost.ts
+++ b/src/lib/billing/typical-short-cost.ts
@@ -17,7 +17,7 @@ import type { EffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
 import { TYPICAL_SHORT_COST_USD } from '@/lib/billing/constants';
 import { microsToUsd } from '@/lib/billing/money';
 import { estimateStoryboardPreflightCost } from '@/lib/billing/storyboard-preflight-cost';
-import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
+import { DEFAULT_ASPECT_RATIO } from '@/shared/constants/aspect-ratios';
 
 /** Enhance's default target duration — the short we quote. */
 const TYPICAL_SHORT_SECONDS = 30;

--- a/src/lib/billing/typical-short-cost.ts
+++ b/src/lib/billing/typical-short-cost.ts
@@ -1,0 +1,52 @@
+/**
+ * Live "cost of another short" for balance copy (#1299).
+ *
+ * Same composition as the signup-grant guard in `__tests__/constants.test.ts`
+ * — Enhance 30s target with Turbo defaults, motion + music on — but priced
+ * from the live catalog instead of a literal, so the low-balance toast quotes
+ * what a run actually costs today. Reference-only because that is the default
+ * for a new sequence (no shot stills to bill).
+ */
+
+import {
+  TURBO_DEFAULT_AUDIO,
+  TURBO_DEFAULT_IMAGE,
+  TURBO_DEFAULT_VIDEO,
+} from '@/lib/ai/generation-mode';
+import type { EffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
+import { TYPICAL_SHORT_COST_USD } from '@/lib/billing/constants';
+import { microsToUsd } from '@/lib/billing/money';
+import { estimateStoryboardPreflightCost } from '@/lib/billing/storyboard-preflight-cost';
+import { DEFAULT_ASPECT_RATIO } from '@/lib/constants/aspect-ratios';
+
+/** Enhance's default target duration — the short we quote. */
+const TYPICAL_SHORT_SECONDS = 30;
+
+/**
+ * Rough USD cost of another default short. Falls back to the static
+ * `TYPICAL_SHORT_COST_USD` when pricing hasn't loaded or the table is empty
+ * (fresh deploy before the pricing cron has run) — an empty table prices
+ * every endpoint at its gate floor, which would quote a short at ~$1.
+ */
+export function typicalShortCostUsd(
+  pricing: Record<string, EffectiveFalPricing> | null | undefined
+): number {
+  if (!pricing || Object.keys(pricing).length === 0) {
+    return TYPICAL_SHORT_COST_USD;
+  }
+
+  return microsToUsd(
+    estimateStoryboardPreflightCost({
+      script: '',
+      imageModel: TURBO_DEFAULT_IMAGE,
+      aspectRatio: DEFAULT_ASPECT_RATIO,
+      autoGenerateMotion: true,
+      videoModels: [TURBO_DEFAULT_VIDEO],
+      autoGenerateMusic: true,
+      audioModels: [TURBO_DEFAULT_AUDIO],
+      referenceOnly: true,
+      targetDurationSeconds: TYPICAL_SHORT_SECONDS,
+      pricing,
+    })
+  );
+}


### PR DESCRIPTION
Closes #1299

The low-balance toast said "Options" and opened the billing gate. In the first-video replays it was the most reacted-to billing moment — 11 of 52 users hovered their balance or went to pricing right after it, then left, because the offer was not in the toast.

## What changed

- **`src/hooks/use-low-balance-warning.ts`** — Sonner `action` + `cancel` so both buttons sit on the toast, on **both** the low-balance and $0 toasts:
  - **Add $10** (primary) → `openAddCreditsDialog('low_balance_toast')`
  - **Other options** (secondary) → `openBillingGate('zero' | 'manual')` — BYOK, gift codes and founder credits stay one tap away
  - Copy names the fact: `Balance is $4.21.` / `Another short is about $13.`; the $0 toast reads `Generation is off until you add credits.`
  - `low_balance_toast_shown` / `low_balance_toast_clicked` kept (#1359), now with `choice: add_credits | other_options` so the two paths are separable.
- **`src/lib/billing/typical-short-cost.ts`** (new) — the run estimate is a live `estimateStoryboardPreflightCost` quote, not a literal: Turbo defaults, 30s target, reference-only (the default for a new sequence), motion + music on — the same composition as the signup-grant guard. Falls back to the static `TYPICAL_SHORT_COST_USD` when the pricing table has no rows, since an empty table prices every endpoint at its gate floor and would quote a short at ~$1.
- **`src/components/billing/add-credits-dialog.tsx`** — resets the amount to $10 on open. The dialog is mounted once, so a previously typed amount would still be sitting there and contradict the toast's promise.

## Test

`src/lib/billing/__tests__/typical-short-cost.test.ts` — a live quote for a default short, and the fallback for a pricing table with no rows.
