### PR TITLE
fix(#1513): silence the stale-chunk death rattle, drop anonymous via 401s, alert per exception

### DIFF
--- a/scripts/setup-posthog-slack-alerts.ts
+++ b/scripts/setup-posthog-slack-alerts.ts
@@ -2,7 +2,12 @@
  * #1088 — Wire PostHog → Slack destinations/alerts.
  *
  * Creates (idempotent by name) the product-activity Slack destinations and the
- * error-tracking spike alert described in issue #1088.
+ * error-tracking spike alert described in issue #1088, plus the per-exception
+ * alert with a replay link from #1513.
+ *
+ * Idempotency is by destination NAME: editing a spec below does not update the
+ * destination that already exists — delete it in PostHog first, or edit it
+ * there.
  *
  * Prerequisites:
  * 1. Slack is connected in PostHog → Settings → Integrations
@@ -130,7 +135,14 @@ async function listSlackIntegrations(): Promise<
   return data.results.filter((i) => i.kind === 'slack');
 }
 
-function eventFilter(eventName: string) {
+type PropertyFilter = {
+  key: string;
+  value: string | string[];
+  operator: string;
+  type: 'event';
+};
+
+function eventFilter(eventName: string, properties: PropertyFilter[] = []) {
   return {
     source: 'events',
     events: [
@@ -139,6 +151,7 @@ function eventFilter(eventName: string) {
         name: eventName,
         type: 'events',
         order: 0,
+        properties,
       },
     ],
     filter_test_accounts: true,
@@ -206,6 +219,58 @@ function spikeBlocks() {
   ];
 }
 
+/**
+ * One message per exception, with the replay cued to the moment it threw
+ * (#1513). The spike alert only fires on a *rate* change, so a two-user
+ * regression right after a deploy reached nobody.
+ *
+ * `replay_url` is stamped client-side in `src/components/providers.tsx`; the
+ * fallback keeps the button a valid URL when there is no recording (Slack
+ * rejects the whole message over one empty button href).
+ */
+function exceptionBlocks() {
+  return [
+    {
+      type: 'header',
+      text: { type: 'plain_text', text: '💥 Exception' },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: '```{event.properties.$exception_types}: {substring(event.properties.$exception_values, 1, 1000)}```',
+      },
+    },
+    {
+      type: 'context',
+      elements: [
+        { type: 'mrkdwn', text: 'URL: {event.properties.$current_url}' },
+        {
+          type: 'mrkdwn',
+          text: 'Person: {person.properties.email ?? event.distinct_id}',
+        },
+        { type: 'mrkdwn', text: 'Project: <{project.url}|{project.name}>' },
+      ],
+    },
+    { type: 'divider' },
+    {
+      type: 'actions',
+      elements: [
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'Watch replay' },
+          url: "{empty(event.properties.replay_url) ? concat(project.url, '/replay/', event.properties.$session_id) : event.properties.replay_url}",
+        },
+        {
+          type: 'button',
+          text: { type: 'plain_text', text: 'View issue' },
+          url: '{project.url}/error_tracking/fingerprint/{encodeURLComponent(event.properties.$exception_fingerprint)}?timestamp={event.timestamp}&utm_source=alert&utm_campaign=exception_alert&utm_medium=slack',
+        },
+      ],
+    },
+  ];
+}
+
 type DestinationSpec = {
   name: string;
   type: 'destination' | 'internal_destination';
@@ -213,6 +278,7 @@ type DestinationSpec = {
   channel: string;
   text: string;
   blocks: unknown[];
+  properties?: PropertyFilter[];
 };
 
 function specs(): DestinationSpec[] {
@@ -260,6 +326,31 @@ function specs(): DestinationSpec[] {
       text: 'Issue spiking: {event.properties.name}',
       blocks: spikeBlocks(),
     },
+    {
+      name: `Exception · ${OPS_CHANNEL} (#1513)`,
+      type: 'destination',
+      event: '$exception',
+      channel: OPS_CHANNEL,
+      text: 'Exception: {event.properties.$exception_types} {event.properties.$exception_values}',
+      blocks: exceptionBlocks(),
+      properties: [
+        // Cancelled fetches, not failures — every navigation away produces one.
+        {
+          key: '$exception_types',
+          value: 'AbortError',
+          operator: 'not_icontains',
+          type: 'event',
+        },
+        // Chrome translate rewrites the DOM out from under React; the crashes
+        // that follow are the translator's, not ours (see react-errors.ts).
+        {
+          key: 'page_translated',
+          value: 'true',
+          operator: 'is_not',
+          type: 'event',
+        },
+      ],
+    },
   ];
 }
 
