### PR TITLE
fix(#1490): unbreak main — LLMTR utils path and boundary-test timeout

### DIFF
--- a/src/lib/ai/llmtr.test.ts
+++ b/src/lib/ai/llmtr.test.ts
@@ -21,7 +21,7 @@ import {
 } from './llmtr';
 import { SCRIPT_ANALYSIS_MODELS } from './models.config';
 import { microsToUsd, ZERO_MICROS } from '@/lib/billing/money';
-import { typedEntries } from '@/lib/utils/typed-object';
+import { typedEntries } from '@/shared/utils/typed-object';
 
 const usage = (promptTokens: number, completionTokens: number) => ({
   promptTokens,

--- a/src/lib/ai/llmtr.ts
+++ b/src/lib/ai/llmtr.ts
@@ -31,7 +31,7 @@
 
 import type { AnalysisModelId } from '@/lib/ai/models.config';
 import { usdToMicros, type Microdollars } from '@/lib/billing/money';
-import { typedEntries } from '@/lib/utils/typed-object';
+import { typedEntries } from '@/shared/utils/typed-object';
 import type { TokenUsage } from '@tanstack/ai';
 
 /** LLMTR's OpenAI-compatible base URL. */

--- a/src/lib/client-server-boundary.test.ts
+++ b/src/lib/client-server-boundary.test.ts
@@ -456,6 +456,8 @@ describe('client/server import boundary', () => {
     expect(MIXED_LIB_DIRS.has('db')).toBe(false);
   });
 
+  // Walks every client-reachable file synchronously, so it runs 5-9s and
+  // tripped the 5s default whenever it shared a worker with other suites.
   test('no server-only module is reachable from client components/hooks/routes/functions', () => {
     const visited = new Set<string>();
     // file → the import edge that got us there, for a readable failure trail.
@@ -504,5 +506,5 @@ describe('client/server import boundary', () => {
       violations,
       `Server-only imports reachable from client code:\n\n${violations.join('\n\n')}\n\nMove the client-safe part into src/shared, or keep the server-side helper in src/lib and reference it only from handler bodies — do not widen the exceptions in .oxlintrc.json.`
     ).toEqual([]);
-  });
+  }, 30_000);
 });


### PR DESCRIPTION
Closes #1490. Two unrelated causes, one red `main` — separate commits so either can be reverted alone.

### 1. LLMTR imports the pre-move utils path

#1445 moved the shared utils to `src/shared`; #1266 merged after it and still imported `@/lib/utils/typed-object`. Each was green on its own branch, so nothing caught it until they were both on `main`.

Six `error TS` (the unresolved module in `llmtr.ts` and `llmtr.test.ts`, plus four downstream `TS7031` implicit-anys) and a knip "Unresolved imports (1)". Repointed at `@/shared/utils/typed-object`.

### 2. The boundary test flaked on the 5s default

`no server-only module is reachable from client…` walks the whole client import graph synchronously — 5–9s — with no `testTimeout` in `vitest.config.ts` or the file. It died with `Test timed out in 5000ms` whenever it shared a worker with other suites, and passed 3/3 when run alone. A timeout, never a real violation. Given it 30s, ~3x headroom over the worst run I measured.

### Verification

On a clean checkout of this branch: `bun typecheck` 0 errors, `bun knip` clean, `bun run test src/lib/ai/llmtr.test.ts` 12 passed. The exact load case that reproduced the flake (`bun run test src/lib/client-server-boundary.test.ts src/shared/generation src/lib/ai`) now passes 59 files / 731 tests.

Found while rebasing #1484 onto current `main`.
