### PR TITLE
fix(#1475): edit a mention pill's target from a hover popover

### DIFF
--- a/src/components/scenes/prompt-mention/mention-items.ts
+++ b/src/components/scenes/prompt-mention/mention-items.ts
@@ -29,6 +29,16 @@ export function mentionShowsAt(section: MentionSection): boolean {
   );
 }
 
+/**
+ * Sections whose target owns a user-editable name (#1475). Element tokens are
+ * the only one: renaming cascades through the script and every prompt. Cast
+ * and location tags derive from rows edited elsewhere, and studio's `@ImageN`
+ * slots are positional.
+ */
+export function mentionIsRenameable(section: MentionSection): boolean {
+  return section === 'elements';
+}
+
 /** Fields buildMentionItems actually consumes. */
 export type MentionCharacterInput = Pick<
   CharacterWithTalent,

--- a/src/components/scenes/scene-script-document.tsx
+++ b/src/components/scenes/scene-script-document.tsx
@@ -86,6 +86,8 @@ type SceneScriptBlockProps = {
   isSelected: boolean;
   onSelect: (sceneId: string) => void;
   mentionItems?: MentionItem[];
+  /** Rename the target a pill points at (#1475); see `MarkdownEditor`. */
+  onMentionRename?: (item: MentionItem, name: string) => void;
 };
 
 const SceneScriptBlock: React.FC<SceneScriptBlockProps> = ({
@@ -94,6 +96,7 @@ const SceneScriptBlock: React.FC<SceneScriptBlockProps> = ({
   isSelected,
   onSelect,
   mentionItems,
+  onMentionRename,
 }) => {
   // `undefined` = no draft; the editor mirrors the saved text. Each block owns
   // its own draft so editing one scene never blocks or discards another's.
@@ -198,6 +201,7 @@ const SceneScriptBlock: React.FC<SceneScriptBlockProps> = ({
         className="min-h-[120px]"
         disabled={saveScript.isPending}
         mentionItems={mentionItems}
+        onMentionRename={onMentionRename}
       />
     </section>
   );
@@ -221,7 +225,8 @@ export const SceneScriptDocument: React.FC<SceneScriptDocumentProps> = ({
   onSelectScene,
   splittingScript,
 }) => {
-  const { items: mentionItems } = useSequenceMentionItems(sequenceId);
+  const { items: mentionItems, onMentionRename } =
+    useSequenceMentionItems(sequenceId);
   const blocks = scenes ? buildScriptBlocks(scenes) : [];
   const tail = splittingScript
     ? unsplitScriptTail(splittingScript, blocks)
@@ -260,6 +265,7 @@ export const SceneScriptDocument: React.FC<SceneScriptDocumentProps> = ({
             isSelected={selected.has(block.sceneId)}
             onSelect={onSelectScene}
             mentionItems={mentionItems}
+            onMentionRename={onMentionRename}
           />
         ))}
         {tail && (

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -501,6 +501,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     characters: mentionCharacters,
     elements: mentionElements,
     locations: mentionLocations,
+    onMentionRename,
   } = useSequenceMentionItems(sequenceId);
   // The realtime hook owns the per-prompt-type stream status — `'pending'`
   // covers the window between a successful enqueue and the first delta, so
@@ -1840,6 +1841,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
           isCopied={copiedTab === 'script'}
           onCopy={(text) => void handleCopy(text, 'script')}
           mentionItems={mentionItems}
+          onMentionRename={onMentionRename}
         />
       </TabsContent>
 
@@ -1951,6 +1953,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               // Lock while streaming so local edits can't fight the LLM.
               disabled={isAwaitingVisualPrompt}
               mentionItems={mentionItems}
+              onMentionRename={onMentionRename}
             />
             {visualPromptDirty && (
               <div className="flex items-center justify-end gap-2">
@@ -2259,6 +2262,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
               // Lock while streaming so local edits can't fight the LLM.
               disabled={isAwaitingMotionPrompt}
               mentionItems={mentionItems}
+              onMentionRename={onMentionRename}
             />
             {motionPromptDirty && (
               <div className="flex items-center justify-end gap-2">

--- a/src/components/scenes/scene-script-tab.tsx
+++ b/src/components/scenes/scene-script-tab.tsx
@@ -26,6 +26,8 @@ type SceneScriptTabProps = {
   onCopy: (text: string) => void;
   /** Pills the script's bare slugs for elements/cast/locations. */
   mentionItems?: MentionItem[];
+  /** Rename the target a pill points at (#1475); see `MarkdownEditor`. */
+  onMentionRename?: (item: MentionItem, name: string) => void;
 };
 
 export const SceneScriptTab: React.FC<SceneScriptTabProps> = ({
@@ -38,6 +40,7 @@ export const SceneScriptTab: React.FC<SceneScriptTabProps> = ({
   isCopied,
   onCopy,
   mentionItems,
+  onMentionRename,
 }) => {
   const { ref: editorRef, voice } = useEditorDictation();
 
@@ -85,6 +88,7 @@ export const SceneScriptTab: React.FC<SceneScriptTabProps> = ({
             className="min-h-[180px] pr-10"
             disabled={!sceneId || isSaving}
             mentionItems={mentionItems}
+            onMentionRename={onMentionRename}
           />
           <Button
             size="icon"

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -1669,11 +1669,15 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
             <div
               id="scene-inspector"
               className={cn(
-                'md:flex md:h-full md:min-h-0 md:w-[380px] lg:w-[420px] md:flex-col md:overflow-hidden md:rounded-lg md:border md:bg-background',
+                // The phone height is on this wrapper, not on the ScrollArea:
+                // a `max-h` alone leaves the Radix viewport (`height: 100%` of
+                // an auto-height root) resolving to its content height, so the
+                // root clipped at 40dvh with nothing scrollable inside it.
+                'max-md:h-[40dvh] md:flex md:h-full md:min-h-0 md:w-[380px] lg:w-[420px] md:flex-col md:overflow-hidden md:rounded-lg md:border md:bg-background',
                 mobileInspectorOpen ? 'block' : 'hidden'
               )}
             >
-              <ScrollArea className="h-full min-h-0 max-md:max-h-[40dvh]">
+              <ScrollArea className="h-full min-h-0">
                 <SceneModelBar
                   scope={scope}
                   sequenceId={sequenceId}

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -49,8 +49,6 @@ type MentionTarget = {
   pos: number;
   dom: HTMLElement;
   attrs: PromptMentionAttrs;
-  /** Opened by click / keyboard — stays open and takes focus. */
-  pinned: boolean;
 };
 
 const pillFrom = (target: EventTarget | null): HTMLElement | null =>
@@ -90,9 +88,6 @@ const mentionPosAtCaret = (view: EditorView): number | null => {
   if ($from.nodeBefore?.type.name === 'mention') return $from.pos - 1;
   return null;
 };
-
-/** Hover-out grace so the pointer can travel from pill to popover. */
-const MENTION_CLOSE_DELAY_MS = 180;
 
 type MentionConfigure = Partial<MentionOptions>;
 
@@ -318,50 +313,23 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const onMentionSelectRef = useRef(onMentionSelect);
   onMentionSelectRef.current = onMentionSelect;
 
-  // The pill whose edit popover is open (#1475), and the timer that grants a
-  // grace period for the pointer to travel from pill to popover.
+  // The pill whose edit popover is open (#1475). Opened by clicking the pill
+  // — hovering only shows the pointer cursor, so reading a prompt with the
+  // mouse in it never pops menus over the text.
   const [mentionTarget, setMentionTarget] = useState<MentionTarget | null>(
     null
   );
-  const mentionTargetRef = useRef<MentionTarget | null>(null);
-  mentionTargetRef.current = mentionTarget;
-  const closeTimer = useRef<number | null>(null);
+  const closeMention = () => setMentionTarget(null);
 
-  const cancelMentionClose = () => {
-    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
-    closeTimer.current = null;
-  };
-  const closeMention = () => {
-    cancelMentionClose();
-    setMentionTarget(null);
-  };
-  const scheduleMentionClose = () => {
-    if (mentionTargetRef.current?.pinned) return;
-    cancelMentionClose();
-    closeTimer.current = window.setTimeout(
-      () => setMentionTarget(null),
-      MENTION_CLOSE_DELAY_MS
-    );
-  };
-  useEffect(() => cancelMentionClose, []);
-
-  const openMention = (
-    view: EditorView,
-    dom: HTMLElement,
-    pinned: boolean
-  ): void => {
+  const openMention = (view: EditorView, dom: HTMLElement): void => {
     // `view.editable` rather than the `disabled` prop: editorProps are captured
     // at init, the view's flag is not.
     if (!view.editable) return;
-    cancelMentionClose();
-    const open = mentionTargetRef.current;
-    // mouseover re-fires for every child of the pill; only the pin can change.
-    if (open?.dom === dom && (open.pinned || !pinned)) return;
     const pos = mentionPosAt(view, dom);
     if (pos === null) return;
     const node = view.state.doc.nodeAt(pos);
     if (!node) return;
-    setMentionTarget({ pos, dom, attrs: readPromptAttrs(node.attrs), pinned });
+    setMentionTarget({ pos, dom, attrs: readPromptAttrs(node.attrs) });
   };
 
   // Signature changes when the set of available tags changes; drives the
@@ -432,30 +400,26 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           const pos = mentionPosAtCaret(view);
           const dom = pos === null ? null : view.nodeDOM(pos);
           if (dom instanceof HTMLElement) {
-            openMention(view, dom, true);
+            openMention(view, dom);
             return true;
           }
         }
         return onKeyDownRef.current?.(event) === true;
       },
       handleDOMEvents: {
-        // Pills are atoms with no editing affordance of their own: hover
-        // previews the target, click opens the picker that repoints it (#1475).
-        mouseover: (view, event) => {
-          const pill = pillFrom(event.target);
-          if (pill) openMention(view, pill, false);
-          return false;
+        // Pills are atoms with no editing affordance of their own, so a click
+        // opens the picker that repoints one (#1475). Swallowing the mousedown
+        // keeps ProseMirror from focusing the view and placing a caret: the
+        // click is opening a menu, and the view's focus would immediately be
+        // stolen back from the popover's filter input.
+        mousedown: (_view, event) => {
+          if (!pillFrom(event.target)) return false;
+          event.preventDefault();
+          return true;
         },
-        mouseout: (_view, event) => {
-          if (pillFrom(event.target)) scheduleMentionClose();
-          return false;
-        },
-        // `click`, not `mousedown`: ProseMirror focuses the view on the way
-        // out of a mousedown, which would pull focus straight back off the
-        // popover's filter input.
         click: (view, event) => {
           const pill = pillFrom(event.target);
-          if (pill) openMention(view, pill, true);
+          if (pill) openMention(view, pill);
           return false;
         },
         beforeinput: (view, event) => {
@@ -769,16 +733,21 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
           <PopoverContent
             align="start"
             className="w-80"
-            // Hover-opened popovers must not steal the caret mid-sentence;
-            // a click-opened one focuses its filter input itself.
-            onOpenAutoFocus={(e) => e.preventDefault()}
-            onPointerEnter={cancelMentionClose}
-            onPointerLeave={scheduleMentionClose}
+            // Radix would focus the popover root; the filter input is the
+            // useful landing spot. Done here rather than in an effect inside
+            // the child because this fires once Radix has mounted the content,
+            // with no frame to race against ProseMirror's own focus.
+            onOpenAutoFocus={(e) => {
+              e.preventDefault();
+              if (!(e.currentTarget instanceof HTMLElement)) return;
+              e.currentTarget
+                .querySelector<HTMLInputElement>('[data-mention-filter]')
+                ?.focus();
+            }}
           >
             <MentionEditPopover
               attrs={mentionTarget.attrs}
               items={mentionItems ?? []}
-              focusOnOpen={mentionTarget.pinned}
               onReplace={replaceMention}
               onRemove={removeMention}
               onRename={onMentionRename ? renameMention : undefined}

--- a/src/components/text-editor/markdown-editor.tsx
+++ b/src/components/text-editor/markdown-editor.tsx
@@ -25,10 +25,74 @@ import {
   useState,
 } from 'react';
 import type { MentionOptions } from '@tiptap/extension-mention';
-import type { MentionItem } from '@/components/scenes/prompt-mention/mention-items';
-import { PromptMention } from './mention/mention-extension';
+import {
+  mentionInsertAttrs,
+  type MentionItem,
+  type MentionSection,
+} from '@/components/scenes/prompt-mention/mention-items';
+import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from '@/components/ui/popover';
+import {
+  PromptMention,
+  readPromptAttrs,
+  type PromptMentionAttrs,
+} from './mention/mention-extension';
+import { MentionEditPopover } from './mention/mention-edit-popover';
 import { createMentionSuggestion } from './mention/mention-suggestion';
 import { tagifyMarkdown } from './mention/tagify';
+
+/** The mention pill the edit popover is anchored to. */
+type MentionTarget = {
+  pos: number;
+  dom: HTMLElement;
+  attrs: PromptMentionAttrs;
+  /** Opened by click / keyboard — stays open and takes focus. */
+  pinned: boolean;
+};
+
+const pillFrom = (target: EventTarget | null): HTMLElement | null =>
+  target instanceof Element
+    ? target.closest<HTMLElement>('[data-type="mention"]')
+    : null;
+
+/**
+ * Document position of the mention node a pill renders. ProseMirror resolves
+ * an atom's DOM to the position either at or just before it depending on the
+ * bias it picks, so accept whichever of the two actually holds the node.
+ */
+const mentionPosAt = (view: EditorView, dom: HTMLElement): number | null => {
+  let pos: number;
+  try {
+    pos = view.posAtDOM(dom, 0);
+  } catch {
+    return null;
+  }
+  for (const candidate of [pos, pos - 1]) {
+    if (candidate < 0) continue;
+    const node = view.state.doc.nodeAt(candidate);
+    if (node?.type.name === 'mention') return candidate;
+  }
+  return null;
+};
+
+/**
+ * Position of the mention pill the caret sits against, or null. Inline atoms
+ * are NOT node-selected by arrow keys (ProseMirror only does that for block
+ * nodes), so caret adjacency is the only keyboard handle on a pill.
+ */
+const mentionPosAtCaret = (view: EditorView): number | null => {
+  const { $from, empty } = view.state.selection;
+  if (!empty) return null;
+  if ($from.nodeAfter?.type.name === 'mention') return $from.pos;
+  if ($from.nodeBefore?.type.name === 'mention') return $from.pos - 1;
+  return null;
+};
+
+/** Hover-out grace so the pointer can travel from pill to popover. */
+const MENTION_CLOSE_DELAY_MS = 180;
 
 type MentionConfigure = Partial<MentionOptions>;
 
@@ -170,6 +234,12 @@ type MarkdownEditorProps = {
   mentionItems?: MentionItem[];
   /** Map the chosen @ row to the item to insert (see `createMentionSuggestion`). */
   onMentionSelect?: (item: MentionItem) => MentionItem;
+  /**
+   * Rename the target a pill points at (#1475). Omit where nothing about the
+   * target is renameable — studio's `@ImageN` slots are positional, so the
+   * popover offers repointing only.
+   */
+  onMentionRename?: (item: MentionItem, name: string) => void;
   /** Imperative handle for streaming dictation in from a toolbar mic. */
   ref?: React.Ref<MarkdownEditorHandle>;
 };
@@ -226,6 +296,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   'data-testid': dataTestId,
   mentionItems,
   onMentionSelect,
+  onMentionRename,
   ref,
 }) => {
   // useEditor captures props at init. Bag the live onKeyDown in a ref so the
@@ -246,6 +317,52 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   const hasMentions = mentionItems !== undefined;
   const onMentionSelectRef = useRef(onMentionSelect);
   onMentionSelectRef.current = onMentionSelect;
+
+  // The pill whose edit popover is open (#1475), and the timer that grants a
+  // grace period for the pointer to travel from pill to popover.
+  const [mentionTarget, setMentionTarget] = useState<MentionTarget | null>(
+    null
+  );
+  const mentionTargetRef = useRef<MentionTarget | null>(null);
+  mentionTargetRef.current = mentionTarget;
+  const closeTimer = useRef<number | null>(null);
+
+  const cancelMentionClose = () => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    closeTimer.current = null;
+  };
+  const closeMention = () => {
+    cancelMentionClose();
+    setMentionTarget(null);
+  };
+  const scheduleMentionClose = () => {
+    if (mentionTargetRef.current?.pinned) return;
+    cancelMentionClose();
+    closeTimer.current = window.setTimeout(
+      () => setMentionTarget(null),
+      MENTION_CLOSE_DELAY_MS
+    );
+  };
+  useEffect(() => cancelMentionClose, []);
+
+  const openMention = (
+    view: EditorView,
+    dom: HTMLElement,
+    pinned: boolean
+  ): void => {
+    // `view.editable` rather than the `disabled` prop: editorProps are captured
+    // at init, the view's flag is not.
+    if (!view.editable) return;
+    cancelMentionClose();
+    const open = mentionTargetRef.current;
+    // mouseover re-fires for every child of the pill; only the pin can change.
+    if (open?.dom === dom && (open.pinned || !pinned)) return;
+    const pos = mentionPosAt(view, dom);
+    if (pos === null) return;
+    const node = view.state.doc.nodeAt(pos);
+    if (!node) return;
+    setMentionTarget({ pos, dom, attrs: readPromptAttrs(node.attrs), pinned });
+  };
 
   // Signature changes when the set of available tags changes; drives the
   // "re-pill on items load" effect below.
@@ -307,8 +424,40 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         ...(name ? { 'data-name': name } : {}),
         class: cn(proseClasses, placeholderClasses),
       },
-      handleKeyDown: (_view, event) => onKeyDownRef.current?.(event) === true,
+      handleKeyDown: (view, event) => {
+        // Alt+Enter beside a pill is the keyboard route into the edit
+        // popover, which the pointer reaches by hovering. Plain Enter is not
+        // available — it belongs to the prose being written around the pill.
+        if (event.key === 'Enter' && event.altKey) {
+          const pos = mentionPosAtCaret(view);
+          const dom = pos === null ? null : view.nodeDOM(pos);
+          if (dom instanceof HTMLElement) {
+            openMention(view, dom, true);
+            return true;
+          }
+        }
+        return onKeyDownRef.current?.(event) === true;
+      },
       handleDOMEvents: {
+        // Pills are atoms with no editing affordance of their own: hover
+        // previews the target, click opens the picker that repoints it (#1475).
+        mouseover: (view, event) => {
+          const pill = pillFrom(event.target);
+          if (pill) openMention(view, pill, false);
+          return false;
+        },
+        mouseout: (_view, event) => {
+          if (pillFrom(event.target)) scheduleMentionClose();
+          return false;
+        },
+        // `click`, not `mousedown`: ProseMirror focuses the view on the way
+        // out of a mousedown, which would pull focus straight back off the
+        // popover's filter input.
+        click: (view, event) => {
+          const pill = pillFrom(event.target);
+          if (pill) openMention(view, pill, true);
+          return false;
+        },
         beforeinput: (view, event) => {
           if (!(event instanceof InputEvent)) return false;
           const newlineInput =
@@ -396,6 +545,21 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     // value intentionally omitted — the sibling effect handles value changes.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [editor, mentionItemsKey, hasMentions, dictationActive]);
+
+  // Any doc change invalidates the anchored position, so drop the popover
+  // rather than let it rewrite the wrong node.
+  useEffect(() => {
+    if (!editor) return;
+    const onTransaction = ({ transaction }: { transaction: Transaction }) => {
+      if (transaction.docChanged) closeMention();
+    };
+    editor.on('transaction', onTransaction);
+    return () => {
+      editor.off('transaction', onTransaction);
+    };
+    // closeMention is a stable local closure over refs/setState.
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [editor]);
 
   useEffect(() => {
     if (!editor) return;
@@ -490,6 +654,43 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     selector: (ctx) => ctx.editor?.isEmpty ?? null,
   });
 
+  const writeMentionAttrs = (attrs: {
+    id: string | null;
+    section: MentionSection | null;
+    label: string | null;
+  }) => {
+    if (!editor || !mentionTarget) return;
+    const { state, dispatch } = editor.view;
+    if (state.doc.nodeAt(mentionTarget.pos)?.type.name !== 'mention') return;
+    dispatch(state.tr.setNodeMarkup(mentionTarget.pos, undefined, attrs));
+    closeMention();
+  };
+
+  // Repoint the pill at another target in place. The host's `onMentionSelect`
+  // runs first for the same reason the `@` dropdown runs it: the studio swaps
+  // a library row for a freshly attached `@ImageN`.
+  const replaceMention = (item: MentionItem) => {
+    writeMentionAttrs(
+      mentionInsertAttrs(onMentionSelectRef.current?.(item) ?? item)
+    );
+  };
+
+  // The cascade rewrites the SAVED script server-side; this editor may hold an
+  // unsaved draft, so the open pill is repointed at the new token here too —
+  // otherwise saving would reintroduce the old one.
+  const renameMention = (item: MentionItem, name: string) => {
+    onMentionRename?.(item, name);
+    writeMentionAttrs({ id: name, section: item.section, label: name });
+  };
+
+  const removeMention = () => {
+    if (!editor || !mentionTarget) return;
+    const { state, dispatch } = editor.view;
+    if (state.doc.nodeAt(mentionTarget.pos)?.type.name !== 'mention') return;
+    dispatch(state.tr.delete(mentionTarget.pos, mentionTarget.pos + 1));
+    closeMention();
+  };
+
   // editable is captured at init; mirror prop changes through to the editor.
   useEffect(() => {
     if (!editor) return;
@@ -557,6 +758,35 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         editor={editor}
         className={cn('relative w-full', !editor && value && 'hidden')}
       />
+      {mentionTarget && !disabled ? (
+        <Popover
+          open
+          onOpenChange={(next) => {
+            if (!next) closeMention();
+          }}
+        >
+          <PopoverAnchor virtualRef={{ current: mentionTarget.dom }} />
+          <PopoverContent
+            align="start"
+            className="w-80"
+            // Hover-opened popovers must not steal the caret mid-sentence;
+            // a click-opened one focuses its filter input itself.
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onPointerEnter={cancelMentionClose}
+            onPointerLeave={scheduleMentionClose}
+          >
+            <MentionEditPopover
+              attrs={mentionTarget.attrs}
+              items={mentionItems ?? []}
+              focusOnOpen={mentionTarget.pinned}
+              onReplace={replaceMention}
+              onRemove={removeMention}
+              onRename={onMentionRename ? renameMention : undefined}
+              onClose={closeMention}
+            />
+          </PopoverContent>
+        </Popover>
+      ) : null}
     </div>
   );
 };

--- a/src/components/text-editor/mention/mention-edit-popover.test.ts
+++ b/src/components/text-editor/mention/mention-edit-popover.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { MentionItem } from '@/components/scenes/prompt-mention/mention-items';
+import { findMentionItem, replacementItems } from './mention-edit-popover';
+
+const item = (
+  over: Partial<MentionItem> & Pick<MentionItem, 'id' | 'section' | 'tag'>
+): MentionItem => ({
+  label: over.tag,
+  haystack: over.tag.toLowerCase(),
+  ...over,
+});
+
+const ELEMENT = item({
+  id: 'element:1',
+  section: 'elements',
+  tag: 'BONDI_SCREEN',
+});
+const LEGACY = item({
+  id: 'element:2',
+  section: 'elements',
+  tag: 'RED_HEX',
+  aliases: ['red-hex-logo'],
+});
+const CAST = item({ id: 'character:1', section: 'cast', tag: 'JACK' });
+const LOCATION = item({
+  id: 'location:1',
+  section: 'locations',
+  tag: 'office-modern',
+});
+
+const ITEMS = [ELEMENT, LEGACY, CAST, LOCATION];
+
+describe('findMentionItem', () => {
+  it('resolves a pill by its canonical tag', () => {
+    expect(findMentionItem(ITEMS, { id: 'JACK', section: 'cast' })).toBe(CAST);
+  });
+
+  it('resolves a stale lowercased tag', () => {
+    expect(
+      findMentionItem(ITEMS, { id: 'bondi_screen', section: 'elements' })
+    ).toBe(ELEMENT);
+  });
+
+  it('falls back to a legacy alias', () => {
+    expect(
+      findMentionItem(ITEMS, { id: 'red-hex-logo', section: 'elements' })
+    ).toBe(LEGACY);
+  });
+
+  it('ignores items from another section', () => {
+    expect(
+      findMentionItem(ITEMS, { id: 'JACK', section: 'elements' })
+    ).toBeUndefined();
+  });
+
+  it('is undefined for a half-typed pill', () => {
+    expect(findMentionItem(ITEMS, { id: null, section: null })).toBeUndefined();
+  });
+});
+
+describe('replacementItems', () => {
+  it('drops the current target and groups by section order', () => {
+    const rows = replacementItems(ITEMS, ELEMENT, '');
+    expect(rows.map((r) => r.id)).toEqual([
+      'element:2',
+      'character:1',
+      'location:1',
+    ]);
+  });
+
+  it('filters on the query', () => {
+    expect(replacementItems(ITEMS, ELEMENT, 'jac').map((r) => r.id)).toEqual([
+      'character:1',
+    ]);
+  });
+});

--- a/src/components/text-editor/mention/mention-edit-popover.tsx
+++ b/src/components/text-editor/mention/mention-edit-popover.tsx
@@ -1,0 +1,192 @@
+/**
+ * Edit affordance for an already-inserted mention pill (#1475). Hovering a
+ * pill previews what it points at; clicking it opens the same sectioned list
+ * the `@` dropdown uses, so the target can be repointed in place instead of
+ * deleted and retyped.
+ *
+ * Rename is optional (`onRename`) because only some targets are renameable —
+ * sequence elements own an editable token, studio's positional `@ImageN`
+ * references do not.
+ */
+
+import {
+  filterMentionItems,
+  mentionIsRenameable,
+  SECTION_ORDER,
+  type MentionItem,
+} from '@/components/scenes/prompt-mention/mention-items';
+import { AppImage } from '@/components/ui/app-image';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { deriveTokenFromFilename } from '@/lib/sequence-elements/derive-token';
+import { Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { MentionList, type MentionListRef } from './mention-list';
+import type { PromptMentionAttrs } from './mention-extension';
+
+/**
+ * The item a pill currently points at. Pills store the canonical tag as their
+ * `id`, so match on that (case-insensitively — a legacy lowercased tag still
+ * resolves) and fall back to the aliases the matcher already accepts.
+ */
+export function findMentionItem(
+  items: MentionItem[],
+  attrs: Pick<PromptMentionAttrs, 'id' | 'section'>
+): MentionItem | undefined {
+  const id = attrs.id?.toLowerCase();
+  if (!id) return undefined;
+  const sectionOk = (item: MentionItem) =>
+    attrs.section === null || item.section === attrs.section;
+  return (
+    items.find((it) => sectionOk(it) && it.tag.toLowerCase() === id) ??
+    items.find(
+      (it) =>
+        sectionOk(it) &&
+        it.aliases?.some((a) => a.toLowerCase() === id) === true
+    )
+  );
+}
+
+/** Rows offered as replacements: everything but the pill's current target. */
+export function replacementItems(
+  items: MentionItem[],
+  current: MentionItem | undefined,
+  query: string
+): MentionItem[] {
+  const filtered = filterMentionItems(items, query).filter(
+    (it) => it.id !== current?.id
+  );
+  const grouped: MentionItem[] = [];
+  for (const section of SECTION_ORDER) {
+    for (const item of filtered)
+      if (item.section === section) grouped.push(item);
+  }
+  return grouped;
+}
+
+export const MentionEditPopover: React.FC<{
+  attrs: PromptMentionAttrs;
+  items: MentionItem[];
+  /** Focus the filter input on mount (click / keyboard open, never hover). */
+  focusOnOpen: boolean;
+  onReplace: (item: MentionItem) => void;
+  onRemove: () => void;
+  /** Omitted when nothing about this target can be renamed. */
+  onRename?: (item: MentionItem, name: string) => void;
+  onClose: () => void;
+}> = ({
+  attrs,
+  items,
+  focusOnOpen,
+  onReplace,
+  onRemove,
+  onRename,
+  onClose,
+}) => {
+  const current = findMentionItem(items, attrs);
+  const [query, setQuery] = useState('');
+  const [name, setName] = useState(current?.tag ?? '');
+  const listRef = useRef<MentionListRef>(null);
+  const queryRef = useRef<HTMLInputElement>(null);
+
+  // Next frame: ProseMirror re-focuses its view after the click that pinned
+  // this popover open, so focusing synchronously would lose the race.
+  useEffect(() => {
+    if (!focusOnOpen) return;
+    const raf = requestAnimationFrame(() => queryRef.current?.focus());
+    return () => cancelAnimationFrame(raf);
+  }, [focusOnOpen]);
+
+  const rows = replacementItems(items, current, query);
+  const renameable =
+    onRename !== undefined &&
+    current !== undefined &&
+    mentionIsRenameable(current.section);
+  // Same normalisation the server applies, so the pill lands on the token the
+  // rename actually stores rather than the raw keystrokes.
+  const nextToken = name.trim() === '' ? '' : deriveTokenFromFilename(name);
+  const renameDirty =
+    renameable && nextToken !== '' && nextToken !== current.tag;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <span className="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
+          {current?.thumbnailUrl ? (
+            <AppImage
+              src={current.thumbnailUrl}
+              alt=""
+              width={36}
+              height={36}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="text-xs text-muted-foreground">@</span>
+          )}
+        </span>
+        <span className="flex min-w-0 flex-col">
+          <span className="truncate">
+            {current?.label ?? attrs.label ?? attrs.id}
+          </span>
+          <span className="truncate font-mono text-xs text-muted-foreground">
+            {attrs.id}
+          </span>
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="ml-auto"
+          aria-label="Remove mention"
+          onClick={onRemove}
+        >
+          <Trash2 aria-hidden="true" />
+        </Button>
+      </div>
+
+      {renameable && (
+        <form
+          className="flex items-center gap-1.5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (renameDirty) onRename(current, nextToken);
+          }}
+        >
+          <Input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            aria-label="Rename target"
+            className="h-8"
+          />
+          <Button type="submit" size="sm" disabled={!renameDirty}>
+            Rename
+          </Button>
+        </form>
+      )}
+
+      <Input
+        ref={queryRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Point at…"
+        aria-label="Replace mention target"
+        className="h-8"
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            onClose();
+            return;
+          }
+          if (listRef.current?.onKeyDown({ event: e.nativeEvent }) === true) {
+            e.preventDefault();
+          }
+        }}
+      />
+      <MentionList
+        ref={listRef}
+        items={rows}
+        command={onReplace}
+        className="max-h-56 w-full border-0 p-0 shadow-none"
+      />
+    </div>
+  );
+};

--- a/src/components/text-editor/mention/mention-edit-popover.tsx
+++ b/src/components/text-editor/mention/mention-edit-popover.tsx
@@ -1,8 +1,8 @@
 /**
- * Edit affordance for an already-inserted mention pill (#1475). Hovering a
- * pill previews what it points at; clicking it opens the same sectioned list
- * the `@` dropdown uses, so the target can be repointed in place instead of
- * deleted and retyped.
+ * Edit affordance for an already-inserted mention pill (#1475). Clicking a
+ * pill opens this: a preview of what it points at plus the same sectioned
+ * list the `@` dropdown uses, so the target can be repointed in place instead
+ * of deleted and retyped.
  *
  * Rename is optional (`onRename`) because only some targets are renameable —
  * sequence elements own an editable token, studio's positional `@ImageN`
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { deriveTokenFromFilename } from '@/lib/sequence-elements/derive-token';
 import { Trash2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { MentionList, type MentionListRef } from './mention-list';
 import type { PromptMentionAttrs } from './mention-extension';
 
@@ -67,35 +67,16 @@ export function replacementItems(
 export const MentionEditPopover: React.FC<{
   attrs: PromptMentionAttrs;
   items: MentionItem[];
-  /** Focus the filter input on mount (click / keyboard open, never hover). */
-  focusOnOpen: boolean;
   onReplace: (item: MentionItem) => void;
   onRemove: () => void;
   /** Omitted when nothing about this target can be renamed. */
   onRename?: (item: MentionItem, name: string) => void;
   onClose: () => void;
-}> = ({
-  attrs,
-  items,
-  focusOnOpen,
-  onReplace,
-  onRemove,
-  onRename,
-  onClose,
-}) => {
+}> = ({ attrs, items, onReplace, onRemove, onRename, onClose }) => {
   const current = findMentionItem(items, attrs);
   const [query, setQuery] = useState('');
   const [name, setName] = useState(current?.tag ?? '');
   const listRef = useRef<MentionListRef>(null);
-  const queryRef = useRef<HTMLInputElement>(null);
-
-  // Next frame: ProseMirror re-focuses its view after the click that pinned
-  // this popover open, so focusing synchronously would lose the race.
-  useEffect(() => {
-    if (!focusOnOpen) return;
-    const raf = requestAnimationFrame(() => queryRef.current?.focus());
-    return () => cancelAnimationFrame(raf);
-  }, [focusOnOpen]);
 
   const rows = replacementItems(items, current, query);
   const renameable =
@@ -165,7 +146,8 @@ export const MentionEditPopover: React.FC<{
       )}
 
       <Input
-        ref={queryRef}
+        // Focused by the popover's `onOpenAutoFocus` — see `markdown-editor`.
+        data-mention-filter=""
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Point at…"

--- a/src/components/text-editor/mention/mention-extension.ts
+++ b/src/components/text-editor/mention/mention-extension.ts
@@ -40,7 +40,9 @@ export type PromptMentionAttrs = {
   label: string | null;
 };
 
-function readPromptAttrs(attrs: Record<string, unknown>): PromptMentionAttrs {
+export function readPromptAttrs(
+  attrs: Record<string, unknown>
+): PromptMentionAttrs {
   const idRaw = attrs.id;
   const sectionRaw = attrs.section;
   const labelRaw = attrs.label;
@@ -106,7 +108,7 @@ export const PromptMention = Mention.extend({
   },
 }).configure({
   HTMLAttributes: {
-    class: BASE_PILL_CLASS,
+    class: `${BASE_PILL_CLASS} cursor-pointer`,
     spellcheck: 'false',
   },
   renderHTML: ({ node, options }) => {

--- a/src/components/text-editor/mention/mention-list.tsx
+++ b/src/components/text-editor/mention/mention-list.tsx
@@ -33,10 +33,12 @@ export type MentionListRef = {
 export type MentionListProps = {
   items: MentionItem[];
   command: (item: MentionItem) => void;
+  /** Overrides the standalone-popup chrome when embedded in another surface. */
+  className?: string;
 };
 
 export const MentionList = forwardRef<MentionListRef, MentionListProps>(
-  ({ items, command }, ref) => {
+  ({ items, command, className }, ref) => {
     const [selectedIdx, setSelectedIdx] = useState(0);
 
     useEffect(() => {
@@ -82,7 +84,10 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
         <div
           role="listbox"
           aria-label="Mention suggestions"
-          className="w-72 rounded-md border bg-popover p-2 text-sm text-muted-foreground shadow-md"
+          className={cn(
+            'w-72 rounded-md border bg-popover p-2 text-sm text-muted-foreground shadow-md',
+            className
+          )}
         >
           No matches
         </div>
@@ -94,7 +99,10 @@ export const MentionList = forwardRef<MentionListRef, MentionListProps>(
       <div
         role="listbox"
         aria-label="Mention suggestions"
-        className="flex max-h-72 w-80 flex-col overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+        className={cn(
+          'flex max-h-72 w-80 flex-col overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md',
+          className
+        )}
       >
         {sections.map(({ section, entries }) => (
           <div key={section} className="py-1 first:pt-0 last:pb-0">

--- a/src/hooks/use-mention-items.ts
+++ b/src/hooks/use-mention-items.ts
@@ -1,8 +1,15 @@
-import { buildMentionItems } from '@/components/scenes/prompt-mention/mention-items';
+import {
+  buildMentionItems,
+  type MentionItem,
+} from '@/components/scenes/prompt-mention/mention-items';
 import { useSequenceCharacters } from '@/hooks/use-sequence-characters';
-import { useSequenceElements } from '@/hooks/use-sequence-elements';
+import {
+  useRenameSequenceElementToken,
+  useSequenceElements,
+} from '@/hooks/use-sequence-elements';
 import { useSequenceLocations } from '@/hooks/use-sequence-locations';
 import { useMemo } from 'react';
+import { toast } from 'sonner';
 
 /**
  * The @-mention autocomplete items for a sequence — the same canonical
@@ -27,8 +34,26 @@ export function useSequenceMentionItems(sequenceId: string) {
     [characters, elements, locations]
   );
 
+  // Renaming an element token from a pill's edit popover (#1475). Only
+  // elements are renameable (`mentionIsRenameable`), and the rename cascades
+  // server-side through the script and every prompt that referenced the token.
+  const renameToken = useRenameSequenceElementToken();
+  const onMentionRename = (item: MentionItem, name: string) => {
+    const elementId = item.id.startsWith('element:')
+      ? item.id.slice('element:'.length)
+      : null;
+    if (!elementId) return;
+    renameToken.mutate(
+      { elementId, sequenceId, token: name },
+      {
+        onError: (error) =>
+          toast.error(error instanceof Error ? error.message : 'Rename failed'),
+      }
+    );
+  };
+
   // The raw lists come back too — callers that also build reference images or
   // resolve tags need the underlying rows, not just the pill items, and would
   // otherwise re-subscribe to the same three queries.
-  return { items, characters, elements, locations };
+  return { items, characters, elements, locations, onMentionRename };
 }


### PR DESCRIPTION
Closes #1475. Also carries #1493 (mobile inspector scrolling).

## What

`@tag` pills were write-once: to point one at a different character / element / location / attached reference you had to delete it and retype the `@`. Clicking a pill now opens an edit popover.

- **Preview** — thumbnail, label and canonical tag of the current target, so `@Image3` stops being opaque.
- **Repoint in place** — a filterable, sectioned list (the same `MentionList` the `@` dropdown uses) rewrites the pill's attrs. The host's `onMentionSelect` still runs, so picking a library still in the studio composer attaches it as a fresh `@ImageN` exactly like the dropdown does.
- **Rename** — for sequence elements only (`mentionIsRenameable`), through the existing `cascadeRename` server fn. The name is normalised with `deriveTokenFromFilename` (what the server stores) and the open pill is repointed at the new token, so an unsaved draft can't reintroduce the old one.
- **Remove** — deletes the pill.

Studio's `@ImageN` slots are positional (they bind to `image_urls[N-1]`), so they get repointing and preview but no rename.

## Opening it

Hovering only shows the pointer cursor — a menu that popped open while reading a prompt was worse than the problem. It opens on:

- **Click** on the pill, which focuses the filter input. The pill's `mousedown` is swallowed so ProseMirror neither places a caret in the atom nor re-focuses the view; the input is focused from the popover's `onOpenAutoFocus`, which fires after Radix mounts the content, so there is no frame to race.
- **`Alt+Enter`** with the caret against a pill. Inline atoms are not node-selected by arrow keys, so caret adjacency is the only keyboard handle; plain `Enter` belongs to the prose being written around the pill.

## Also here: #1493

The phone inspector ("Shot assets") clipped at 40dvh with nothing scrollable — the cap was on the `ScrollArea` while its wrapper had no definite height, so Radix's `height: 100%` viewport resolved to its content height. Measured at 500px wide: root 249px over a 626px viewport. The height moves onto the wrapper so the existing `h-full` resolves. Desktop is untouched.

## Verified

Locally against seeded data. Mentions: click opens / hover does not, repointing `PALE_ROSE_SERUM` → `ARIA` rewrites the pill and the markdown, remove deletes it, rename cascades to `sequence_elements` and closes the popover, `Alt+Enter` opens it, and cast pills correctly show no rename field. Mobile panel: measured non-scrollable before, scrolling after, at both sequence and shot scope.

Unit tests cover the pure lookup (`findMentionItem`, `replacementItems`). `bun run test` (3966), `bun typecheck`, `bun lint`, `bun dead-code` all pass.

https://claude.ai/code/session_01QgyKNtGjgXiQ14QU4bX8sD