@@ -280,7 +371,7 @@ async function ensureDestination(
     name: spec.name,
     description: 'Created by scripts/setup-posthog-slack-alerts.ts for #1088',
     enabled: true,
-    filters: eventFilter(spec.event),
+    filters: eventFilter(spec.event, spec.properties),
     inputs: {
       slack_workspace: { value: slackWorkspaceId },
       channel: { value: spec.channel },

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -6,6 +6,7 @@ import { installChunkReload } from '@/shared/chunk-reload';
 import { configureLogging } from '@/lib/observability/logger';
 import { flushReactErrors } from '@/lib/observability/react-errors';
 import { PostHogProvider } from '@posthog/react';
+import posthog, { type BeforeSendFn } from 'posthog-js';
 import type { QueryClient } from '@tanstack/react-query';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RealtimeContext, RealtimeProvider } from '@/lib/realtime/client';
@@ -54,6 +55,26 @@ const TanStackDevtoolsLazy: FC =
       })
     : () => null;
 
+/**
+ * Stamp every `$exception` with the replay URL for the moment it happened
+ * (#1513), so the Slack alert can link straight into the recording instead of
+ * making someone hunt for the session. `withTimestamp` starts playback
+ * ~10s before the throw — enough to see what the user did to get there.
+ *
+ * Module-level so the identity is stable: `PostHogProvider` deep-compares its
+ * `options` on every render and calls `set_config` when they differ, and a
+ * fresh closure would differ every time.
+ */
+const stampReplayUrl: BeforeSendFn = (event) => {
+  if (event?.event === '$exception') {
+    event.properties.replay_url = posthog.get_session_replay_url({
+      withTimestamp: true,
+      timestampLookBack: 10,
+    });
+  }
+  return event;
+};
+
 type ProvidersProps = {
   children: React.ReactNode;
   queryClient: QueryClient;
@@ -92,6 +113,7 @@ const ObservabilityProvider: FC<{
         api_host: apiHost,
         defaults: '2025-05-24',
         capture_exceptions: true,
+        before_send: stampReplayUrl,
         loaded: flushReactErrors,
         debug: false,
         ...(user && {

--- a/src/hooks/use-via-availability.ts
+++ b/src/hooks/use-via-availability.ts
@@ -19,6 +19,7 @@ import {
   type ViaAvailability,
 } from '@/functions/via-availability';
 import { referenceOnlyMotionModels } from '@/lib/ai/models';
+import { useAuthSession } from '@/lib/auth/session-query';
 
 /** No native vias — every model that qualifies on its fal route alone. */
 const CONSERVATIVE: ViaAvailability = {
@@ -36,11 +37,14 @@ export const viaAvailabilityQueryOptions = queryOptions({
 });
 
 export function useViaAvailability(): ViaAvailability {
+  const { data: session } = useAuthSession();
   const { data } = useQuery({
     ...viaAvailabilityQueryOptions,
-    // Anonymous visitors 401 here (the fn needs a team). Browsing the composer
-    // signed-out is supported, so failing back to the conservative list is the
-    // designed outcome, not an error to surface.
+    // The fn needs a team, so an anonymous visitor can only ever 401 — and
+    // every one of those landed in the server error stream (#1513). Browsing
+    // the composer signed-out is supported and the conservative list is the
+    // right answer for them, so don't ask the question at all.
+    enabled: session != null,
     retry: false,
   });
   return data ?? CONSERVATIVE;

--- a/src/lib/observability/react-errors.ts
+++ b/src/lib/observability/react-errors.ts
@@ -9,13 +9,10 @@
  *
  * PostHog inits in a provider effect, so a boundary hit during the first
  * render queues until the SDK's `loaded` callback calls `flushReactErrors`.
- *
- * It is also where a deploy-stale route chunk surfaces (#1513) — see
- * `reloadOnStaleRouteChunk`.
  */
 
 import { errorCode } from '@/shared/errors';
-import { reloadOnStaleRouteChunk } from '@/shared/chunk-reload';
+import { isReloadPending } from '@/shared/chunk-reload';
 import { getLogger } from '@/lib/observability/logger';
 import posthog from 'posthog-js';
 import type { ErrorInfo } from 'react';
@@ -31,6 +28,9 @@ const pending: Pending[] = [];
 export function captureRouteError(error: unknown, info: ErrorInfo): void {
   // A 404 from a stale link renders the not-found page; not an app error.
   if (errorCode(error) === 'NOT_FOUND') return;
+  // A stale-chunk reload is already under way (#1513): whatever the router
+  // threw in the meantime is the page shutting down, not something to fix.
+  if (isReloadPending()) return;
   const props = {
     component_stack: info.componentStack ?? null,
     // Chrome translate leaves these wrappers; lets the dashboard split
@@ -45,10 +45,6 @@ export function captureRouteError(error: unknown, info: ErrorInfo): void {
   } else if (pending.length < MAX_PENDING) {
     pending.push([error, props]);
   }
-  // After capturing, not before: a deploy-stale route chunk is repaired by a
-  // reload, and we still want the event that says it happened. posthog-js
-  // flushes its queue on pagehide, so the capture survives the navigation.
-  reloadOnStaleRouteChunk(error);
 }
 
 export function flushReactErrors(): void {

--- a/src/lib/observability/react-errors.ts
+++ b/src/lib/observability/react-errors.ts
@@ -9,9 +9,13 @@
  *
  * PostHog inits in a provider effect, so a boundary hit during the first
  * render queues until the SDK's `loaded` callback calls `flushReactErrors`.
+ *
+ * It is also where a deploy-stale route chunk surfaces (#1513) — see
+ * `reloadOnStaleRouteChunk`.
  */
 
 import { errorCode } from '@/shared/errors';
+import { reloadOnStaleRouteChunk } from '@/shared/chunk-reload';
 import { getLogger } from '@/lib/observability/logger';
 import posthog from 'posthog-js';
 import type { ErrorInfo } from 'react';
@@ -41,6 +45,10 @@ export function captureRouteError(error: unknown, info: ErrorInfo): void {
   } else if (pending.length < MAX_PENDING) {
     pending.push([error, props]);
   }
+  // After capturing, not before: a deploy-stale route chunk is repaired by a
+  // reload, and we still want the event that says it happened. posthog-js
+  // flushes its queue on pagehide, so the capture survives the navigation.
+  reloadOnStaleRouteChunk(error);
 }
 
 export function flushReactErrors(): void {

--- a/src/shared/chunk-reload.test.ts
+++ b/src/shared/chunk-reload.test.ts
@@ -8,6 +8,19 @@ type PreloadHandler = (event: {
 const store = new Map<string, string>();
 const reload = vi.fn();
 let handler: PreloadHandler | undefined;
+let reloadOnStaleRouteChunk: (error: unknown) => void;
+
+/** A route chunk that imported but resolved to the wrong shape. */
+function staleRouteChunkError() {
+  const error = new TypeError(
+    "Cannot read properties of undefined (reading 'component')"
+  );
+  error.stack =
+    "TypeError: Cannot read properties of undefined (reading 'component')\n" +
+    '    at https://openstory.so/assets/lazyRouteComponent-7ROn1-wk.js:1:1234\n' +
+    '    at async Xe.load (https://openstory.so/assets/breadcrumbs-c67hzjKa.js:1:17940)';
+  return error;
+}
 
 /** Dispatch what Vite's preload helper dispatches. */
 function firePreloadError() {
@@ -31,8 +44,9 @@ beforeEach(async () => {
   });
   vi.stubGlobal('location', { reload });
   vi.resetModules();
-  const { installChunkReload } = await import('./chunk-reload');
-  installChunkReload();
+  const mod = await import('./chunk-reload');
+  reloadOnStaleRouteChunk = mod.reloadOnStaleRouteChunk;
+  mod.installChunkReload();
 });
 
 describe('installChunkReload', () => {
@@ -62,5 +76,24 @@ describe('installChunkReload', () => {
     const preventDefault = firePreloadError();
     expect(reload).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe('reloadOnStaleRouteChunk', () => {
+  it('reloads when the stack originates in the lazyRouteComponent chunk', () => {
+    reloadOnStaleRouteChunk(staleRouteChunkError());
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores any other error', () => {
+    reloadOnStaleRouteChunk(new TypeError('x is not a function'));
+    reloadOnStaleRouteChunk('not an error at all');
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it('shares the one reload with the preload-error path', () => {
+    firePreloadError();
+    reloadOnStaleRouteChunk(staleRouteChunkError());
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/shared/chunk-reload.test.ts
+++ b/src/shared/chunk-reload.test.ts
@@ -8,19 +8,7 @@ type PreloadHandler = (event: {
 const store = new Map<string, string>();
 const reload = vi.fn();
 let handler: PreloadHandler | undefined;
-let reloadOnStaleRouteChunk: (error: unknown) => void;
-
-/** A route chunk that imported but resolved to the wrong shape. */
-function staleRouteChunkError() {
-  const error = new TypeError(
-    "Cannot read properties of undefined (reading 'component')"
-  );
-  error.stack =
-    "TypeError: Cannot read properties of undefined (reading 'component')\n" +
-    '    at https://openstory.so/assets/lazyRouteComponent-7ROn1-wk.js:1:1234\n' +
-    '    at async Xe.load (https://openstory.so/assets/breadcrumbs-c67hzjKa.js:1:17940)';
-  return error;
-}
+let isReloadPending: () => boolean;
 
 /** Dispatch what Vite's preload helper dispatches. */
 function firePreloadError() {
@@ -45,15 +33,18 @@ beforeEach(async () => {
   vi.stubGlobal('location', { reload });
   vi.resetModules();
   const mod = await import('./chunk-reload');
-  reloadOnStaleRouteChunk = mod.reloadOnStaleRouteChunk;
+  isReloadPending = mod.isReloadPending;
   mod.installChunkReload();
 });
 
 describe('installChunkReload', () => {
   it('reloads on the first preload error and suppresses the throw', () => {
+    expect(isReloadPending()).toBe(false);
     const preventDefault = firePreloadError();
     expect(reload).toHaveBeenCalledTimes(1);
     expect(preventDefault).toHaveBeenCalled();
+    // The page runs on for a beat; the boundary uses this to stay quiet.
+    expect(isReloadPending()).toBe(true);
   });
 
   it('does not reload twice for the same page load', () => {
@@ -76,24 +67,6 @@ describe('installChunkReload', () => {
     const preventDefault = firePreloadError();
     expect(reload).not.toHaveBeenCalled();
     expect(preventDefault).not.toHaveBeenCalled();
-  });
-});
-
-describe('reloadOnStaleRouteChunk', () => {
-  it('reloads when the stack originates in the lazyRouteComponent chunk', () => {
-    reloadOnStaleRouteChunk(staleRouteChunkError());
-    expect(reload).toHaveBeenCalledTimes(1);
-  });
-
-  it('ignores any other error', () => {
-    reloadOnStaleRouteChunk(new TypeError('x is not a function'));
-    reloadOnStaleRouteChunk('not an error at all');
-    expect(reload).not.toHaveBeenCalled();
-  });
-
-  it('shares the one reload with the preload-error path', () => {
-    firePreloadError();
-    reloadOnStaleRouteChunk(staleRouteChunkError());
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(isReloadPending()).toBe(false);
   });
 });

--- a/src/shared/chunk-reload.ts
+++ b/src/shared/chunk-reload.ts
@@ -1,36 +1,27 @@
 /**
- * Reload once when a deploy leaves this tab pointing at chunks that are gone
- * or no longer match (#1395, #1513).
+ * Reload once when a lazy chunk fails to import after a deploy (#1395).
  *
  * A deploy replaces every hashed chunk filename, but an already-loaded tab
- * still points at the old ones. The user sits on "Something went wrong" until
- * they refresh by hand. Reloading fetches fresh HTML, which points at chunks
- * that exist; there is no lighter repair, since the missing chunk is what the
- * render needed.
+ * still points at the old ones. The next lazy import — a route chunk on
+ * navigation, a `React.lazy` component — 404s, and the user sits on
+ * "Something went wrong" until they refresh by hand. Reloading fetches fresh
+ * HTML, which points at chunks that exist; there is no lighter repair, since
+ * the missing chunk is what the render needed.
  *
- * Two arrival paths, because staleness has two shapes:
+ * Vite's preload helper wraps every dynamic import and dispatches a cancelable
+ * `vite:preloadError` when either the dep preload or the module import
+ * rejects — so the event already *means* "a chunk failed to load". We
+ * deliberately don't sniff the error message on top of it: the wording is
+ * browser-specific ("Failed to fetch dynamically imported module" /
+ * "Importing a module script failed"), so a matcher can only ever go stale
+ * and silently stop firing.
  *
- * 1. The chunk 404s. Vite's preload helper wraps every dynamic import and
- *    dispatches a cancelable `vite:preloadError` when either the dep preload
- *    or the module import rejects — so the event already *means* "a chunk
- *    failed to load". We deliberately don't sniff the error message on top of
- *    it: the wording is browser-specific ("Failed to fetch dynamically
- *    imported module" / "Importing a module script failed"), so a matcher can
- *    only ever go stale and silently stop firing.
- *
- * 2. The chunk *imports* and has the wrong shape. Start's code splitting loads
- *    a route through `lazyRouteComponent(importer, 'component')`; against a
- *    cached-but-mismatched chunk the import resolves to something without the
- *    expected export and the router throws `Cannot read properties of
- *    undefined (reading 'component')`. No preload event fires — nothing
- *    failed to load — so the route boundary is the only place to catch it
- *    (`reloadOnStaleRouteChunk`, called from `captureRouteError`).
- *
- * The second path has to match on *something*, and the least fragile signal is
- * the frame's file: Vite names that chunk after the module it splits at, so
- * the stack carries `/assets/lazyRouteComponent-<hash>.js`. That is a build
- * artifact of the router's own file layout, not a browser-authored message,
- * so it doesn't drift the way the path-1 wording would.
+ * The page keeps running for a beat after `location.reload()`, and
+ * `preventDefault()` makes the helper *resolve* the failed import with
+ * `undefined` instead of throwing. The router then reads `.component` off it,
+ * the route boundary catches that, and — before #1513 — reported it as a
+ * fresh TypeError from `lazyRouteComponent`. It is the death rattle of a page
+ * we are already leaving; `isReloadPending` lets the boundary tell.
  */
 
 import { getLogger } from '@/lib/observability/logger';
@@ -45,38 +36,28 @@ const KEY = 'os:chunk-reloaded-at';
 // instead of a loop. Anything longer than a page load would do.
 const RETRY_WINDOW_MS = 10_000;
 
-/**
- * True when this page load may spend its one reload. Shared by both arrival
- * paths so a 404 chunk and a mismatched one can't each burn a reload.
- */
-function claimReload(): boolean {
-  const now = Date.now();
-  try {
-    if (now - Number(sessionStorage.getItem(KEY) ?? 0) < RETRY_WINDOW_MS)
-      return false;
-    sessionStorage.setItem(KEY, String(now));
-  } catch {
-    // No sessionStorage means no loop guard — surface the error instead.
-    return false;
-  }
-  return true;
+let reloadPending = false;
+
+/** True once this page has called `location.reload()` and is on its way out. */
+export function isReloadPending(): boolean {
+  return reloadPending;
 }
 
 export function installChunkReload(): void {
   if (typeof window === 'undefined') return;
   window.addEventListener('vite:preloadError', (event) => {
-    if (!claimReload()) return;
+    const now = Date.now();
+    try {
+      if (now - Number(sessionStorage.getItem(KEY) ?? 0) < RETRY_WINDOW_MS)
+        return;
+      sessionStorage.setItem(KEY, String(now));
+    } catch {
+      // No sessionStorage means no loop guard — surface the error instead.
+      return;
+    }
     logger.warn('stale chunk after deploy, reloading', { err: event.payload });
     event.preventDefault(); // Suppress the throw; we're leaving the page.
+    reloadPending = true;
     location.reload();
   });
-}
-
-/** Reload once if `error` looks like a route chunk that loaded but mismatched. */
-export function reloadOnStaleRouteChunk(error: unknown): void {
-  const stack = error instanceof Error ? error.stack : undefined;
-  if (!stack?.includes('lazyRouteComponent')) return;
-  if (!claimReload()) return;
-  logger.warn('stale route chunk after deploy, reloading', { err: error });
-  location.reload();
 }

--- a/src/shared/chunk-reload.ts
+++ b/src/shared/chunk-reload.ts
@@ -1,20 +1,36 @@
 /**
- * Reload once when a lazy chunk fails to import after a deploy (#1395).
+ * Reload once when a deploy leaves this tab pointing at chunks that are gone
+ * or no longer match (#1395, #1513).
  *
  * A deploy replaces every hashed chunk filename, but an already-loaded tab
- * still points at the old ones. The next lazy import — a route chunk on
- * navigation, a `React.lazy` component — 404s, and the user sits on
- * "Something went wrong" until they refresh by hand. Reloading fetches fresh
- * HTML, which points at chunks that exist; there is no lighter repair, since
- * the missing chunk is what the render needed.
+ * still points at the old ones. The user sits on "Something went wrong" until
+ * they refresh by hand. Reloading fetches fresh HTML, which points at chunks
+ * that exist; there is no lighter repair, since the missing chunk is what the
+ * render needed.
  *
- * Vite's preload helper wraps every dynamic import and dispatches a cancelable
- * `vite:preloadError` when either the dep preload or the module import
- * rejects — so the event already *means* "a chunk failed to load". We
- * deliberately don't sniff the error message on top of it: the wording is
- * browser-specific ("Failed to fetch dynamically imported module" /
- * "Importing a module script failed"), so a matcher can only ever go stale
- * and silently stop firing.
+ * Two arrival paths, because staleness has two shapes:
+ *
+ * 1. The chunk 404s. Vite's preload helper wraps every dynamic import and
+ *    dispatches a cancelable `vite:preloadError` when either the dep preload
+ *    or the module import rejects — so the event already *means* "a chunk
+ *    failed to load". We deliberately don't sniff the error message on top of
+ *    it: the wording is browser-specific ("Failed to fetch dynamically
+ *    imported module" / "Importing a module script failed"), so a matcher can
+ *    only ever go stale and silently stop firing.
+ *
+ * 2. The chunk *imports* and has the wrong shape. Start's code splitting loads
+ *    a route through `lazyRouteComponent(importer, 'component')`; against a
+ *    cached-but-mismatched chunk the import resolves to something without the
+ *    expected export and the router throws `Cannot read properties of
+ *    undefined (reading 'component')`. No preload event fires — nothing
+ *    failed to load — so the route boundary is the only place to catch it
+ *    (`reloadOnStaleRouteChunk`, called from `captureRouteError`).
+ *
+ * The second path has to match on *something*, and the least fragile signal is
+ * the frame's file: Vite names that chunk after the module it splits at, so
+ * the stack carries `/assets/lazyRouteComponent-<hash>.js`. That is a build
+ * artifact of the router's own file layout, not a browser-authored message,
+ * so it doesn't drift the way the path-1 wording would.
  */
 
 import { getLogger } from '@/lib/observability/logger';
@@ -29,20 +45,38 @@ const KEY = 'os:chunk-reloaded-at';
 // instead of a loop. Anything longer than a page load would do.
 const RETRY_WINDOW_MS = 10_000;
 
+/**
+ * True when this page load may spend its one reload. Shared by both arrival
+ * paths so a 404 chunk and a mismatched one can't each burn a reload.
+ */
+function claimReload(): boolean {
+  const now = Date.now();
+  try {
+    if (now - Number(sessionStorage.getItem(KEY) ?? 0) < RETRY_WINDOW_MS)
+      return false;
+    sessionStorage.setItem(KEY, String(now));
+  } catch {
+    // No sessionStorage means no loop guard — surface the error instead.
+    return false;
+  }
+  return true;
+}
+
 export function installChunkReload(): void {
   if (typeof window === 'undefined') return;
   window.addEventListener('vite:preloadError', (event) => {
-    const now = Date.now();
-    try {
-      if (now - Number(sessionStorage.getItem(KEY) ?? 0) < RETRY_WINDOW_MS)
-        return;
-      sessionStorage.setItem(KEY, String(now));
-    } catch {
-      // No sessionStorage means no loop guard — surface the error instead.
-      return;
-    }
+    if (!claimReload()) return;
     logger.warn('stale chunk after deploy, reloading', { err: event.payload });
     event.preventDefault(); // Suppress the throw; we're leaving the page.
     location.reload();
   });
+}
+
+/** Reload once if `error` looks like a route chunk that loaded but mismatched. */
+export function reloadOnStaleRouteChunk(error: unknown): void {
+  const stack = error instanceof Error ? error.stack : undefined;
+  if (!stack?.includes('lazyRouteComponent')) return;
+  if (!claimReload()) return;
+  logger.warn('stale route chunk after deploy, reloading', { err: error });
+  location.reload();
 }


### PR DESCRIPTION
Closes #1513.

## 1. The stale-chunk TypeError is the existing reload already firing

The issue premise was wrong, and I initially built on it. Vite's preload helper does
`baseModule().catch(handlePreloadError)`, and `handlePreloadError` only *throws*
when the `vite:preloadError` event was not cancelled. `installChunkReload`
cancels it and calls `location.reload()` — but the page runs on for a beat, so
the import **resolves with `undefined`**, `lazyRouteComponent` reads
`.component` off it, and the route boundary reports that as a fresh TypeError.

Both reported sessions confirm it: `$exception` → `$pageleave` → `$pageview` of
the same URL within 1–3s, then normal browsing. The #1395 reload worked; the
error is its death rattle.

So instead of a second reload, `captureRouteError` returns early when
`isReloadPending()` — no error-level log, no PostHog issue. `chunk-reload.ts`
exposes that flag and nothing else changes there.

## 2. Stop logging anonymous 401s from `getViaAvailabilityFn`

`useViaAvailability` now gates on a session. Anonymous visitors keep the
conservative fallback — that was already the designed answer for them — and
never make the call that could only 401. `AUTHENTICATION_ERROR` stays out of
`EXPECTED_REJECTION_CODES`.

## 3. Slack alert per exception, with a replay link

- `before_send` in `providers.tsx` stamps `replay_url` on every `$exception`
  via `get_session_replay_url({ withTimestamp: true, timestampLookBack: 10 })`
  — playback starts ~10s before the throw. It's a module-level function so
  `PostHogProvider`'s deep-compare of `options` doesn't re-`set_config` on
  every render.
- New destination spec in `scripts/setup-posthog-slack-alerts.ts`: `$exception`
  → `#ops-alerts`, with "Watch replay" and "View issue" buttons. AbortError and
  `page_translated = true` are filtered out.
- The replay button falls back to `{project.url}/replay/{$session_id}` when
  there's no `replay_url`: Slack rejects the whole message over one empty
  button href.

**Not applied yet** — the script needs `POSTHOG_PERSONAL_API_KEY`
(`hog_function:write`). `DRY_RUN=1` still hits `/integrations/` to resolve the
Slack workspace id, so it can't be exercised without one either. Run:

```
DRY_RUN=1 POSTHOG_PERSONAL_API_KEY=phx_… POSTHOG_PROJECT_ID=379820 \
  bun scripts/setup-posthog-slack-alerts.ts
```

then drop `DRY_RUN` to apply. Note the script is idempotent **by destination
name**, so it won't update the four that already exist.

## Tests

`chunk-reload.test.ts` asserts `isReloadPending()` flips only when a reload is
actually claimed. The `enabled` flag in (2) is a one-liner with no branch worth
a harness.

https://claude.ai/code/session_01WAkaHJzcCCYRdAxyXSs4Lw
