### PR TITLE
fix(#1494): pin GLM-5.3 thinking to low; retry abort timeouts

### DIFF
--- a/src/lib/ai/llm-client.test.ts
+++ b/src/lib/ai/llm-client.test.ts
@@ -53,10 +53,13 @@ const {
   callLLM,
   callLLMStream,
   createUsageCapture,
+  glmReasoningEffortForCall,
+  isForcedGlmReasoningModel,
   llmCostFromUsage,
   preferUsage,
   RECOMMENDED_MODELS,
   toGeminiThinkingLevel,
+  toGlmReasoningEffort,
 } = await import('./llm-client');
 const { DEFAULT_ANALYSIS_MODEL, DEFAULT_VISION_MODEL } =
   await import('./models.config');
@@ -958,6 +961,68 @@ describe('llm-client', () => {
         if (!callArgs) throw new Error('expected mockChat to have been called');
         expect(callArgs.modelOptions.reasoning).toBeUndefined();
       });
+
+      it('pins GLM-5.3 Flash unrequested reasoning to low (#1494)', async () => {
+        mockChat.mockReturnValue(
+          (async function* () {
+            yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'ok' };
+          })()
+        );
+
+        await drain(
+          callLLMStream({
+            model: 'z-ai/glm-5.3-flash',
+            messages: [{ role: 'user', content: 'test' }],
+          })
+        );
+
+        const callArgs = mockChat.mock.calls[0]?.[0];
+        if (!callArgs) throw new Error('expected mockChat to have been called');
+        expect(callArgs.modelOptions.reasoning).toEqual({ effort: 'low' });
+        expect(callArgs.modelOptions.reasoning).not.toHaveProperty('enabled');
+      });
+
+      it('maps GLM-5.3 medium reasoning to high (Z.AI rejects medium)', async () => {
+        mockChat.mockReturnValue(
+          (async function* () {
+            yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'ok' };
+          })()
+        );
+
+        await drain(
+          callLLMStream({
+            model: 'z-ai/glm-5.3-flash',
+            messages: [{ role: 'user', content: 'test' }],
+            reasoning: { enabled: true, effort: 'medium' },
+          })
+        );
+
+        const callArgs = mockChat.mock.calls[0]?.[0];
+        if (!callArgs) throw new Error('expected mockChat to have been called');
+        expect(callArgs.modelOptions.reasoning).toEqual({ effort: 'high' });
+      });
+
+      it('sends GLM-5.3 reasoning_effort low on LLMTR when unrequested', async () => {
+        mockChat.mockReturnValue(
+          (async function* () {
+            yield { type: 'TEXT_MESSAGE_CONTENT', delta: 'ok' };
+          })()
+        );
+
+        await drain(
+          callLLMStream({
+            model: 'z-ai/glm-5.3-flash',
+            messages: [{ role: 'user', content: 'test' }],
+            apiKey: { key: 'llmtr-team', via: 'llmtr' },
+          })
+        );
+
+        const options = mockChat.mock.calls[0]?.[0]?.modelOptions;
+        expect(options).toEqual(
+          expect.objectContaining({ reasoning_effort: 'low' })
+        );
+        expect(options).not.toHaveProperty('reasoning');
+      });
     });
 
     describe('web search tool', () => {
@@ -1301,6 +1366,33 @@ describe('llm-client', () => {
       expect(toGeminiThinkingLevel(undefined)).toBe('MEDIUM');
       expect(toGeminiThinkingLevel('high')).toBe('HIGH');
       expect(toGeminiThinkingLevel('xhigh')).toBe('HIGH');
+    });
+  });
+
+  describe('GLM-5.3 reasoning (#1494)', () => {
+    it('recognises registry and LLMTR ids', () => {
+      expect(isForcedGlmReasoningModel('z-ai/glm-5.3-flash')).toBe(true);
+      expect(isForcedGlmReasoningModel('zai/glm-5.3-flash')).toBe(true);
+      expect(isForcedGlmReasoningModel('z-ai/glm-5.3')).toBe(true);
+      expect(isForcedGlmReasoningModel('anthropic/claude-sonnet-5')).toBe(
+        false
+      );
+    });
+
+    it('maps the five-level scale onto max|high|low', () => {
+      expect(toGlmReasoningEffort(undefined)).toBe('low');
+      expect(toGlmReasoningEffort('minimal')).toBe('low');
+      expect(toGlmReasoningEffort('low')).toBe('low');
+      expect(toGlmReasoningEffort('medium')).toBe('high');
+      expect(toGlmReasoningEffort('high')).toBe('high');
+      expect(toGlmReasoningEffort('xhigh')).toBe('max');
+    });
+
+    it('never disables thinking — unrequested and enabled:false both become low', () => {
+      expect(glmReasoningEffortForCall(undefined)).toBe('low');
+      expect(glmReasoningEffortForCall(false)).toBe('low');
+      expect(glmReasoningEffortForCall({ enabled: false })).toBe('low');
+      expect(glmReasoningEffortForCall(true)).toBe('high');
     });
   });
 

