### PR TITLE
fix(#1503): retry a failed fal result fetch and re-roll Omni Flash safety verdicts

### DIFF
--- a/src/lib/ai/content-rejection.test.ts
+++ b/src/lib/ai/content-rejection.test.ts
@@ -28,6 +28,7 @@ describe('isContentRejectionError', () => {
       'Could not generate images with the given prompts and images. Please try again with different inputs.',
       'Unexpected result from the model.',
       'Output audio has sensitive content.',
+      'Video generation failed: body.prompt: Request blocked due to safety violations (harmful content). Please modify your input and retry.',
     ];
     for (const message of observed) {
       expect(isContentRejectionError(new Error(message)), message).toBe(true);

--- a/src/lib/ai/content-rejection.ts
+++ b/src/lib/ai/content-rejection.ts
@@ -50,6 +50,9 @@ export const CONTENT_REJECTION_PATTERNS: readonly RegExp[] = [
   /content could not be processed/i,
   /content (?:filter|policy|moderation)/i,
   /\bnsfw\b/i,
+  // Gemini Omni Flash via fal: "Request blocked due to safety violations (harmful content)"
+  /safety violations?/i,
+  /harmful content/i,
 ];
 
 /**

--- a/src/lib/ai/video-job-status.test.ts
+++ b/src/lib/ai/video-job-status.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import * as tanstackAi from '@tanstack/ai';
+
+const mockStatus = vi.fn();
+vi.doMock('@tanstack/ai', () => ({
+  ...tanstackAi,
+  getVideoJobStatus: mockStatus,
+}));
+
+const { getVideoJobStatus } = await import('./video-job-status');
+// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- the wrapper only forwards args; the adapter is mocked away
+const ARGS = { adapter: {}, jobId: 'job' } as never;
+const call = () => getVideoJobStatus(ARGS);
+
+describe('getVideoJobStatus', () => {
+  it('rethrows a swallowed result-fetch failure so the poll step retries', async () => {
+    mockStatus.mockResolvedValueOnce({
+      jobId: 'job',
+      status: 'failed',
+      error: 'Failed to retrieve video result: HTTP 504: Gateway Timeout',
+    });
+    await expect(call()).rejects.toThrow('HTTP 504');
+  });
+
+  it('passes a real provider failure through', async () => {
+    const failed = {
+      jobId: 'job',
+      status: 'failed',
+      error:
+        'Video generation failed: body.prompt: Request blocked due to safety violations (harmful content).',
+    };
+    mockStatus.mockResolvedValueOnce(failed);
+    await expect(call()).resolves.toEqual(failed);
+  });
+});

--- a/src/lib/ai/video-job-status.ts
+++ b/src/lib/ai/video-job-status.ts
@@ -1,0 +1,29 @@
+import { getVideoJobStatus as tanstackGetVideoJobStatus } from '@tanstack/ai';
+
+/**
+ * The fal adapter wraps ANY `queue.result` failure (5xx, network, deadline)
+ * in this prefix; a 422 with `body.detail` becomes `Video generation failed:`
+ * instead and is a real provider verdict.
+ */
+const RESULT_FETCH_FAILURE = /^Failed to retrieve video result/;
+
+/**
+ * `@tanstack/ai`'s `getVideoJobStatus` swallows a thrown `getVideoUrl` into
+ * `{ status: 'failed', error }`, which the workflows read as a terminal
+ * provider failure. But by then the job has already reported COMPLETED — only
+ * the result fetch failed (fal answered 504 on nine clips of one run). Rethrow
+ * so the poll step retries instead of failing the clip.
+ */
+export async function getVideoJobStatus(
+  ...args: Parameters<typeof tanstackGetVideoJobStatus>
+): ReturnType<typeof tanstackGetVideoJobStatus> {
+  const result = await tanstackGetVideoJobStatus(...args);
+  if (
+    result.status === 'failed' &&
+    result.error &&
+    RESULT_FETCH_FAILURE.test(result.error)
+  ) {
+    throw new Error(result.error);
+  }
+  return result;
+}

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -60,11 +60,8 @@ import {
   ensureExternallyFetchableUrl,
   toDataOrCdnUrl,
 } from '@/lib/storage/external-url';
-import {
-  generateVideo,
-  getVideoJobStatus,
-  type TokenUsage,
-} from '@tanstack/ai';
+import { generateVideo, type TokenUsage } from '@tanstack/ai';
+import { getVideoJobStatus } from '@/lib/ai/video-job-status';
 import { falVideo } from '@tanstack/ai-fal';
 import { createGeminiVideo } from '@tanstack/ai-gemini';
 import { createGrokVideo } from '@tanstack/ai-grok';

--- a/src/lib/studio/studio-video-generation.ts
+++ b/src/lib/studio/studio-video-generation.ts
@@ -67,11 +67,8 @@ import {
   type StudioVideoMode,
   type StudioVideoRequest,
 } from '@/lib/studio/text-to-video';
-import {
-  generateVideo,
-  getVideoJobStatus,
-  type TokenUsage,
-} from '@tanstack/ai';
+import { generateVideo, type TokenUsage } from '@tanstack/ai';
+import { getVideoJobStatus } from '@/lib/ai/video-job-status';
 import { falVideo } from '@tanstack/ai-fal';
 import { createGeminiVideo } from '@tanstack/ai-gemini';
 import { createGrokVideo } from '@tanstack/ai-grok';


### PR DESCRIPTION
Closes #1503

## What went wrong

Prod sequence `01M1Q80A7EKNFVGF1VT8EBK9WB` (Omni Flash, reference-only) lost 9 of 18 clips to

    Motion generation failed: Failed to retrieve video result: HTTP 504: Gateway Timeout

The jobs had already reported COMPLETED on fal; fal's queue **result** endpoint then answered 504. `@tanstack/ai`'s `getVideoJobStatus` swallows a thrown `getVideoUrl` into `{ status: 'failed', error }`, and both video workflows read `failed` as a terminal provider verdict, so a transient fetch failure failed the clip.

Separately, Google's Omni Flash verdict via fal — `Video generation failed: body.prompt: Request blocked due to safety violations (harmful content). Please modify your input and retry.` — matched none of `CONTENT_REJECTION_PATTERNS`, so the same-model re-roll and prompt soften never ran.

## Changes

- `src/lib/ai/video-job-status.ts`: wraps `getVideoJobStatus`; a `failed` status whose error starts with `Failed to retrieve video result` (the fal adapter's prefix for any `queue.result` failure — a real 422 becomes `Video generation failed:` instead) is rethrown, so the CF poll step retries. Motion and studio workflows both route through it.
- `content-rejection.ts`: add `/safety violations?/i` and `/harmful content/i`.
- Tests for both; the Google string added to the observed-rejections list.

## Verification

- `bun run test` on `src/lib/ai`, `src/lib/motion`, `src/lib/studio`, `motion-workflow.test.ts`: 392 pass.
- lint, format, typecheck clean on the changed files.