### PR TITLE
fix(#1506): show Omni video in PostHog generations with cost and via

### DIFF
--- a/src/lib/ai/gemini-native.test.ts
+++ b/src/lib/ai/gemini-native.test.ts
@@ -133,8 +133,14 @@ describe('geminiTextCostFromUsage', () => {
 
 describe('geminiVideoCostFromUsage', () => {
   it('prices the interaction’s video-output tokens at $17.50/1M', () => {
-    // A 10-second 720p clip: 57,920 output tokens → $1.0136.
-    expect(geminiVideoCostFromUsage(usage(120, 57_920))).toBe(1_013_600);
+    // A 10-second 720p clip: 57,920 output tokens → $1.0136. Zero prompt
+    // tokens so this is the video-output line alone.
+    expect(geminiVideoCostFromUsage(usage(0, 57_920))).toBe(1_013_600);
+  });
+
+  it('adds input tokens at the published $1.50/1M rate', () => {
+    // Same 10s clip plus 120 prompt tokens → $1.0136 + $0.00018.
+    expect(geminiVideoCostFromUsage(usage(120, 57_920))).toBe(1_013_780);
   });
 
   it('returns undefined for missing usage or zero output tokens', () => {

--- a/src/lib/ai/gemini-native.ts
+++ b/src/lib/ai/gemini-native.ts
@@ -131,10 +131,16 @@ const TEXT_RATES: Record<
 /**
  * Omni Flash bills video output as tokens: a fixed 5,792 tokens per second of
  * 720p video at the video-output rate of $17.50 per 1M tokens (≈$0.101/s).
- * The adapter surfaces those output tokens as `usage.completionTokens`.
+ * Input (text / image / video / audio) is $1.50 per 1M tokens. Published
+ * rates, ai.google.dev/gemini-api/docs/pricing, read 2026-09-04.
+ *
+ * The adapter surfaces video-output tokens as `usage.completionTokens`. Text
+ * / thinking output ($9/1M) is not split out of that field, so it is priced
+ * at the video rate when present.
  */
 const OMNI_VIDEO_TOKENS_PER_SECOND = 5_792;
 const OMNI_VIDEO_USD_PER_1M_TOKENS = 17.5;
+const OMNI_VIDEO_INPUT_USD_PER_1M_TOKENS = 1.5;
 
 /** Undefined when the adapter reported no usage — the caller reports that as a
  *  missing cost rather than inventing one. */
@@ -157,7 +163,7 @@ export function geminiTextCostFromUsage(
 
 /**
  * Settled charge for an Omni Flash video, from the interaction's reported
- * output tokens. Undefined when the adapter reported no usage (or zero output
+ * tokens. Undefined when the adapter reported no usage (or zero output
  * tokens — a completed video always bills some), so the caller reports a
  * missing cost instead of recording $0 owed.
  */
@@ -166,8 +172,12 @@ export function geminiVideoCostFromUsage(
 ): Microdollars | undefined {
   if (!usage || !Number.isFinite(usage.completionTokens)) return undefined;
   if (usage.completionTokens <= 0) return undefined;
+  const inputTokens = Number.isFinite(usage.promptTokens)
+    ? Math.max(0, usage.promptTokens)
+    : 0;
   return usdToMicros(
-    (usage.completionTokens / 1_000_000) * OMNI_VIDEO_USD_PER_1M_TOKENS
+    (inputTokens / 1_000_000) * OMNI_VIDEO_INPUT_USD_PER_1M_TOKENS +
+      (usage.completionTokens / 1_000_000) * OMNI_VIDEO_USD_PER_1M_TOKENS
   );
 }
 

--- a/src/lib/motion/motion-generation.test.ts
+++ b/src/lib/motion/motion-generation.test.ts
@@ -65,6 +65,7 @@ const {
   pollMotionJob,
   motionCostFromUsage,
   calculateMotionMetadata,
+  resolveMotionVia,
 } = await import('./motion-generation');
 
 describe('Motion Service', () => {
@@ -815,15 +816,29 @@ describe('Motion Service', () => {
     });
 
     it('prices Google video-output tokens and skips fal usage sampling', async () => {
-      // 5s of 720p video = 28,960 output tokens @ $17.50/1M = $0.5068.
+      // 5s of 720p video = 28,960 output tokens @ $17.50/1M = $0.5068
+      // plus 120 prompt tokens @ $1.50/1M = $0.00018.
       const billing = await motionCostFromUsage(
         'google',
         { promptTokens: 120, completionTokens: 28_960, totalTokens: 29_080 },
         { modelKey: 'gemini_omni_flash', hasReferenceImages: false }
       );
-      expect(billing.cost).toBe(506_800);
+      expect(billing.cost).toBe(506_980);
       expect(billing.recordFalUsage).toBe(false);
       expect(billing.endpointId).toBe('gemini-omni-1.1-flash');
+    });
+  });
+
+  describe('resolveMotionVia', () => {
+    it('claims Google for Omni Flash when a Google key is present', async () => {
+      testEnv.GEMINI_API_KEY = 'platform-google';
+      await expect(resolveMotionVia('gemini_omni_flash')).resolves.toBe(
+        'google'
+      );
+    });
+
+    it('falls back to fal for Omni Flash when no Google key exists', async () => {
+      await expect(resolveMotionVia('gemini_omni_flash')).resolves.toBe('fal');
     });
   });
 });

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -193,6 +193,33 @@ export async function canRenderReferenceOnly(
   });
 }
 
+/**
+ * Which via this model would submit to right now. Same claim order as
+ * `submitMotionJob` (native xAI → native Google → BytePlus → fal). Used by
+ * motion `onFailure` so a Google Omni failure is not recorded as `fal`.
+ */
+export async function resolveMotionVia(
+  modelKey: ImageToVideoModel,
+  scopedDb?: CredentialScopedDb
+): Promise<MediaVia> {
+  if (isNativeGrokVideoModel(modelKey)) {
+    const xaiKey = await resolveOptionalXaiKey(scopedDb);
+    if (xaiKey) return 'xai';
+  }
+  if (isNativeGeminiVideoModel(modelKey)) {
+    const googleKey = await resolveOptionalGoogleKey(scopedDb);
+    if (googleKey) return 'google';
+  }
+  if (isNativeBytePlusVideoModel(modelKey) && isBytePlusConfigured()) {
+    const falKey = await resolveOptionalFalKey(scopedDb);
+    return claimBytePlusVia({
+      native: true,
+      usingOwnFalKey: falKey?.source === 'team',
+    });
+  }
+  return 'fal';
+}
+
 function createNativeMotionAdapter(apiKey: string) {
   const env = getEnv();
   return createGrokVideo(NATIVE_GROK_VIDEO_MODEL, apiKey, {
@@ -326,29 +353,15 @@ export async function submitMotionJob(
   // `resolveKey('fal')` throws with no fal key, so an xAI-only (or
   // Google-only) deploy must not reach it. BytePlus is platform-only (no
   // resolveOptionalKey('byteplus')) and yields to a BYOK fal team.
-  const xaiKey = isNativeGrokVideoModel(modelKey)
-    ? await resolveOptionalXaiKey(options.scopedDb)
-    : undefined;
-  const googleKey = isNativeGeminiVideoModel(modelKey)
-    ? await resolveOptionalGoogleKey(options.scopedDb)
-    : undefined;
+  const via = await resolveMotionVia(modelKey, options.scopedDb);
+  const xaiKey =
+    via === 'xai' ? await resolveOptionalXaiKey(options.scopedDb) : undefined;
+  const googleKey =
+    via === 'google'
+      ? await resolveOptionalGoogleKey(options.scopedDb)
+      : undefined;
 
   const hasReferenceImages = (options.referenceImages?.length ?? 0) > 0;
-
-  let via: MediaVia;
-  if (xaiKey) {
-    via = 'xai';
-  } else if (googleKey) {
-    via = 'google';
-  } else if (isNativeBytePlusVideoModel(modelKey) && isBytePlusConfigured()) {
-    const falKey = await resolveOptionalFalKey(options.scopedDb);
-    via = claimBytePlusVia({
-      native: true,
-      usingOwnFalKey: falKey?.source === 'team',
-    });
-  } else {
-    via = 'fal';
-  }
 
   const endpoint = resolveMotionEndpoint(
     modelKey,

--- a/src/lib/observability/ai-otel.test.ts
+++ b/src/lib/observability/ai-otel.test.ts
@@ -415,10 +415,14 @@ describe('recordMediaGenerationSpan', () => {
     expect(name).toBe('motion');
     expect(options?.attributes).toEqual({
       'gen_ai.system': 'fal',
-      'gen_ai.operation.name': 'video_generation',
+      // PostHog only classifies `chat` as $ai_generation; the histogram
+      // below still records `video_generation`.
+      'gen_ai.operation.name': 'chat',
       'gen_ai.request.model': 'kling-v2.5',
       // 350_000 microdollars → $0.35.
       'gen_ai.usage.cost': 0.35,
+      $ai_total_cost_usd: 0.35,
+      $ai_output_cost_usd: 0.35,
       'tanstack.ai.usage.units_billed': 5,
       'gen_ai.input.messages': JSON.stringify([
         {
@@ -561,6 +565,24 @@ describe('recordMediaGenerationSpan', () => {
     expect(message).not.toBe(otelPayload);
     expect(message).toContain('{otelMessage}');
     expect(properties?.otelMessage).toBe(otelPayload);
+  });
+
+  it('forwards token counts onto the span for token-billed vias', async () => {
+    const { recordMediaGenerationSpan } = await importAiOtel({
+      token: 'phc_test',
+    });
+
+    recordMediaGenerationSpan({
+      ...record,
+      inputTokens: 120,
+      outputTokens: 28_960,
+    });
+
+    const [, options] = mockStartSpan.mock.calls[0] ?? [];
+    expect(options?.attributes).toMatchObject({
+      'gen_ai.usage.input_tokens': 120,
+      'gen_ai.usage.output_tokens': 28_960,
+    });
   });
 
   it('keeps per-user attributes and provider prose out of the histogram', async () => {

--- a/src/lib/observability/ai-otel.ts
+++ b/src/lib/observability/ai-otel.ts
@@ -475,6 +475,15 @@ export type MediaActivity = 'video' | 'image' | 'audio';
  */
 export type MediaErrorType = 'content_filter' | 'provider_error';
 
+/**
+ * PostHog's OTLP mapper only classifies `gen_ai.operation.name=chat` as an
+ * `$ai_generation` event. Media semconv names (`video_generation` etc.) land
+ * as empty `$ai_trace` rows: no nested generation, `$ai_total_cost_usd`
+ * null, invisible on the Generations tab. The duration histogram below keeps
+ * the real activity so video latency is not mixed into chat.
+ */
+const POSTHOG_GENERATION_OPERATION = 'chat';
+
 export type MediaGenerationRecord = AIObservabilityMeta & {
   /** Model id as submitted to the provider. */
   model: string;
@@ -499,6 +508,10 @@ export type MediaGenerationRecord = AIObservabilityMeta & {
   costMicros?: Microdollars;
   /** Provider-reported billable units for the completed job. */
   unitsBilled?: number;
+  /** Provider-reported prompt tokens, when the via bills in tokens. */
+  inputTokens?: number;
+  /** Provider-reported completion tokens, when the via bills in tokens. */
+  outputTokens?: number;
   /**
    * True when a team's own provider key paid for this. `costMicros` is priced
    * the same either way, but only the `false` case is spend on us — without
@@ -569,6 +582,10 @@ function emitMediaGenerationSpan(record: MediaGenerationRecord): void {
     typeof record.outputUrl === 'string'
       ? [record.outputUrl]
       : record.outputUrl;
+  const costUsd =
+    record.costMicros !== undefined
+      ? microsToUsd(record.costMicros)
+      : undefined;
   const span = active.tracer.startSpan(
     record.observationName ?? `${operationName} ${record.model}`,
     {
@@ -576,10 +593,20 @@ function emitMediaGenerationSpan(record: MediaGenerationRecord): void {
       startTime: endTime - (durationMs ?? 0),
       attributes: {
         'gen_ai.system': record.provider,
-        'gen_ai.operation.name': operationName,
+        'gen_ai.operation.name': POSTHOG_GENERATION_OPERATION,
         'gen_ai.request.model': record.model,
-        ...(record.costMicros !== undefined && {
-          'gen_ai.usage.cost': microsToUsd(record.costMicros),
+        ...(costUsd !== undefined && {
+          'gen_ai.usage.cost': costUsd,
+          // PostHog's cost column reads these, not gen_ai.usage.cost, and
+          // cannot look up gemini_omni_flash in OpenRouter's price table.
+          $ai_total_cost_usd: costUsd,
+          $ai_output_cost_usd: costUsd,
+        }),
+        ...(record.inputTokens !== undefined && {
+          'gen_ai.usage.input_tokens': record.inputTokens,
+        }),
+        ...(record.outputTokens !== undefined && {
+          'gen_ai.usage.output_tokens': record.outputTokens,
         }),
         ...(record.unitsBilled !== undefined && {
           'tanstack.ai.usage.units_billed': record.unitsBilled,

--- a/src/lib/studio/studio-video-generation.test.ts
+++ b/src/lib/studio/studio-video-generation.test.ts
@@ -555,7 +555,7 @@ describe('studioVideoCostFromUsage', () => {
       },
       { promptTokens: 120, completionTokens: 28_960, totalTokens: 29_080 }
     );
-    expect(billing.cost).toBe(506_800);
+    expect(billing.cost).toBe(506_980);
     expect(billing.recordFalUsage).toBe(false);
     expect(billing.endpointId).toBe('gemini-omni-1.1-flash');
   });

--- a/src/lib/workflows/motion-workflow.test.ts
+++ b/src/lib/workflows/motion-workflow.test.ts
@@ -18,6 +18,10 @@ const mockSubmit = vi.fn();
 const mockPoll = vi.fn();
 const mockSoften = vi.fn();
 const mockDeductWorkflowCredits = vi.fn();
+const mockResolveMotionVia = vi.fn(
+  async (): Promise<'fal' | 'google'> => 'fal'
+);
+const mockRecordMediaGenerationSpan = vi.fn();
 const emit = vi.fn(async () => {});
 
 vi.doMock('@/lib/motion/motion-generation', () => ({
@@ -31,6 +35,7 @@ vi.doMock('@/lib/motion/motion-generation', () => ({
     endpointId: 'fal/x',
     recordFalUsage: false,
   }),
+  resolveMotionVia: mockResolveMotionVia,
 }));
 vi.doMock('@/lib/ai/fal-pricing-live', () => ({
   getEffectiveFalPricing: async () => ({}),
@@ -55,7 +60,7 @@ vi.doMock('@/lib/compliance/provenance', () => ({
   recordProvenance: vi.fn(async () => {}),
 }));
 vi.doMock('@/lib/observability/ai-otel', () => ({
-  recordMediaGenerationSpan: () => {},
+  recordMediaGenerationSpan: mockRecordMediaGenerationSpan,
 }));
 vi.doMock('@/lib/realtime', () => ({
   getGenerationChannel: () => ({ emit }),
@@ -85,6 +90,13 @@ class Probe extends MotionWorkflow {
     scopedDb: WorkflowScopedDb
   ) {
     return this.runImpl(event, step, scopedDb);
+  }
+  fail(
+    event: Readonly<WorkflowEvent<MotionWorkflowInput>>,
+    scopedDb: WorkflowScopedDb,
+    error = 'Motion generation failed: boom'
+  ) {
+    return this.onFailure({ event, error, scopedDb });
   }
 }
 
@@ -224,6 +236,7 @@ beforeEach(() => {
   mockSubmit.mockImplementation(async () => job());
   mockPoll.mockResolvedValue({ status: 'completed', url: 'https://fal/a.mp4' });
   mockSoften.mockResolvedValue('the softened prompt');
+  mockResolveMotionVia.mockResolvedValue('fal');
 });
 
 describe('MotionWorkflow content-flag rescue (#1373)', () => {
@@ -435,6 +448,31 @@ describe('MotionWorkflow reference-only provenance', () => {
             frameVersionId: null,
           }),
         ],
+      })
+    );
+  });
+});
+
+describe('MotionWorkflow onFailure observation', () => {
+  it('records the resolved via, not a hardcoded fal', async () => {
+    mockResolveMotionVia.mockResolvedValueOnce('google');
+    const { scopedDb } = makeScopedDb();
+
+    await makeWorkflow().fail(
+      makeEvent({ model: 'gemini_omni_flash' }),
+      scopedDb
+    );
+
+    expect(mockResolveMotionVia).toHaveBeenCalledWith(
+      'gemini_omni_flash',
+      scopedDb.credentials
+    );
+    expect(mockRecordMediaGenerationSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gemini_omni_flash',
+        provider: 'google',
+        activity: 'video',
+        errorType: 'provider_error',
       })
     );
   });

--- a/src/lib/workflows/motion-workflow.ts
+++ b/src/lib/workflows/motion-workflow.ts
@@ -47,6 +47,7 @@ import {
   canRenderReferenceOnly,
   motionCostFromUsage,
   pollMotionJob,
+  resolveMotionVia,
   submitMotionJob,
 } from '@/lib/motion/motion-generation';
 import { getEffectiveFalPricing } from '@/lib/ai/fal-pricing-live';
@@ -924,6 +925,8 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
         durationMs: Date.now() - job.submittedAt,
         costMicros: actualCost,
         unitsBilled: billing.unitsBilled,
+        inputTokens: billedUsage?.promptTokens,
+        outputTokens: billedUsage?.completionTokens,
         usedOwnKey: job.usedOwnKey,
         prompt,
         outputUrl: videoUrl,
@@ -1069,7 +1072,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
             assetKind: 'video_variant',
             assetId: provenanceVersionId,
             storageKey: buildR2Key(STORAGE_BUCKETS.VIDEOS, storageResult.path),
-            provider: 'fal',
+            provider: job.via,
             model: activeModel,
             providerRequestId: job.jobId,
             workflowRunId: event.instanceId,
@@ -1108,7 +1111,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
     // a step return this hook can't see.
     recordMediaGenerationSpan({
       model,
-      provider: 'fal',
+      provider: await resolveMotionVia(model, scopedDb.credentials),
       activity: 'video',
       prompt: input.prompt,
       errorType: isContentRejectionError(error)

--- a/src/lib/workflows/studio-generation-workflow.test.ts
+++ b/src/lib/workflows/studio-generation-workflow.test.ts
@@ -18,6 +18,10 @@ const mockRecordProvenance = vi.fn();
 const mockSubmit = vi.fn();
 const mockPoll = vi.fn();
 const mockCost = vi.fn();
+const mockRecordMediaGenerationSpan = vi.fn();
+const mockResolveMotionVia = vi.fn(
+  async (): Promise<'fal' | 'google'> => 'fal'
+);
 
 vi.doMock('@/lib/image/image-generation', () => ({
   generateImageWithProvider: mockGenerateImageWithProvider,
@@ -45,6 +49,12 @@ vi.doMock('@/lib/studio/studio-video-generation', () => ({
   submitStudioVideoJob: mockSubmit,
   pollStudioVideoJob: mockPoll,
   studioVideoCostFromUsage: mockCost,
+}));
+vi.doMock('@/lib/observability/ai-otel', () => ({
+  recordMediaGenerationSpan: mockRecordMediaGenerationSpan,
+}));
+vi.doMock('@/lib/motion/motion-generation', () => ({
+  resolveMotionVia: mockResolveMotionVia,
 }));
 
 const { StudioGenerationWorkflow } =
@@ -240,6 +250,7 @@ describe('StudioGenerationWorkflow video', () => {
       'price-video-generation',
       'deduct-video-credits',
       'upload-video',
+      'record-video-observation',
       'record-provenance',
       'persist-result',
     ]);
@@ -253,6 +264,14 @@ describe('StudioGenerationWorkflow video', () => {
       outputs: [{ url: '/r2/videos/a.mp4', contentType: 'video/mp4' }],
       costMicros: 70_000,
     });
+    expect(mockRecordMediaGenerationSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'fal',
+        activity: 'video',
+        observationName: 'studio-video',
+        costMicros: 70_000,
+      })
+    );
   });
 
   it('gives up after three content flags without billing', async () => {
@@ -290,5 +309,25 @@ describe('StudioGenerationWorkflow onFailure', () => {
     const { scopedDb, generatedAssets } = makeScopedDb();
     await makeWorkflow().fail(makeEvent(IMAGE), scopedDb);
     expect(generatedAssets.markFailed).toHaveBeenCalledWith('asset-1', 'boom');
+    // Image failures are recorded inside generateImageWithProvider.
+    expect(mockRecordMediaGenerationSpan).not.toHaveBeenCalled();
+  });
+
+  it('records a video failure span on the resolved via', async () => {
+    mockResolveMotionVia.mockResolvedValueOnce('google');
+    const { scopedDb, generatedAssets } = makeScopedDb();
+    await makeWorkflow().fail(
+      makeEvent({ ...VIDEO, videoModel: 'gemini_omni_flash' }),
+      scopedDb
+    );
+    expect(generatedAssets.markFailed).toHaveBeenCalledWith('asset-1', 'boom');
+    expect(mockRecordMediaGenerationSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gemini_omni_flash',
+        provider: 'google',
+        activity: 'video',
+        observationName: 'studio-video',
+      })
+    );
   });
 });

--- a/src/lib/workflows/studio-generation-workflow.ts
+++ b/src/lib/workflows/studio-generation-workflow.ts
@@ -9,8 +9,9 @@
  *   2. generate-image, or submit/poll video (retried on a content flag)
  *   3. capture credits against the run envelope from reported units
  *   4. upload outputs to R2
- *   5. record-provenance
- *   6. persist-result on the reserved `generated_assets` row — last, so a
+ *   5. record-video-observation (clips only; stills record inside generateImage)
+ *   6. record-provenance
+ *   7. persist-result on the reserved `generated_assets` row — last, so a
  *      failure anywhere before it leaves the row `failed`, never
  *      `completed` then flipped
  */
@@ -32,15 +33,17 @@ import { aspectRatioToImageSize } from '@/shared/constants/aspect-ratios';
 import type { WorkflowScopedDb } from '@/lib/db/scoped-workflow';
 import type { GeneratedAssetOutput } from '@/lib/db/schema';
 import { generateImageWithProvider } from '@/lib/image/image-generation';
+import { resolveMotionVia } from '@/lib/motion/motion-generation';
+import { videoUrlFitsWorkflowCheckpoint } from '@/lib/motion/video-storage';
+import { recordMediaGenerationSpan } from '@/lib/observability/ai-otel';
 import { getLogger } from '@/lib/observability/logger';
+import type { StudioCreateInput } from '@/lib/studio/schema';
 import {
   pollStudioVideoJob,
   studioVideoCostFromUsage,
   submitStudioVideoJob,
 } from '@/lib/studio/studio-video-generation';
-import type { StudioCreateInput } from '@/lib/studio/schema';
 import { tagStudioReferences } from '@/lib/studio/text-to-video';
-import { videoUrlFitsWorkflowCheckpoint } from '@/lib/motion/video-storage';
 import { uploadStudioImage, uploadStudioVideo } from '@/lib/studio/upload';
 import { OpenStoryWorkflowEntrypoint } from '@/lib/workflow/base-workflow';
 import type { StudioGenerationWorkflowInput } from '@/lib/workflow/types';
@@ -434,6 +437,26 @@ export class StudioGenerationWorkflow extends OpenStoryWorkflowEntrypoint<Studio
       { url: videoUpload.url, contentType: videoUpload.contentType },
     ];
 
+    await step.do('record-video-observation', async () => {
+      recordMediaGenerationSpan({
+        model: videoModel,
+        provider: job.via,
+        activity: 'video',
+        costMicros: videoCost,
+        unitsBilled: billing.unitsBilled,
+        inputTokens: billedUsage?.promptTokens,
+        outputTokens: billedUsage?.completionTokens,
+        usedOwnKey: job.usedOwnKey,
+        prompt: input.prompt,
+        outputUrl: videoUpload.url,
+        observationName: 'studio-video',
+        tags: ['studio', 'motion'],
+        userId,
+        sessionId: assetId,
+        metadata: { model: videoModel, assetId },
+      });
+    });
+
     await step.do('record-provenance', async () => {
       await recordProvenance(scopedDb.provenance, {
         teamId,
@@ -468,9 +491,31 @@ export class StudioGenerationWorkflow extends OpenStoryWorkflowEntrypoint<Studio
     error: string;
     scopedDb: WorkflowScopedDb;
   }): Promise<void> {
-    await scopedDb.generatedAssets.markFailed(event.payload.assetId, error);
+    const { assetId, userId, input } = event.payload;
+    if (input.activity === 'video') {
+      // Image failures are already recorded inside generateImageWithProvider.
+      recordMediaGenerationSpan({
+        model: input.videoModel,
+        provider: await resolveMotionVia(
+          input.videoModel,
+          scopedDb.credentials
+        ),
+        activity: 'video',
+        prompt: input.prompt,
+        errorType: isContentRejectionError(error)
+          ? 'content_filter'
+          : 'provider_error',
+        errorMessage: error,
+        observationName: 'studio-video',
+        tags: ['studio', 'motion'],
+        userId,
+        sessionId: assetId,
+        metadata: { model: input.videoModel, assetId },
+      });
+    }
+    await scopedDb.generatedAssets.markFailed(assetId, error);
     logger.error(
-      `[StudioGenerationWorkflow] Asset ${event.payload.assetId} failed: ${error}`
+      `[StudioGenerationWorkflow] Asset ${assetId} failed: ${error}`
     );
   }
 }


### PR DESCRIPTION
Fixes #1506

Native Google Omni 1.1 was generating (production traces from 2026-09-04 succeeded at ~\$1.02 / 10s). It did not show up usefully in PostHog AI observability.

**Observability**
- Media spans used `gen_ai.operation.name=video_generation`. PostHog only classifies `chat` as `\$ai_generation`, so Omni landed as empty `\$ai_trace` rows (no nested generation, `\$ai_total_cost_usd` null, invisible on the Generations tab). Spans now export as `chat` and set `\$ai_total_cost_usd` / `\$ai_output_cost_usd`. The duration histogram still uses `video_generation`.
- `MotionWorkflow.onFailure` hardcoded `provider: 'fal'`. Failures now record the resolved via (Google when a Google key is present).
- Studio video never recorded a span. Success and failure now do.

**Pricing**
- Video output \$17.50/1M at 5,792 tokens/s of 720p was already correct.
- Input is \$1.50/1M and was not billed; settled charges now include prompt tokens.

The original “unsupported data type” report did not reproduce in the last 3 days of production traces (failures were fal 504s and safety blocks).