### PR TITLE
fix(#1502): show runtime/build columns and push only Worker secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,6 @@ BETTER_AUTH_SECRET=
 # OPENROUTER_KEY=    # https://openrouter.ai - LLM access for script analysis (optional with FAL_KEY set)
 # XAI_API_KEY=       # https://console.x.ai - Grok chat, image & video served first-party; without it Grok routes via OpenRouter/fal as before
 # GEMINI_API_KEY=    # https://aistudio.google.com/apikey - Gemini chat & Omni Flash video served first-party; without it Gemini routes via OpenRouter/fal as before
-# LLMTR_API_KEY=     # https://llmtr.com/dashboard/keys - Turkey-hosted OpenAI-compatible gateway. Last-resort platform LLM key for models it carries when OPENROUTER_KEY and FAL_KEY are unset.
 # ARK_API_KEY=       # https://console.byteplus.com/ark - routes Seedance (video) + Seedream (image) natively to BytePlus instead of via fal (#1157). Optional: without it those models fall back to their fal endpoints. Keys are REGION-scoped and Seedance is served only from ap-southeast.
 # ARK_BASE_URL=      # Overrides the Ark data-plane host (default https://ark.ap-southeast.bytepluses.com/api/v3). Set by e2e to point at aimock.
 # BYTEPLUS_ACCESS_KEY=  # IAM Access Key (not ARK_API_KEY). Needed to register every still (start frame + refs) in the virtual portrait library so Seedance 2.5 accepts photorealistic generated faces as asset:// IDs. Console: IAM → Key management.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -430,8 +430,8 @@ OpenRouter Speakeasy client, whose chunk schema rejects LLMTR's SSE as
 "Response validation failed". Every OpenAI model (and Grok) uses
 Responses; posting those to Chat Completions 400s. `llmtrCompatibleApi`
 picks the endpoint. UI:
-**Settings → API Keys → LLMTR**. Platform `LLMTR_API_KEY` is last-resort
-(after OpenRouter and fal) for models it carries. e2e never sets it.
+**Settings → API Keys → LLMTR**. Team BYOK only — there is no platform
+LLMTR key; without a team key, resolution falls through to OpenRouter/fal.
 
 `src/lib/ai/llmtr.ts` pins the two silent-break traps:
 
@@ -456,9 +456,8 @@ picks the endpoint. UI:
 
 Resolution order (`resolveLlmKey`): native xAI (Grok) → native Google
 (Gemini) → **team LLMTR when `llmtrTextModel` maps** → team OpenRouter →
-team fal → platform (`OPENROUTER_KEY`, else `FAL_KEY`, else `LLMTR_API_KEY`
-if mapped). A team that adds an LLMTR key chose that gateway, so it
-outranks their OpenRouter key. `validateKey` cannot use `/v1/models` — it
+team fal → platform (`OPENROUTER_KEY`, else `FAL_KEY`). A team that adds
+an LLMTR key chose that gateway, so it outranks their OpenRouter key. `validateKey` cannot use `/v1/models` — it
 is public and answers 200 for a bogus key — so validation is a 1-token
 completion on a $0 model and requires `response.ok`.
 

--- a/scripts/push-secrets.ts
+++ b/scripts/push-secrets.ts
@@ -78,7 +78,6 @@ export const SECRETS = {
   LANGFUSE_PROMPTS_ENABLED: { runtime: false, build: false },
   LANGFUSE_PUBLIC_KEY: { runtime: false, build: false },
   LANGFUSE_SECRET_KEY: { runtime: false, build: false },
-  LLMTR_API_KEY: { runtime: true, build: false },
   OPENROUTER_KEY: { runtime: true, build: false },
   R2_PUBLIC_ASSETS_DOMAIN: { runtime: false, build: false },
   R2_PUBLIC_STORAGE_DOMAIN: { runtime: true, build: false },
@@ -113,6 +112,8 @@ export const TOOLING_OR_LEGACY = new Set([
   // Local fal billing-compare tooling (`scripts/verify-fal-costs.ts --compare`,
   // `scripts/env-file.ts`). The Worker's admin-scoped fal key is FAL_BILLING_KEY.
   'FAL_PRICING_KEY',
+  // LLMTR is team BYOK only (Settings → API Keys). Never a Worker secret.
+  'LLMTR_API_KEY',
   // Pre-rename / retired names sometimes left on the Worker
   'APP_NAME',
   'APP_URL',

--- a/scripts/push-secrets.ts
+++ b/scripts/push-secrets.ts
@@ -5,6 +5,23 @@
  * `wrangler login`. No service tokens land in CI; blast radius stays this
  * laptop.
  *
+ * Classify every new secret before adding it. "Where the value lives"
+ * (Doppler, Worker) is not "where the value is needed":
+ *
+ *   runtime  Worker reads it at request/cron time (`getEnv()` / `env.`).
+ *            Script `process.env` does not count — that is local tooling.
+ *   build    Vite inlines it at `vite build` (`import.meta.env`). A Worker
+ *            secret is never visible to that build, so the value belongs in
+ *            Workers Builds variables (next to `CLOUDFLARE_ENV=production`),
+ *            not a runtime binding. GitHub vars from `setup-prod.ts` only
+ *            feed CI tests and PR-preview deploys.
+ *
+ * Grep those two spellings in `src/` (and `worker-configuration.d.ts` does
+ * not count — wrangler types every secret already on the Worker). Then set
+ * the flags. `--push` writes only `runtime: true`. Build-only and unused
+ * entries stay on the list so the next person classifies them instead of
+ * re-adding them to a flat allowlist.
+ *
  * Safety rules:
  * - Values stay in memory only. Never written to disk, never passed as argv
  *   (visible in `ps`), never echoed. They reach wrangler over stdin.
@@ -29,44 +46,51 @@ import { spawnSync } from 'node:child_process';
 
 const DOPPLER_PROJECT = 'openstory';
 
+/** Worker reads it at request/cron time (`getEnv()` / `env.`). */
+export type SecretNeed = {
+  runtime: boolean;
+  /** Vite inlines it at build time (`import.meta.env`) — Workers Builds vars. */
+  build: boolean;
+};
+
 /**
- * App secrets production may hold. Source of truth is Doppler; this list only
- * gates what we write. Extend when the Worker starts reading a new env var.
+ * App secrets production may hold. Source of truth is Doppler; this catalog
+ * only gates what we write and how we report. Extend when the Worker starts
+ * reading a new env var — classify runtime vs build, do not append blindly.
  */
-const PUSHABLE_SECRETS = [
-  'ADMIN_EMAILS',
-  'API_KEY_ENCRYPTION_KEY',
-  'ARK_API_KEY',
-  'ARK_BASE_URL',
-  'BYTEPLUS_ACCESS_KEY',
-  'BYTEPLUS_SECRET_KEY',
-  'BYTEPLUS_ASSET_GROUP_ID',
-  'BYTEPLUS_OPENAPI_HOST',
-  'BETTER_AUTH_SECRET',
-  'EMAIL_FROM',
-  'FAL_BILLING_KEY',
-  'FAL_KEY',
-  'FAL_PRICING_KEY',
-  'GEMINI_API_KEY',
-  'GOOGLE_CLIENT_ID',
-  'GOOGLE_CLIENT_SECRET',
-  'LANGFUSE_BASE_URL',
-  'LANGFUSE_PROMPTS_ENABLED',
-  'LANGFUSE_PUBLIC_KEY',
-  'LANGFUSE_SECRET_KEY',
-  'LLMTR_API_KEY',
-  'OPENROUTER_KEY',
-  'R2_PUBLIC_ASSETS_DOMAIN',
-  'R2_PUBLIC_STORAGE_DOMAIN',
-  'STRIPE_SECRET_KEY',
-  'STRIPE_WEBHOOK_SECRET',
-  'VITE_APP_NAME',
-  'VITE_APP_URL',
-  'VITE_PUBLIC_POSTHOG_HOST',
-  'VITE_PUBLIC_POSTHOG_PROJECT_TOKEN',
-  'VITE_R2_PUBLIC_ASSETS_DOMAIN',
-  'XAI_API_KEY',
-] as const;
+export const SECRETS = {
+  ADMIN_EMAILS: { runtime: true, build: false },
+  API_KEY_ENCRYPTION_KEY: { runtime: true, build: false },
+  ARK_API_KEY: { runtime: true, build: false },
+  ARK_BASE_URL: { runtime: true, build: false },
+  BYTEPLUS_ACCESS_KEY: { runtime: true, build: false },
+  BYTEPLUS_SECRET_KEY: { runtime: true, build: false },
+  BYTEPLUS_ASSET_GROUP_ID: { runtime: true, build: false },
+  BYTEPLUS_OPENAPI_HOST: { runtime: true, build: false },
+  BETTER_AUTH_SECRET: { runtime: true, build: false },
+  EMAIL_FROM: { runtime: true, build: false },
+  FAL_BILLING_KEY: { runtime: true, build: false },
+  FAL_KEY: { runtime: true, build: false },
+  GEMINI_API_KEY: { runtime: true, build: false },
+  GOOGLE_CLIENT_ID: { runtime: true, build: false },
+  GOOGLE_CLIENT_SECRET: { runtime: true, build: false },
+  LANGFUSE_BASE_URL: { runtime: false, build: false },
+  LANGFUSE_PROMPTS_ENABLED: { runtime: false, build: false },
+  LANGFUSE_PUBLIC_KEY: { runtime: false, build: false },
+  LANGFUSE_SECRET_KEY: { runtime: false, build: false },
+  LLMTR_API_KEY: { runtime: true, build: false },
+  OPENROUTER_KEY: { runtime: true, build: false },
+  R2_PUBLIC_ASSETS_DOMAIN: { runtime: false, build: false },
+  R2_PUBLIC_STORAGE_DOMAIN: { runtime: true, build: false },
+  STRIPE_SECRET_KEY: { runtime: true, build: false },
+  STRIPE_WEBHOOK_SECRET: { runtime: true, build: false },
+  VITE_APP_NAME: { runtime: true, build: true },
+  VITE_APP_URL: { runtime: true, build: true },
+  VITE_PUBLIC_POSTHOG_HOST: { runtime: true, build: true },
+  VITE_PUBLIC_POSTHOG_PROJECT_TOKEN: { runtime: true, build: true },
+  VITE_R2_PUBLIC_ASSETS_DOMAIN: { runtime: false, build: true },
+  XAI_API_KEY: { runtime: true, build: false },
+} as const satisfies Record<string, SecretNeed>;
 
 /** Doppler self-describing context — never Worker bindings. */
 const NEVER_PUSH = /^DOPPLER_/;
@@ -76,7 +100,7 @@ const NEVER_PUSH = /^DOPPLER_/;
  * Worker (deploy tokens, retired integrations, S3-style R2 keys — prod uses
  * R2 bindings). Reported when skipped, never pushed.
  */
-const TOOLING_OR_LEGACY = new Set([
+export const TOOLING_OR_LEGACY = new Set([
   'CLOUDFLARE_ACCOUNT_ID',
   'CLOUDFLARE_API_TOKEN',
   'CLOUDFLARE_OAUTH_CLIENT_ID',
@@ -86,6 +110,9 @@ const TOOLING_OR_LEGACY = new Set([
   'R2_ACCOUNT_ID',
   'R2_BUCKET_NAME',
   'R2_SECRET_ACCESS_KEY',
+  // Local fal billing-compare tooling (`scripts/verify-fal-costs.ts --compare`,
+  // `scripts/env-file.ts`). The Worker's admin-scoped fal key is FAL_BILLING_KEY.
+  'FAL_PRICING_KEY',
   // Pre-rename / retired names sometimes left on the Worker
   'APP_NAME',
   'APP_URL',
@@ -109,12 +136,99 @@ const WRANGLER_ENV_FOR_CONFIG: Record<string, string | undefined> = {
   // stg / ci / dev have no dedicated wrangler env block for secret push.
 };
 
-const args = new Set(process.argv.slice(2));
-const push = args.has('--push');
-const configIndex = process.argv.indexOf('--config');
-const dopplerConfig =
-  configIndex !== -1 ? (process.argv[configIndex + 1] ?? 'prd') : 'prd';
-const wranglerEnv = WRANGLER_ENV_FOR_CONFIG[dopplerConfig];
+export type SecretRow = {
+  name: string;
+  runtime: boolean;
+  build: boolean;
+  doppler: boolean;
+  worker: boolean;
+  action: string;
+};
+
+export function secretAction(
+  need: SecretNeed,
+  inDoppler: boolean,
+  onWorker: boolean
+): string {
+  if (!need.runtime && need.build) {
+    return 'build-only - set in Workers Builds';
+  }
+  if (!need.runtime) {
+    return 'unused - nothing reads it';
+  }
+  if (inDoppler) return onWorker ? 'update' : 'CREATE';
+  return onWorker ? 'worker-only (not in Doppler)' : 'MISSING';
+}
+
+/**
+ * Runtime secrets with a non-empty Doppler value. Never emits null, never
+ * includes build-only or unused entries.
+ */
+export function buildPushPayload(
+  catalog: Record<string, SecretNeed>,
+  doppler: Record<string, string>
+): Record<string, string> {
+  const payload: Record<string, string> = {};
+  for (const [name, need] of Object.entries(catalog)) {
+    if (!need.runtime) continue;
+    const value = doppler[name];
+    if (value !== undefined && value !== '') payload[name] = value;
+  }
+  return payload;
+}
+
+export function secretRows(
+  catalog: Record<string, SecretNeed>,
+  dopplerNames: ReadonlySet<string>,
+  workerNames: ReadonlySet<string>
+): Array<SecretRow> {
+  return Object.keys(catalog)
+    .sort()
+    .map((name) => {
+      const need = catalog[name] ?? { runtime: false, build: false };
+      const inDoppler = dopplerNames.has(name);
+      const onWorker = workerNames.has(name);
+      return {
+        name,
+        runtime: need.runtime,
+        build: need.build,
+        doppler: inDoppler,
+        worker: onWorker,
+        action: secretAction(need, inDoppler, onWorker),
+      };
+    });
+}
+
+function yn(value: boolean): 'y' | '-' {
+  return value ? 'y' : '-';
+}
+
+export function formatSecretsTable(rows: Array<SecretRow>): string {
+  const nameWidth = Math.max(
+    ...rows.map((r) => r.name.length),
+    'SECRET'.length
+  );
+  const flagWidth = 8;
+  const header = [
+    'SECRET'.padEnd(nameWidth),
+    'runtime'.padStart(flagWidth),
+    'build'.padStart(flagWidth),
+    'doppler'.padStart(flagWidth),
+    'worker'.padStart(flagWidth),
+    '  action',
+  ].join('');
+  const body = rows.map((row) =>
+    [
+      row.name.padEnd(nameWidth),
+      yn(row.runtime).padStart(flagWidth),
+      yn(row.build).padStart(flagWidth),
+      yn(row.doppler).padStart(flagWidth),
+      yn(row.worker).padStart(flagWidth),
+      `  ${row.action}`,
+    ].join('')
+  );
+  return [header, ...body].join('\n');
+}
 
 function run(
   command: string,
@@ -177,7 +291,7 @@ function parseDopplerJson(raw: string): Record<string, string> {
 }
 
 /** Secret names currently bound to the target Worker (names only). */
-function workerSecretNames(): Set<string> {
+function workerSecretNames(wranglerEnv: string | undefined): Set<string> {
   const cmdArgs = ['wrangler', 'secret', 'list'];
   if (wranglerEnv) cmdArgs.push('--env', wranglerEnv);
   const raw = run('bunx', cmdArgs);
@@ -200,113 +314,115 @@ function dopplerSecrets(config: string): Record<string, string> {
   return parseDopplerJson(raw);
 }
 
-const expectedSet = new Set<string>(PUSHABLE_SECRETS);
-const expected = [...PUSHABLE_SECRETS].sort();
-const doppler = dopplerSecrets(dopplerConfig);
-const onWorker = workerSecretNames();
+function main(): void {
+  const args = new Set(process.argv.slice(2));
+  const push = args.has('--push');
+  const configIndex = process.argv.indexOf('--config');
+  const dopplerConfig =
+    configIndex !== -1 ? (process.argv[configIndex + 1] ?? 'prd') : 'prd';
+  const wranglerEnv = WRANGLER_ENV_FOR_CONFIG[dopplerConfig];
 
-const dopplerNames = Object.keys(doppler).filter((n) => !NEVER_PUSH.test(n));
-const payload: Record<string, string> = {};
-const rows: Array<[string, string]> = [];
+  const catalog: Record<string, SecretNeed> = SECRETS;
+  const expectedSet = new Set(Object.keys(catalog));
+  const doppler = dopplerSecrets(dopplerConfig);
+  const onWorker = workerSecretNames(wranglerEnv);
 
-for (const name of expected) {
-  const inDoppler = name in doppler;
-  const deployed = onWorker.has(name);
-  if (inDoppler) {
-    const value = doppler[name];
-    if (value !== undefined && value !== '') payload[name] = value;
-    rows.push([name, deployed ? 'update' : 'CREATE']);
-  } else {
-    rows.push([name, deployed ? 'worker-only (not in Doppler)' : 'MISSING']);
+  const dopplerNames = Object.keys(doppler).filter((n) => !NEVER_PUSH.test(n));
+  const payload = buildPushPayload(catalog, doppler);
+  const rows = secretRows(catalog, new Set(dopplerNames), onWorker);
+
+  const targetLabel = wranglerEnv
+    ? `openstory --env=${wranglerEnv}`
+    : 'openstory (default)';
+
+  console.log(
+    `\nDoppler: ${DOPPLER_PROJECT}/${dopplerConfig}   Worker: ${targetLabel}   mode: ${
+      push ? 'PUSH' : 'dry run'
+    }\n`
+  );
+  console.log(
+    '  runtime = Worker reads it (pushed).  build = Vite inlines it (Workers Builds vars, not pushed).\n'
+  );
+  console.log(formatSecretsTable(rows));
+
+  const unexpected = dopplerNames.filter((n) => !expectedSet.has(n));
+  const tooling = unexpected.filter((n) => TOOLING_OR_LEGACY.has(n));
+  const unknown = unexpected.filter((n) => !TOOLING_OR_LEGACY.has(n));
+  if (tooling.length > 0) {
+    console.log(
+      `\n  tooling/legacy in Doppler, skipped: ${tooling.join(', ')}`
+    );
   }
-}
+  if (unknown.length > 0) {
+    console.log(
+      `\n  not in the catalog, skipped: ${unknown.join(', ')}` +
+        `\n  (add to SECRETS in scripts/push-secrets.ts with runtime/build flags if the Worker should have them)`
+    );
+  }
+  const contextVars = Object.keys(doppler).filter((n) => NEVER_PUSH.test(n));
+  if (contextVars.length > 0) {
+    console.log(
+      `  Doppler context vars, never pushed: ${contextVars.join(', ')}`
+    );
+  }
 
-const targetLabel = wranglerEnv
-  ? `openstory --env=${wranglerEnv}`
-  : 'openstory (default)';
+  const missing = rows
+    .filter((r) => r.runtime && r.action === 'MISSING')
+    .map((r) => r.name);
+  const workerOnly = rows
+    .filter((r) => r.runtime && r.action.startsWith('worker-only'))
+    .map((r) => r.name);
+  if (workerOnly.length > 0) {
+    console.log(
+      `\n  ${workerOnly.length} runtime secret(s) live on the Worker but not in Doppler:\n    ${workerOnly.join(', ')}` +
+        `\n  Add them to the '${dopplerConfig}' config before relying on this script.`
+    );
+  }
+  if (missing.length > 0) {
+    console.log(
+      `\n  ${missing.length} runtime secret(s) absent from BOTH:\n    ${missing.join(', ')}`
+    );
+  }
 
-console.log(
-  `\nDoppler: ${DOPPLER_PROJECT}/${dopplerConfig}   Worker: ${targetLabel}   mode: ${
-    push ? 'PUSH' : 'dry run'
-  }\n`
-);
+  // Worker secrets we do not manage — informational only.
+  const unmanagedOnWorker = [...onWorker]
+    .filter((n) => !expectedSet.has(n) && !NEVER_PUSH.test(n))
+    .sort();
+  if (unmanagedOnWorker.length > 0) {
+    console.log(
+      `\n  already on Worker, not managed by this script (left alone):\n    ${unmanagedOnWorker.join(', ')}`
+    );
+  }
 
-const width = Math.max(...rows.map(([name]) => name.length), 8);
-for (const [name, action] of rows) {
-  console.log(`  ${name.padEnd(width)}  ${action}`);
-}
+  const count = Object.keys(payload).length;
+  if (!push) {
+    console.log(
+      `\nDry run — nothing sent. ${count} runtime secret(s) would be written.` +
+        ` Re-run with --push to apply (or \`bun secrets:push:prd\`).\n`
+    );
+    process.exit(0);
+  }
+  if (count === 0) {
+    console.log('\nNothing to push.\n');
+    process.exit(0);
+  }
 
-const unexpected = dopplerNames.filter((n) => !expectedSet.has(n));
-const tooling = unexpected.filter((n) => TOOLING_OR_LEGACY.has(n));
-const unknown = unexpected.filter((n) => !TOOLING_OR_LEGACY.has(n));
-if (tooling.length > 0) {
-  console.log(`\n  tooling/legacy in Doppler, skipped: ${tooling.join(', ')}`);
-}
-if (unknown.length > 0) {
+  /**
+   * One API call, over stdin: no temp file, nothing in argv, nothing in shell
+   * history. Deletions are impossible here because no key is ever set to null.
+   *
+   * `wrangler versions secret bulk` rather than plain `wrangler secret bulk`,
+   * which edits the live Worker and refuses with Cloudflare error 10215 when
+   * the newest uploaded version is not the deployed one (common with Workers
+   * Builds). The versions API has no such precondition.
+   */
+  const bulkArgs = ['wrangler', 'versions', 'secret', 'bulk'];
+  if (wranglerEnv) bulkArgs.push('--env', wranglerEnv);
+  run('bunx', bulkArgs, JSON.stringify(payload));
   console.log(
-    `\n  not in the allowlist, skipped: ${unknown.join(', ')}` +
-      `\n  (add to PUSHABLE_SECRETS in scripts/push-secrets.ts if the Worker should have them)`
+    `\nWrote ${count} runtime secret(s) into a new version.` +
+      `\nThey go live with the next deploy, which inherits them.\n`
   );
 }
-const contextVars = Object.keys(doppler).filter((n) => NEVER_PUSH.test(n));
-if (contextVars.length > 0) {
-  console.log(
-    `  Doppler context vars, never pushed: ${contextVars.join(', ')}`
-  );
-}
 
-const missing = rows.filter(([, a]) => a === 'MISSING').map(([n]) => n);
-const workerOnly = rows
-  .filter(([, a]) => a.startsWith('worker-only'))
-  .map(([n]) => n);
-if (workerOnly.length > 0) {
-  console.log(
-    `\n  ${workerOnly.length} allowlisted secret(s) live on the Worker but not in Doppler:\n    ${workerOnly.join(', ')}` +
-      `\n  Add them to the '${dopplerConfig}' config before relying on this script.`
-  );
-}
-if (missing.length > 0) {
-  console.log(
-    `\n  ${missing.length} allowlisted secret(s) absent from BOTH:\n    ${missing.join(', ')}`
-  );
-}
-
-// Worker secrets we do not manage — informational only.
-const unmanagedOnWorker = [...onWorker]
-  .filter((n) => !expectedSet.has(n) && !NEVER_PUSH.test(n))
-  .sort();
-if (unmanagedOnWorker.length > 0) {
-  console.log(
-    `\n  already on Worker, not managed by this script (left alone):\n    ${unmanagedOnWorker.join(', ')}`
-  );
-}
-
-const count = Object.keys(payload).length;
-if (!push) {
-  console.log(
-    `\nDry run — nothing sent. ${count} secret(s) would be written.` +
-      ` Re-run with --push to apply (or \`bun secrets:push:prd\`).\n`
-  );
-  process.exit(0);
-}
-if (count === 0) {
-  console.log('\nNothing to push.\n');
-  process.exit(0);
-}
-
-/**
- * One API call, over stdin: no temp file, nothing in argv, nothing in shell
- * history. Deletions are impossible here because no key is ever set to null.
- *
- * `wrangler versions secret bulk` rather than plain `wrangler secret bulk`,
- * which edits the live Worker and refuses with Cloudflare error 10215 when
- * the newest uploaded version is not the deployed one (common with Workers
- * Builds). The versions API has no such precondition.
- */
-const bulkArgs = ['wrangler', 'versions', 'secret', 'bulk'];
-if (wranglerEnv) bulkArgs.push('--env', wranglerEnv);
-run('bunx', bulkArgs, JSON.stringify(payload));
-console.log(
-  `\nWrote ${count} secret(s) into a new version.` +
-    `\nThey go live with the next deploy, which inherits them.\n`
-);
+if (import.meta.main) main();

--- a/scripts/push-secrets.ts
+++ b/scripts/push-secrets.ts
@@ -18,7 +18,9 @@
  *
  * Grep those two spellings in `src/` (and `worker-configuration.d.ts` does
  * not count — wrangler types every secret already on the Worker). Then set
- * the flags. `--push` writes only `runtime: true`. Build-only and unused
+ * the flags. `--push` writes only `runtime: true` entries that are not
+ * `hold`. `hold` keeps a runtime secret visible without writing it —
+ * BytePlus native is off until we drop the hold. Build-only and unused
  * entries stay on the list so the next person classifies them instead of
  * re-adding them to a flat allowlist.
  *
@@ -51,7 +53,12 @@ export type SecretNeed = {
   runtime: boolean;
   /** Vite inlines it at build time (`import.meta.env`) — Workers Builds vars. */
   build: boolean;
+  /** Report this reason and never push, even when runtime. */
+  hold?: string;
 };
+
+/** Live `ARK_API_KEY` on the Worker is what claims the BytePlus via. */
+const BYTEPLUS_NATIVE_OFF = 'BytePlus native is off';
 
 /**
  * App secrets production may hold. Source of truth is Doppler; this catalog
@@ -61,12 +68,28 @@ export type SecretNeed = {
 export const SECRETS = {
   ADMIN_EMAILS: { runtime: true, build: false },
   API_KEY_ENCRYPTION_KEY: { runtime: true, build: false },
-  ARK_API_KEY: { runtime: true, build: false },
-  ARK_BASE_URL: { runtime: true, build: false },
-  BYTEPLUS_ACCESS_KEY: { runtime: true, build: false },
-  BYTEPLUS_SECRET_KEY: { runtime: true, build: false },
-  BYTEPLUS_ASSET_GROUP_ID: { runtime: true, build: false },
-  BYTEPLUS_OPENAPI_HOST: { runtime: true, build: false },
+  ARK_API_KEY: { runtime: true, build: false, hold: BYTEPLUS_NATIVE_OFF },
+  ARK_BASE_URL: { runtime: true, build: false, hold: BYTEPLUS_NATIVE_OFF },
+  BYTEPLUS_ACCESS_KEY: {
+    runtime: true,
+    build: false,
+    hold: BYTEPLUS_NATIVE_OFF,
+  },
+  BYTEPLUS_SECRET_KEY: {
+    runtime: true,
+    build: false,
+    hold: BYTEPLUS_NATIVE_OFF,
+  },
+  BYTEPLUS_ASSET_GROUP_ID: {
+    runtime: true,
+    build: false,
+    hold: BYTEPLUS_NATIVE_OFF,
+  },
+  BYTEPLUS_OPENAPI_HOST: {
+    runtime: true,
+    build: false,
+    hold: BYTEPLUS_NATIVE_OFF,
+  },
   BETTER_AUTH_SECRET: { runtime: true, build: false },
   EMAIL_FROM: { runtime: true, build: false },
   FAL_BILLING_KEY: { runtime: true, build: false },
@@ -151,6 +174,7 @@ export function secretAction(
   inDoppler: boolean,
   onWorker: boolean
 ): string {
+  if (need.hold) return `held - ${need.hold}`;
   if (!need.runtime && need.build) {
     return 'build-only - set in Workers Builds';
   }
@@ -163,7 +187,7 @@ export function secretAction(
 
 /**
  * Runtime secrets with a non-empty Doppler value. Never emits null, never
- * includes build-only or unused entries.
+ * includes build-only, unused, or held entries.
  */
 export function buildPushPayload(
   catalog: Record<string, SecretNeed>,
@@ -171,7 +195,7 @@ export function buildPushPayload(
 ): Record<string, string> {
   const payload: Record<string, string> = {};
   for (const [name, need] of Object.entries(catalog)) {
-    if (!need.runtime) continue;
+    if (!need.runtime || need.hold) continue;
     const value = doppler[name];
     if (value !== undefined && value !== '') payload[name] = value;
   }
@@ -342,7 +366,7 @@ function main(): void {
     }\n`
   );
   console.log(
-    '  runtime = Worker reads it (pushed).  build = Vite inlines it (Workers Builds vars, not pushed).\n'
+    '  runtime = Worker reads it (pushed unless held).  build = Vite inlines it (Workers Builds vars, not pushed).\n'
   );
   console.log(formatSecretsTable(rows));
 

--- a/src/components/settings/api-key-settings.tsx
+++ b/src/components/settings/api-key-settings.tsx
@@ -445,7 +445,7 @@ type ManualKeyRowProps = {
   placeholder: string;
   keyUrl: string;
   existingKey?: { keyHint: string };
-  status?: 'team' | 'platform';
+  status?: 'team' | 'platform' | 'none';
   isLoading: boolean;
   onSave: (apiKey: string) => void;
   onDelete: () => void;
@@ -552,7 +552,7 @@ function ManualKeyRow({
   );
 }
 
-function StatusBadge({ source }: { source?: 'team' | 'platform' }) {
+function StatusBadge({ source }: { source?: 'team' | 'platform' | 'none' }) {
   if (source === 'team') {
     return (
       <Badge variant="default" className="text-xs">
@@ -560,9 +560,12 @@ function StatusBadge({ source }: { source?: 'team' | 'platform' }) {
       </Badge>
     );
   }
-  return (
-    <Badge variant="secondary" className="text-xs">
-      Platform key
-    </Badge>
-  );
+  if (source === 'platform') {
+    return (
+      <Badge variant="secondary" className="text-xs">
+        Platform key
+      </Badge>
+    );
+  }
+  return null;
 }

--- a/src/functions/api-keys.ts
+++ b/src/functions/api-keys.ts
@@ -116,7 +116,7 @@ export const checkApiKeyStatusFn = createServerFn({ method: 'GET' })
       fal: hasFal ? 'team' : 'platform',
       xai: hasXai ? 'team' : 'platform',
       google: hasGoogle ? 'team' : 'platform',
-      llmtr: hasLlmtr ? 'team' : 'platform',
+      llmtr: hasLlmtr ? 'team' : 'none',
     } as const;
   });
 

--- a/src/lib/ai/create-adapter.test.ts
+++ b/src/lib/ai/create-adapter.test.ts
@@ -16,7 +16,6 @@ const testEnv: {
   FAL_KEY: string | undefined;
   XAI_API_KEY: string | undefined;
   GEMINI_API_KEY: string | undefined;
-  LLMTR_API_KEY: string | undefined;
   OPENROUTER_BASE_URL: string | undefined;
   XAI_BASE_URL: string | undefined;
   GEMINI_BASE_URL: string | undefined;
@@ -28,7 +27,6 @@ const testEnv: {
   FAL_KEY: undefined,
   XAI_API_KEY: undefined,
   GEMINI_API_KEY: undefined,
-  LLMTR_API_KEY: undefined,
   OPENROUTER_BASE_URL: undefined,
   XAI_BASE_URL: undefined,
   GEMINI_BASE_URL: undefined,
@@ -174,7 +172,6 @@ beforeEach(() => {
   testEnv.XAI_BASE_URL = undefined;
   testEnv.GEMINI_API_KEY = undefined;
   testEnv.GEMINI_BASE_URL = undefined;
-  testEnv.LLMTR_API_KEY = undefined;
   adapterCalls.length = 0;
   grokCalls.length = 0;
   geminiCalls.length = 0;
@@ -247,55 +244,10 @@ describe('createAdapter LLMTR routing', () => {
     expect(createOpenRouterTextMock).not.toHaveBeenCalled();
   });
 
-  it('does not let platform LLMTR steal OpenRouter traffic', () => {
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
+  it('never resolves a platform LLMTR key — LLMTR is team BYOK only', () => {
+    expect(getPlatformLlmKey('anthropic/claude-sonnet-5')).toBeUndefined();
     testEnv.OPENROUTER_KEY = 'platform-or';
-
     expect(getPlatformLlmKey('anthropic/claude-sonnet-5')).toEqual({
-      key: 'platform-or',
-      via: 'openrouter',
-      source: 'platform',
-    });
-  });
-
-  it('uses platform LLMTR only when OpenRouter and fal are unset', () => {
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
-
-    expect(getPlatformLlmKey('anthropic/claude-sonnet-5')).toEqual({
-      key: 'platform-llmtr',
-      via: 'llmtr',
-      source: 'platform',
-    });
-  });
-
-  it('leaves a model LLMTR does not carry on the platform OpenRouter key', () => {
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
-    testEnv.OPENROUTER_KEY = 'platform-or';
-
-    expect(getPlatformLlmKey('anthropic/claude-opus-5-fast')).toEqual({
-      key: 'platform-or',
-      via: 'openrouter',
-      source: 'platform',
-    });
-  });
-
-  it('keeps xAI first for Grok — first-party beats a gateway', () => {
-    testEnv.XAI_API_KEY = 'platform-xai';
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
-
-    expect(getPlatformLlmKey(MODEL)).toEqual({
-      key: 'platform-xai',
-      via: 'xai',
-      source: 'platform',
-    });
-  });
-
-  it('ignores LLMTR when the caller cannot name the model', () => {
-    // Without a model there is no way to know LLMTR carries it.
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
-    testEnv.OPENROUTER_KEY = 'platform-or';
-
-    expect(getPlatformLlmKey()).toEqual({
       key: 'platform-or',
       via: 'openrouter',
       source: 'platform',

--- a/src/lib/ai/create-adapter.ts
+++ b/src/lib/ai/create-adapter.ts
@@ -71,13 +71,12 @@ function falAuthHttpClient(falKey: string): HTTPClient {
 /**
  * Resolve the platform-level LLM key from env. A Grok model prefers
  * XAI_API_KEY (#1167) and a Gemini model GEMINI_API_KEY; otherwise
- * OPENROUTER_KEY, then FAL_KEY (issue #895). A platform `LLMTR_API_KEY` is
- * last-resort for models LLMTR carries — it must not steal traffic from
- * OpenRouter or fal. Returns undefined when none is configured.
+ * OPENROUTER_KEY, then FAL_KEY (issue #895). LLMTR is team BYOK only —
+ * there is no platform LLMTR key. Returns undefined when none is configured.
  *
  * Omitting `model` keeps the OpenRouter-first order, which every model
  * supports — a caller that can't name the model can't promise it's a Grok
- * or Gemini one, nor that LLMTR carries it.
+ * or Gemini one.
  */
 export function getPlatformLlmKey(
   model?: string
@@ -94,9 +93,6 @@ export function getPlatformLlmKey(
   }
   if (env.FAL_KEY) {
     return { key: env.FAL_KEY, via: 'fal', source: 'platform' };
-  }
-  if (model && llmtrTextModel(model) && env.LLMTR_API_KEY) {
-    return { key: env.LLMTR_API_KEY, via: 'llmtr', source: 'platform' };
   }
   return undefined;
 }

--- a/src/lib/db/scoped/api-keys.test.ts
+++ b/src/lib/db/scoped/api-keys.test.ts
@@ -39,14 +39,12 @@ const testEnv: {
   FAL_KEY: string | undefined;
   XAI_API_KEY: string | undefined;
   GEMINI_API_KEY: string | undefined;
-  LLMTR_API_KEY: string | undefined;
 } = {
   API_KEY_ENCRYPTION_KEY: 'test-secret-for-api-keys-memoization',
   OPENROUTER_KEY: 'platform-openrouter-key',
   FAL_KEY: 'platform-fal-key',
   XAI_API_KEY: undefined,
   GEMINI_API_KEY: undefined,
-  LLMTR_API_KEY: undefined,
 };
 
 vi.doMock('#env', () => ({
@@ -120,7 +118,6 @@ beforeEach(async () => {
   testEnv.FAL_KEY = 'platform-fal-key';
   testEnv.XAI_API_KEY = undefined;
   testEnv.GEMINI_API_KEY = undefined;
-  testEnv.LLMTR_API_KEY = undefined;
   await seed();
 });
 
@@ -588,39 +585,22 @@ describe('resolveLlmKey — LLMTR gateway', () => {
     });
   });
 
-  it('uses the platform LLMTR key when OpenRouter and fal are unset', async () => {
+  it('does not fall back to a platform LLMTR key when OpenRouter and fal are unset', async () => {
     testEnv.OPENROUTER_KEY = undefined;
     testEnv.FAL_KEY = undefined;
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
     const scope = createApiKeysReadMethods(db, teamId);
 
-    expect(await scope.resolveLlmKey(CARRIED)).toStrictEqual({
-      key: 'platform-llmtr',
-      source: 'platform',
-      via: 'llmtr',
-      fallbackReason: undefined,
-    });
+    await expect(scope.resolveLlmKey(CARRIED)).rejects.toThrow(
+      /No platform LLM key available \(set OPENROUTER_KEY or FAL_KEY\)/
+    );
   });
 
-  it('does not let platform LLMTR outrank OPENROUTER_KEY', async () => {
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
+  it('throws from resolveKey when there is no team LLMTR key', async () => {
     const scope = createApiKeysReadMethods(db, teamId);
 
-    expect(await scope.resolveLlmKey(CARRIED)).toMatchObject({
-      key: 'platform-openrouter-key',
-      source: 'platform',
-      via: 'openrouter',
-    });
-  });
-
-  it('resolves the platform LLMTR key via resolveKey too', async () => {
-    testEnv.LLMTR_API_KEY = 'platform-llmtr';
-    const scope = createApiKeysReadMethods(db, teamId);
-
-    expect(await scope.resolveKey('llmtr')).toEqual({
-      key: 'platform-llmtr',
-      source: 'platform',
-    });
+    await expect(scope.resolveKey('llmtr')).rejects.toThrow(
+      /No API key available for provider: llmtr/
+    );
   });
 });
 

--- a/src/lib/db/scoped/api-keys.ts
+++ b/src/lib/db/scoped/api-keys.ts
@@ -297,7 +297,8 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
       case 'google':
         return env.GEMINI_API_KEY || undefined;
       case 'llmtr':
-        return env.LLMTR_API_KEY || undefined;
+        // Team BYOK only — OpenRouter/fal cover platform LLM calls.
+        return undefined;
       default: {
         const _exhaustive: never = provider;
         throw new Error(`Unknown provider: ${String(_exhaustive)}`);
@@ -376,8 +377,7 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
   //   2. team OpenRouter key (direct OpenRouter)
   //   3. team fal key (routed through fal's OpenRouter endpoint) — a fal-only
   //      team still covers LLM calls on their own key (issue #895)
-  //   4. platform key (OPENROUTER_KEY, else FAL_KEY, else LLMTR_API_KEY when
-  //      it carries the model)
+  //   4. platform key (OPENROUTER_KEY, else FAL_KEY)
   // A skipped OpenRouter key that a working fal key supersedes returns
   // `source: 'team'` with no fallbackReason — the reason only surfaces when
   // resolution falls all the way through to the platform key.
@@ -440,7 +440,7 @@ export function createApiKeysReadMethods(db: Database, teamId: string) {
     const platform = getPlatformLlmKey(model);
     if (!platform) {
       throw new Error(
-        'No platform LLM key available (set OPENROUTER_KEY, FAL_KEY or LLMTR_API_KEY)'
+        'No platform LLM key available (set OPENROUTER_KEY or FAL_KEY)'
       );
     }
     if (fallbackReason) {

--- a/src/lib/env/push-secrets.test.ts
+++ b/src/lib/env/push-secrets.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SECRETS,
+  TOOLING_OR_LEGACY,
+  buildPushPayload,
+  formatSecretsTable,
+  secretAction,
+  secretRows,
+  type SecretNeed,
+} from '../../../scripts/push-secrets';
+
+const catalog: Record<string, SecretNeed> = {
+  ADMIN_EMAILS: { runtime: true, build: false },
+  VITE_APP_URL: { runtime: true, build: true },
+  VITE_R2_PUBLIC_ASSETS_DOMAIN: { runtime: false, build: true },
+  LANGFUSE_SECRET_KEY: { runtime: false, build: false },
+};
+
+describe('secretAction', () => {
+  const runtime: SecretNeed = { runtime: true, build: false };
+
+  it('reports update when a runtime secret is in Doppler and on the Worker', () => {
+    expect(secretAction(runtime, true, true)).toBe('update');
+  });
+
+  it('reports CREATE when a runtime secret is in Doppler but not on the Worker', () => {
+    expect(secretAction(runtime, true, false)).toBe('CREATE');
+  });
+
+  it('reports worker-only when a runtime secret is on the Worker but not in Doppler', () => {
+    expect(secretAction(runtime, false, true)).toBe(
+      'worker-only (not in Doppler)'
+    );
+  });
+
+  it('reports MISSING when a runtime secret is in neither store', () => {
+    expect(secretAction(runtime, false, false)).toBe('MISSING');
+  });
+
+  it('reports build-only regardless of Doppler/Worker presence', () => {
+    const build: SecretNeed = { runtime: false, build: true };
+    expect(secretAction(build, true, true)).toBe(
+      'build-only - set in Workers Builds'
+    );
+    expect(secretAction(build, false, false)).toBe(
+      'build-only - set in Workers Builds'
+    );
+  });
+
+  it('reports unused regardless of Doppler/Worker presence', () => {
+    const unused: SecretNeed = { runtime: false, build: false };
+    expect(secretAction(unused, true, true)).toBe('unused - nothing reads it');
+    expect(secretAction(unused, false, false)).toBe(
+      'unused - nothing reads it'
+    );
+  });
+
+  it('still pushes dual runtime+build secrets (action is the push verb)', () => {
+    const both: SecretNeed = { runtime: true, build: true };
+    expect(secretAction(both, true, true)).toBe('update');
+    expect(secretAction(both, true, false)).toBe('CREATE');
+  });
+});
+
+describe('buildPushPayload', () => {
+  it('includes only runtime secrets with a non-empty Doppler value', () => {
+    const payload = buildPushPayload(catalog, {
+      ADMIN_EMAILS: 'a@example.com',
+      VITE_APP_URL: 'https://openstory.so',
+      VITE_R2_PUBLIC_ASSETS_DOMAIN: 'assets.openstory.so',
+      LANGFUSE_SECRET_KEY: 'lf-secret',
+    });
+    expect(payload).toEqual({
+      ADMIN_EMAILS: 'a@example.com',
+      VITE_APP_URL: 'https://openstory.so',
+    });
+  });
+
+  it('never emits build-only, unused, empty, or missing keys', () => {
+    const payload = buildPushPayload(catalog, {
+      ADMIN_EMAILS: '',
+      VITE_R2_PUBLIC_ASSETS_DOMAIN: 'assets.openstory.so',
+      LANGFUSE_SECRET_KEY: 'lf-secret',
+    });
+    expect(payload).toEqual({});
+  });
+
+  it('never serializes nulls so wrangler cannot delete', () => {
+    const payload = buildPushPayload(SECRETS, {
+      FAL_KEY: 'fal-key',
+      VITE_R2_PUBLIC_ASSETS_DOMAIN: 'assets.openstory.so',
+      LANGFUSE_SECRET_KEY: 'lf-secret',
+      R2_PUBLIC_ASSETS_DOMAIN: 'assets.openstory.so',
+    });
+    const parsed: unknown = JSON.parse(JSON.stringify(payload));
+    expect(parsed).toEqual({ FAL_KEY: 'fal-key' });
+    expect(JSON.stringify(payload)).not.toContain(':null');
+  });
+});
+
+describe('SECRETS catalog (#1502)', () => {
+  it('classifies VITE_R2_PUBLIC_ASSETS_DOMAIN as build-only', () => {
+    expect(SECRETS.VITE_R2_PUBLIC_ASSETS_DOMAIN).toEqual({
+      runtime: false,
+      build: true,
+    });
+  });
+
+  it('classifies LANGFUSE_* and R2_PUBLIC_ASSETS_DOMAIN as unused', () => {
+    expect(SECRETS.LANGFUSE_BASE_URL).toEqual({ runtime: false, build: false });
+    expect(SECRETS.LANGFUSE_PROMPTS_ENABLED).toEqual({
+      runtime: false,
+      build: false,
+    });
+    expect(SECRETS.LANGFUSE_PUBLIC_KEY).toEqual({
+      runtime: false,
+      build: false,
+    });
+    expect(SECRETS.LANGFUSE_SECRET_KEY).toEqual({
+      runtime: false,
+      build: false,
+    });
+    expect(SECRETS.R2_PUBLIC_ASSETS_DOMAIN).toEqual({
+      runtime: false,
+      build: false,
+    });
+  });
+
+  it('keeps FAL_PRICING_KEY in tooling/legacy, not the catalog', () => {
+    expect('FAL_PRICING_KEY' in SECRETS).toBe(false);
+    expect(TOOLING_OR_LEGACY.has('FAL_PRICING_KEY')).toBe(true);
+  });
+
+  it('classifies LLMTR_API_KEY as runtime (Worker env., not process.env)', () => {
+    expect(SECRETS.LLMTR_API_KEY).toEqual({ runtime: true, build: false });
+  });
+
+  it('classifies VITE_APP_* and PostHog as both runtime and build', () => {
+    expect(SECRETS.VITE_APP_NAME).toEqual({ runtime: true, build: true });
+    expect(SECRETS.VITE_APP_URL).toEqual({ runtime: true, build: true });
+    expect(SECRETS.VITE_PUBLIC_POSTHOG_HOST).toEqual({
+      runtime: true,
+      build: true,
+    });
+    expect(SECRETS.VITE_PUBLIC_POSTHOG_PROJECT_TOKEN).toEqual({
+      runtime: true,
+      build: true,
+    });
+  });
+});
+
+describe('formatSecretsTable', () => {
+  it('prints runtime / build / doppler / worker columns and an action', () => {
+    const table = formatSecretsTable(
+      secretRows(
+        catalog,
+        new Set(['ADMIN_EMAILS', 'VITE_APP_URL', 'LANGFUSE_SECRET_KEY']),
+        new Set([
+          'ADMIN_EMAILS',
+          'VITE_APP_URL',
+          'VITE_R2_PUBLIC_ASSETS_DOMAIN',
+        ])
+      )
+    );
+    expect(table).toContain('SECRET');
+    expect(table).toContain('runtime');
+    expect(table).toContain('build');
+    expect(table).toContain('doppler');
+    expect(table).toContain('worker');
+    expect(table).toContain('action');
+    expect(table).toContain('update');
+    expect(table).toContain('build-only - set in Workers Builds');
+    expect(table).toContain('unused - nothing reads it');
+  });
+});

--- a/src/lib/env/push-secrets.test.ts
+++ b/src/lib/env/push-secrets.test.ts
@@ -60,6 +60,20 @@ describe('secretAction', () => {
     expect(secretAction(both, true, true)).toBe('update');
     expect(secretAction(both, true, false)).toBe('CREATE');
   });
+
+  it('reports held and never treats it as a push verb', () => {
+    const held: SecretNeed = {
+      runtime: true,
+      build: false,
+      hold: 'BytePlus native is off',
+    };
+    expect(secretAction(held, true, false)).toBe(
+      'held - BytePlus native is off'
+    );
+    expect(secretAction(held, false, true)).toBe(
+      'held - BytePlus native is off'
+    );
+  });
 });
 
 describe('buildPushPayload', () => {
@@ -95,6 +109,20 @@ describe('buildPushPayload', () => {
     const parsed: unknown = JSON.parse(JSON.stringify(payload));
     expect(parsed).toEqual({ FAL_KEY: 'fal-key' });
     expect(JSON.stringify(payload)).not.toContain(':null');
+  });
+
+  it('never writes held BytePlus keys even when Doppler has them', () => {
+    const payload = buildPushPayload(SECRETS, {
+      FAL_KEY: 'fal-key',
+      ARK_API_KEY: 'ark-key',
+      ARK_BASE_URL: 'https://ark.example',
+      BYTEPLUS_ACCESS_KEY: 'ak',
+      BYTEPLUS_SECRET_KEY: 'sk',
+      BYTEPLUS_ASSET_GROUP_ID: 'group',
+      BYTEPLUS_OPENAPI_HOST: 'host',
+    });
+    expect(payload).toEqual({ FAL_KEY: 'fal-key' });
+    expect(payload).not.toHaveProperty('ARK_API_KEY');
   });
 });
 
@@ -134,6 +162,20 @@ describe('SECRETS catalog (#1502)', () => {
   it('keeps LLMTR_API_KEY in tooling/legacy — team BYOK, never a Worker secret', () => {
     expect('LLMTR_API_KEY' in SECRETS).toBe(false);
     expect(TOOLING_OR_LEGACY.has('LLMTR_API_KEY')).toBe(true);
+  });
+
+  it('holds BytePlus keys as runtime-but-not-pushed', () => {
+    const held = {
+      runtime: true,
+      build: false,
+      hold: 'BytePlus native is off',
+    };
+    expect(SECRETS.ARK_API_KEY).toEqual(held);
+    expect(SECRETS.ARK_BASE_URL).toEqual(held);
+    expect(SECRETS.BYTEPLUS_ACCESS_KEY).toEqual(held);
+    expect(SECRETS.BYTEPLUS_SECRET_KEY).toEqual(held);
+    expect(SECRETS.BYTEPLUS_ASSET_GROUP_ID).toEqual(held);
+    expect(SECRETS.BYTEPLUS_OPENAPI_HOST).toEqual(held);
   });
 
   it('classifies VITE_APP_* and PostHog as both runtime and build', () => {

--- a/src/lib/env/push-secrets.test.ts
+++ b/src/lib/env/push-secrets.test.ts
@@ -131,8 +131,9 @@ describe('SECRETS catalog (#1502)', () => {
     expect(TOOLING_OR_LEGACY.has('FAL_PRICING_KEY')).toBe(true);
   });
 
-  it('classifies LLMTR_API_KEY as runtime (Worker env., not process.env)', () => {
-    expect(SECRETS.LLMTR_API_KEY).toEqual({ runtime: true, build: false });
+  it('keeps LLMTR_API_KEY in tooling/legacy — team BYOK, never a Worker secret', () => {
+    expect('LLMTR_API_KEY' in SECRETS).toBe(false);
+    expect(TOOLING_OR_LEGACY.has('LLMTR_API_KEY')).toBe(true);
   });
 
   it('classifies VITE_APP_* and PostHog as both runtime and build', () => {

--- a/src/lib/workflows/llm-call-helper.ts
+++ b/src/lib/workflows/llm-call-helper.ts
@@ -279,7 +279,7 @@ async function resolveCallKey(
   const platform = getPlatformLlmKey(model);
   if (!platform) {
     throw new NonRetryableError(
-      'No platform LLM key available (set OPENROUTER_KEY, FAL_KEY or LLMTR_API_KEY)',
+      'No platform LLM key available (set OPENROUTER_KEY or FAL_KEY)',
       'WorkflowValidationError'
     );
   }


### PR DESCRIPTION
## Related Issue

Closes #1502

## Summary of Changes

`bun secrets:check:prd` no longer treats “where the value lives” as “where the value is needed.”

- Replace the flat `PUSHABLE_SECRETS` array with a `SECRETS` catalog that flags each name as **runtime** (`getEnv()` / `env.` on the Worker) and/or **build** (`import.meta.env`).
- Print `runtime / build / doppler / worker` columns plus an action (`update`, `CREATE`, `MISSING`, `worker-only`, `build-only - set in Workers Builds`, `unused - nothing reads it`).
- `--push` writes only `runtime: true` secrets. Build-only (`VITE_R2_PUBLIC_ASSETS_DOMAIN`) and unread (`LANGFUSE_*`, `R2_PUBLIC_ASSETS_DOMAIN`) stay visible and are never sent.
- Move `FAL_PRICING_KEY` to `TOOLING_OR_LEGACY` (local `verify-fal-costs` tooling; the Worker key is `FAL_BILLING_KEY`).
- Keep every safety rule: allowlist-gated, no nulls, values only over stdin, dry run unless `--push`, `wrangler versions secret bulk`.
- Classify `LLMTR_API_KEY` as runtime — the Worker reads `env.LLMTR_API_KEY`. Script `process.env` is not a runtime signal.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

CLI/report-only change. `--push` now writes a smaller payload (skips build-only and unused). Nothing is deleted.

## Additional Notes

Out of scope, as on the issue: whether to push `GEMINI_API_KEY`, and removing unused `LANGFUSE_*` / `R2_PUBLIC_ASSETS_DOMAIN` bindings from the Worker.