--- a/src/lib/ai/llm-client.ts
+++ b/src/lib/ai/llm-client.ts
@@ -332,14 +332,58 @@ export const PROMPT_REASONING = {
 
 /**
  * Reasoning for script enhancement. Always on at `low`: some providers
- * (Grok) cannot disable thinking, and omitting the param falls through to
- * a high default — so sending `low` is the fastest we can ask for.
- * Workflows keep {@link PROMPT_REASONING} (`medium`); latency is hidden there.
+ * (Grok, GLM-5.3) cannot disable thinking, and omitting the param falls
+ * through to a high/`max` default — so sending `low` is the fastest we can
+ * ask for. Workflows keep {@link PROMPT_REASONING} (`medium`); latency is
+ * hidden there.
  */
 export const ENHANCE_REASONING = {
   enabled: true,
   effort: 'low',
 } as const satisfies NonNullable<LLMRequestParams['reasoning']>;
+
+type ReasoningEffort = NonNullable<
+  NonNullable<LLMRequestParams['reasoning']>['effort']
+>;
+
+/**
+ * GLM-5.3 / Flash force thinking: Z.AI 400s `thinking.type: disabled`, and
+ * the default effort is `max` (OpenRouter launch note). Omitting `reasoning`
+ * therefore runs a five-minute think on a music-prompt call (#1494). Same
+ * trap as Grok — send `low` when the caller did not ask for reasoning.
+ * Matches registry (`z-ai/glm-5.3-flash`) and LLMTR (`zai/glm-5.3-flash`) ids.
+ */
+export function isForcedGlmReasoningModel(modelId: string): boolean {
+  return modelId.includes('glm-5.3');
+}
+
+export type GlmReasoningEffort = 'low' | 'high' | 'max';
+
+/**
+ * GLM-5.3 only accepts `max | high | low`. Our five-level scale includes
+ * `medium` ({@link PROMPT_REASONING}), which Z.AI rejects. Map like GLM-5.2:
+ * medium → high; xhigh → max; unrequested / minimal → low.
+ */
+export function toGlmReasoningEffort(
+  effort: ReasoningEffort | undefined
+): GlmReasoningEffort {
+  if (effort === undefined || effort === 'minimal' || effort === 'low') {
+    return 'low';
+  }
+  if (effort === 'xhigh') return 'max';
+  return 'high';
+}
+
+/** Wire `reasoning.effort` for GLM-5.3. Unrequested → `low`, never `enabled: false`. */
+export function glmReasoningEffortForCall(
+  reasoning: LLMRequestParams['reasoning'] | boolean | undefined
+): GlmReasoningEffort {
+  if (reasoning === true) return toGlmReasoningEffort(PROMPT_REASONING.effort);
+  if (reasoning === false || reasoning === undefined) return 'low';
+  return toGlmReasoningEffort(
+    reasoning.enabled === false ? undefined : reasoning.effort
+  );
+}
 
 /**
  * System messages must be strings (they become systemPrompts on the adapter).
@@ -457,8 +501,13 @@ function toLlmtrReasoningEffort(
 function buildLlmtrModelOptions(params: LLMRequestParams) {
   const allowSampling = modelAllowsClassicSampling(params.model);
   const api = llmtrCompatibleApi(params.model);
+  const glmEffort = isForcedGlmReasoningModel(params.model)
+    ? glmReasoningEffortForCall(params.reasoning)
+    : undefined;
   const reasoning =
-    params.reasoning && params.reasoning.enabled !== false
+    glmEffort === undefined &&
+    params.reasoning &&
+    params.reasoning.enabled !== false
       ? toLlmtrReasoningEffort(params.reasoning.effort, api)
       : undefined;
   const sampling = {
@@ -476,7 +525,9 @@ function buildLlmtrModelOptions(params: LLMRequestParams) {
   };
   if (api === 'responses') {
     return {
-      ...(reasoning && { reasoning: { effort: reasoning } }),
+      ...(glmEffort
+        ? { reasoning: { effort: glmEffort } }
+        : reasoning && { reasoning: { effort: reasoning } }),
       ...(params.max_tokens != null && {
         max_output_tokens: params.max_tokens,
       }),
@@ -484,7 +535,9 @@ function buildLlmtrModelOptions(params: LLMRequestParams) {
     };
   }
   return {
-    ...(reasoning && { reasoning_effort: reasoning }),
+    ...(glmEffort
+      ? { reasoning_effort: glmEffort }
+      : reasoning && { reasoning_effort: reasoning }),
     ...(params.max_tokens != null && { max_tokens: params.max_tokens }),
     ...sampling,
   };
@@ -556,10 +609,15 @@ function buildModelOptions(params: LLMRequestParams) {
       ? { ...reasoningConfig, enabled: false as const }
       : reasoningConfig;
   const allowSampling = modelAllowsClassicSampling(params.model);
+  const reasoningOptions = isForcedGlmReasoningModel(params.model)
+    ? { reasoning: { effort: glmReasoningEffortForCall(params.reasoning) } }
+    : params.reasoning
+      ? { reasoning }
+      : {};
   return {
     provider,
     serviceTier: SERVICE_TIER,
-    ...(params.reasoning && { reasoning }),
+    ...reasoningOptions,
     // `maxTokens`, not `maxCompletionTokens`: DeepSeek endpoints advertise only
     // `max_tokens`, so `max_completion_tokens` + requireParameters empties the
     // candidate set ("No endpoints found…") on the region fallback. Native

--- a/src/lib/workflows/llm-call-helper.test.ts
+++ b/src/lib/workflows/llm-call-helper.test.ts
@@ -98,6 +98,44 @@ describe('chatModelOptionsForCall', () => {
       max_output_tokens: expect.any(Number),
     });
   });
+
+  it('pins GLM-5.3 Flash unrequested reasoning to low on OpenRouter (#1494)', () => {
+    const options = chatModelOptionsForCall(
+      'z-ai/glm-5.3-flash',
+      { key: 'k', via: 'openrouter' },
+      undefined
+    );
+    expect(options).toEqual(
+      expect.objectContaining({
+        reasoning: { effort: 'low' },
+      })
+    );
+  });
+
+  it('maps GLM-5.3 requested medium reasoning to high', () => {
+    const options = chatModelOptionsForCall(
+      'z-ai/glm-5.3-flash',
+      { key: 'k', via: 'openrouter' },
+      true
+    );
+    expect(options).toEqual(
+      expect.objectContaining({
+        reasoning: { effort: 'high' },
+      })
+    );
+  });
+
+  it('sends GLM-5.3 reasoning_effort low on LLMTR when unrequested', () => {
+    const options = chatModelOptionsForCall(
+      'z-ai/glm-5.3-flash',
+      { key: 'k', via: 'llmtr' },
+      undefined
+    );
+    expect(options).toEqual({
+      reasoning_effort: 'low',
+      max_tokens: expect.any(Number),
+    });
+  });
 });
 
 describe('durableLLMCallCf usage cost capture', () => {
@@ -192,6 +230,21 @@ describe('durableLLMCallCf usage cost capture', () => {
     await expect(
       durableLLMCallCf(step, callConfig, nonStreamContext)
     ).rejects.toThrow(/structured-output\.complete/);
+  });
+
+  it('throws a retryable timeout when the abort fires without a complete event (#1494)', async () => {
+    mockChat.mockImplementation(
+      (opts: { abortController?: AbortController }) => {
+        opts.abortController?.abort();
+        return (async function* () {
+          // Stream ends with no complete event — the abort is why.
+        })();
+      }
+    );
+
+    await expect(
+      durableLLMCallCf(step, callConfig, nonStreamContext)
+    ).rejects.toThrow(/Timed out after 300s waiting for structured output/);
   });
 
   it('drains chat() after RUN_ERROR so otel onError can end the span', async () => {

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -19,6 +19,8 @@ import { llmtrCompatibleApi } from '@/lib/ai/llmtr';
 import {
   createUsageCapture,
   extractRunError,
+  glmReasoningEffortForCall,
+  isForcedGlmReasoningModel,
   llmCostFromUsage,
   openRouterProviderForModel,
   PROMPT_REASONING,
@@ -52,6 +54,9 @@ import { NonRetryableError } from 'cloudflare:workflows';
 import type { z } from 'zod';
 
 const logger = getLogger(['openstory', 'workflow', 'llm-call-helper']);
+
+/** Client-side abort so a hung provider cannot pin a workflow step forever. */
+const LLM_CALL_TIMEOUT_MS = 300_000;
 
 export type DurableLLMCallConfig<TSchema extends z.ZodType> = {
   name: string;
@@ -178,13 +183,37 @@ function reasoningModelOptions(reasoning: boolean | undefined): {
   return reasoning ? { reasoning: PROMPT_REASONING } : {};
 }
 
+/**
+ * After draining `chat()`, either we have a structured object or we don't.
+ * An abort is a timeout (retryable — the GLM hang in #1494 later succeeded
+ * on the same instance). A clean end without the complete event is a
+ * schema/provider fault and must not be retried.
+ */
+function assertStructuredOutput<T>(
+  value: T | undefined | null,
+  logName: string,
+  aborted: boolean,
+  kind: 'Call' | 'Stream'
+): asserts value is T {
+  if (value !== undefined && value !== null) return;
+  if (aborted) {
+    throw new Error(
+      `[LLM:${logName}:cf] Timed out after ${LLM_CALL_TIMEOUT_MS / 1000}s waiting for structured output`
+    );
+  }
+  throw new NonRetryableError(
+    `[LLM:${logName}:cf] ${kind} ended without a structured-output.complete event`
+  );
+}
+
 /** OpenRouter vs xAI Responses vs Gemini vs LLMTR Chat Completions options.
  *  xAI and Google reject `streamOptions`; xAI uses `max_output_tokens` and
  *  Gemini camelCase `maxOutputTokens`. LLMTR spreads native Chat Completions
  *  names (`max_tokens`, `reasoning_effort`) — OpenRouter camelCase would
  *  land as unknown fields. Omitting reasoning on grok-4.6 falls through to
  *  xAI's `high` default, so unrequested reasoning is sent as `low`; Gemini's
- *  unset `thinkingConfig` keeps the model's dynamic-thinking default. */
+ *  unset `thinkingConfig` keeps the model's dynamic-thinking default. GLM-5.3
+ *  forces thinking at `max` unless we send `low` (#1494). */
 export function chatModelOptionsForCall(
   modelId: TextModel,
   llmKeyInfo: LlmKeyInfo,
@@ -211,23 +240,34 @@ export function chatModelOptionsForCall(
       maxOutputTokens: maxTokens,
     };
   }
+  const glmEffort = isForcedGlmReasoningModel(modelId)
+    ? glmReasoningEffortForCall(reasoning)
+    : undefined;
   if (llmKeyInfo.via === 'llmtr') {
     if (llmtrCompatibleApi(modelId) === 'responses') {
       return {
-        ...(reasoning
-          ? { reasoning: { effort: PROMPT_REASONING.effort } }
-          : {}),
+        ...(glmEffort
+          ? { reasoning: { effort: glmEffort } }
+          : reasoning
+            ? { reasoning: { effort: PROMPT_REASONING.effort } }
+            : {}),
         max_output_tokens: maxTokens,
       };
     }
     return {
-      ...(reasoning ? { reasoning_effort: PROMPT_REASONING.effort } : {}),
+      ...(glmEffort
+        ? { reasoning_effort: glmEffort }
+        : reasoning
+          ? { reasoning_effort: PROMPT_REASONING.effort }
+          : {}),
       max_tokens: maxTokens,
     };
   }
   return {
     provider: openRouterProviderForModel(modelId),
-    ...reasoningModelOptions(reasoning),
+    ...(glmEffort
+      ? { reasoning: { effort: glmEffort } }
+      : reasoningModelOptions(reasoning)),
     // Native OpenAI GPT-5 endpoints advertise `max_tokens`, not
     // `max_completion_tokens` (Azure-only). Match llm-client.
     maxTokens,
@@ -379,7 +419,10 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
         // step so siblings that all 429'd together can stagger through.
         return withLlmRateLimitRetry(logName, async () => {
           const abortController = new AbortController();
-          const timeout = setTimeout(() => abortController.abort(), 300_000);
+          const timeout = setTimeout(
+            () => abortController.abort(),
+            LLM_CALL_TIMEOUT_MS
+          );
           const usageCapture = createUsageCapture();
           try {
             const commonOptions = {
@@ -433,12 +476,12 @@ export async function durableLLMCallCf<TSchema extends z.ZodType>(
               }
             }
             throwNotedRunError(runError);
-
-            if (structuredObject === undefined) {
-              throw new NonRetryableError(
-                `[LLM:${logName}:cf] Call ended without a structured-output.complete event`
-              );
-            }
+            assertStructuredOutput(
+              structuredObject,
+              logName,
+              abortController.signal.aborted,
+              'Call'
+            );
             logger.info(`[LLM:${logName}:cf] Call succeeded`);
             // Return as JSON string — round-trips through step.do without hitting
             // CF's Rpc.Serializable constraint on the Zod-inferred shape.
@@ -573,7 +616,10 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
 
         return withLlmRateLimitRetry(logName, async () => {
           const abortController = new AbortController();
-          const timeout = setTimeout(() => abortController.abort(), 300_000);
+          const timeout = setTimeout(
+            () => abortController.abort(),
+            LLM_CALL_TIMEOUT_MS
+          );
           let accumulated = '';
           let lastExtracted = '';
           let pendingDelta = '';
@@ -661,11 +707,12 @@ export async function durableStreamingLLMCallCf<TSchema extends z.ZodType>(
             }
             throwNotedRunError(runError);
             await flushDelta();
-            if (structuredJson === null) {
-              throw new NonRetryableError(
-                `[LLM:${logName}:cf] Stream ended without a structured-output.complete event`
-              );
-            }
+            assertStructuredOutput(
+              structuredJson,
+              logName,
+              abortController.signal.aborted,
+              'Stream'
+            );
             logger.info(`[LLM:${logName}:cf] Streaming call succeeded`);
             return {
               jsonText: structuredJson,


### PR DESCRIPTION
## Related Issue

Closes #1494

## Summary of Changes

GLM-5.3 Flash music-prompt hung for 300s with zero tokens, then our abort ended the TanStack stream without `structured-output.complete`. That looked like a parse failure and was thrown as `NonRetryableError`, so Cloudflare Workflows would not retry.

- GLM-5.3 / Flash force thinking and default to `max` effort (cannot disable). Unrequested reasoning now sends `effort: 'low'` on OpenRouter and `reasoning_effort: 'low'` on LLMTR — same trap we already handled for Grok.
- Requested `medium` maps to `high` because Z.AI rejects `medium`.
- A 300s abort with no structured object throws a **retryable** timeout instead of a missing-complete `NonRetryableError`.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Scoped to GLM-5.3 option mapping and abort classification. Other models still omit reasoning when it was not requested. A hang that used to fail the generation now retries the workflow step.

## Additional Notes

Production trace: session `01M16YE4C9T1GJKAZ67KKNZYNG` (2026-08-29). The cancelled call produced no tokens; a later call on the same instance succeeded in 62s.

## Test plan

- [x] `bun run test src/lib/ai/llm-client.test.ts src/lib/workflows/llm-call-helper.test.ts`
- [x] `bun tsgo --noEmit`
- [ ] Generate a sequence with GLM-5.3 Flash through music; confirm it finishes (or, on hang, retries with a timeout rather than "missing structured-output")