### PR TITLE
fix(#1521): route reference-only motion with no matched sheets to text-to-video on fal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,7 +232,7 @@ render-only switch: it picks the motion-prompt template and folds into the
 motion hash, so flipping it re-stales that shot's motion prompt.
 
 **Two capability questions, don't mix them.** `supportsReferenceOnlyMotion` is
-the model-only floor (fal `reference-to-video`: Seedance 2.0 / 2.5, H3 Max);
+the model-only floor (fal `reference-to-video`: Seedance 2.0 / 2.5, H3 Max, Omni Flash);
 `referenceOnlyCapableWith(model, vias)` is its isomorphic via-aware form, which
 `createSequenceSchema` asks with `{ xai: true }` for **every** selected video
 model, not just the primary. Anywhere a team's keys are
@@ -255,8 +255,9 @@ Gotchas: motion references gain the location sheet (ordered first — the budget
 is spent in order); `buildReferenceVideoPrompt` drops the "Use @Image1 as the
 starting frame" line and binds refs from slot 1; Ark `size` switches from
 `adaptive` to the sequence's ratio (nothing is left to adapt to, and a portrait
-sheet would silently render 9:16); billing prices the r2v endpoint per shot,
-since a batch can mix. The mode folds into the motion-prompt hash **only when
+sheet would silently render 9:16); billing prices the endpoint the shot hits per shot
+(r2v with sheets, the model's `textToVideoEndpointId` with none — fal r2v
+rejects an empty image list, #1521), since a batch can mix. The mode folds into the motion-prompt hash **only when
 true**, so no stored digest moves — and it is REQUIRED on
 `ShotPromptContextSequence` because omitting it would make every reference-only
 prompt read stale forever, silently. The manifest records
@@ -354,7 +355,7 @@ fal is the default **via** for every image / video / audio model. Catalog **vend
 Two vias, one catalog key. `IMAGE_TO_VIDEO_MODELS.seedance_v2_5` / `IMAGE_MODELS.seedream_v5` carry a `byteplusId` alongside their fal endpoint id. `seedance_v2` is fal Seedance 2.0 enterprise (no Ark via). fal has no enterprise 2.5. Claim is the Grok pattern (#1167): `isNativeBytePlus*Model` + live `ARK_API_KEY` (`claimBytePlusVia`), then `resolveMotionEndpoint(..., via)` / the image `switch (via)` — **BytePlus when Ark is configured AND the model is native AND the team is not on its own fal key**. BYOK fal stays on fal (their key, their bill). Stamp `via` on the job; poll MUST follow the stamp (default missing stamps to `'fal'`). Sequences store the model _key_, never the endpoint.
 
 - **Platform key only.** `team_api_keys` stays `'openrouter' | 'fal'` — there is no `'byteplus'` on `API_KEY_PROVIDERS` and no `resolveOptionalKey('byteplus')`.
-- **Ark is not fal-shaped**, so the fal codegen (`bun motion:codegen`, `MOTION_TRANSFORMS`) does not apply. `resolveMotionEndpoint` stays fal i2v vs reference-to-video. Ark Seedance with refs uses `buildBytePlusVideoRequest` — Ark **rejects frame roles mixed with reference roles** (a shot with cast refs sends the still AS a reference). Seedream's `2K` token is **square**, so non-square sizes must be spelled in pixels. Image `watermark` **defaults to true**.
+- **Ark is not fal-shaped**, so the fal codegen (`bun motion:codegen`, `MOTION_TRANSFORMS`) does not apply. `resolveMotionEndpoint` stays fal i2v / reference-to-video / text-to-video. Ark Seedance with refs uses `buildBytePlusVideoRequest` — Ark **rejects frame roles mixed with reference roles** (a shot with cast refs sends the still AS a reference). Seedream's `2K` token is **square**, so non-square sizes must be spelled in pixels. Image `watermark` **defaults to true**.
 - **Pricing is a static card**, not `model_pricing` — BytePlus publishes no pricing API. `src/lib/ai/byteplus-pricing.ts` holds dated, advertised (NOT bill-verified) rates and is merged into the effective pricing map at read time, so a fresh deploy never bills $0. When Ark is configured, `applyBytePlusRouteAliases` points the fal endpoint ids at the Ark rate, which is why **no estimator or UI call site needs to know the via**. Video bills in tokens (÷1000 for the `1000 tokens` unit); images bill per image. Ark units set `recordFalUsage: false`.
 - **Ark quotas are per-ACCOUNT** (shared by every team), where fal's are per-key — so the backpressure is 429 classification + exponential backoff in `byteplus-rate-limit.ts` (`withBytePlusQuotaRetry` lives inside the byteplus via case), which deliberately does **not** consume the content-flag retry budget. Deliberately **not** a per-run fan-out cap: #1143 deleted that mechanism because it is per workflow RUN. Real admission control has to live where it can see the whole system. Every rejection emits a `byteplus_quota_backoff` PostHog event (`byteplus-observability.ts`) — un-deduped. Watch the `exhausted: true` rate: non-zero means it is time for a bounded queue in front of Ark (#891).
 - **Photorealistic faces (including generated ones).** Seedance 2.5/2.0 reject a public URL that _may contain a real person_ (`InputImageSensitiveContentDetected.PrivacyInformation`). Advanced Creation Rights unlock the **virtual** portrait library. Submit registers **every still** as `asset://` (`BYTEPLUS_ACCESS_KEY` / `BYTEPLUS_SECRET_KEY`) — start frame and all references. If ingest is missing or Ark still 400s, fal fallback remains. Do **not** fold it into the content-flag re-roll.
@@ -413,13 +414,13 @@ pass top-level `duration`/`size` to `generateVideo` — the adapter overwrites
 API instead of inlining a multi-MB `data:` URL. Inline bytes miss Cloudflare
 Workflows' 1 MiB `step.do` cap; poll/upload download the Files URI with the
 Google key. Without a Google key the same model runs on fal's
-`fal-ai/gemini-omni-1.1-flash[/image-to-video|/reference-to-video]` endpoints.
+`fal-ai/gemini-omni-1.1-flash[/image-to-video|/reference-to-video]` endpoints
+(the bare id is fal's text-to-video route, used when a reference-only shot
+matched nothing).|/reference-to-video]`endpoints.
 Data-URI stills must be decomposed to inline base64 on the native path —
-Google won't fetch `data:` as a URI. Chat vision (motion prompts) and
-native image refs must also inline stored stills: Google's
-`fileData.fileUri` HTTP fetch (CDN / fal URLs) sits on a separate quota
-that 429s while the same bytes as `inlineData` succeed.
-`toVisionImageSource(..., { inline: true })` is that path.
+Google won't fetch`data:`as a URI. Chat vision (motion prompts) and
+native image refs must also inline stored stills: Google's`fileData.fileUri`HTTP fetch (CDN / fal URLs) sits on a separate quota
+that 429s while the same bytes as`inlineData`succeed.`toVisionImageSource(..., { inline: true })` is that path.
 
 ### LLMTR Gateway
 

--- a/docs/architecture/reference-only-motion.md
+++ b/docs/architecture/reference-only-motion.md
@@ -150,11 +150,15 @@ player before it loses its set.
 
 `resolveMotionEndpoint(model, hasRefs, via, referenceOnly)`:
 
-- Forces the reference route even when a scene matched no sheets at all. A
-  two-hander in an unmatched location still needs an endpoint whose start frame
-  is optional.
-- Throws for a model with no such route rather than submitting a request the
-  endpoint must reject.
+- Forces the reference route whenever a scene matched at least one sheet.
+- Routes a scene that matched NO sheets (an abstract piece, an unmatched
+  location) to the model's `textToVideoEndpointId` (#1521). Every fal
+  reference-to-video endpoint rejects an empty image list ("At least one
+  reference image, video, or audio must be provided"); an empty bible is a
+  valid outcome, not a bug, so the shot renders prompt-only rather than failing.
+  The native Ark / xAI / Google builders already send plain text-to-video here.
+- Throws for a model with no reference route rather than submitting a request
+  the endpoint must reject.
 
 `buildReferenceVideoPrompt` drops the `Use @Image1 as the starting frame.` line
 and binds references from slot 1. Pointing the model at `@Image1` when
@@ -170,8 +174,8 @@ Billing prices the reference-to-video endpoint the job actually hits, not the
 image-to-video row — the post-hoc charge (`motionCostFromUsage`), the workflow
 estimate (`calculateMotionMetadata`), AND the pre-flight credit gates, which
 take `referenceOnly` through `estimateVideoCost`. A reference-only shot routes
-to r2v even having matched no sheets at all, so resolving on `hasReferenceImages`
-alone under-prices exactly the shots with the least to go on.
+to r2v (or its t2v sibling with nothing matched), so resolving on
+`hasReferenceImages` alone under-prices exactly the shots with the least to go on.
 
 `video_variants.manifest` records `frameVersionId: null` — the documented
 encoding of "reference-driven shot with no dedicated first frame". Every write

--- a/docs/architecture/reference-only-motion.md
+++ b/docs/architecture/reference-only-motion.md
@@ -208,10 +208,12 @@ predate reference-only and so were image-to-video.
 ## Model gating
 
 Only models in `MOTION_REFERENCE_ENDPOINTS` qualify — today Seedance 2.0 and
-2.5 and MiniMax H3 Max, whose `reference-to-video` route requires only a
-prompt and takes its images in `reference_image_urls` rather than `image_urls`
-(`imageField` on the endpoint config; every builder reads it, so a fourth model
-with a fourth field name needs no code).
+2.5, MiniMax H3 Max and Gemini Omni Flash, each with a `reference-to-video`
+route that needs no start frame (H3 Max takes its images in
+`reference_image_urls` rather than `image_urls` — `imageField` on the endpoint
+config; every builder reads it, so a fifth model with a fifth field name needs
+no code) and a `textToVideoEndpointId` sibling for a shot that matched nothing
+(#1521).
 `supportsReferenceOnlyMotion` is keyed on the MODEL, not the resolved via — the
 conservative floor, safe in a pure isomorphic schema. It is NOT the question to
 ask anywhere a team's keys are reachable; see below.

--- a/scripts/pull-motion-schemas.ts
+++ b/scripts/pull-motion-schemas.ts
@@ -48,9 +48,11 @@ async function main() {
   const endpointIds = [
     ...new Set([
       ...Object.values(IMAGE_TO_VIDEO_MODELS).map((m) => m.id),
-      ...Object.values(MOTION_REFERENCE_ENDPOINTS).map(
-        (config) => config.endpointId
-      ),
+      ...Object.values(MOTION_REFERENCE_ENDPOINTS).flatMap((config) => [
+        config.endpointId,
+        // Reference-only with no matched sheets submits here (#1521).
+        config.textToVideoEndpointId,
+      ]),
     ]),
   ];
 

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -1433,9 +1433,8 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
             ? generateAudio
             : undefined,
           referenceImages,
-          // Forces the reference-to-video route even when this scene matched
-          // no sheets — exactly as submit does, so the endpoint shown is the
-          // endpoint used.
+          // Same routing as submit (r2v with sheets, the t2v sibling with
+          // none, #1521), so the endpoint shown is the endpoint used.
           referenceOnly: !shotUsesStartFrame,
         },
         modelKey

--- a/src/lib/ai/fal-endpoints.ts
+++ b/src/lib/ai/fal-endpoints.ts
@@ -15,9 +15,12 @@ export function getFalEndpointIds(): string[] {
   const image = Object.values(IMAGE_MODELS).map((m) => m.id);
   const audio = Object.values(AUDIO_MODELS).map((m) => m.id);
   const edit = Object.values(EDIT_ENDPOINTS);
-  const motionRef = Object.values(MOTION_REFERENCE_ENDPOINTS).map(
-    (m) => m.endpointId
-  );
+  // Both rows a reference-only shot can bill on (#1521): the reference
+  // endpoint, and the text-to-video sibling it takes with no matched sheets.
+  const motionRef = Object.values(MOTION_REFERENCE_ENDPOINTS).flatMap((m) => [
+    m.endpointId,
+    m.textToVideoEndpointId,
+  ]);
   const studioVideo = studioVideoEndpointIds();
 
   return [

--- a/src/lib/ai/fal-pricing-live.test.ts
+++ b/src/lib/ai/fal-pricing-live.test.ts
@@ -186,9 +186,10 @@ describe('BytePlus route aliasing', () => {
     const { getEffectiveFalPricing } = await loadWithRows(falRows, {
       ARK_API_KEY: 'ark-test',
     });
-    expect((await getEffectiveFalPricing())[SEEDANCE_REF]?.unitPrice).toBe(
-      10_700
-    );
+    const map = await getEffectiveFalPricing();
+    expect(map[SEEDANCE_REF]?.unitPrice).toBe(10_700);
+    // Reference-only with no matched sheets bills on the t2v sibling (#1521).
+    expect(map['bytedance/seedance-2.5/text-to-video']?.unitPrice).toBe(10_700);
   });
 
   it('leaves models with no BytePlus via on their fal rate', async () => {

--- a/src/lib/ai/fal-pricing-live.ts
+++ b/src/lib/ai/fal-pricing-live.ts
@@ -154,7 +154,11 @@ function applyBytePlusRouteAliases(
     // it is the same model id, so that endpoint aliases too — otherwise a
     // referenced shot silently quotes the fal rate.
     const referenceEndpoint = MOTION_REFERENCE_ENDPOINTS[modelKey];
-    if (referenceEndpoint) map[referenceEndpoint.endpointId] = rate;
+    if (referenceEndpoint) {
+      map[referenceEndpoint.endpointId] = rate;
+      // Reference-only with no matched sheets bills on the t2v sibling (#1521).
+      map[referenceEndpoint.textToVideoEndpointId] = rate;
+    }
   }
 }
 

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -692,6 +692,13 @@ export type MotionReferenceEndpointConfig = {
   /** The fal reference-to-video endpoint id to submit to. */
   endpointId: string;
   /**
+   * The model's fal text-to-video sibling (#1521). Every fal
+   * reference-to-video endpoint rejects an empty image list ("At least one
+   * reference image, video, or audio must be provided"), so a reference-only
+   * shot that matched no cast, location or element sheets submits here.
+   */
+  textToVideoEndpointId: string;
+  /**
    * Renders the prompt token bound to the image-list field at
    * `position - 1` (1-based) — e.g. `@Image1` for Seedance, `Image 1`
    * for H3 Max.
@@ -724,16 +731,21 @@ export const MOTION_REFERENCE_ENDPOINTS: Partial<
 > = {
   seedance_v2: {
     endpointId: 'bytedance/seedance-2.0/enterprise/v2/reference-to-video',
+    textToVideoEndpointId: 'bytedance/seedance-2.0/enterprise/v2/text-to-video',
     tag: (position) => `@Image${position}`,
     maxImages: 9,
   },
   seedance_v2_5: {
     endpointId: 'bytedance/seedance-2.5/reference-to-video',
+    textToVideoEndpointId: 'bytedance/seedance-2.5/text-to-video',
     tag: (position) => `@Image${position}`,
     maxImages: 9,
   },
   gemini_omni_flash: {
     endpointId: 'fal-ai/gemini-omni-1.1-flash/reference-to-video',
+    // fal serves Omni Flash text-to-video from the bare model id; there is no
+    // `/text-to-video` path (the queue answers "Path /text-to-video not found").
+    textToVideoEndpointId: 'fal-ai/gemini-omni-1.1-flash',
     // Google numbers references from zero (Omni Flash prompt guide); the API
     // caps a request at 7 reference images.
     tag: (position) => `<IMAGE_REF_${position - 1}>`,
@@ -742,6 +754,7 @@ export const MOTION_REFERENCE_ENDPOINTS: Partial<
   // Schema caps images at 9 (videos 3, audio 3; combined 12 files).
   minimax_h3_max: {
     endpointId: 'minimax/h3-max/reference-to-video',
+    textToVideoEndpointId: 'minimax/h3-max/text-to-video',
     tag: (position) => `Image ${position}`,
     maxImages: 9,
     imageField: 'reference_image_urls',

--- a/src/lib/ai/models.ts
+++ b/src/lib/ai/models.ts
@@ -8,7 +8,10 @@
 import { isNativeGrokVideoModel } from '@/lib/ai/grok-native';
 import type { AnalysisModelId } from '@/lib/ai/models.config';
 import type { AspectRatio } from '@/shared/constants/aspect-ratios';
-import { MOTION_INPUT_SCHEMAS } from '@/lib/motion/endpoint-map';
+import {
+  MOTION_INPUT_SCHEMAS,
+  type MotionEndpointId,
+} from '@/lib/motion/endpoint-map';
 // Type-only: the Seedream adapter narrows `model` to a literal union, so the
 // catalog's `byteplusId` has to be that union rather than a bare string —
 // a retired id then fails typecheck instead of at request time (#1157).
@@ -690,14 +693,14 @@ export function getEditEndpoint(model: TextToImageModel): string | null {
  */
 export type MotionReferenceEndpointConfig = {
   /** The fal reference-to-video endpoint id to submit to. */
-  endpointId: string;
+  endpointId: MotionEndpointId;
   /**
    * The model's fal text-to-video sibling (#1521). Every fal
    * reference-to-video endpoint rejects an empty image list ("At least one
    * reference image, video, or audio must be provided"), so a reference-only
    * shot that matched no cast, location or element sheets submits here.
    */
-  textToVideoEndpointId: string;
+  textToVideoEndpointId: MotionEndpointId;
   /**
    * Renders the prompt token bound to the image-list field at
    * `position - 1` (1-based) — e.g. `@Image1` for Seedance, `Image 1`
@@ -790,10 +793,11 @@ export function attachesInlineReferences(model: ImageToVideoModel): boolean {
  * Reference-only mode (see `docs/architecture/reference-only-motion.md`) skips
  * still generation entirely, so the model must have a route whose start frame
  * is optional. That is exactly the `MOTION_REFERENCE_ENDPOINTS` set: fal's
- * `reference-to-video` endpoints take an optional `image_urls[]` and have no
- * `image_url` field at all, and the same models' BytePlus Ark route sends
- * every image as a `reference` role (Ark's frame/reference mix-ban means the
- * still was never a frame there either).
+ * `reference-to-video` endpoints have no `image_url` field at all (the image
+ * list is schema-optional but rejected when empty — a shot with nothing
+ * matched goes to `textToVideoEndpointId`, #1521), and the same models'
+ * BytePlus Ark route sends every image as a `reference` role (Ark's
+ * frame/reference mix-ban means the still was never a frame there either).
  *
  * Keyed on the MODEL alone, so it is true on EVERY via — the floor, safe to
  * call anywhere including a pure isomorphic schema. Kling is excluded: its

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -187,10 +187,10 @@ export function estimateVideoCost(
      */
     hasReferenceImages?: boolean;
     /**
-     * Reference-only shots route to reference-to-video even when the scene
-     * matched no sheets at all, so the estimate has to be told: resolving on
-     * `hasReferenceImages` alone would price the image-to-video row for a job
-     * that never runs there.
+     * Reference-only shots route to reference-to-video (or, with no sheets
+     * matched, its text-to-video sibling — #1521), so the estimate has to be
+     * told: resolving on `hasReferenceImages` alone would price the
+     * image-to-video row for a job that never runs there.
      */
     referenceOnly?: boolean;
   }

--- a/src/lib/billing/cost-estimation.ts
+++ b/src/lib/billing/cost-estimation.ts
@@ -195,15 +195,20 @@ export function estimateVideoCost(
     referenceOnly?: boolean;
   }
 ): Microdollars | null {
+  // Gated on the model: `resolveMotionEndpoint` THROWS for reference-only on
+  // a model with no fal reference-to-video route, and an estimator must not.
+  // Grok reference-only is exactly that case — it runs on the native xAI via,
+  // whose cost is the flat per-second rate off `modelConfig.id` anyway.
+  const referenceOnly =
+    opts.referenceOnly === true && supportsReferenceOnlyMotion(model);
   const { endpointId } = resolveMotionEndpoint(
     model,
-    opts.hasReferenceImages === true,
+    // A caller that has not matched sheets yet assumes a reference-only shot
+    // will bind some: r2v is the conservative quote, and the t2v sibling
+    // (#1521) is only priced when the caller KNOWS nothing matched.
+    opts.hasReferenceImages ?? referenceOnly,
     'fal',
-    // Gated on the model: `resolveMotionEndpoint` THROWS for reference-only on
-    // a model with no fal reference-to-video route, and an estimator must not.
-    // Grok reference-only is exactly that case — it runs on the native xAI via,
-    // whose cost is the flat per-second rate off `modelConfig.id` anyway.
-    opts.referenceOnly === true && supportsReferenceOnlyMotion(model)
+    referenceOnly
   );
   // Keep the catalog model id path when unresolved (tests / unknown keys).
   // Both ids alias to the Ark rate when the platform routes there (#1157).

--- a/src/lib/motion/batch-motion-cost.ts
+++ b/src/lib/motion/batch-motion-cost.ts
@@ -72,9 +72,10 @@ export function estimateBatchMotionCost(
      */
     hasReferenceImages?: boolean | ((shot: BatchShot) => boolean);
     /**
-     * @see estimateVideoCost — reference-only always routes to r2v. Per shot
-     * like its neighbour: a batch can mix, and pricing every shot on one
-     * shot's answer quotes the wrong endpoint for the rest.
+     * @see estimateVideoCost — reference-only routes to r2v, or to the t2v
+     * sibling when the shot matched no sheets (#1521). Per shot like its
+     * neighbour: a batch can mix, and pricing every shot on one shot's answer
+     * quotes the wrong endpoint for the rest.
      */
     referenceOnly?: boolean | ((shot: BatchShot) => boolean);
   }

--- a/src/lib/motion/build-gemini-video-request.ts
+++ b/src/lib/motion/build-gemini-video-request.ts
@@ -9,14 +9,13 @@
  */
 
 import { NATIVE_GEMINI_VIDEO_MODEL } from '@/lib/ai/gemini-native';
-import {
-  IMAGE_TO_VIDEO_MODELS,
-  type ImageToVideoModel,
-  type MotionReferenceEndpointConfig,
-} from '@/lib/ai/models';
+import { IMAGE_TO_VIDEO_MODELS, type ImageToVideoModel } from '@/lib/ai/models';
 import type { AspectRatio } from '@/shared/constants/aspect-ratios';
 import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
-import { buildReferenceVideoPrompt } from './build-reference-video-prompt';
+import {
+  buildReferenceVideoPrompt,
+  type ReferencePromptBinding,
+} from './build-reference-video-prompt';
 import { snapDuration } from './snap-duration';
 
 /**
@@ -28,10 +27,9 @@ import { snapDuration } from './snap-duration';
  * line.
  */
 const GEMINI_VIDEO_REFERENCE_CONFIG = {
-  endpointId: NATIVE_GEMINI_VIDEO_MODEL,
   tag: (position: number) => `<IMAGE_REF_${position - 1}>`,
   maxImages: 7,
-} satisfies MotionReferenceEndpointConfig;
+} satisfies ReferencePromptBinding;
 
 type GeminiVideoPromptPart =
   | { type: 'text'; content: string }

--- a/src/lib/motion/build-grok-video-request.ts
+++ b/src/lib/motion/build-grok-video-request.ts
@@ -8,18 +8,17 @@
  */
 
 import { NATIVE_GROK_VIDEO_MODEL } from '@/lib/ai/grok-native';
-import {
-  IMAGE_TO_VIDEO_MODELS,
-  type ImageToVideoModel,
-  type MotionReferenceEndpointConfig,
-} from '@/lib/ai/models';
+import { IMAGE_TO_VIDEO_MODELS, type ImageToVideoModel } from '@/lib/ai/models';
 import type { AspectRatio } from '@/shared/constants/aspect-ratios';
 import {
   pickVideoResolution,
   type Resolution,
 } from '@/shared/constants/resolutions';
 import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
-import { buildReferenceVideoPrompt } from './build-reference-video-prompt';
+import {
+  buildReferenceVideoPrompt,
+  type ReferencePromptBinding,
+} from './build-reference-video-prompt';
 
 /**
  * Imagine 1.5 reference-to-video: still first, then up to 6 library refs
@@ -28,10 +27,9 @@ import { buildReferenceVideoPrompt } from './build-reference-video-prompt';
  * a start-frame `image` with `reference_images`.
  */
 const GROK_VIDEO_REFERENCE_CONFIG = {
-  endpointId: NATIVE_GROK_VIDEO_MODEL,
   tag: (position: number) => `<IMAGE_${position - 1}>`,
   maxImages: 7,
-} satisfies MotionReferenceEndpointConfig;
+} satisfies ReferencePromptBinding;
 
 type GrokVideoPromptPart =
   | { type: 'text'; content: string }

--- a/src/lib/motion/build-model-input.test.ts
+++ b/src/lib/motion/build-model-input.test.ts
@@ -364,7 +364,9 @@ describe('buildModelInput', () => {
       });
 
       it('forwards generate_audio=false when caller suppresses audio', () => {
-        expect(buildRef({ generateAudio: false }).generate_audio).toBe(false);
+        expect(buildRef({ generateAudio: false })).toMatchObject({
+          generate_audio: false,
+        });
       });
     }
   );
@@ -525,6 +527,19 @@ describe('buildMotionRequest — reference-only', () => {
     }
   );
 
+  it('refuses to drop a start frame on the text-to-video route', () => {
+    expect(() =>
+      buildMotionRequest(
+        {
+          ...referenceOnlyOptions,
+          referenceImages: [],
+          imageUrl: 'https://example.com/shot.jpg',
+        },
+        'seedance_v2_5'
+      )
+    ).toThrow(/start frame in reference-only mode/);
+  });
+
   it('keeps H3 Max quality overrides on the text-to-video route', () => {
     const { input } = buildMotionRequest(
       { ...referenceOnlyOptions, referenceImages: [], resolution: '720p' },
@@ -542,7 +557,7 @@ describe('buildMotionRequest — reference-only', () => {
       { ...referenceOnlyOptions, aspectRatio: '9:16' },
       'seedance_v2_5'
     );
-    expect(input.aspect_ratio).toBe('9:16');
+    expect(input).toMatchObject({ aspect_ratio: '9:16' });
   });
 
   it('refuses a start-frame model asked to render without one', () => {

--- a/src/lib/motion/build-model-input.test.ts
+++ b/src/lib/motion/build-model-input.test.ts
@@ -498,16 +498,43 @@ describe('buildMotionRequest — reference-only', () => {
     expect(input.prompt).toContain('Image 1');
   });
 
-  it('omits image_urls entirely when nothing matched', () => {
-    const { input } = buildMotionRequest(
-      { ...referenceOnlyOptions, referenceImages: [] },
-      'seedance_v2_5'
-    );
+  // Every fal reference-to-video endpoint rejects an empty image list ("At
+  // least one reference image, video, or audio must be provided"), so a shot
+  // that matched no sheets must go to the text-to-video sibling (#1521).
+  it.each([
+    ['seedance_v2', 'bytedance/seedance-2.0/enterprise/v2/text-to-video'],
+    ['seedance_v2_5', 'bytedance/seedance-2.5/text-to-video'],
+    ['minimax_h3_max', 'minimax/h3-max/text-to-video'],
+    ['gemini_omni_flash', 'fal-ai/gemini-omni-1.1-flash'],
+  ] as const)(
+    'routes %s to text-to-video with no image field when nothing matched',
+    (model, expectedEndpoint) => {
+      const { endpointId, input } = buildMotionRequest(
+        { ...referenceOnlyOptions, referenceImages: [] },
+        model
+      );
 
-    expect(
-      'image_urls' in input ? input.image_urls : undefined
-    ).toBeUndefined();
-    expect(input.prompt).toBe(referenceOnlyOptions.prompt);
+      expect(endpointId).toBe(expectedEndpoint);
+      expect(input).not.toHaveProperty('image_url');
+      expect(input).not.toHaveProperty('image_urls');
+      expect(input).not.toHaveProperty('reference_image_urls');
+      expect(input).toMatchObject({
+        prompt: referenceOnlyOptions.prompt,
+        aspect_ratio: '16:9',
+      });
+    }
+  );
+
+  it('keeps H3 Max quality overrides on the text-to-video route', () => {
+    const { input } = buildMotionRequest(
+      { ...referenceOnlyOptions, referenceImages: [], resolution: '720p' },
+      'minimax_h3_max'
+    );
+    expect(input).toMatchObject({
+      prompt_expansion_mode: 'balanced',
+      resolution: '768P',
+      duration: 5,
+    });
   });
 
   it('carries the sequence aspect ratio rather than adapting to a still', () => {

--- a/src/lib/motion/build-model-input.ts
+++ b/src/lib/motion/build-model-input.ts
@@ -182,6 +182,16 @@ type ReferenceVideoOutput =
     >
   | z.output<(typeof MOTION_TRANSFORMS)['minimax/h3-max/reference-to-video']>;
 
+/** Output of a text-to-video transform (`textToVideoEndpointId` in
+ *  `MOTION_REFERENCE_ENDPOINTS`, #1521). */
+type TextToVideoOutput =
+  | z.output<(typeof MOTION_TRANSFORMS)['bytedance/seedance-2.5/text-to-video']>
+  | z.output<
+      (typeof MOTION_TRANSFORMS)['bytedance/seedance-2.0/enterprise/v2/text-to-video']
+    >
+  | z.output<(typeof MOTION_TRANSFORMS)['minimax/h3-max/text-to-video']>
+  | z.output<(typeof MOTION_TRANSFORMS)['fal-ai/gemini-omni-1.1-flash']>;
+
 /**
  * Resolve the endpoint and build the exact fal request body for a motion run
  * (#873). Shared by `submitMotionJob` and the scene editor's optimised-prompt
@@ -194,14 +204,16 @@ type ReferenceVideoOutput =
  * first in the image-list field with the sheets after it — there is no
  * separate start-frame `image_url` on that endpoint. In reference-only mode
  * (`options.referenceOnly`) there is no still at all: the sheets fill that
- * field from slot 1 and the prompt carries the composition.
+ * field from slot 1 and the prompt carries the composition. A reference-only
+ * shot that matched no sheets is prompt-only and goes to the model's
+ * text-to-video sibling (#1521) — the reference endpoints reject an empty list.
  */
 export function buildMotionRequest<T extends ImageToVideoModel>(
   options: GenerateMotionOptions,
   modelKey: T
 ): {
   endpointId: string;
-  input: ModelOutputMap[T] | ReferenceVideoOutput;
+  input: ModelOutputMap[T] | ReferenceVideoOutput | TextToVideoOutput;
 } {
   const modelConfig = IMAGE_TO_VIDEO_MODELS[modelKey];
   const endpoint = resolveMotionEndpoint(
@@ -210,6 +222,30 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
     'fal',
     options.referenceOnly ?? false
   );
+
+  if (endpoint.references === 'text-to-video') {
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- guarded below: unregistered endpoints throw
+    const textEndpointId = endpoint.endpointId as MotionEndpointId;
+    const textTransform = MOTION_TRANSFORMS[textEndpointId];
+    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- defensive guard for exhaustiveness
+    if (!textTransform) {
+      throw new Error(
+        `No motion transform registered for text-to-video endpoint: ${textEndpointId}`
+      );
+    }
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- transform is the text-to-video schema
+    const input = textTransform.parse({
+      prompt: options.prompt,
+      duration: options.duration,
+      aspectRatio: options.aspectRatio,
+      ...QUALITY_OVERRIDES[modelKey],
+      ...resolutionOverride(textEndpointId, options.resolution),
+      ...(options.generateAudio !== undefined && {
+        generate_audio: options.generateAudio,
+      }),
+    }) as TextToVideoOutput;
+    return { endpointId: endpoint.endpointId, input };
+  }
 
   if (endpoint.references !== 'endpoint') {
     if (!options.imageUrl) {
@@ -262,10 +298,9 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
     prompt,
     duration: options.duration,
     aspectRatio: options.aspectRatio,
-    // The image list is optional on the reference-to-video schema; a
-    // reference-only shot whose scene matched no cast, location or element
-    // sheets degenerates to pure text-to-video, which the endpoint serves.
-    ...(imageUrls.length > 0 && { [imageField]: imageUrls }),
+    // Never empty here: a reference-only shot with nothing matched resolved to
+    // the text-to-video branch above, because fal rejects an empty list.
+    [imageField]: imageUrls,
     ...QUALITY_OVERRIDES[modelKey],
     ...resolutionOverride(endpointId, options.resolution),
     ...(options.generateAudio !== undefined && {

--- a/src/lib/motion/build-model-input.ts
+++ b/src/lib/motion/build-model-input.ts
@@ -171,26 +171,12 @@ export function buildModelInput<T extends ImageToVideoModel>(
   return result;
 }
 
-/** Output of a reference-to-video transform (the endpoints in
- *  `MOTION_REFERENCE_ENDPOINTS`). */
-type ReferenceVideoOutput =
-  | z.output<
-      (typeof MOTION_TRANSFORMS)['bytedance/seedance-2.5/reference-to-video']
-    >
-  | z.output<
-      (typeof MOTION_TRANSFORMS)['bytedance/seedance-2.0/enterprise/v2/reference-to-video']
-    >
-  | z.output<(typeof MOTION_TRANSFORMS)['minimax/h3-max/reference-to-video']>;
-
-/** Output of a text-to-video transform (`textToVideoEndpointId` in
- *  `MOTION_REFERENCE_ENDPOINTS`, #1521). */
-type TextToVideoOutput =
-  | z.output<(typeof MOTION_TRANSFORMS)['bytedance/seedance-2.5/text-to-video']>
-  | z.output<
-      (typeof MOTION_TRANSFORMS)['bytedance/seedance-2.0/enterprise/v2/text-to-video']
-    >
-  | z.output<(typeof MOTION_TRANSFORMS)['minimax/h3-max/text-to-video']>
-  | z.output<(typeof MOTION_TRANSFORMS)['fal-ai/gemini-omni-1.1-flash']>;
+/** Output of any registered fal transform: the reference-to-video and
+ *  text-to-video rows `MOTION_REFERENCE_ENDPOINTS` names are typed
+ *  `MotionEndpointId`, so this can never drift from the map. */
+type RegisteredMotionOutput = z.output<
+  (typeof MOTION_TRANSFORMS)[MotionEndpointId]
+>;
 
 /**
  * Resolve the endpoint and build the exact fal request body for a motion run
@@ -213,7 +199,7 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
   modelKey: T
 ): {
   endpointId: string;
-  input: ModelOutputMap[T] | ReferenceVideoOutput | TextToVideoOutput;
+  input: ModelOutputMap[T] | RegisteredMotionOutput;
 } {
   const modelConfig = IMAGE_TO_VIDEO_MODELS[modelKey];
   const endpoint = resolveMotionEndpoint(
@@ -224,27 +210,26 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
   );
 
   if (endpoint.references === 'text-to-video') {
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- guarded below: unregistered endpoints throw
-    const textEndpointId = endpoint.endpointId as MotionEndpointId;
-    const textTransform = MOTION_TRANSFORMS[textEndpointId];
-    // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- defensive guard for exhaustiveness
-    if (!textTransform) {
+    if (options.imageUrl) {
+      // The prompt-only route has nowhere to put a still. Reaching here with
+      // one means a caller set `referenceOnly` on a shot that rendered a
+      // frame; dropping it silently would return a different kind of clip.
       throw new Error(
-        `No motion transform registered for text-to-video endpoint: ${textEndpointId}`
+        `Motion model "${modelKey}" was given a start frame in reference-only mode`
       );
     }
-    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- transform is the text-to-video schema
-    const input = textTransform.parse({
+    const { endpointId } = endpoint;
+    const input = MOTION_TRANSFORMS[endpointId].parse({
       prompt: options.prompt,
       duration: options.duration,
       aspectRatio: options.aspectRatio,
       ...QUALITY_OVERRIDES[modelKey],
-      ...resolutionOverride(textEndpointId, options.resolution),
+      ...resolutionOverride(endpointId, options.resolution),
       ...(options.generateAudio !== undefined && {
         generate_audio: options.generateAudio,
       }),
-    }) as TextToVideoOutput;
-    return { endpointId: endpoint.endpointId, input };
+    });
+    return { endpointId, input };
   }
 
   if (endpoint.references !== 'endpoint') {
@@ -263,15 +248,8 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
     };
   }
 
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- guarded below: unregistered endpoints throw
-  const endpointId = endpoint.referenceConfig.endpointId as MotionEndpointId;
+  const endpointId = endpoint.referenceConfig.endpointId;
   const transform = MOTION_TRANSFORMS[endpointId];
-  // oxlint-disable-next-line typescript-eslint/no-unnecessary-condition -- defensive guard for exhaustiveness
-  if (!transform) {
-    throw new Error(
-      `No motion transform registered for reference endpoint: ${endpointId}`
-    );
-  }
 
   if (!options.imageUrl && !options.referenceOnly) {
     // The reference-to-video endpoint accepts a request with no still, so a
@@ -293,7 +271,6 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
 
   const imageField = endpoint.referenceConfig.imageField ?? 'image_urls';
 
-  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- transform is the reference-to-video schema
   const input = transform.parse({
     prompt,
     duration: options.duration,
@@ -306,7 +283,7 @@ export function buildMotionRequest<T extends ImageToVideoModel>(
     ...(options.generateAudio !== undefined && {
       generate_audio: options.generateAudio,
     }),
-  }) as ReferenceVideoOutput;
+  });
 
   return { endpointId: endpoint.endpointId, input };
 }

--- a/src/lib/motion/build-reference-video-prompt.test.ts
+++ b/src/lib/motion/build-reference-video-prompt.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { getMotionReferenceEndpoint } from '@/lib/ai/models';
-import type { MotionReferenceEndpointConfig } from '@/lib/ai/models';
 import type { ReferenceImageDescription } from '@/lib/prompts/reference-image-prompt';
-import { buildReferenceVideoPrompt } from './build-reference-video-prompt';
+import {
+  buildReferenceVideoPrompt,
+  type ReferencePromptBinding,
+} from './build-reference-video-prompt';
 
 const STILL = 'https://example.com/still.png';
 
@@ -31,7 +33,7 @@ describe.each([
   ['seedance_v2_5', seedanceV25Config] as const,
 ])(
   'buildReferenceVideoPrompt (%s)',
-  (_model, seedanceConfig: MotionReferenceEndpointConfig) => {
+  (_model, seedanceConfig: ReferencePromptBinding) => {
     it('declares the still as the starting frame on the first line', () => {
       const result = buildReferenceVideoPrompt(
         seedanceConfig,
@@ -192,8 +194,7 @@ describe('buildReferenceVideoPrompt (minimax_h3_max)', () => {
 
 describe('buildReferenceVideoPrompt (per-model config knobs)', () => {
   // Gemini Omni Flash-style config: 0-indexed angle-bracket tags, tighter cap.
-  const omniStyleConfig: MotionReferenceEndpointConfig = {
-    endpointId: 'google/gemini-omni-flash/reference-to-video',
+  const omniStyleConfig: ReferencePromptBinding = {
     tag: (position) => `<IMAGE_REF_${position - 1}>`,
     maxImages: 4,
   };
@@ -228,8 +229,7 @@ describe('buildReferenceVideoPrompt (per-model config knobs)', () => {
   });
 
   it('tags Grok Imagine 1.5 refs as <IMAGE_0>… in request order', () => {
-    const grokConfig: MotionReferenceEndpointConfig = {
-      endpointId: 'grok-imagine-video-1.5',
+    const grokConfig: ReferencePromptBinding = {
       tag: (position) => `<IMAGE_${position - 1}>`,
       maxImages: 7,
     };

--- a/src/lib/motion/build-reference-video-prompt.ts
+++ b/src/lib/motion/build-reference-video-prompt.ts
@@ -39,8 +39,18 @@ import {
   substituteReferenceTags,
 } from '@/lib/prompts/reference-legend';
 
+/**
+ * The two knobs the prompt binding needs. The native Grok / Gemini builders
+ * pass their own (one model id serves every task there, so they have no
+ * separate reference or text-to-video endpoint to name).
+ */
+export type ReferencePromptBinding = Pick<
+  MotionReferenceEndpointConfig,
+  'tag' | 'maxImages'
+>;
+
 export function buildReferenceVideoPrompt(
-  config: MotionReferenceEndpointConfig,
+  config: ReferencePromptBinding,
   basePrompt: string,
   /** The rendered still, or null in reference-only mode (no start frame). */
   startImageUrl: string | null,

--- a/src/lib/motion/endpoint-map.ts
+++ b/src/lib/motion/endpoint-map.ts
@@ -7,49 +7,61 @@ import { motionTransform } from './motion-transform';
 
 import {
   zGeminiOmni11FlashImageToVideoInput,
+  zGeminiOmni11FlashInput,
   zGeminiOmni11FlashReferenceToVideoInput,
   zGrokImagineVideoV15ImageToVideoInput,
   zH3MaxImageToVideoInput,
   zH3MaxReferenceToVideoInput,
+  zH3MaxTextToVideoInput,
   zKlingVideoV3ProImageToVideoInput,
   zLtx23ImageToVideoInput,
   zMinimaxHailuo23ProImageToVideoInput,
   zSeedance20EnterpriseV2ImageToVideoInput,
   zSeedance20EnterpriseV2ReferenceToVideoInput,
+  zSeedance20EnterpriseV2TextToVideoInput,
   zSeedance25ImageToVideoInput,
   zSeedance25ReferenceToVideoInput,
+  zSeedance25TextToVideoInput,
   zVeo31ImageToVideoInput,
 } from './generated/zod.gen';
 
 import {
   GeminiOmni11FlashImageToVideoInputSchema,
+  GeminiOmni11FlashInputSchema,
   GeminiOmni11FlashReferenceToVideoInputSchema,
   GrokImagineVideoV15ImageToVideoInputSchema,
   H3MaxImageToVideoInputSchema,
   H3MaxReferenceToVideoInputSchema,
+  H3MaxTextToVideoInputSchema,
   KlingVideoV3ProImageToVideoInputSchema,
   Ltx23ImageToVideoInputSchema,
   MinimaxHailuo23ProImageToVideoInputSchema,
   Seedance20EnterpriseV2ImageToVideoInputSchema,
   Seedance20EnterpriseV2ReferenceToVideoInputSchema,
+  Seedance20EnterpriseV2TextToVideoInputSchema,
   Seedance25ImageToVideoInputSchema,
   Seedance25ReferenceToVideoInputSchema,
+  Seedance25TextToVideoInputSchema,
   Veo31ImageToVideoInputSchema,
 } from './generated/schemas.gen';
 
 export type MotionJSONSchema =
   | typeof GeminiOmni11FlashImageToVideoInputSchema
+  | typeof GeminiOmni11FlashInputSchema
   | typeof GeminiOmni11FlashReferenceToVideoInputSchema
   | typeof GrokImagineVideoV15ImageToVideoInputSchema
   | typeof H3MaxImageToVideoInputSchema
   | typeof H3MaxReferenceToVideoInputSchema
+  | typeof H3MaxTextToVideoInputSchema
   | typeof KlingVideoV3ProImageToVideoInputSchema
   | typeof Ltx23ImageToVideoInputSchema
   | typeof MinimaxHailuo23ProImageToVideoInputSchema
   | typeof Seedance20EnterpriseV2ImageToVideoInputSchema
   | typeof Seedance20EnterpriseV2ReferenceToVideoInputSchema
+  | typeof Seedance20EnterpriseV2TextToVideoInputSchema
   | typeof Seedance25ImageToVideoInputSchema
   | typeof Seedance25ReferenceToVideoInputSchema
+  | typeof Seedance25TextToVideoInputSchema
   | typeof Veo31ImageToVideoInputSchema;
 
 export const MOTION_INPUT_SCHEMAS = {
@@ -57,8 +69,12 @@ export const MOTION_INPUT_SCHEMAS = {
     zSeedance20EnterpriseV2ImageToVideoInput,
   'bytedance/seedance-2.0/enterprise/v2/reference-to-video':
     zSeedance20EnterpriseV2ReferenceToVideoInput,
+  'bytedance/seedance-2.0/enterprise/v2/text-to-video':
+    zSeedance20EnterpriseV2TextToVideoInput,
   'bytedance/seedance-2.5/image-to-video': zSeedance25ImageToVideoInput,
   'bytedance/seedance-2.5/reference-to-video': zSeedance25ReferenceToVideoInput,
+  'bytedance/seedance-2.5/text-to-video': zSeedance25TextToVideoInput,
+  'fal-ai/gemini-omni-1.1-flash': zGeminiOmni11FlashInput,
   'fal-ai/gemini-omni-1.1-flash/image-to-video':
     zGeminiOmni11FlashImageToVideoInput,
   'fal-ai/gemini-omni-1.1-flash/reference-to-video':
@@ -70,6 +86,7 @@ export const MOTION_INPUT_SCHEMAS = {
   'fal-ai/veo3.1/image-to-video': zVeo31ImageToVideoInput,
   'minimax/h3-max/image-to-video': zH3MaxImageToVideoInput,
   'minimax/h3-max/reference-to-video': zH3MaxReferenceToVideoInput,
+  'minimax/h3-max/text-to-video': zH3MaxTextToVideoInput,
   'xai/grok-imagine-video/v1.5/image-to-video':
     zGrokImagineVideoV15ImageToVideoInput,
 };
@@ -90,9 +107,13 @@ export const MOTION_JSON_SCHEMAS = {
     Seedance20EnterpriseV2ImageToVideoInputSchema,
   'bytedance/seedance-2.0/enterprise/v2/reference-to-video':
     Seedance20EnterpriseV2ReferenceToVideoInputSchema,
+  'bytedance/seedance-2.0/enterprise/v2/text-to-video':
+    Seedance20EnterpriseV2TextToVideoInputSchema,
   'bytedance/seedance-2.5/image-to-video': Seedance25ImageToVideoInputSchema,
   'bytedance/seedance-2.5/reference-to-video':
     Seedance25ReferenceToVideoInputSchema,
+  'bytedance/seedance-2.5/text-to-video': Seedance25TextToVideoInputSchema,
+  'fal-ai/gemini-omni-1.1-flash': GeminiOmni11FlashInputSchema,
   'fal-ai/gemini-omni-1.1-flash/image-to-video':
     GeminiOmni11FlashImageToVideoInputSchema,
   'fal-ai/gemini-omni-1.1-flash/reference-to-video':
@@ -105,6 +126,7 @@ export const MOTION_JSON_SCHEMAS = {
   'fal-ai/veo3.1/image-to-video': Veo31ImageToVideoInputSchema,
   'minimax/h3-max/image-to-video': H3MaxImageToVideoInputSchema,
   'minimax/h3-max/reference-to-video': H3MaxReferenceToVideoInputSchema,
+  'minimax/h3-max/text-to-video': H3MaxTextToVideoInputSchema,
   'xai/grok-imagine-video/v1.5/image-to-video':
     GrokImagineVideoV15ImageToVideoInputSchema,
 } satisfies Record<MotionEndpointId, MotionJSONSchema>;
@@ -118,6 +140,10 @@ export const MOTION_TRANSFORMS = {
     zSeedance20EnterpriseV2ReferenceToVideoInput,
     Seedance20EnterpriseV2ReferenceToVideoInputSchema
   ),
+  'bytedance/seedance-2.0/enterprise/v2/text-to-video': motionTransform(
+    zSeedance20EnterpriseV2TextToVideoInput,
+    Seedance20EnterpriseV2TextToVideoInputSchema
+  ),
   'bytedance/seedance-2.5/image-to-video': motionTransform(
     zSeedance25ImageToVideoInput,
     Seedance25ImageToVideoInputSchema
@@ -125,6 +151,14 @@ export const MOTION_TRANSFORMS = {
   'bytedance/seedance-2.5/reference-to-video': motionTransform(
     zSeedance25ReferenceToVideoInput,
     Seedance25ReferenceToVideoInputSchema
+  ),
+  'bytedance/seedance-2.5/text-to-video': motionTransform(
+    zSeedance25TextToVideoInput,
+    Seedance25TextToVideoInputSchema
+  ),
+  'fal-ai/gemini-omni-1.1-flash': motionTransform(
+    zGeminiOmni11FlashInput,
+    GeminiOmni11FlashInputSchema
   ),
   'fal-ai/gemini-omni-1.1-flash/image-to-video': motionTransform(
     zGeminiOmni11FlashImageToVideoInput,
@@ -157,6 +191,10 @@ export const MOTION_TRANSFORMS = {
   'minimax/h3-max/reference-to-video': motionTransform(
     zH3MaxReferenceToVideoInput,
     H3MaxReferenceToVideoInputSchema
+  ),
+  'minimax/h3-max/text-to-video': motionTransform(
+    zH3MaxTextToVideoInput,
+    H3MaxTextToVideoInputSchema
   ),
   'xai/grok-imagine-video/v1.5/image-to-video': motionTransform(
     zGrokImagineVideoV15ImageToVideoInput,

--- a/src/lib/motion/generated/schemas.gen.ts
+++ b/src/lib/motion/generated/schemas.gen.ts
@@ -49,13 +49,8 @@ export const QueueStatusSchema = {
 } as const;
 
 export const GrokImagineVideoV15ImageToVideoInputSchema = {
+  type: 'object',
   description: '``grok-imagine-video-1.5`` image-to-video (no ``aspect_ratio``).\n\nWidens ``resolution`` to add the 1080p tier supported by the 1.5 model\n(the standard model remains 480p/720p only).',
-  'x-fal-order-properties': [
-    'prompt',
-    'duration',
-    'resolution',
-    'image_url'
-  ],
   properties: {
     image_url: {
       anyOf: [
@@ -69,12 +64,21 @@ export const GrokImagineVideoV15ImageToVideoInputSchema = {
       ],
       'x-fal-file-input': true,
       description: 'URL of the input image for video generation.',
+      title: 'Image URL',
       examples: [
         'https://v3b.fal.media/files/b/0a8b90e0/BFLE9VDlZqsryU-UA3BoD_image_004.png'
-      ],
-      title: 'Image URL'
+      ]
+    },
+    duration: {
+      description: 'Video duration in seconds.',
+      type: 'integer',
+      default: 6,
+      maximum: 15,
+      title: 'Duration',
+      minimum: 1
     },
     resolution: {
+      description: 'Resolution of the output video.',
       type: 'string',
       default: '720p',
       title: 'Resolution',
@@ -82,65 +86,174 @@ export const GrokImagineVideoV15ImageToVideoInputSchema = {
         '480p',
         '720p',
         '1080p'
-      ],
-      description: 'Resolution of the output video.'
-    },
-    duration: {
-      type: 'integer',
-      default: 6,
-      minimum: 1,
-      maximum: 15,
-      title: 'Duration',
-      description: 'Video duration in seconds.'
+      ]
     },
     prompt: {
+      type: 'string',
+      maxLength: 4096,
       description: 'Text description of desired changes or motion in the video.',
+      title: 'Prompt',
       examples: [
         'Medieval knight in ornate armor walking through a mystical forest, bioluminescent plants pulsing with light, ancient stone ruins overgrown with glowing vines, over-the-shoulder camera, dark fantasy aesthetic, volumetric fog and Lumen lighting'
-      ],
-      maxLength: 4096,
-      title: 'Prompt',
-      type: 'string'
+      ]
     }
   },
+  'x-fal-order-properties': [
+    'prompt',
+    'duration',
+    'resolution',
+    'image_url'
+  ],
   title: 'XAIImageToVideoV15Input',
   required: [
     'prompt',
     'image_url'
-  ],
-  type: 'object'
+  ]
 } as const;
 
 export const GrokImagineVideoV15ImageToVideoOutputSchema = {
-  'x-fal-order-properties': [
-    'video'
-  ],
+  type: 'object',
   properties: {
     video: {
+      description: 'The generated video.',
       $ref: '#/components/schemas/VideoFile',
       examples: [
         {
           width: 1280,
-          num_frames: 145,
-          fps: 24,
           file_name: '0Ci1dviuSnEyUZzBUq-_5_nu7MrAAa.mp4',
+          fps: 24,
+          num_frames: 145,
+          height: 720,
           url: 'https://v3b.fal.media/files/b/0a8b90e0/0Ci1dviuSnEyUZzBUq-_5_nu7MrAAa.mp4',
           content_type: 'video/mp4',
-          height: 720,
           duration: 6.041667
         }
-      ],
-      description: 'The generated video.'
+      ]
     }
   },
+  'x-fal-order-properties': [
+    'video'
+  ],
   title: 'XAIImageToVideoOutput',
   required: [
     'video'
-  ],
-  type: 'object'
+  ]
 } as const;
 
 export const VideoFileSchema = {
+  type: 'object',
+  properties: {
+    file_size: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The size of the file in bytes.',
+      title: 'File Size',
+      examples: [
+        4404019
+      ]
+    },
+    width: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The width of the video',
+      title: 'Width'
+    },
+    file_name: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The name of the file. It will be auto-generated if not provided.',
+      title: 'File Name',
+      examples: [
+        'z9RV14K95DvU.png'
+      ]
+    },
+    fps: {
+      anyOf: [
+        {
+          type: 'number'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The FPS of the video',
+      title: 'Fps'
+    },
+    num_frames: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The number of frames in the video',
+      title: 'Num Frames'
+    },
+    height: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The height of the video',
+      title: 'Height'
+    },
+    url: {
+      type: 'string',
+      description: 'The URL where the file can be downloaded from.',
+      title: 'Url'
+    },
+    content_type: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The mime type of the file.',
+      title: 'Content Type',
+      examples: [
+        'image/png'
+      ]
+    },
+    duration: {
+      anyOf: [
+        {
+          type: 'number'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The duration of the video',
+      title: 'Duration'
+    }
+  },
   'x-fal-order-properties': [
     'url',
     'content_type',
@@ -152,150 +265,15 @@ export const VideoFileSchema = {
     'duration',
     'num_frames'
   ],
-  properties: {
-    width: {
-      title: 'Width',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The width of the video'
-    },
-    num_frames: {
-      title: 'Num Frames',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The number of frames in the video'
-    },
-    fps: {
-      title: 'Fps',
-      anyOf: [
-        {
-          type: 'number'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The FPS of the video'
-    },
-    file_name: {
-      examples: [
-        'z9RV14K95DvU.png'
-      ],
-      title: 'File Name',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The name of the file. It will be auto-generated if not provided.'
-    },
-    url: {
-      description: 'The URL where the file can be downloaded from.',
-      title: 'Url',
-      type: 'string'
-    },
-    content_type: {
-      examples: [
-        'image/png'
-      ],
-      title: 'Content Type',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The mime type of the file.'
-    },
-    height: {
-      title: 'Height',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The height of the video'
-    },
-    file_size: {
-      examples: [
-        4404019
-      ],
-      title: 'File Size',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The size of the file in bytes.'
-    },
-    duration: {
-      title: 'Duration',
-      anyOf: [
-        {
-          type: 'number'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'The duration of the video'
-    }
-  },
   title: 'VideoFile',
   required: [
     'url'
-  ],
-  type: 'object'
+  ]
 } as const;
 
 export const Ltx23ImageToVideoInputSchema = {
-  title: 'LTXV23ImageToVideoRequest',
   type: 'object',
-  'x-fal-order-properties': [
-    'image_url',
-    'end_image_url',
-    'prompt',
-    'duration',
-    'resolution',
-    'aspect_ratio',
-    'fps',
-    'generate_audio'
-  ],
   properties: {
-    resolution: {
-      enum: [
-        '1080p',
-        '1440p',
-        '2160p'
-      ],
-      description: 'The resolution of the generated video',
-      type: 'string',
-      default: '1080p',
-      title: 'Resolution'
-    },
     image_url: {
       anyOf: [
         {
@@ -308,21 +286,10 @@ export const Ltx23ImageToVideoInputSchema = {
       ],
       'x-fal-file-input': true,
       description: 'The URL of the start image to use for the generated video.',
+      title: 'Start Image URL',
       examples: [
         'https://v3b.fal.media/files/b/0a90dd31/uJG2pMMJMcnVeC4PmwnAF_image_004.png'
-      ],
-      title: 'Start Image URL'
-    },
-    aspect_ratio: {
-      enum: [
-        'auto',
-        '16:9',
-        '9:16'
-      ],
-      description: 'The aspect ratio of the generated video. If \'auto\', the aspect ratio will be determined automatically based on the input image.',
-      type: 'string',
-      default: 'auto',
-      title: 'Aspect Ratio'
+      ]
     },
     end_image_url: {
       description: 'The URL of the end image to use for the generated video. When provided, generates a transition video between start and end frames.',
@@ -336,16 +303,39 @@ export const Ltx23ImageToVideoInputSchema = {
       ],
       title: 'End Image URL'
     },
+    aspect_ratio: {
+      description: 'The aspect ratio of the generated video. If \'auto\', the aspect ratio will be determined automatically based on the input image.',
+      type: 'string',
+      default: 'auto',
+      title: 'Aspect Ratio',
+      enum: [
+        'auto',
+        '16:9',
+        '9:16'
+      ]
+    },
+    fps: {
+      description: 'The frames per second of the generated video',
+      type: 'integer',
+      default: 25,
+      title: 'Frames per Second',
+      enum: [
+        24,
+        25,
+        48,
+        50
+      ]
+    },
     duration: {
+      description: 'The duration of the generated video in seconds',
+      type: 'integer',
+      default: 6,
+      title: 'Duration',
       enum: [
         6,
         8,
         10
-      ],
-      description: 'The duration of the generated video in seconds',
-      type: 'integer',
-      default: 6,
-      title: 'Duration'
+      ]
     },
     generate_audio: {
       description: 'Whether to generate audio for the generated video',
@@ -354,89 +344,95 @@ export const Ltx23ImageToVideoInputSchema = {
       title: 'Generate Audio'
     },
     prompt: {
-      maxLength: 5000,
       description: 'The prompt to use for the generated video',
+      maxLength: 5000,
       type: 'string',
+      minLength: 1,
+      title: 'Prompt',
       examples: [
         'Periscope-level shot from behind tall grass of two Maasai warriors mid-leap during an adumu jumping dance, bodies fully airborne against a golden savanna sunset, red shuka robes frozen in motion, dust kicked up from the earth catching backlight, 85mm f/1.4 isolating the pair from a blurred circle of onlookers, Steve McCurry meets Emmanuel Lubezki'
-      ],
-      title: 'Prompt',
-      minLength: 1
+      ]
     },
-    fps: {
+    resolution: {
+      description: 'The resolution of the generated video',
+      type: 'string',
+      default: '1080p',
+      title: 'Resolution',
       enum: [
-        24,
-        25,
-        48,
-        50
-      ],
-      description: 'The frames per second of the generated video',
-      type: 'integer',
-      default: 25,
-      title: 'Frames per Second'
+        '1080p',
+        '1440p',
+        '2160p'
+      ]
     }
   },
+  'x-fal-order-properties': [
+    'image_url',
+    'end_image_url',
+    'prompt',
+    'duration',
+    'resolution',
+    'aspect_ratio',
+    'fps',
+    'generate_audio'
+  ],
   required: [
     'prompt',
     'image_url'
-  ]
+  ],
+  title: 'LTXV23ImageToVideoRequest'
 } as const;
 
 export const Ltx23ImageToVideoOutputSchema = {
-  title: 'LTXV23ImageToVideoResponse',
   type: 'object',
-  'x-fal-order-properties': [
-    'video'
-  ],
   properties: {
     video: {
       description: 'The generated video file',
       $ref: '#/components/schemas/VideoFile',
       examples: [
         {
-          content_type: 'video/mp4',
           file_name: 'VUCTD0YYJIp_K4qQkkneL_wMVDWNRn.mp4',
-          url: 'https://v3b.fal.media/files/b/0a90dd31/VUCTD0YYJIp_K4qQkkneL_wMVDWNRn.mp4'
+          url: 'https://v3b.fal.media/files/b/0a90dd31/VUCTD0YYJIp_K4qQkkneL_wMVDWNRn.mp4',
+          content_type: 'video/mp4'
         }
       ]
     }
   },
+  'x-fal-order-properties': [
+    'video'
+  ],
   required: [
     'video'
-  ]
+  ],
+  title: 'LTXV23ImageToVideoResponse'
 } as const;
 
 export const Veo31ImageToVideoInputSchema = {
-  title: 'Veo31ImageToVideoInput',
-  'x-fal-order-properties': [
-    'prompt',
-    'aspect_ratio',
-    'duration',
-    'negative_prompt',
-    'resolution',
-    'generate_audio',
-    'seed',
-    'auto_fix',
-    'safety_tolerance',
-    'image_url'
-  ],
-  required: [
-    'prompt',
-    'image_url'
-  ],
   properties: {
     prompt: {
-      title: 'Prompt',
+      maxLength: 20000,
       description: 'The text prompt describing the video you want to generate',
+      title: 'Prompt',
+      type: 'string',
       examples: [
         'A monkey and polar bear host a casual podcast about AI inference, bringing their unique perspectives from different environments (tropical vs. arctic) to discuss how AI systems make decisions and process information.\nSample Dialogue:\nMonkey (Banana): "Welcome back to Bananas & Ice! I am Banana"\nPolar Bear (Ice): "And I\'m Ice!"'
-      ],
+      ]
+    },
+    aspect_ratio: {
+      default: 'auto',
+      description: 'The aspect ratio of the generated video. Only 16:9 and 9:16 are supported.',
+      title: 'Aspect Ratio',
       type: 'string',
-      maxLength: 20000
+      enum: [
+        'auto',
+        '16:9',
+        '9:16'
+      ]
     },
     safety_tolerance: {
+      default: '4',
       description: 'The safety tolerance level for content moderation. 1 is the most strict (blocks most content), 6 is the least strict.',
       title: 'Safety Tolerance',
+      type: 'string',
       enum: [
         '1',
         '2',
@@ -444,31 +440,31 @@ export const Veo31ImageToVideoInputSchema = {
         '4',
         '5',
         '6'
-      ],
-      default: '4',
-      type: 'string'
+      ]
     },
-    duration: {
-      title: 'Duration',
-      description: 'The duration of the generated video.',
-      enum: [
-        '4s',
-        '6s',
-        '8s'
-      ],
-      default: '8s',
-      type: 'string'
+    auto_fix: {
+      description: 'Whether to automatically attempt to fix prompts that fail content policy or other validation checks by rewriting them.',
+      title: 'Auto Fix',
+      type: 'boolean',
+      default: false
     },
-    aspect_ratio: {
-      description: 'The aspect ratio of the generated video. Only 16:9 and 9:16 are supported.',
-      title: 'Aspect Ratio',
-      enum: [
-        'auto',
-        '16:9',
-        '9:16'
+    negative_prompt: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
       ],
-      default: 'auto',
-      type: 'string'
+      description: 'A negative prompt to guide the video generation.',
+      title: 'Negative Prompt'
+    },
+    generate_audio: {
+      description: 'Whether to generate audio for the video.',
+      title: 'Generate Audio',
+      type: 'boolean',
+      default: true
     },
     image_url: {
       anyOf: [
@@ -481,32 +477,24 @@ export const Veo31ImageToVideoInputSchema = {
         }
       ],
       'x-fal-file-input': true,
-      title: 'Image URL',
       description: 'URL of the input image to animate. Should be 720p or higher resolution in 16:9 or 9:16 aspect ratio. If the image is not in 16:9 or 9:16 aspect ratio, it will be cropped to fit.',
+      title: 'Image URL',
       examples: [
         'https://storage.googleapis.com/falserverless/example_inputs/veo31_i2v_input.jpg'
       ]
     },
-    negative_prompt: {
-      title: 'Negative Prompt',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'A negative prompt to guide the video generation.'
-    },
-    generate_audio: {
-      title: 'Generate Audio',
-      description: 'Whether to generate audio for the video.',
-      default: true,
-      type: 'boolean'
+    resolution: {
+      default: '720p',
+      description: 'The resolution of the generated video.',
+      title: 'Resolution',
+      type: 'string',
+      enum: [
+        '720p',
+        '1080p',
+        '4k'
+      ]
     },
     seed: {
-      title: 'Seed',
       anyOf: [
         {
           type: 'integer'
@@ -515,114 +503,126 @@ export const Veo31ImageToVideoInputSchema = {
           type: 'null'
         }
       ],
-      description: 'The seed for the random number generator.'
+      description: 'The seed for the random number generator.',
+      title: 'Seed'
     },
-    resolution: {
-      title: 'Resolution',
-      description: 'The resolution of the generated video.',
+    duration: {
+      default: '8s',
+      description: 'The duration of the generated video.',
+      title: 'Duration',
+      type: 'string',
       enum: [
-        '720p',
-        '1080p',
-        '4k'
-      ],
-      default: '720p',
-      type: 'string'
-    },
-    auto_fix: {
-      title: 'Auto Fix',
-      description: 'Whether to automatically attempt to fix prompts that fail content policy or other validation checks by rewriting them.',
-      default: false,
-      type: 'boolean'
+        '4s',
+        '6s',
+        '8s'
+      ]
     }
   },
+  required: [
+    'prompt',
+    'image_url'
+  ],
+  'x-fal-order-properties': [
+    'prompt',
+    'aspect_ratio',
+    'duration',
+    'negative_prompt',
+    'resolution',
+    'generate_audio',
+    'seed',
+    'auto_fix',
+    'safety_tolerance',
+    'image_url'
+  ],
+  title: 'Veo31ImageToVideoInput',
   type: 'object'
 } as const;
 
 export const Veo31ImageToVideoOutputSchema = {
-  title: 'Veo31ImageToVideoOutput',
-  'x-fal-order-properties': [
-    'video'
-  ],
-  required: [
-    'video'
-  ],
   properties: {
     video: {
+      $ref: '#/components/schemas/File',
       description: 'The generated video.',
       examples: [
         {
           url: 'https://storage.googleapis.com/falserverless/model_tests/gallery/veo3-1-i2v.mp4'
         }
-      ],
-      $ref: '#/components/schemas/File'
+      ]
     }
   },
+  required: [
+    'video'
+  ],
+  'x-fal-order-properties': [
+    'video'
+  ],
+  title: 'Veo31ImageToVideoOutput',
   type: 'object'
 } as const;
 
 export const FileSchema = {
-  title: 'File',
+  properties: {
+    file_name: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The name of the file. It will be auto-generated if not provided.',
+      title: 'File Name',
+      examples: [
+        'z9RV14K95DvU.png'
+      ]
+    },
+    content_type: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The mime type of the file.',
+      title: 'Content Type',
+      examples: [
+        'image/png'
+      ]
+    },
+    url: {
+      description: 'The URL where the file can be downloaded from.',
+      title: 'Url',
+      type: 'string'
+    },
+    file_size: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The size of the file in bytes.',
+      title: 'File Size',
+      examples: [
+        4404019
+      ]
+    }
+  },
+  required: [
+    'url'
+  ],
   'x-fal-order-properties': [
     'url',
     'content_type',
     'file_name',
     'file_size'
   ],
-  required: [
-    'url'
-  ],
-  properties: {
-    file_name: {
-      title: 'File Name',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      examples: [
-        'z9RV14K95DvU.png'
-      ],
-      description: 'The name of the file. It will be auto-generated if not provided.'
-    },
-    url: {
-      title: 'Url',
-      description: 'The URL where the file can be downloaded from.',
-      type: 'string'
-    },
-    file_size: {
-      title: 'File Size',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      examples: [
-        4404019
-      ],
-      description: 'The size of the file in bytes.'
-    },
-    content_type: {
-      title: 'Content Type',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      examples: [
-        'image/png'
-      ],
-      description: 'The mime type of the file.'
-    }
-  },
+  title: 'File',
   type: 'object'
 } as const;
 
@@ -635,16 +635,50 @@ export const GeminiOmni11FlashImageToVideoInputSchema = {
     'resolution',
     'duration'
   ],
+  type: 'object',
+  title: 'Omni11FlashImageToVideoInput',
   properties: {
+    duration: {
+      maximum: 10,
+      description: 'The duration of the generated video, in seconds.',
+      type: 'integer',
+      title: 'Duration',
+      default: 8,
+      minimum: 3
+    },
+    resolution: {
+      enum: [
+        '360p',
+        '720p',
+        '1080p',
+        '4k'
+      ],
+      description: 'The resolution of the generated video.',
+      type: 'string',
+      title: 'Resolution',
+      default: '720p'
+    },
     aspect_ratio: {
-      description: 'The aspect ratio of the generated video.',
-      default: '16:9',
-      title: 'Aspect Ratio',
       enum: [
         '16:9',
         '9:16'
       ],
-      type: 'string'
+      description: 'The aspect ratio of the generated video.',
+      type: 'string',
+      title: 'Aspect Ratio',
+      default: '16:9'
+    },
+    end_image_url: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'Optional URL of the end frame. When provided, the model interpolates between the two images in their listed order.',
+      title: 'End Image URL'
     },
     image_url: {
       anyOf: [
@@ -658,76 +692,42 @@ export const GeminiOmni11FlashImageToVideoInputSchema = {
       ],
       'x-fal-file-input': true,
       description: 'URL of the first frame to animate.',
+      title: 'Image URL',
       examples: [
         'https://storage.googleapis.com/falserverless/example_inputs/dog.png'
-      ],
-      title: 'Image URL'
-    },
-    resolution: {
-      description: 'The resolution of the generated video.',
-      default: '720p',
-      title: 'Resolution',
-      enum: [
-        '360p',
-        '720p',
-        '1080p',
-        '4k'
-      ],
-      type: 'string'
+      ]
     },
     prompt: {
       description: 'The text prompt describing how the first image should be animated or interpolated into the optional end image.',
+      type: 'string',
+      title: 'Prompt',
       examples: [
         'The dog turns its head and wags its tail in warm sunlight.'
       ],
-      maxLength: 20000,
-      title: 'Prompt',
-      type: 'string'
-    },
-    duration: {
-      description: 'The duration of the generated video, in seconds.',
-      default: 8,
-      minimum: 3,
-      title: 'Duration',
-      maximum: 10,
-      type: 'integer'
-    },
-    end_image_url: {
-      title: 'End Image URL',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      description: 'Optional URL of the end frame. When provided, the model interpolates between the two images in their listed order.'
+      maxLength: 20000
     }
   },
-  title: 'Omni11FlashImageToVideoInput',
   required: [
     'prompt',
     'image_url'
-  ],
-  type: 'object'
+  ]
 } as const;
 
 export const GeminiOmni11FlashImageToVideoOutputSchema = {
   'x-fal-order-properties': [
     'video'
   ],
+  type: 'object',
+  title: 'VideoOutput',
   properties: {
     video: {
       $ref: '#/components/schemas/File',
       description: 'The generated video.'
     }
   },
-  title: 'VideoOutput',
   required: [
     'video'
-  ],
-  type: 'object'
+  ]
 } as const;
 
 export const KlingVideoV3ProImageToVideoInputSchema = {
@@ -743,16 +743,93 @@ export const KlingVideoV3ProImageToVideoInputSchema = {
     'negative_prompt',
     'cfg_scale'
   ],
+  required: [
+    'start_image_url'
+  ],
+  type: 'object',
   properties: {
+    prompt: {
+      description: 'Text prompt for video generation. Either prompt or multi_prompt must be provided, but not both.',
+      examples: [
+        'The craftsman slowly examines the bowl, turning it gently in his weathered hands. His eyes reflect years of wisdom. Subtle smile forms on his face. Dust particles drift in warm light. Breathing motion, blinking eyes.'
+      ],
+      anyOf: [
+        {
+          maxLength: 2500,
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      title: 'Prompt'
+    },
+    start_image_url: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'string',
+          format: 'binary'
+        }
+      ],
+      'x-fal-file-input': true,
+      'x-fal': {
+        max_aspect_ratio: 2.5,
+        min_width: 300,
+        max_file_size: 10485760,
+        timeout: 20,
+        min_height: 300,
+        min_aspect_ratio: 0.4
+      },
+      limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
+      description: 'URL of the image to be used for the video',
+      examples: [
+        'https://storage.googleapis.com/falserverless/example_inputs/kling-v3/pro-i2v/start_image.png'
+      ],
+      title: 'Start Image Url'
+    },
+    generate_audio: {
+      default: true,
+      description: 'Whether to generate native audio for the video. Supports Chinese and English voice output. Other languages are automatically translated to English. For English speech, use lowercase letters; for acronyms or proper nouns, use uppercase.',
+      type: 'boolean',
+      title: 'Generate Audio'
+    },
+    duration: {
+      enum: [
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15'
+      ],
+      description: 'The duration of the generated video in seconds',
+      examples: [
+        '12'
+      ],
+      type: 'string',
+      default: '5',
+      title: 'Duration'
+    },
     cfg_scale: {
-      type: 'number',
-      default: 0.5,
-      minimum: 0,
       maximum: 1,
-      title: 'Cfg Scale',
-      description: '\n            The CFG (Classifier Free Guidance) scale is a measure of how close you want\n            the model to stick to your prompt.\n        '
+      description: '\n            The CFG (Classifier Free Guidance) scale is a measure of how close you want\n            the model to stick to your prompt.\n        ',
+      default: 0.5,
+      type: 'number',
+      minimum: 0,
+      title: 'Cfg Scale'
     },
     elements: {
+      description: 'Elements (characters/objects) to include in the video. Each example can either be an image set (frontal + reference images) or a video. Reference in prompt as @Element1, @Element2, etc.',
       examples: [
         [
           {
@@ -777,82 +854,20 @@ export const KlingVideoV3ProImageToVideoInputSchema = {
           type: 'null'
         }
       ],
-      title: 'Elements',
-      description: 'Elements (characters/objects) to include in the video. Each example can either be an image set (frontal + reference images) or a video. Reference in prompt as @Element1, @Element2, etc.'
+      title: 'Elements'
     },
-    start_image_url: {
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'string',
-          format: 'binary'
-        }
+    shot_type: {
+      enum: [
+        'customize',
+        'intelligent'
       ],
-      'x-fal-file-input': true,
-      'x-fal': {
-        max_aspect_ratio: 2.5,
-        min_width: 300,
-        min_height: 300,
-        min_aspect_ratio: 0.4,
-        max_file_size: 10485760,
-        timeout: 20
-      },
-      examples: [
-        'https://storage.googleapis.com/falserverless/example_inputs/kling-v3/pro-i2v/start_image.png'
-      ],
-      limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
-      title: 'Start Image Url',
-      description: 'URL of the image to be used for the video'
-    },
-    end_image_url: {
-      anyOf: [
-        {
-          'x-fal': {
-            max_aspect_ratio: 2.5,
-            min_width: 300,
-            min_height: 300,
-            min_aspect_ratio: 0.4,
-            max_file_size: 10485760,
-            timeout: 20
-          },
-          ui: {
-            field: 'image'
-          },
-          limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'End Image Url',
-      description: 'URL of the image to be used for the end of the video'
-    },
-    prompt: {
-      examples: [
-        'The craftsman slowly examines the bowl, turning it gently in his weathered hands. His eyes reflect years of wisdom. Subtle smile forms on his face. Dust particles drift in warm light. Breathing motion, blinking eyes.'
-      ],
-      anyOf: [
-        {
-          maxLength: 2500,
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'Prompt',
-      description: 'Text prompt for video generation. Either prompt or multi_prompt must be provided, but not both.'
-    },
-    generate_audio: {
-      description: 'Whether to generate native audio for the video. Supports Chinese and English voice output. Other languages are automatically translated to English. For English speech, use lowercase letters; for acronyms or proper nouns, use uppercase.',
-      default: true,
-      title: 'Generate Audio',
-      type: 'boolean'
+      description: 'The type of multi-shot video generation. \'intelligent\' lets the model automatically determine shot structure.',
+      default: 'customize',
+      type: 'string',
+      title: 'Shot Type'
     },
     multi_prompt: {
+      description: 'List of prompts for multi-shot video generation. If provided, divides the video into multiple shots.',
       examples: [
         null
       ],
@@ -867,80 +882,65 @@ export const KlingVideoV3ProImageToVideoInputSchema = {
           type: 'null'
         }
       ],
-      title: 'Multi Prompt',
-      description: 'List of prompts for multi-shot video generation. If provided, divides the video into multiple shots.'
+      title: 'Multi Prompt'
     },
-    shot_type: {
-      type: 'string',
-      default: 'customize',
-      title: 'Shot Type',
-      enum: [
-        'customize',
-        'intelligent'
+    end_image_url: {
+      description: 'URL of the image to be used for the end of the video',
+      anyOf: [
+        {
+          limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
+          type: 'string',
+          ui: {
+            field: 'image'
+          },
+          'x-fal': {
+            max_aspect_ratio: 2.5,
+            min_width: 300,
+            max_file_size: 10485760,
+            timeout: 20,
+            min_height: 300,
+            min_aspect_ratio: 0.4
+          }
+        },
+        {
+          type: 'null'
+        }
       ],
-      description: 'The type of multi-shot video generation. \'intelligent\' lets the model automatically determine shot structure.'
+      title: 'End Image Url'
     },
     negative_prompt: {
       default: 'blur, distort, and low quality',
       maxLength: 2500,
-      title: 'Negative Prompt',
-      type: 'string'
-    },
-    duration: {
       type: 'string',
-      default: '5',
-      examples: [
-        '12'
-      ],
-      title: 'Duration',
-      enum: [
-        '3',
-        '4',
-        '5',
-        '6',
-        '7',
-        '8',
-        '9',
-        '10',
-        '11',
-        '12',
-        '13',
-        '14',
-        '15'
-      ],
-      description: 'The duration of the generated video in seconds'
+      title: 'Negative Prompt'
     }
   },
-  title: 'ImageToVideoV3ProRequest',
-  required: [
-    'start_image_url'
-  ],
-  type: 'object'
+  title: 'ImageToVideoV3ProRequest'
 } as const;
 
 export const KlingVideoV3ProImageToVideoOutputSchema = {
   'x-fal-order-properties': [
     'video'
   ],
-  properties: {
-    video: {
-      $ref: '#/components/schemas/File',
-      examples: [
-        {
-          file_name: 'out.mp4',
-          file_size: 8431922,
-          content_type: 'video/mp4',
-          url: 'https://storage.googleapis.com/falserverless/example_outputs/kling-v3/pro-i2v/out.mp4'
-        }
-      ],
-      description: 'The generated video'
-    }
-  },
-  title: 'ImageToVideoV3ProOutput',
   required: [
     'video'
   ],
-  type: 'object'
+  type: 'object',
+  properties: {
+    video: {
+      $ref: '#/components/schemas/File',
+      description: 'The generated video',
+      examples: [
+        {
+          content_type: 'video/mp4',
+          file_size: 8431922,
+          file_name: 'out.mp4',
+          url: 'https://storage.googleapis.com/falserverless/example_outputs/kling-v3/pro-i2v/out.mp4'
+        }
+      ]
+    }
+  },
+  title: 'ImageToVideoV3ProOutput'
 } as const;
 
 export const KlingV3ComboElementInputSchema = {
@@ -950,25 +950,67 @@ export const KlingV3ComboElementInputSchema = {
     'video_url',
     'voice_id'
   ],
+  type: 'object',
   properties: {
+    voice_id: {
+      description: 'The voice ID for this element. The voice will be binded to the element and references to this element will use the binded voice. Get voice IDs from the following endpoint: https://fal.ai/models/fal-ai/kling-video/create-voice',
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      title: 'Voice Id'
+    },
+    video_url: {
+      description: 'The video URL of the element. A request can only have one element with a video.',
+      anyOf: [
+        {
+          limit_description: 'Max file size: 200.0MB, Min width: 720px, Min height: 720px, Max width: 2160px, Max height: 2160px, Min duration: 3.0s, Max duration: 10.05s, Min FPS: 24.0, Max FPS: 60.0, Timeout: 30.0s',
+          type: 'string',
+          ui: {
+            field: 'video'
+          },
+          'x-fal': {
+            min_fps: 24,
+            max_width: 2160,
+            timeout: 30,
+            max_file_size: 209715200,
+            min_width: 720,
+            min_height: 720,
+            max_fps: 60,
+            max_height: 2160,
+            max_duration: 10.05,
+            min_duration: 3
+          }
+        },
+        {
+          type: 'null'
+        }
+      ],
+      title: 'Video Url'
+    },
     reference_image_urls: {
+      description: 'Additional reference images from different angles. 1-3 images supported. At least one image is required.',
       anyOf: [
         {
           items: {
             'x-fal': {
               max_aspect_ratio: 2.5,
               min_width: 300,
-              min_height: 300,
-              min_aspect_ratio: 0.4,
               max_file_size: 10485760,
-              timeout: 20
+              timeout: 20,
+              min_height: 300,
+              min_aspect_ratio: 0.4
             },
+            limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
+            type: 'string',
             ui: {
               field: 'image'
             },
-            limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
-            _fal_ui_field: 'image',
-            type: 'string'
+            _fal_ui_field: 'image'
           },
           type: 'array'
         },
@@ -976,76 +1018,34 @@ export const KlingV3ComboElementInputSchema = {
           type: 'null'
         }
       ],
-      title: 'Reference Image Urls',
-      description: 'Additional reference images from different angles. 1-3 images supported. At least one image is required.'
+      title: 'Reference Image Urls'
     },
     frontal_image_url: {
+      description: 'The frontal image of the element (main view).',
       anyOf: [
         {
-          'x-fal': {
-            max_aspect_ratio: 2.5,
-            min_width: 300,
-            min_height: 300,
-            min_aspect_ratio: 0.4,
-            max_file_size: 10485760,
-            timeout: 20
-          },
+          limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
+          type: 'string',
           ui: {
             field: 'image'
           },
-          limit_description: 'Max file size: 10.0MB, Min width: 300px, Min height: 300px, Min aspect ratio: 0.40, Max aspect ratio: 2.50, Timeout: 20.0s',
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'Frontal Image Url',
-      description: 'The frontal image of the element (main view).'
-    },
-    video_url: {
-      anyOf: [
-        {
           'x-fal': {
-            max_width: 2160,
-            min_duration: 3,
-            min_width: 720,
-            min_fps: 24,
-            max_duration: 10.05,
-            max_fps: 60,
-            max_height: 2160,
-            min_height: 720,
-            max_file_size: 209715200,
-            timeout: 30
-          },
-          ui: {
-            field: 'video'
-          },
-          limit_description: 'Max file size: 200.0MB, Min width: 720px, Min height: 720px, Max width: 2160px, Max height: 2160px, Min duration: 3.0s, Max duration: 10.05s, Min FPS: 24.0, Max FPS: 60.0, Timeout: 30.0s',
-          type: 'string'
+            max_aspect_ratio: 2.5,
+            min_width: 300,
+            max_file_size: 10485760,
+            timeout: 20,
+            min_height: 300,
+            min_aspect_ratio: 0.4
+          }
         },
         {
           type: 'null'
         }
       ],
-      title: 'Video Url',
-      description: 'The video URL of the element. A request can only have one element with a video.'
-    },
-    voice_id: {
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'Voice Id',
-      description: 'The voice ID for this element. The voice will be binded to the element and references to this element will use the binded voice. Get voice IDs from the following endpoint: https://fal.ai/models/fal-ai/kling-video/create-voice'
+      title: 'Frontal Image Url'
     }
   },
-  title: 'KlingV3ComboElementInput',
-  type: 'object'
+  title: 'KlingV3ComboElementInput'
 } as const;
 
 export const KlingV3MultiPromptElementSchema = {
@@ -1053,16 +1053,17 @@ export const KlingV3MultiPromptElementSchema = {
     'prompt',
     'duration'
   ],
+  required: [
+    'prompt'
+  ],
+  type: 'object',
   properties: {
     prompt: {
+      description: 'The prompt for this shot.',
       type: 'string',
-      title: 'Prompt',
-      description: 'The prompt for this shot.'
+      title: 'Prompt'
     },
     duration: {
-      type: 'string',
-      default: '5',
-      title: 'Duration',
       enum: [
         '1',
         '2',
@@ -1080,28 +1081,16 @@ export const KlingV3MultiPromptElementSchema = {
         '14',
         '15'
       ],
-      description: 'The duration of this shot in seconds'
+      description: 'The duration of this shot in seconds',
+      default: '5',
+      type: 'string',
+      title: 'Duration'
     }
   },
-  title: 'KlingV3MultiPromptElement',
-  required: [
-    'prompt'
-  ],
-  type: 'object'
+  title: 'KlingV3MultiPromptElement'
 } as const;
 
 export const MinimaxHailuo23ProImageToVideoInputSchema = {
-  required: [
-    'prompt',
-    'image_url'
-  ],
-  type: 'object',
-  'x-fal-order-properties': [
-    'prompt',
-    'prompt_optimizer',
-    'image_url'
-  ],
-  title: 'ProImageToVideoHailuo23Input',
   properties: {
     image_url: {
       anyOf: [
@@ -1114,41 +1103,44 @@ export const MinimaxHailuo23ProImageToVideoInputSchema = {
         }
       ],
       'x-fal-file-input': true,
-      _fal_ui_field: 'image',
       description: 'URL of the image to use as the first frame',
+      _fal_ui_field: 'image',
+      title: 'Image Url',
       examples: [
         'https://storage.googleapis.com/falserverless/example_inputs/hailuo23/pro_i2v_in.jpg'
-      ],
-      title: 'Image Url'
-    },
-    prompt: {
-      maxLength: 2000,
-      description: 'Text prompt for video generation',
-      type: 'string',
-      examples: [
-        'The camera follows the mountain biker as they navigate a technical forest trail at high speed, wheels bouncing over roots and rocks. The rider approaches a jump, launching into the air with the bike, both rider and machine perfectly synchronized. They land smoothly and continue through tight turns, splashing through a stream crossing. Mud and water spray as the bike powers through challenging terrain. The atmosphere is wild and adventurous. Audio: Tires gripping dirt, gears shifting, heavy breathing, branches whipping past, and water splashing.'
-      ],
-      title: 'Prompt',
-      minLength: 1
+      ]
     },
     prompt_optimizer: {
       description: 'Whether to use the model\'s prompt optimizer',
-      type: 'boolean',
+      title: 'Prompt Optimizer',
       default: true,
-      title: 'Prompt Optimizer'
+      type: 'boolean'
+    },
+    prompt: {
+      description: 'Text prompt for video generation',
+      minLength: 1,
+      maxLength: 2000,
+      type: 'string',
+      title: 'Prompt',
+      examples: [
+        'The camera follows the mountain biker as they navigate a technical forest trail at high speed, wheels bouncing over roots and rocks. The rider approaches a jump, launching into the air with the bike, both rider and machine perfectly synchronized. They land smoothly and continue through tight turns, splashing through a stream crossing. Mud and water spray as the bike powers through challenging terrain. The atmosphere is wild and adventurous. Audio: Tires gripping dirt, gears shifting, heavy breathing, branches whipping past, and water splashing.'
+      ]
     }
-  }
+  },
+  required: [
+    'prompt',
+    'image_url'
+  ],
+  type: 'object',
+  title: 'ProImageToVideoHailuo23Input',
+  'x-fal-order-properties': [
+    'prompt',
+    'prompt_optimizer',
+    'image_url'
+  ]
 } as const;
 
 export const MinimaxHailuo23ProImageToVideoOutputSchema = {
-  required: [
-    'video'
-  ],
-  type: 'object',
-  'x-fal-order-properties': [
-    'video'
-  ],
-  title: 'ProImageToVideoHailuo23Output',
   properties: {
     video: {
       description: 'The generated video',
@@ -1159,7 +1151,15 @@ export const MinimaxHailuo23ProImageToVideoOutputSchema = {
         }
       ]
     }
-  }
+  },
+  required: [
+    'video'
+  ],
+  type: 'object',
+  title: 'ProImageToVideoHailuo23Output',
+  'x-fal-order-properties': [
+    'video'
+  ]
 } as const;
 
 export const H3MaxImageToVideoInputSchema = {
@@ -1178,12 +1178,18 @@ export const H3MaxImageToVideoInputSchema = {
     'image_url',
     'end_image_url'
   ],
-  type: 'object',
-  title: 'TurboImageToVideoHailuo03Input',
   properties: {
+    prompt_expansion_mode: {
+      examples: [
+        'balanced',
+        'quality'
+      ],
+      default: 'balanced',
+      type: 'string',
+      description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.',
+      title: 'Prompt Expansion Mode'
+    },
     end_image_url: {
-      description: 'Optional URL of the image to use as the last frame, for first-to-last keyframe generation.',
-      title: 'End Image URL',
       anyOf: [
         {
           type: 'string'
@@ -1191,53 +1197,45 @@ export const H3MaxImageToVideoInputSchema = {
         {
           type: 'null'
         }
-      ]
+      ],
+      description: 'Optional URL of the image to use as the last frame. It may be provided alone for end-only keyframe generation; in that case the output canvas follows this image.',
+      title: 'End Image URL'
+    },
+    duration: {
+      maximum: 15,
+      minimum: 5,
+      default: 5,
+      type: 'integer',
+      description: 'The duration of the video in seconds.',
+      title: 'Duration'
+    },
+    sync_mode: {
+      default: false,
+      type: 'boolean',
+      description: 'Return the generated video as base64 instead of a CDN URL.',
+      title: 'Sync Mode'
+    },
+    resolution: {
+      enum: [
+        '480P',
+        '768P'
+      ],
+      default: '768P',
+      type: 'string',
+      description: 'The native generation resolution of the video.',
+      title: 'Resolution'
     },
     prompt: {
-      minLength: 1,
-      description: 'Text prompt for video generation',
-      type: 'string',
-      title: 'Prompt',
+      maxLength: 50000,
       examples: [
         'The camera slowly pulls back from the scene, revealing the full landscape as clouds drift overhead and light shifts across the terrain.'
       ],
-      maxLength: 50000
-    },
-    seed: {
-      description: 'Random seed. A random seed is selected when omitted.',
-      title: 'Seed',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ]
-    },
-    enable_safety_checker: {
-      description: 'If set to true, the safety checker will be enabled.',
-      type: 'boolean',
-      title: 'Enable Safety Checker',
-      default: true
-    },
-    duration: {
-      description: 'The duration of the video in seconds.',
-      type: 'integer',
-      title: 'Duration',
-      default: 5,
-      minimum: 5,
-      maximum: 15
-    },
-    sync_mode: {
-      description: 'Return the generated video as base64 instead of a CDN URL.',
-      type: 'boolean',
-      title: 'Sync Mode',
-      default: false
+      minLength: 1,
+      type: 'string',
+      description: 'Text prompt for video generation',
+      title: 'Prompt'
     },
     image_url: {
-      description: 'Optional URL of the image to use as the first frame. When provided, the output aspect ratio follows this image. When omitted, the request is handled as text-to-video (16:9 by default).',
-      title: 'Image URL',
       examples: [
         'https://storage.googleapis.com/falserverless/example_inputs/hailuo23/pro_i2v_in.jpg'
       ],
@@ -1248,29 +1246,31 @@ export const H3MaxImageToVideoInputSchema = {
         {
           type: 'null'
         }
-      ]
-    },
-    prompt_expansion_mode: {
-      description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.',
-      type: 'string',
-      title: 'Prompt Expansion Mode',
-      default: 'balanced',
-      examples: [
-        'balanced',
-        'quality'
-      ]
-    },
-    resolution: {
-      enum: [
-        '480P',
-        '768P'
       ],
-      description: 'The native generation resolution of the video.',
-      type: 'string',
-      title: 'Resolution',
-      default: '768P'
+      description: 'Optional URL of the image to use as the first frame. When provided, the output canvas follows this image. If only end_image_url is provided, the canvas follows that last frame instead. If both images are omitted, the request is handled as text-to-video (16:9 by default).',
+      title: 'Image URL'
+    },
+    enable_safety_checker: {
+      default: true,
+      type: 'boolean',
+      description: 'If set to true, the safety checker will be enabled.',
+      title: 'Enable Safety Checker'
+    },
+    seed: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'Random seed. A random seed is selected when omitted.',
+      title: 'Seed'
     }
-  }
+  },
+  type: 'object',
+  title: 'TurboImageToVideoHailuo03Input'
 } as const;
 
 export const H3MaxImageToVideoOutputSchema = {
@@ -1282,12 +1282,8 @@ export const H3MaxImageToVideoOutputSchema = {
     'expanded_prompt',
     'timings'
   ],
-  type: 'object',
-  title: 'TurboImageToVideoHailuo03Output',
   properties: {
     expanded_prompt: {
-      description: 'The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax\'s hosted API.',
-      title: 'Expanded Prompt',
       anyOf: [
         {
           type: 'string'
@@ -1295,15 +1291,15 @@ export const H3MaxImageToVideoOutputSchema = {
         {
           type: 'null'
         }
-      ]
+      ],
+      description: 'The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax\'s hosted API.',
+      title: 'Expanded Prompt'
     },
     video: {
       $ref: '#/components/schemas/File',
       description: 'The generated video'
     },
     timings: {
-      description: 'Timing breakdown in seconds. \'inference\' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.',
-      title: 'Timings',
       anyOf: [
         {
           additionalProperties: {
@@ -1314,136 +1310,16 @@ export const H3MaxImageToVideoOutputSchema = {
         {
           type: 'null'
         }
-      ]
+      ],
+      description: 'Timing breakdown in seconds. \'inference\' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.',
+      title: 'Timings'
     }
-  }
+  },
+  type: 'object',
+  title: 'TurboImageToVideoHailuo03Output'
 } as const;
 
 export const Seedance20EnterpriseV2ImageToVideoInputSchema = {
-  type: 'object',
-  properties: {
-    end_image_url: {
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'End Image Url',
-      description: 'The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.'
-    },
-    prompt: {
-      description: 'The text prompt describing the desired motion and action for the video.',
-      examples: [
-        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
-      ],
-      title: 'Prompt',
-      type: 'string'
-    },
-    generate_audio: {
-      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.',
-      default: true,
-      title: 'Generate Audio',
-      type: 'boolean'
-    },
-    bitrate_mode: {
-      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
-      default: 'standard',
-      examples: [
-        'standard'
-      ],
-      enum: [
-        'standard',
-        'high'
-      ],
-      title: 'Bitrate Mode',
-      type: 'string'
-    },
-    image_url: {
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'string',
-          format: 'binary'
-        }
-      ],
-      'x-fal-file-input': true,
-      description: 'The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.',
-      examples: [
-        'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
-      ],
-      title: 'Image Url'
-    },
-    aspect_ratio: {
-      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to infer from the input image.',
-      default: 'auto',
-      enum: [
-        'auto',
-        '21:9',
-        '16:9',
-        '4:3',
-        '1:1',
-        '3:4',
-        '9:16'
-      ],
-      title: 'Aspect Ratio',
-      type: 'string'
-    },
-    duration: {
-      description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.',
-      default: 'auto',
-      enum: [
-        'auto',
-        '4',
-        '5',
-        '6',
-        '7',
-        '8',
-        '9',
-        '10',
-        '11',
-        '12',
-        '13',
-        '14',
-        '15'
-      ],
-      title: 'Duration',
-      type: 'string'
-    },
-    resolution: {
-      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.',
-      default: '720p',
-      enum: [
-        '480p',
-        '720p',
-        '1080p',
-        '4k'
-      ],
-      title: 'Resolution',
-      type: 'string'
-    },
-    end_user_id: {
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'End User Id',
-      description: 'The unique user ID of the end user.'
-    }
-  },
-  title: 'Seedance2I2VInput',
-  required: [
-    'prompt',
-    'image_url'
-  ],
   'x-fal-order-properties': [
     'prompt',
     'image_url',
@@ -1454,49 +1330,34 @@ export const Seedance20EnterpriseV2ImageToVideoInputSchema = {
     'generate_audio',
     'bitrate_mode',
     'end_user_id'
-  ]
-} as const;
-
-export const Seedance20EnterpriseV2ImageToVideoOutputSchema = {
-  type: 'object',
-  properties: {
-    video: {
-      $ref: '#/components/schemas/File',
-      examples: [
-        {
-          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
-        }
-      ],
-      description: 'The generated video file.'
-    },
-    seed: {
-      description: 'The seed used for generation.',
-      examples: [
-        42
-      ],
-      title: 'Seed',
-      type: 'integer'
-    }
-  },
-  title: 'Seedance2VideoOutput',
-  required: [
-    'video',
-    'seed'
   ],
-  'x-fal-order-properties': [
-    'video',
-    'seed'
-  ]
-} as const;
-
-export const Seedance25ImageToVideoInputSchema = {
   required: [
     'prompt',
     'image_url'
   ],
-  type: 'object',
   properties: {
+    end_user_id: {
+      title: 'End User Id',
+      description: 'The unique user ID of the end user.',
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ]
+    },
+    prompt: {
+      title: 'Prompt',
+      type: 'string',
+      examples: [
+        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+      ],
+      description: 'The text prompt describing the desired motion and action for the video.'
+    },
     end_image_url: {
+      title: 'End Image Url',
       description: 'The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.',
       anyOf: [
         {
@@ -1505,59 +1366,20 @@ export const Seedance25ImageToVideoInputSchema = {
         {
           type: 'null'
         }
-      ],
-      title: 'End Image Url'
+      ]
     },
-    aspect_ratio: {
-      const: 'auto',
+    bitrate_mode: {
+      default: 'standard',
       type: 'string',
-      description: 'The aspect ratio of the generated video. Always "auto" for image-to-video',
-      title: 'Aspect Ratio',
-      default: 'auto'
-    },
-    prompt: {
+      title: 'Bitrate Mode',
       examples: [
-        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+        'standard'
       ],
-      type: 'string',
-      description: 'The text prompt describing the desired motion and action for the video.',
-      title: 'Prompt'
-    },
-    duration: {
       enum: [
-        'auto',
-        '4',
-        '5',
-        '6',
-        '7',
-        '8',
-        '9',
-        '10',
-        '11',
-        '12',
-        '13',
-        '14',
-        '15',
-        '16',
-        '17',
-        '18',
-        '19',
-        '20',
-        '21',
-        '22',
-        '23',
-        '24',
-        '25',
-        '26',
-        '27',
-        '28',
-        '29',
-        '30'
+        'standard',
+        'high'
       ],
-      type: 'string',
-      description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.',
-      title: 'Duration',
-      default: 'auto'
+      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
     },
     image_url: {
       anyOf: [
@@ -1570,107 +1392,34 @@ export const Seedance25ImageToVideoInputSchema = {
         }
       ],
       'x-fal-file-input': true,
+      title: 'Image Url',
       examples: [
         'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
       ],
-      description: 'The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.',
-      title: 'Image Url'
-    },
-    bitrate_mode: {
-      enum: [
-        'standard',
-        'high'
-      ],
-      examples: [
-        'standard'
-      ],
-      type: 'string',
-      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
-      title: 'Bitrate Mode',
-      default: 'standard'
-    },
-    generate_audio: {
-      type: 'boolean',
-      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.',
-      title: 'Generate Audio',
-      default: true
-    },
-    end_user_id: {
-      description: 'The unique user ID of the end user.',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'End User Id'
+      description: 'The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.'
     },
     resolution: {
+      default: '720p',
+      type: 'string',
+      title: 'Resolution',
       enum: [
         '480p',
         '720p',
-        '1080p'
+        '1080p',
+        '4k'
       ],
-      type: 'string',
-      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.',
-      title: 'Resolution',
-      default: '720p'
-    }
-  },
-  title: 'Seedance2I2VInput',
-  'x-fal-order-properties': [
-    'prompt',
-    'image_url',
-    'end_image_url',
-    'resolution',
-    'duration',
-    'aspect_ratio',
-    'generate_audio',
-    'bitrate_mode',
-    'end_user_id'
-  ]
-} as const;
-
-export const Seedance25ImageToVideoOutputSchema = {
-  required: [
-    'video',
-    'seed'
-  ],
-  type: 'object',
-  properties: {
-    seed: {
-      examples: [
-        42
-      ],
-      type: 'integer',
-      description: 'The seed used for generation.',
-      title: 'Seed'
+      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.'
     },
-    video: {
-      examples: [
-        {
-          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
-        }
-      ],
-      description: 'The generated video file.',
-      $ref: '#/components/schemas/File'
-    }
-  },
-  title: 'Seedance2VideoOutput',
-  'x-fal-order-properties': [
-    'video',
-    'seed'
-  ]
-} as const;
-
-export const Seedance20EnterpriseV2ReferenceToVideoInputSchema = {
-  type: 'object',
-  properties: {
+    generate_audio: {
+      default: true,
+      type: 'boolean',
+      title: 'Generate Audio',
+      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+    },
     duration: {
-      description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.',
       default: 'auto',
+      type: 'string',
+      title: 'Duration',
       enum: [
         'auto',
         '4',
@@ -1686,61 +1435,12 @@ export const Seedance20EnterpriseV2ReferenceToVideoInputSchema = {
         '14',
         '15'
       ],
-      title: 'Duration',
-      type: 'string'
-    },
-    audio_urls: {
-      description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file. At least one reference image or video is required.',
-      items: {
-        _fal_ui_field: 'audio',
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      maxItems: 3,
-      title: 'Audio Urls',
-      type: 'array'
-    },
-    prompt: {
-      description: 'The text prompt used to generate the video.',
-      examples: [
-        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
-      ],
-      title: 'Prompt',
-      type: 'string'
-    },
-    generate_audio: {
-      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.',
-      default: true,
-      title: 'Generate Audio',
-      type: 'boolean'
-    },
-    bitrate_mode: {
-      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
-      default: 'standard',
-      examples: [
-        'standard'
-      ],
-      enum: [
-        'standard',
-        'high'
-      ],
-      title: 'Bitrate Mode',
-      type: 'string'
-    },
-    video_urls: {
-      description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.',
-      items: {
-        _fal_ui_field: 'video',
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      maxItems: 3,
-      title: 'Video Urls',
-      type: 'array'
+      description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.'
     },
     aspect_ratio: {
-      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.',
       default: 'auto',
+      type: 'string',
+      title: 'Aspect Ratio',
       enum: [
         'auto',
         '21:9',
@@ -1750,35 +1450,83 @@ export const Seedance20EnterpriseV2ReferenceToVideoInputSchema = {
         '3:4',
         '9:16'
       ],
-      title: 'Aspect Ratio',
-      type: 'string'
-    },
-    image_urls: {
-      description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPEG, PNG, WebP. Max 30 MB per image. Up to 9 images. Total files across all modalities must not exceed 12.',
-      items: {
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      maxItems: 9,
-      title: 'Image Urls',
+      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to infer from the input image.'
+    }
+  },
+  type: 'object',
+  title: 'Seedance2I2VInput'
+} as const;
+
+export const Seedance20EnterpriseV2ImageToVideoOutputSchema = {
+  'x-fal-order-properties': [
+    'video',
+    'seed'
+  ],
+  required: [
+    'video',
+    'seed'
+  ],
+  properties: {
+    seed: {
+      title: 'Seed',
+      type: 'integer',
       examples: [
-        [
-          'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
-        ]
+        42
       ],
-      type: 'array'
+      description: 'The seed used for generation.'
     },
-    resolution: {
-      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.',
-      default: '720p',
-      enum: [
-        '480p',
-        '720p',
-        '1080p',
-        '4k'
+    video: {
+      $ref: '#/components/schemas/File',
+      examples: [
+        {
+          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
+        }
       ],
-      title: 'Resolution',
-      type: 'string'
+      description: 'The generated video file.'
+    }
+  },
+  type: 'object',
+  title: 'Seedance2VideoOutput'
+} as const;
+
+export const Seedance25ImageToVideoInputSchema = {
+  type: 'object',
+  properties: {
+    image_url: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'string',
+          format: 'binary'
+        }
+      ],
+      'x-fal-file-input': true,
+      description: 'The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.',
+      title: 'Image Url',
+      examples: [
+        'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
+      ]
+    },
+    end_image_url: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.',
+      title: 'End Image Url'
+    },
+    aspect_ratio: {
+      type: 'string',
+      default: 'auto',
+      const: 'auto',
+      description: 'The aspect ratio of the generated video. Always "auto" for image-to-video',
+      title: 'Aspect Ratio'
     },
     end_user_id: {
       anyOf: [
@@ -1789,100 +1537,27 @@ export const Seedance20EnterpriseV2ReferenceToVideoInputSchema = {
           type: 'null'
         }
       ],
-      title: 'End User Id',
-      description: 'The unique user ID of the end user.'
-    }
-  },
-  title: 'Seedance2R2VInput',
-  required: [
-    'prompt'
-  ],
-  'x-fal-order-properties': [
-    'prompt',
-    'image_urls',
-    'video_urls',
-    'audio_urls',
-    'resolution',
-    'duration',
-    'aspect_ratio',
-    'generate_audio',
-    'bitrate_mode',
-    'end_user_id'
-  ]
-} as const;
-
-export const Seedance20EnterpriseV2ReferenceToVideoOutputSchema = {
-  type: 'object',
-  properties: {
-    video: {
-      $ref: '#/components/schemas/File',
-      examples: [
-        {
-          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
-        }
-      ],
-      description: 'The generated video file.'
+      description: 'The unique user ID of the end user.',
+      title: 'End User Id'
     },
-    seed: {
-      description: 'The seed used for generation.',
-      examples: [
-        42
-      ],
-      title: 'Seed',
-      type: 'integer'
-    }
-  },
-  title: 'Seedance2VideoOutput',
-  required: [
-    'video',
-    'seed'
-  ],
-  'x-fal-order-properties': [
-    'video',
-    'seed'
-  ]
-} as const;
-
-export const Seedance25ReferenceToVideoInputSchema = {
-  required: [
-    'prompt'
-  ],
-  type: 'object',
-  properties: {
-    prompt: {
-      examples: [
-        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
-      ],
+    bitrate_mode: {
       type: 'string',
-      description: 'The text prompt used to generate the video.',
-      title: 'Prompt'
-    },
-    video_urls: {
-      items: {
-        _fal_ui_field: 'video',
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      type: 'array',
-      description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 10 videos. Each video must be 1.8 to 30.2 seconds and no larger than 200 MB; combined duration must not exceed 30.2 seconds. Dimensions must be 300 to 6,000 pixels per side, aspect ratio 0.4 to 2.5, and frame rate 24 to 60 FPS.',
-      title: 'Video Urls'
-    },
-    aspect_ratio: {
+      default: 'standard',
+      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
+      title: 'Bitrate Mode',
+      examples: [
+        'standard'
+      ],
       enum: [
-        'auto',
-        '21:9',
-        '16:9',
-        '4:3',
-        '1:1',
-        '3:4',
-        '9:16'
-      ],
-      type: 'string',
-      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.',
-      title: 'Aspect Ratio',
-      default: 'auto'
+        'standard',
+        'high'
+      ]
     },
     duration: {
+      type: 'string',
+      default: 'auto',
+      description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.',
+      title: 'Duration',
       enum: [
         'auto',
         '4',
@@ -1912,80 +1587,85 @@ export const Seedance25ReferenceToVideoInputSchema = {
         '28',
         '29',
         '30'
-      ],
-      type: 'string',
-      description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.',
-      title: 'Duration',
-      default: 'auto'
-    },
-    audio_urls: {
-      items: {
-        _fal_ui_field: 'audio',
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      type: 'array',
-      description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. At least one reference image or video is required.',
-      title: 'Audio Urls'
-    },
-    bitrate_mode: {
-      enum: [
-        'standard',
-        'high'
-      ],
-      examples: [
-        'standard'
-      ],
-      type: 'string',
-      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
-      title: 'Bitrate Mode',
-      default: 'standard'
-    },
-    image_urls: {
-      items: {
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      type: 'array',
-      description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.',
-      title: 'Image Urls',
-      examples: [
-        [
-          'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
-        ]
       ]
     },
     generate_audio: {
       type: 'boolean',
+      default: true,
       description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.',
-      title: 'Generate Audio',
-      default: true
+      title: 'Generate Audio'
     },
-    end_user_id: {
-      description: 'The unique user ID of the end user.',
-      anyOf: [
-        {
-          type: 'string'
-        },
-        {
-          type: 'null'
-        }
-      ],
-      title: 'End User Id'
+    prompt: {
+      type: 'string',
+      description: 'The text prompt describing the desired motion and action for the video.',
+      title: 'Prompt',
+      examples: [
+        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+      ]
     },
     resolution: {
+      type: 'string',
+      default: '720p',
+      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.',
+      title: 'Resolution',
       enum: [
         '480p',
         '720p',
         '1080p'
-      ],
-      type: 'string',
-      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.',
-      title: 'Resolution',
-      default: '720p'
+      ]
     }
   },
-  title: 'Seedance2R2VInput',
+  'x-fal-order-properties': [
+    'prompt',
+    'image_url',
+    'end_image_url',
+    'resolution',
+    'duration',
+    'aspect_ratio',
+    'generate_audio',
+    'bitrate_mode',
+    'end_user_id'
+  ],
+  required: [
+    'prompt',
+    'image_url'
+  ],
+  title: 'Seedance2I2VInput'
+} as const;
+
+export const Seedance25ImageToVideoOutputSchema = {
+  type: 'object',
+  properties: {
+    seed: {
+      type: 'integer',
+      description: 'The seed used for generation.',
+      title: 'Seed',
+      examples: [
+        42
+      ]
+    },
+    video: {
+      description: 'The generated video file.',
+      $ref: '#/components/schemas/File',
+      examples: [
+        {
+          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
+        }
+      ]
+    }
+  },
+  'x-fal-order-properties': [
+    'video',
+    'seed'
+  ],
+  required: [
+    'video',
+    'seed'
+  ],
+  title: 'Seedance2VideoOutput'
+} as const;
+
+export const Seedance20EnterpriseV2ReferenceToVideoInputSchema = {
   'x-fal-order-properties': [
     'prompt',
     'image_urls',
@@ -1997,39 +1677,649 @@ export const Seedance25ReferenceToVideoInputSchema = {
     'generate_audio',
     'bitrate_mode',
     'end_user_id'
-  ]
+  ],
+  required: [
+    'prompt'
+  ],
+  properties: {
+    end_user_id: {
+      title: 'End User Id',
+      description: 'The unique user ID of the end user.',
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ]
+    },
+    prompt: {
+      title: 'Prompt',
+      type: 'string',
+      examples: [
+        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+      ],
+      description: 'The text prompt used to generate the video.'
+    },
+    audio_urls: {
+      title: 'Audio Urls',
+      type: 'array',
+      maxItems: 3,
+      items: {
+        _fal_ui_field: 'audio',
+        type: 'string',
+        'x-fal-file-input': true
+      },
+      description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file. At least one reference image or video is required.'
+    },
+    bitrate_mode: {
+      default: 'standard',
+      type: 'string',
+      title: 'Bitrate Mode',
+      examples: [
+        'standard'
+      ],
+      enum: [
+        'standard',
+        'high'
+      ],
+      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+    },
+    video_urls: {
+      title: 'Video Urls',
+      type: 'array',
+      maxItems: 3,
+      items: {
+        _fal_ui_field: 'video',
+        type: 'string',
+        'x-fal-file-input': true
+      },
+      description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.'
+    },
+    resolution: {
+      default: '720p',
+      type: 'string',
+      title: 'Resolution',
+      enum: [
+        '480p',
+        '720p',
+        '1080p',
+        '4k'
+      ],
+      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.'
+    },
+    image_urls: {
+      description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPEG, PNG, WebP. Max 30 MB per image. Up to 9 images. Total files across all modalities must not exceed 12.',
+      title: 'Image Urls',
+      type: 'array',
+      maxItems: 9,
+      items: {
+        type: 'string',
+        'x-fal-file-input': true
+      },
+      examples: [
+        [
+          'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
+        ]
+      ]
+    },
+    generate_audio: {
+      default: true,
+      type: 'boolean',
+      title: 'Generate Audio',
+      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+    },
+    duration: {
+      default: 'auto',
+      type: 'string',
+      title: 'Duration',
+      enum: [
+        'auto',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15'
+      ],
+      description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.'
+    },
+    aspect_ratio: {
+      default: 'auto',
+      type: 'string',
+      title: 'Aspect Ratio',
+      enum: [
+        'auto',
+        '21:9',
+        '16:9',
+        '4:3',
+        '1:1',
+        '3:4',
+        '9:16'
+      ],
+      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.'
+    }
+  },
+  type: 'object',
+  title: 'Seedance2R2VInput'
 } as const;
 
-export const Seedance25ReferenceToVideoOutputSchema = {
+export const Seedance20EnterpriseV2ReferenceToVideoOutputSchema = {
+  'x-fal-order-properties': [
+    'video',
+    'seed'
+  ],
   required: [
     'video',
     'seed'
   ],
-  type: 'object',
   properties: {
     seed: {
+      title: 'Seed',
+      type: 'integer',
       examples: [
         42
       ],
-      type: 'integer',
-      description: 'The seed used for generation.',
-      title: 'Seed'
+      description: 'The seed used for generation.'
     },
     video: {
+      $ref: '#/components/schemas/File',
       examples: [
         {
           url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
         }
       ],
-      description: 'The generated video file.',
-      $ref: '#/components/schemas/File'
+      description: 'The generated video file.'
     }
   },
-  title: 'Seedance2VideoOutput',
+  type: 'object',
+  title: 'Seedance2VideoOutput'
+} as const;
+
+export const Seedance20EnterpriseV2TextToVideoInputSchema = {
+  'x-fal-order-properties': [
+    'prompt',
+    'resolution',
+    'duration',
+    'aspect_ratio',
+    'generate_audio',
+    'bitrate_mode',
+    'end_user_id'
+  ],
+  required: [
+    'prompt'
+  ],
+  properties: {
+    resolution: {
+      default: '720p',
+      type: 'string',
+      title: 'Resolution',
+      enum: [
+        '480p',
+        '720p',
+        '1080p',
+        '4k'
+      ],
+      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.'
+    },
+    end_user_id: {
+      title: 'End User Id',
+      description: 'The unique user ID of the end user.',
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ]
+    },
+    generate_audio: {
+      default: true,
+      type: 'boolean',
+      title: 'Generate Audio',
+      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+    },
+    duration: {
+      default: 'auto',
+      type: 'string',
+      title: 'Duration',
+      enum: [
+        'auto',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15'
+      ],
+      description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.'
+    },
+    aspect_ratio: {
+      default: 'auto',
+      type: 'string',
+      title: 'Aspect Ratio',
+      enum: [
+        'auto',
+        '21:9',
+        '16:9',
+        '4:3',
+        '1:1',
+        '3:4',
+        '9:16'
+      ],
+      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.'
+    },
+    bitrate_mode: {
+      default: 'standard',
+      type: 'string',
+      title: 'Bitrate Mode',
+      examples: [
+        'standard'
+      ],
+      enum: [
+        'standard',
+        'high'
+      ],
+      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+    },
+    prompt: {
+      title: 'Prompt',
+      type: 'string',
+      examples: [
+        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+      ],
+      description: 'The text prompt used to generate the video'
+    }
+  },
+  type: 'object',
+  title: 'Seedance2T2VInput'
+} as const;
+
+export const Seedance20EnterpriseV2TextToVideoOutputSchema = {
   'x-fal-order-properties': [
     'video',
     'seed'
-  ]
+  ],
+  required: [
+    'video',
+    'seed'
+  ],
+  properties: {
+    seed: {
+      title: 'Seed',
+      type: 'integer',
+      examples: [
+        42
+      ],
+      description: 'The seed used for generation.'
+    },
+    video: {
+      $ref: '#/components/schemas/File',
+      examples: [
+        {
+          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
+        }
+      ],
+      description: 'The generated video file.'
+    }
+  },
+  type: 'object',
+  title: 'Seedance2VideoOutput'
+} as const;
+
+export const Seedance25ReferenceToVideoInputSchema = {
+  type: 'object',
+  properties: {
+    video_urls: {
+      type: 'array',
+      description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 10 videos. Each video must be 1.8 to 30.2 seconds and no larger than 200 MB; combined duration must not exceed 30.2 seconds. Dimensions must be 300 to 6,000 pixels per side, aspect ratio 0.4 to 2.5, and frame rate 24 to 60 FPS.',
+      title: 'Video Urls',
+      items: {
+        type: 'string',
+        _fal_ui_field: 'video',
+        'x-fal-file-input': true
+      }
+    },
+    audio_urls: {
+      type: 'array',
+      description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. At least one reference image or video is required.',
+      title: 'Audio Urls',
+      items: {
+        type: 'string',
+        _fal_ui_field: 'audio',
+        'x-fal-file-input': true
+      }
+    },
+    aspect_ratio: {
+      type: 'string',
+      default: 'auto',
+      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.',
+      title: 'Aspect Ratio',
+      enum: [
+        'auto',
+        '21:9',
+        '16:9',
+        '4:3',
+        '1:1',
+        '3:4',
+        '9:16'
+      ]
+    },
+    image_urls: {
+      type: 'array',
+      description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.',
+      title: 'Image Urls',
+      examples: [
+        [
+          'https://v3b.fal.media/files/b/0a8eba37/Cqg-4Uwzyz4DELfceT1CF_a17e588773ec45b1a9e6f100a787b80b.jpg'
+        ]
+      ],
+      items: {
+        type: 'string',
+        'x-fal-file-input': true
+      }
+    },
+    end_user_id: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The unique user ID of the end user.',
+      title: 'End User Id'
+    },
+    bitrate_mode: {
+      type: 'string',
+      default: 'standard',
+      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
+      title: 'Bitrate Mode',
+      examples: [
+        'standard'
+      ],
+      enum: [
+        'standard',
+        'high'
+      ]
+    },
+    duration: {
+      type: 'string',
+      default: 'auto',
+      description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.',
+      title: 'Duration',
+      enum: [
+        'auto',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15',
+        '16',
+        '17',
+        '18',
+        '19',
+        '20',
+        '21',
+        '22',
+        '23',
+        '24',
+        '25',
+        '26',
+        '27',
+        '28',
+        '29',
+        '30'
+      ]
+    },
+    resolution: {
+      type: 'string',
+      default: '720p',
+      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.',
+      title: 'Resolution',
+      enum: [
+        '480p',
+        '720p',
+        '1080p'
+      ]
+    },
+    prompt: {
+      type: 'string',
+      description: 'The text prompt used to generate the video.',
+      title: 'Prompt',
+      examples: [
+        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+      ]
+    },
+    generate_audio: {
+      type: 'boolean',
+      default: true,
+      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.',
+      title: 'Generate Audio'
+    }
+  },
+  'x-fal-order-properties': [
+    'prompt',
+    'image_urls',
+    'video_urls',
+    'audio_urls',
+    'resolution',
+    'duration',
+    'aspect_ratio',
+    'generate_audio',
+    'bitrate_mode',
+    'end_user_id'
+  ],
+  required: [
+    'prompt'
+  ],
+  title: 'Seedance2R2VInput'
+} as const;
+
+export const Seedance25ReferenceToVideoOutputSchema = {
+  type: 'object',
+  properties: {
+    seed: {
+      type: 'integer',
+      description: 'The seed used for generation.',
+      title: 'Seed',
+      examples: [
+        42
+      ]
+    },
+    video: {
+      description: 'The generated video file.',
+      $ref: '#/components/schemas/File',
+      examples: [
+        {
+          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
+        }
+      ]
+    }
+  },
+  'x-fal-order-properties': [
+    'video',
+    'seed'
+  ],
+  required: [
+    'video',
+    'seed'
+  ],
+  title: 'Seedance2VideoOutput'
+} as const;
+
+export const Seedance25TextToVideoInputSchema = {
+  type: 'object',
+  properties: {
+    generate_audio: {
+      type: 'boolean',
+      default: true,
+      description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.',
+      title: 'Generate Audio'
+    },
+    end_user_id: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The unique user ID of the end user.',
+      title: 'End User Id'
+    },
+    bitrate_mode: {
+      type: 'string',
+      default: 'standard',
+      description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.',
+      title: 'Bitrate Mode',
+      examples: [
+        'standard'
+      ],
+      enum: [
+        'standard',
+        'high'
+      ]
+    },
+    duration: {
+      type: 'string',
+      default: 'auto',
+      description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.',
+      title: 'Duration',
+      enum: [
+        'auto',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15',
+        '16',
+        '17',
+        '18',
+        '19',
+        '20',
+        '21',
+        '22',
+        '23',
+        '24',
+        '25',
+        '26',
+        '27',
+        '28',
+        '29',
+        '30'
+      ]
+    },
+    resolution: {
+      type: 'string',
+      default: '720p',
+      description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.',
+      title: 'Resolution',
+      enum: [
+        '480p',
+        '720p',
+        '1080p'
+      ]
+    },
+    prompt: {
+      type: 'string',
+      description: 'The text prompt used to generate the video',
+      title: 'Prompt',
+      examples: [
+        'An octopus finds a football in the ocean and excitedly calls its octopus friends to come and play. Cut scene to an octopus football game under the sea.'
+      ]
+    },
+    aspect_ratio: {
+      type: 'string',
+      default: 'auto',
+      description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.',
+      title: 'Aspect Ratio',
+      enum: [
+        'auto',
+        '21:9',
+        '16:9',
+        '4:3',
+        '1:1',
+        '3:4',
+        '9:16'
+      ]
+    }
+  },
+  'x-fal-order-properties': [
+    'prompt',
+    'resolution',
+    'duration',
+    'aspect_ratio',
+    'generate_audio',
+    'bitrate_mode',
+    'end_user_id'
+  ],
+  required: [
+    'prompt'
+  ],
+  title: 'Seedance2T2VInput'
+} as const;
+
+export const Seedance25TextToVideoOutputSchema = {
+  type: 'object',
+  properties: {
+    seed: {
+      type: 'integer',
+      description: 'The seed used for generation.',
+      title: 'Seed',
+      examples: [
+        42
+      ]
+    },
+    video: {
+      description: 'The generated video file.',
+      $ref: '#/components/schemas/File',
+      examples: [
+        {
+          url: 'https://storage.googleapis.com/falserverless/example_outputs/bytedance/seedance_2/output.mp4'
+        }
+      ]
+    }
+  },
+  'x-fal-order-properties': [
+    'video',
+    'seed'
+  ],
+  required: [
+    'video',
+    'seed'
+  ],
+  title: 'Seedance2VideoOutput'
 } as const;
 
 export const GeminiOmni11FlashReferenceToVideoInputSchema = {
@@ -2041,89 +2331,161 @@ export const GeminiOmni11FlashReferenceToVideoInputSchema = {
     'resolution',
     'duration'
   ],
+  type: 'object',
+  title: 'Omni11FlashReferenceToVideoInput',
   properties: {
-    duration: {
-      description: 'The duration of the generated video, in seconds.',
-      default: 8,
-      minimum: 3,
-      title: 'Duration',
-      maximum: 10,
-      type: 'integer'
-    },
-    aspect_ratio: {
-      description: 'The aspect ratio of the generated video.',
-      default: '16:9',
-      title: 'Aspect Ratio',
-      enum: [
-        '16:9',
-        '9:16'
-      ],
-      type: 'string'
+    reference_video_urls: {
+      maxItems: 3,
+      items: {
+        type: 'string',
+        'x-fal-file-input': true
+      },
+      type: 'array',
+      title: 'Reference Video URLs',
+      description: 'URLs of up to three reference videos. Each video must be at most three seconds long.'
     },
     resolution: {
-      description: 'The resolution of the generated video.',
-      default: '720p',
-      title: 'Resolution',
       enum: [
         '360p',
         '720p',
         '1080p',
         '4k'
       ],
-      type: 'string'
+      description: 'The resolution of the generated video.',
+      type: 'string',
+      title: 'Resolution',
+      default: '720p'
+    },
+    duration: {
+      maximum: 10,
+      description: 'The duration of the generated video, in seconds.',
+      type: 'integer',
+      title: 'Duration',
+      default: 8,
+      minimum: 3
+    },
+    aspect_ratio: {
+      enum: [
+        '16:9',
+        '9:16'
+      ],
+      description: 'The aspect ratio of the generated video.',
+      type: 'string',
+      title: 'Aspect Ratio',
+      default: '16:9'
     },
     image_urls: {
-      description: 'URLs of reference images to incorporate into the video.',
+      maxItems: 10,
       items: {
         type: 'string',
         'x-fal-file-input': true
       },
-      maxItems: 10,
+      type: 'array',
       title: 'Image URLs',
-      type: 'array'
+      description: 'URLs of reference images to incorporate into the video.'
     },
     prompt: {
       description: 'The text prompt describing the video. Reference media is sent in list order before the prompt.',
+      type: 'string',
+      title: 'Prompt',
       examples: [
         'A cat inspired by <IMAGE_REF_0> walks through the setting in <VIDEO_REF_0>.'
       ],
-      maxLength: 20000,
-      title: 'Prompt',
-      type: 'string'
-    },
-    reference_video_urls: {
-      description: 'URLs of up to three reference videos. Each video must be at most three seconds long.',
-      items: {
-        type: 'string',
-        'x-fal-file-input': true
-      },
-      maxItems: 3,
-      title: 'Reference Video URLs',
-      type: 'array'
+      maxLength: 20000
     }
   },
-  title: 'Omni11FlashReferenceToVideoInput',
   required: [
     'prompt'
-  ],
-  type: 'object'
+  ]
 } as const;
 
 export const GeminiOmni11FlashReferenceToVideoOutputSchema = {
   'x-fal-order-properties': [
     'video'
   ],
+  type: 'object',
+  title: 'VideoOutput',
   properties: {
     video: {
       $ref: '#/components/schemas/File',
       description: 'The generated video.'
     }
   },
-  title: 'VideoOutput',
   required: [
     'video'
+  ]
+} as const;
+
+export const GeminiOmni11FlashInputSchema = {
+  'x-fal-order-properties': [
+    'prompt',
+    'aspect_ratio',
+    'resolution',
+    'duration'
   ],
-  type: 'object'
+  type: 'object',
+  title: 'Omni11FlashTextToVideoInput',
+  properties: {
+    duration: {
+      maximum: 10,
+      description: 'The duration of the generated video, in seconds.',
+      type: 'integer',
+      title: 'Duration',
+      default: 8,
+      minimum: 3
+    },
+    resolution: {
+      enum: [
+        '360p',
+        '720p',
+        '1080p',
+        '4k'
+      ],
+      description: 'The resolution of the generated video.',
+      type: 'string',
+      title: 'Resolution',
+      default: '720p'
+    },
+    aspect_ratio: {
+      enum: [
+        '16:9',
+        '9:16'
+      ],
+      description: 'The aspect ratio of the generated video.',
+      type: 'string',
+      title: 'Aspect Ratio',
+      default: '16:9'
+    },
+    prompt: {
+      description: 'The text prompt describing the video you want to generate.',
+      type: 'string',
+      title: 'Prompt',
+      examples: [
+        'A cinematic wide shot of a lighthouse on a rocky cliff at dusk, waves crashing below, the beam sweeping across the dark sea.'
+      ],
+      maxLength: 20000
+    }
+  },
+  required: [
+    'prompt'
+  ]
+} as const;
+
+export const GeminiOmni11FlashOutputSchema = {
+  'x-fal-order-properties': [
+    'video'
+  ],
+  type: 'object',
+  title: 'VideoOutput',
+  properties: {
+    video: {
+      $ref: '#/components/schemas/File',
+      description: 'The generated video.'
+    }
+  },
+  required: [
+    'video'
+  ]
 } as const;
 
 export const H3MaxReferenceToVideoInputSchema = {
@@ -2144,47 +2506,7 @@ export const H3MaxReferenceToVideoInputSchema = {
     'reference_video_urls',
     'reference_audio_urls'
   ],
-  type: 'object',
-  title: 'TurboReferenceToVideoHailuo03Input',
   properties: {
-    reference_video_urls: {
-      maxItems: 3,
-      description: 'URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.',
-      type: 'array',
-      title: 'Reference Video URLs',
-      items: {
-        type: 'string',
-        'x-fal-file-input': true
-      }
-    },
-    reference_audio_urls: {
-      maxItems: 3,
-      description: 'URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.',
-      type: 'array',
-      title: 'Reference Audio URLs',
-      items: {
-        type: 'string',
-        'x-fal-file-input': true
-      }
-    },
-    seed: {
-      description: 'Random seed. A random seed is selected when omitted.',
-      title: 'Seed',
-      anyOf: [
-        {
-          type: 'integer'
-        },
-        {
-          type: 'null'
-        }
-      ]
-    },
-    enable_safety_checker: {
-      description: 'If set to true, the safety checker will be enabled.',
-      type: 'boolean',
-      title: 'Enable Safety Checker',
-      default: true
-    },
     aspect_ratio: {
       enum: [
         'adaptive',
@@ -2195,71 +2517,111 @@ export const H3MaxReferenceToVideoInputSchema = {
         '3:4',
         '9:16'
       ],
-      description: 'The aspect ratio of the generated video.',
+      default: 'adaptive',
       type: 'string',
-      title: 'Aspect Ratio',
-      default: 'adaptive'
+      description: 'The aspect ratio of the generated video.',
+      title: 'Aspect Ratio'
     },
-    duration: {
-      description: 'The duration of the video in seconds.',
-      type: 'integer',
-      title: 'Duration',
-      default: 5,
-      minimum: 5,
-      maximum: 15
-    },
-    sync_mode: {
-      description: 'Return the generated video as base64 instead of a CDN URL.',
-      type: 'boolean',
-      title: 'Sync Mode',
-      default: false
-    },
-    reference_image_urls: {
-      maxItems: 9,
-      description: 'URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.',
-      type: 'array',
-      title: 'Reference Image URLs',
+    reference_video_urls: {
       items: {
         type: 'string',
         'x-fal-file-input': true
       },
-      examples: [
-        [
-          'https://storage.googleapis.com/falserverless/example_inputs/hailuo23/pro_i2v_in.jpg'
-        ]
-      ]
-    },
-    prompt: {
-      minLength: 1,
-      description: 'Text prompt for video generation. Refer to reference assets by their modality and order in the reference lists: Image 1, Image 2, Video 1, Audio 1, and so on.',
-      type: 'string',
-      title: 'Prompt',
-      examples: [
-        'Image 1 is the female protagonist. Image 2 is her small dog. Keep the woman and dog consistent with their respective reference images while they walk together through a sunlit garden.'
-      ],
-      maxLength: 50000
+      maxItems: 3,
+      type: 'array',
+      description: 'URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.',
+      title: 'Reference Video URLs'
     },
     prompt_expansion_mode: {
-      description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.',
-      type: 'string',
-      title: 'Prompt Expansion Mode',
-      default: 'balanced',
       examples: [
         'balanced',
         'quality'
-      ]
+      ],
+      default: 'balanced',
+      type: 'string',
+      description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.',
+      title: 'Prompt Expansion Mode'
+    },
+    reference_audio_urls: {
+      items: {
+        type: 'string',
+        'x-fal-file-input': true
+      },
+      maxItems: 3,
+      type: 'array',
+      description: 'URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.',
+      title: 'Reference Audio URLs'
+    },
+    duration: {
+      maximum: 15,
+      minimum: 5,
+      default: 5,
+      type: 'integer',
+      description: 'The duration of the video in seconds.',
+      title: 'Duration'
+    },
+    sync_mode: {
+      default: false,
+      type: 'boolean',
+      description: 'Return the generated video as base64 instead of a CDN URL.',
+      title: 'Sync Mode'
     },
     resolution: {
       enum: [
         '480P',
         '768P'
       ],
-      description: 'The native generation resolution of the video.',
+      default: '768P',
       type: 'string',
-      title: 'Resolution',
-      default: '768P'
+      description: 'The native generation resolution of the video.',
+      title: 'Resolution'
+    },
+    prompt: {
+      maxLength: 50000,
+      examples: [
+        'Image 1 is the female protagonist. Image 2 is her small dog. Keep the woman and dog consistent with their respective reference images while they walk together through a sunlit garden.'
+      ],
+      minLength: 1,
+      type: 'string',
+      description: 'Text prompt for video generation. Refer to reference assets by their modality and order in the reference lists: Image 1, Image 2, Video 1, Audio 1, and so on.',
+      title: 'Prompt'
+    },
+    reference_image_urls: {
+      examples: [
+        [
+          'https://storage.googleapis.com/falserverless/example_inputs/hailuo23/pro_i2v_in.jpg'
+        ]
+      ],
+      items: {
+        type: 'string',
+        'x-fal-file-input': true
+      },
+      maxItems: 9,
+      type: 'array',
+      description: 'URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.',
+      title: 'Reference Image URLs'
+    },
+    enable_safety_checker: {
+      default: true,
+      type: 'boolean',
+      description: 'If set to true, the safety checker will be enabled.',
+      title: 'Enable Safety Checker'
+    },
+    seed: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'Random seed. A random seed is selected when omitted.',
+      title: 'Seed'
     }
-  }
+  },
+  type: 'object',
+  title: 'TurboReferenceToVideoHailuo03Input'
 } as const;
 
 export const H3MaxReferenceToVideoOutputSchema = {
@@ -2273,12 +2635,8 @@ export const H3MaxReferenceToVideoOutputSchema = {
     'seed',
     'timings'
   ],
-  type: 'object',
-  title: 'TurboReferenceToVideoHailuo03Output',
   properties: {
     expanded_prompt: {
-      description: 'The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax\'s hosted API.',
-      title: 'Expanded Prompt',
       anyOf: [
         {
           type: 'string'
@@ -2286,20 +2644,15 @@ export const H3MaxReferenceToVideoOutputSchema = {
         {
           type: 'null'
         }
-      ]
-    },
-    seed: {
-      description: 'Base seed for reproducing the generation.',
-      type: 'integer',
-      title: 'Seed'
+      ],
+      description: 'The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax\'s hosted API.',
+      title: 'Expanded Prompt'
     },
     video: {
       $ref: '#/components/schemas/File',
       description: 'The generated video'
     },
     timings: {
-      description: 'Timing breakdown in seconds. \'inference\' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.',
-      title: 'Timings',
       anyOf: [
         {
           additionalProperties: {
@@ -2310,7 +2663,167 @@ export const H3MaxReferenceToVideoOutputSchema = {
         {
           type: 'null'
         }
-      ]
+      ],
+      description: 'Timing breakdown in seconds. \'inference\' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.',
+      title: 'Timings'
+    },
+    seed: {
+      type: 'integer',
+      description: 'Base seed for reproducing the generation.',
+      title: 'Seed'
     }
-  }
+  },
+  type: 'object',
+  title: 'TurboReferenceToVideoHailuo03Output'
+} as const;
+
+export const H3MaxTextToVideoInputSchema = {
+  required: [
+    'prompt',
+    'prompt_expansion_mode'
+  ],
+  'x-fal-order-properties': [
+    'prompt',
+    'duration',
+    'resolution',
+    'seed',
+    'enable_safety_checker',
+    'sync_mode',
+    'prompt_expansion_mode',
+    'aspect_ratio'
+  ],
+  properties: {
+    aspect_ratio: {
+      enum: [
+        '21:9',
+        '16:9',
+        '4:3',
+        '1:1',
+        '3:4',
+        '9:16'
+      ],
+      default: '16:9',
+      type: 'string',
+      description: 'The aspect ratio of the generated video.',
+      title: 'Aspect Ratio'
+    },
+    prompt_expansion_mode: {
+      examples: [
+        'balanced',
+        'quality'
+      ],
+      default: 'balanced',
+      type: 'string',
+      description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.',
+      title: 'Prompt Expansion Mode'
+    },
+    duration: {
+      maximum: 15,
+      minimum: 5,
+      default: 5,
+      type: 'integer',
+      description: 'The duration of the video in seconds.',
+      title: 'Duration'
+    },
+    sync_mode: {
+      default: false,
+      type: 'boolean',
+      description: 'Return the generated video as base64 instead of a CDN URL.',
+      title: 'Sync Mode'
+    },
+    resolution: {
+      enum: [
+        '480P',
+        '768P'
+      ],
+      default: '768P',
+      type: 'string',
+      description: 'The native generation resolution of the video.',
+      title: 'Resolution'
+    },
+    prompt: {
+      maxLength: 50000,
+      examples: [
+        'A white kitten chases a butterfly across a sunlit garden. Gentle camera tracking, natural movement, soft afternoon light filtering through the leaves.'
+      ],
+      minLength: 1,
+      type: 'string',
+      description: 'Text prompt for video generation',
+      title: 'Prompt'
+    },
+    enable_safety_checker: {
+      default: true,
+      type: 'boolean',
+      description: 'If set to true, the safety checker will be enabled.',
+      title: 'Enable Safety Checker'
+    },
+    seed: {
+      anyOf: [
+        {
+          type: 'integer'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'Random seed. A random seed is selected when omitted.',
+      title: 'Seed'
+    }
+  },
+  type: 'object',
+  title: 'TurboTextToVideoHailuo03Input'
+} as const;
+
+export const H3MaxTextToVideoOutputSchema = {
+  required: [
+    'video'
+  ],
+  'x-fal-order-properties': [
+    'video',
+    'expanded_prompt',
+    'timings'
+  ],
+  properties: {
+    expanded_prompt: {
+      anyOf: [
+        {
+          type: 'string'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax\'s hosted API.',
+      title: 'Expanded Prompt'
+    },
+    video: {
+      examples: [
+        {
+          content_type: 'video/mp4',
+          url: 'https://v3b.fal.media/files/b/0aa46818/--prs89fkHtWW406fmEs__NRhTqNku.mp4',
+          file_size: 6463396,
+          file_name: '--prs89fkHtWW406fmEs__NRhTqNku.mp4'
+        }
+      ],
+      $ref: '#/components/schemas/File',
+      description: 'The generated video'
+    },
+    timings: {
+      anyOf: [
+        {
+          additionalProperties: {
+            type: 'number'
+          },
+          type: 'object'
+        },
+        {
+          type: 'null'
+        }
+      ],
+      description: 'Timing breakdown in seconds. \'inference\' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.',
+      title: 'Timings'
+    }
+  },
+  type: 'object',
+  title: 'TurboTextToVideoHailuo03Output'
 } as const;

--- a/src/lib/motion/generated/types.gen.ts
+++ b/src/lib/motion/generated/types.gen.ts
@@ -7,36 +7,36 @@ export type ClientOptions = {
 export type QueueStatus = {
   status: 'IN_QUEUE' | 'IN_PROGRESS' | 'COMPLETED';
   /**
-     * The request id.
-     */
+   * The request id.
+   */
   request_id: string;
   /**
-     * The response url.
-     */
+   * The response url.
+   */
   response_url?: string;
   /**
-     * The status url.
-     */
+   * The status url.
+   */
   status_url?: string;
   /**
-     * The cancel url.
-     */
+   * The cancel url.
+   */
   cancel_url?: string;
   /**
-     * The logs.
-     */
+   * The logs.
+   */
   logs?: {
     [key: string]: unknown;
   };
   /**
-     * The metrics.
-     */
+   * The metrics.
+   */
   metrics?: {
     [key: string]: unknown;
   };
   /**
-     * The queue position.
-     */
+   * The queue position.
+   */
   queue_position?: number;
 };
 
@@ -50,28 +50,28 @@ export type QueueStatus = {
  */
 export type GrokImagineVideoV15ImageToVideoInput = {
   /**
-     * Image URL
-     *
-     * URL of the input image for video generation.
-     */
+   * Image URL
+   *
+   * URL of the input image for video generation.
+   */
   image_url: string | Blob | File;
   /**
-     * Resolution
-     *
-     * Resolution of the output video.
-     */
-  resolution?: '480p' | '720p' | '1080p';
-  /**
-     * Duration
-     *
-     * Video duration in seconds.
-     */
+   * Duration
+   *
+   * Video duration in seconds.
+   */
   duration?: number;
   /**
-     * Prompt
-     *
-     * Text description of desired changes or motion in the video.
-     */
+   * Resolution
+   *
+   * Resolution of the output video.
+   */
+  resolution?: '480p' | '720p' | '1080p';
+  /**
+   * Prompt
+   *
+   * Text description of desired changes or motion in the video.
+   */
   prompt: string;
 };
 
@@ -87,58 +87,58 @@ export type GrokImagineVideoV15ImageToVideoOutput = {
  */
 export type VideoFile = {
   /**
-     * Width
-     *
-     * The width of the video
-     */
-  width?: number | unknown;
-  /**
-     * Num Frames
-     *
-     * The number of frames in the video
-     */
-  num_frames?: number | unknown;
-  /**
-     * Fps
-     *
-     * The FPS of the video
-     */
-  fps?: number | unknown;
-  /**
-     * File Name
-     *
-     * The name of the file. It will be auto-generated if not provided.
-     */
-  file_name?: string | unknown;
-  /**
-     * Url
-     *
-     * The URL where the file can be downloaded from.
-     */
-  url: string;
-  /**
-     * Content Type
-     *
-     * The mime type of the file.
-     */
-  content_type?: string | unknown;
-  /**
-     * Height
-     *
-     * The height of the video
-     */
-  height?: number | unknown;
-  /**
-     * File Size
-     *
-     * The size of the file in bytes.
-     */
+   * File Size
+   *
+   * The size of the file in bytes.
+   */
   file_size?: number | unknown;
   /**
-     * Duration
-     *
-     * The duration of the video
-     */
+   * Width
+   *
+   * The width of the video
+   */
+  width?: number | unknown;
+  /**
+   * File Name
+   *
+   * The name of the file. It will be auto-generated if not provided.
+   */
+  file_name?: string | unknown;
+  /**
+   * Fps
+   *
+   * The FPS of the video
+   */
+  fps?: number | unknown;
+  /**
+   * Num Frames
+   *
+   * The number of frames in the video
+   */
+  num_frames?: number | unknown;
+  /**
+   * Height
+   *
+   * The height of the video
+   */
+  height?: number | unknown;
+  /**
+   * Url
+   *
+   * The URL where the file can be downloaded from.
+   */
+  url: string;
+  /**
+   * Content Type
+   *
+   * The mime type of the file.
+   */
+  content_type?: string | unknown;
+  /**
+   * Duration
+   *
+   * The duration of the video
+   */
   duration?: number | unknown;
 };
 
@@ -147,53 +147,53 @@ export type VideoFile = {
  */
 export type Ltx23ImageToVideoInput = {
   /**
-     * Resolution
-     *
-     * The resolution of the generated video
-     */
-  resolution?: '1080p' | '1440p' | '2160p';
-  /**
-     * Start Image URL
-     *
-     * The URL of the start image to use for the generated video.
-     */
+   * Start Image URL
+   *
+   * The URL of the start image to use for the generated video.
+   */
   image_url: string | Blob | File;
   /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image.
-     */
-  aspect_ratio?: 'auto' | '16:9' | '9:16';
-  /**
-     * End Image URL
-     *
-     * The URL of the end image to use for the generated video. When provided, generates a transition video between start and end frames.
-     */
+   * End Image URL
+   *
+   * The URL of the end image to use for the generated video. When provided, generates a transition video between start and end frames.
+   */
   end_image_url?: string | unknown;
   /**
-     * Duration
-     *
-     * The duration of the generated video in seconds
-     */
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. If 'auto', the aspect ratio will be determined automatically based on the input image.
+   */
+  aspect_ratio?: 'auto' | '16:9' | '9:16';
+  /**
+   * Frames per Second
+   *
+   * The frames per second of the generated video
+   */
+  fps?: 24 | 25 | 48 | 50;
+  /**
+   * Duration
+   *
+   * The duration of the generated video in seconds
+   */
   duration?: 6 | 8 | 10;
   /**
-     * Generate Audio
-     *
-     * Whether to generate audio for the generated video
-     */
+   * Generate Audio
+   *
+   * Whether to generate audio for the generated video
+   */
   generate_audio?: boolean;
   /**
-     * Prompt
-     *
-     * The prompt to use for the generated video
-     */
+   * Prompt
+   *
+   * The prompt to use for the generated video
+   */
   prompt: string;
   /**
-     * Frames per Second
-     *
-     * The frames per second of the generated video
-     */
-  fps?: 24 | 25 | 48 | 50;
+   * Resolution
+   *
+   * The resolution of the generated video
+   */
+  resolution?: '1080p' | '1440p' | '2160p';
 };
 
 /**
@@ -208,65 +208,65 @@ export type Ltx23ImageToVideoOutput = {
  */
 export type Veo31ImageToVideoInput = {
   /**
-     * Prompt
-     *
-     * The text prompt describing the video you want to generate
-     */
+   * Prompt
+   *
+   * The text prompt describing the video you want to generate
+   */
   prompt: string;
   /**
-     * Safety Tolerance
-     *
-     * The safety tolerance level for content moderation. 1 is the most strict (blocks most content), 6 is the least strict.
-     */
-  safety_tolerance?: '1' | '2' | '3' | '4' | '5' | '6';
-  /**
-     * Duration
-     *
-     * The duration of the generated video.
-     */
-  duration?: '4s' | '6s' | '8s';
-  /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video. Only 16:9 and 9:16 are supported.
-     */
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Only 16:9 and 9:16 are supported.
+   */
   aspect_ratio?: 'auto' | '16:9' | '9:16';
   /**
-     * Image URL
-     *
-     * URL of the input image to animate. Should be 720p or higher resolution in 16:9 or 9:16 aspect ratio. If the image is not in 16:9 or 9:16 aspect ratio, it will be cropped to fit.
-     */
-  image_url: string | Blob | File;
+   * Safety Tolerance
+   *
+   * The safety tolerance level for content moderation. 1 is the most strict (blocks most content), 6 is the least strict.
+   */
+  safety_tolerance?: '1' | '2' | '3' | '4' | '5' | '6';
   /**
-     * Negative Prompt
-     *
-     * A negative prompt to guide the video generation.
-     */
+   * Auto Fix
+   *
+   * Whether to automatically attempt to fix prompts that fail content policy or other validation checks by rewriting them.
+   */
+  auto_fix?: boolean;
+  /**
+   * Negative Prompt
+   *
+   * A negative prompt to guide the video generation.
+   */
   negative_prompt?: string | unknown;
   /**
-     * Generate Audio
-     *
-     * Whether to generate audio for the video.
-     */
+   * Generate Audio
+   *
+   * Whether to generate audio for the video.
+   */
   generate_audio?: boolean;
   /**
-     * Seed
-     *
-     * The seed for the random number generator.
-     */
-  seed?: number | unknown;
+   * Image URL
+   *
+   * URL of the input image to animate. Should be 720p or higher resolution in 16:9 or 9:16 aspect ratio. If the image is not in 16:9 or 9:16 aspect ratio, it will be cropped to fit.
+   */
+  image_url: string | Blob | File;
   /**
-     * Resolution
-     *
-     * The resolution of the generated video.
-     */
+   * Resolution
+   *
+   * The resolution of the generated video.
+   */
   resolution?: '720p' | '1080p' | '4k';
   /**
-     * Auto Fix
-     *
-     * Whether to automatically attempt to fix prompts that fail content policy or other validation checks by rewriting them.
-     */
-  auto_fix?: boolean;
+   * Seed
+   *
+   * The seed for the random number generator.
+   */
+  seed?: number | unknown;
+  /**
+   * Duration
+   *
+   * The duration of the generated video.
+   */
+  duration?: '4s' | '6s' | '8s';
 };
 
 /**
@@ -281,29 +281,29 @@ export type Veo31ImageToVideoOutput = {
  */
 export type File = {
   /**
-     * File Name
-     *
-     * The name of the file. It will be auto-generated if not provided.
-     */
+   * File Name
+   *
+   * The name of the file. It will be auto-generated if not provided.
+   */
   file_name?: string | unknown;
   /**
-     * Url
-     *
-     * The URL where the file can be downloaded from.
-     */
+   * Content Type
+   *
+   * The mime type of the file.
+   */
+  content_type?: string | unknown;
+  /**
+   * Url
+   *
+   * The URL where the file can be downloaded from.
+   */
   url: string;
   /**
-     * File Size
-     *
-     * The size of the file in bytes.
-     */
+   * File Size
+   *
+   * The size of the file in bytes.
+   */
   file_size?: number | unknown;
-  /**
-     * Content Type
-     *
-     * The mime type of the file.
-     */
-  content_type?: string | unknown;
 };
 
 /**
@@ -311,41 +311,41 @@ export type File = {
  */
 export type GeminiOmni11FlashImageToVideoInput = {
   /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video.
-     */
-  aspect_ratio?: '16:9' | '9:16';
-  /**
-     * Image URL
-     *
-     * URL of the first frame to animate.
-     */
-  image_url: string | Blob | File;
-  /**
-     * Resolution
-     *
-     * The resolution of the generated video.
-     */
-  resolution?: '360p' | '720p' | '1080p' | '4k';
-  /**
-     * Prompt
-     *
-     * The text prompt describing how the first image should be animated or interpolated into the optional end image.
-     */
-  prompt: string;
-  /**
-     * Duration
-     *
-     * The duration of the generated video, in seconds.
-     */
+   * Duration
+   *
+   * The duration of the generated video, in seconds.
+   */
   duration?: number;
   /**
-     * End Image URL
-     *
-     * Optional URL of the end frame. When provided, the model interpolates between the two images in their listed order.
-     */
+   * Resolution
+   *
+   * The resolution of the generated video.
+   */
+  resolution?: '360p' | '720p' | '1080p' | '4k';
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video.
+   */
+  aspect_ratio?: '16:9' | '9:16';
+  /**
+   * End Image URL
+   *
+   * Optional URL of the end frame. When provided, the model interpolates between the two images in their listed order.
+   */
   end_image_url?: string | unknown;
+  /**
+   * Image URL
+   *
+   * URL of the first frame to animate.
+   */
+  image_url: string | Blob | File;
+  /**
+   * Prompt
+   *
+   * The text prompt describing how the first image should be animated or interpolated into the optional end image.
+   */
+  prompt: string;
 };
 
 /**
@@ -360,66 +360,66 @@ export type GeminiOmni11FlashImageToVideoOutput = {
  */
 export type KlingVideoV3ProImageToVideoInput = {
   /**
-     * Cfg Scale
-     *
-     *
-     * The CFG (Classifier Free Guidance) scale is a measure of how close you want
-     * the model to stick to your prompt.
-     *
-     */
-  cfg_scale?: number;
-  /**
-     * Elements
-     *
-     * Elements (characters/objects) to include in the video. Each example can either be an image set (frontal + reference images) or a video. Reference in prompt as @Element1, @Element2, etc.
-     */
-  elements?: Array<KlingV3ComboElementInput> | unknown;
-  /**
-     * Start Image Url
-     *
-     * URL of the image to be used for the video
-     */
-  start_image_url: string | Blob | File;
-  /**
-     * End Image Url
-     *
-     * URL of the image to be used for the end of the video
-     */
-  end_image_url?: string | unknown;
-  /**
-     * Prompt
-     *
-     * Text prompt for video generation. Either prompt or multi_prompt must be provided, but not both.
-     */
+   * Prompt
+   *
+   * Text prompt for video generation. Either prompt or multi_prompt must be provided, but not both.
+   */
   prompt?: string | unknown;
   /**
-     * Generate Audio
-     *
-     * Whether to generate native audio for the video. Supports Chinese and English voice output. Other languages are automatically translated to English. For English speech, use lowercase letters; for acronyms or proper nouns, use uppercase.
-     */
+   * Start Image Url
+   *
+   * URL of the image to be used for the video
+   */
+  start_image_url: string | Blob | File;
+  /**
+   * Generate Audio
+   *
+   * Whether to generate native audio for the video. Supports Chinese and English voice output. Other languages are automatically translated to English. For English speech, use lowercase letters; for acronyms or proper nouns, use uppercase.
+   */
   generate_audio?: boolean;
   /**
-     * Multi Prompt
-     *
-     * List of prompts for multi-shot video generation. If provided, divides the video into multiple shots.
-     */
-  multi_prompt?: Array<KlingV3MultiPromptElement> | unknown;
+   * Duration
+   *
+   * The duration of the generated video in seconds
+   */
+  duration?: '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
   /**
-     * Shot Type
-     *
-     * The type of multi-shot video generation. 'intelligent' lets the model automatically determine shot structure.
-     */
+   * Cfg Scale
+   *
+   *
+   *             The CFG (Classifier Free Guidance) scale is a measure of how close you want
+   *             the model to stick to your prompt.
+   *
+   */
+  cfg_scale?: number;
+  /**
+   * Elements
+   *
+   * Elements (characters/objects) to include in the video. Each example can either be an image set (frontal + reference images) or a video. Reference in prompt as @Element1, @Element2, etc.
+   */
+  elements?: Array<KlingV3ComboElementInput> | unknown;
+  /**
+   * Shot Type
+   *
+   * The type of multi-shot video generation. 'intelligent' lets the model automatically determine shot structure.
+   */
   shot_type?: 'customize' | 'intelligent';
   /**
-     * Negative Prompt
-     */
-  negative_prompt?: string;
+   * Multi Prompt
+   *
+   * List of prompts for multi-shot video generation. If provided, divides the video into multiple shots.
+   */
+  multi_prompt?: Array<KlingV3MultiPromptElement> | unknown;
   /**
-     * Duration
-     *
-     * The duration of the generated video in seconds
-     */
-  duration?: '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
+   * End Image Url
+   *
+   * URL of the image to be used for the end of the video
+   */
+  end_image_url?: string | unknown;
+  /**
+   * Negative Prompt
+   */
+  negative_prompt?: string;
 };
 
 /**
@@ -434,29 +434,29 @@ export type KlingVideoV3ProImageToVideoOutput = {
  */
 export type KlingV3ComboElementInput = {
   /**
-     * Reference Image Urls
-     *
-     * Additional reference images from different angles. 1-3 images supported. At least one image is required.
-     */
-  reference_image_urls?: Array<string> | unknown;
+   * Voice Id
+   *
+   * The voice ID for this element. The voice will be binded to the element and references to this element will use the binded voice. Get voice IDs from the following endpoint: https://fal.ai/models/fal-ai/kling-video/create-voice
+   */
+  voice_id?: string | unknown;
   /**
-     * Frontal Image Url
-     *
-     * The frontal image of the element (main view).
-     */
-  frontal_image_url?: string | unknown;
-  /**
-     * Video Url
-     *
-     * The video URL of the element. A request can only have one element with a video.
-     */
+   * Video Url
+   *
+   * The video URL of the element. A request can only have one element with a video.
+   */
   video_url?: string | unknown;
   /**
-     * Voice Id
-     *
-     * The voice ID for this element. The voice will be binded to the element and references to this element will use the binded voice. Get voice IDs from the following endpoint: https://fal.ai/models/fal-ai/kling-video/create-voice
-     */
-  voice_id?: string | unknown;
+   * Reference Image Urls
+   *
+   * Additional reference images from different angles. 1-3 images supported. At least one image is required.
+   */
+  reference_image_urls?: Array<string> | unknown;
+  /**
+   * Frontal Image Url
+   *
+   * The frontal image of the element (main view).
+   */
+  frontal_image_url?: string | unknown;
 };
 
 /**
@@ -464,16 +464,16 @@ export type KlingV3ComboElementInput = {
  */
 export type KlingV3MultiPromptElement = {
   /**
-     * Prompt
-     *
-     * The prompt for this shot.
-     */
+   * Prompt
+   *
+   * The prompt for this shot.
+   */
   prompt: string;
   /**
-     * Duration
-     *
-     * The duration of this shot in seconds
-     */
+   * Duration
+   *
+   * The duration of this shot in seconds
+   */
   duration?: '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
 };
 
@@ -482,23 +482,23 @@ export type KlingV3MultiPromptElement = {
  */
 export type MinimaxHailuo23ProImageToVideoInput = {
   /**
-     * Image Url
-     *
-     * URL of the image to use as the first frame
-     */
+   * Image Url
+   *
+   * URL of the image to use as the first frame
+   */
   image_url: string | Blob | File;
   /**
-     * Prompt
-     *
-     * Text prompt for video generation
-     */
-  prompt: string;
-  /**
-     * Prompt Optimizer
-     *
-     * Whether to use the model's prompt optimizer
-     */
+   * Prompt Optimizer
+   *
+   * Whether to use the model's prompt optimizer
+   */
   prompt_optimizer?: boolean;
+  /**
+   * Prompt
+   *
+   * Text prompt for video generation
+   */
+  prompt: string;
 };
 
 /**
@@ -513,59 +513,59 @@ export type MinimaxHailuo23ProImageToVideoOutput = {
  */
 export type H3MaxImageToVideoInput = {
   /**
-     * End Image URL
-     *
-     * Optional URL of the image to use as the last frame, for first-to-last keyframe generation.
-     */
-  end_image_url?: string | unknown;
-  /**
-     * Prompt
-     *
-     * Text prompt for video generation
-     */
-  prompt: string;
-  /**
-     * Seed
-     *
-     * Random seed. A random seed is selected when omitted.
-     */
-  seed?: number | unknown;
-  /**
-     * Enable Safety Checker
-     *
-     * If set to true, the safety checker will be enabled.
-     */
-  enable_safety_checker?: boolean;
-  /**
-     * Duration
-     *
-     * The duration of the video in seconds.
-     */
-  duration?: number;
-  /**
-     * Sync Mode
-     *
-     * Return the generated video as base64 instead of a CDN URL.
-     */
-  sync_mode?: boolean;
-  /**
-     * Image URL
-     *
-     * Optional URL of the image to use as the first frame. When provided, the output aspect ratio follows this image. When omitted, the request is handled as text-to-video (16:9 by default).
-     */
-  image_url?: string | unknown;
-  /**
-     * Prompt Expansion Mode
-     *
-     * How much effort to spend rewriting the prompt before generation. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.
-     */
+   * Prompt Expansion Mode
+   *
+   * How much effort to spend rewriting the prompt before generation. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.
+   */
   prompt_expansion_mode: string;
   /**
-     * Resolution
-     *
-     * The native generation resolution of the video.
-     */
+   * End Image URL
+   *
+   * Optional URL of the image to use as the last frame. It may be provided alone for end-only keyframe generation; in that case the output canvas follows this image.
+   */
+  end_image_url?: string | unknown;
+  /**
+   * Duration
+   *
+   * The duration of the video in seconds.
+   */
+  duration?: number;
+  /**
+   * Sync Mode
+   *
+   * Return the generated video as base64 instead of a CDN URL.
+   */
+  sync_mode?: boolean;
+  /**
+   * Resolution
+   *
+   * The native generation resolution of the video.
+   */
   resolution?: '480P' | '768P';
+  /**
+   * Prompt
+   *
+   * Text prompt for video generation
+   */
+  prompt: string;
+  /**
+   * Image URL
+   *
+   * Optional URL of the image to use as the first frame. When provided, the output canvas follows this image. If only end_image_url is provided, the canvas follows that last frame instead. If both images are omitted, the request is handled as text-to-video (16:9 by default).
+   */
+  image_url?: string | unknown;
+  /**
+   * Enable Safety Checker
+   *
+   * If set to true, the safety checker will be enabled.
+   */
+  enable_safety_checker?: boolean;
+  /**
+   * Seed
+   *
+   * Random seed. A random seed is selected when omitted.
+   */
+  seed?: number | unknown;
 };
 
 /**
@@ -573,17 +573,17 @@ export type H3MaxImageToVideoInput = {
  */
 export type H3MaxImageToVideoOutput = {
   /**
-     * Expanded Prompt
-     *
-     * The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.
-     */
+   * Expanded Prompt
+   *
+   * The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.
+   */
   expanded_prompt?: string | unknown;
   video: File;
   /**
-     * Timings
-     *
-     * Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.
-     */
+   * Timings
+   *
+   * Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.
+   */
   timings?: {
     [key: string]: number;
   } | unknown;
@@ -594,72 +594,72 @@ export type H3MaxImageToVideoOutput = {
  */
 export type Seedance20EnterpriseV2ImageToVideoInput = {
   /**
-     * End Image Url
-     *
-     * The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.
-     */
-  end_image_url?: string | unknown;
+   * End User Id
+   *
+   * The unique user ID of the end user.
+   */
+  end_user_id?: string | unknown;
   /**
-     * Prompt
-     *
-     * The text prompt describing the desired motion and action for the video.
-     */
+   * Prompt
+   *
+   * The text prompt describing the desired motion and action for the video.
+   */
   prompt: string;
   /**
-     * Generate Audio
-     *
-     * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
-     */
-  generate_audio?: boolean;
+   * End Image Url
+   *
+   * The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.
+   */
+  end_image_url?: string | unknown;
   /**
-     * Bitrate Mode
-     *
-     * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
-     */
+   * Bitrate Mode
+   *
+   * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
+   */
   bitrate_mode?: 'standard' | 'high';
   /**
-     * Image Url
-     *
-     * The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.
-     */
+   * Image Url
+   *
+   * The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.
+   */
   image_url: string | Blob | File;
   /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to infer from the input image.
-     */
-  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
-  /**
-     * Duration
-     *
-     * Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.
-     */
-  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
-  /**
-     * Resolution
-     *
-     * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.
-     */
+   * Resolution
+   *
+   * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.
+   */
   resolution?: '480p' | '720p' | '1080p' | '4k';
   /**
-     * End User Id
-     *
-     * The unique user ID of the end user.
-     */
-  end_user_id?: string | unknown;
+   * Generate Audio
+   *
+   * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
+   */
+  generate_audio?: boolean;
+  /**
+   * Duration
+   *
+   * Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.
+   */
+  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to infer from the input image.
+   */
+  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
 };
 
 /**
  * Seedance2VideoOutput
  */
 export type Seedance20EnterpriseV2ImageToVideoOutput = {
-  video: File;
   /**
-     * Seed
-     *
-     * The seed used for generation.
-     */
+   * Seed
+   *
+   * The seed used for generation.
+   */
   seed: number;
+  video: File;
 };
 
 /**
@@ -667,58 +667,58 @@ export type Seedance20EnterpriseV2ImageToVideoOutput = {
  */
 export type Seedance25ImageToVideoInput = {
   /**
-     * End Image Url
-     *
-     * The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.
-     */
-  end_image_url?: string | unknown;
-  /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video. Always "auto" for image-to-video
-     */
-  aspect_ratio?: string;
-  /**
-     * Prompt
-     *
-     * The text prompt describing the desired motion and action for the video.
-     */
-  prompt: string;
-  /**
-     * Duration
-     *
-     * Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.
-     */
-  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19' | '20' | '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '30';
-  /**
-     * Image Url
-     *
-     * The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.
-     */
+   * Image Url
+   *
+   * The URL of the starting frame image to animate. Supported formats: JPEG, PNG, WebP. Max 30 MB.
+   */
   image_url: string | Blob | File;
   /**
-     * Bitrate Mode
-     *
-     * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
-     */
-  bitrate_mode?: 'standard' | 'high';
+   * End Image Url
+   *
+   * The URL of the image to use as the last frame of the video. When provided, the generated video will transition from the starting image to this ending image. Supported formats: JPEG, PNG, WebP. Max 30 MB.
+   */
+  end_image_url?: string | unknown;
   /**
-     * Generate Audio
-     *
-     * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
-     */
-  generate_audio?: boolean;
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Always "auto" for image-to-video
+   */
+  aspect_ratio?: string;
   /**
-     * End User Id
-     *
-     * The unique user ID of the end user.
-     */
+   * End User Id
+   *
+   * The unique user ID of the end user.
+   */
   end_user_id?: string | unknown;
   /**
-     * Resolution
-     *
-     * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.
-     */
+   * Bitrate Mode
+   *
+   * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
+   */
+  bitrate_mode?: 'standard' | 'high';
+  /**
+   * Duration
+   *
+   * Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.
+   */
+  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19' | '20' | '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '30';
+  /**
+   * Generate Audio
+   *
+   * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
+   */
+  generate_audio?: boolean;
+  /**
+   * Prompt
+   *
+   * The text prompt describing the desired motion and action for the video.
+   */
+  prompt: string;
+  /**
+   * Resolution
+   *
+   * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.
+   */
   resolution?: '480p' | '720p' | '1080p';
 };
 
@@ -727,10 +727,10 @@ export type Seedance25ImageToVideoInput = {
  */
 export type Seedance25ImageToVideoOutput = {
   /**
-     * Seed
-     *
-     * The seed used for generation.
-     */
+   * Seed
+   *
+   * The seed used for generation.
+   */
   seed: number;
   video: File;
 };
@@ -740,78 +740,139 @@ export type Seedance25ImageToVideoOutput = {
  */
 export type Seedance20EnterpriseV2ReferenceToVideoInput = {
   /**
-     * Duration
-     *
-     * Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.
-     */
-  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
+   * End User Id
+   *
+   * The unique user ID of the end user.
+   */
+  end_user_id?: string | unknown;
   /**
-     * Audio Urls
-     *
-     * Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file. At least one reference image or video is required.
-     */
-  audio_urls?: Array<string>;
-  /**
-     * Prompt
-     *
-     * The text prompt used to generate the video.
-     */
+   * Prompt
+   *
+   * The text prompt used to generate the video.
+   */
   prompt: string;
   /**
-     * Generate Audio
-     *
-     * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
-     */
-  generate_audio?: boolean;
+   * Audio Urls
+   *
+   * Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file. At least one reference image or video is required.
+   */
+  audio_urls?: Array<string>;
   /**
-     * Bitrate Mode
-     *
-     * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
-     */
+   * Bitrate Mode
+   *
+   * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
+   */
   bitrate_mode?: 'standard' | 'high';
   /**
-     * Video Urls
-     *
-     * Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.
-     */
+   * Video Urls
+   *
+   * Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.
+   */
   video_urls?: Array<string>;
   /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.
-     */
-  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
-  /**
-     * Image Urls
-     *
-     * Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPEG, PNG, WebP. Max 30 MB per image. Up to 9 images. Total files across all modalities must not exceed 12.
-     */
-  image_urls?: Array<string>;
-  /**
-     * Resolution
-     *
-     * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.
-     */
+   * Resolution
+   *
+   * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.
+   */
   resolution?: '480p' | '720p' | '1080p' | '4k';
   /**
-     * End User Id
-     *
-     * The unique user ID of the end user.
-     */
-  end_user_id?: string | unknown;
+   * Image Urls
+   *
+   * Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPEG, PNG, WebP. Max 30 MB per image. Up to 9 images. Total files across all modalities must not exceed 12.
+   */
+  image_urls?: Array<string>;
+  /**
+   * Generate Audio
+   *
+   * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
+   */
+  generate_audio?: boolean;
+  /**
+   * Duration
+   *
+   * Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.
+   */
+  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.
+   */
+  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
 };
 
 /**
  * Seedance2VideoOutput
  */
 export type Seedance20EnterpriseV2ReferenceToVideoOutput = {
-  video: File;
   /**
-     * Seed
-     *
-     * The seed used for generation.
-     */
+   * Seed
+   *
+   * The seed used for generation.
+   */
   seed: number;
+  video: File;
+};
+
+/**
+ * Seedance2T2VInput
+ */
+export type Seedance20EnterpriseV2TextToVideoInput = {
+  /**
+   * Resolution
+   *
+   * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.
+   */
+  resolution?: '480p' | '720p' | '1080p' | '4k';
+  /**
+   * End User Id
+   *
+   * The unique user ID of the end user.
+   */
+  end_user_id?: string | unknown;
+  /**
+   * Generate Audio
+   *
+   * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
+   */
+  generate_audio?: boolean;
+  /**
+   * Duration
+   *
+   * Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.
+   */
+  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15';
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.
+   */
+  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
+  /**
+   * Bitrate Mode
+   *
+   * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
+   */
+  bitrate_mode?: 'standard' | 'high';
+  /**
+   * Prompt
+   *
+   * The text prompt used to generate the video
+   */
+  prompt: string;
+};
+
+/**
+ * Seedance2VideoOutput
+ */
+export type Seedance20EnterpriseV2TextToVideoOutput = {
+  /**
+   * Seed
+   *
+   * The seed used for generation.
+   */
+  seed: number;
+  video: File;
 };
 
 /**
@@ -819,65 +880,65 @@ export type Seedance20EnterpriseV2ReferenceToVideoOutput = {
  */
 export type Seedance25ReferenceToVideoInput = {
   /**
-     * Prompt
-     *
-     * The text prompt used to generate the video.
-     */
-  prompt: string;
-  /**
-     * Video Urls
-     *
-     * Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 10 videos. Each video must be 1.8 to 30.2 seconds and no larger than 200 MB; combined duration must not exceed 30.2 seconds. Dimensions must be 300 to 6,000 pixels per side, aspect ratio 0.4 to 2.5, and frame rate 24 to 60 FPS.
-     */
+   * Video Urls
+   *
+   * Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 10 videos. Each video must be 1.8 to 30.2 seconds and no larger than 200 MB; combined duration must not exceed 30.2 seconds. Dimensions must be 300 to 6,000 pixels per side, aspect ratio 0.4 to 2.5, and frame rate 24 to 60 FPS.
+   */
   video_urls?: Array<string>;
   /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.
-     */
-  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
-  /**
-     * Duration
-     *
-     * Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.
-     */
-  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19' | '20' | '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '30';
-  /**
-     * Audio Urls
-     *
-     * Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. At least one reference image or video is required.
-     */
+   * Audio Urls
+   *
+   * Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. At least one reference image or video is required.
+   */
   audio_urls?: Array<string>;
   /**
-     * Bitrate Mode
-     *
-     * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
-     */
-  bitrate_mode?: 'standard' | 'high';
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.
+   */
+  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
   /**
-     * Image Urls
-     *
-     * Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.
-     */
+   * Image Urls
+   *
+   * Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.
+   */
   image_urls?: Array<string>;
   /**
-     * Generate Audio
-     *
-     * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
-     */
-  generate_audio?: boolean;
-  /**
-     * End User Id
-     *
-     * The unique user ID of the end user.
-     */
+   * End User Id
+   *
+   * The unique user ID of the end user.
+   */
   end_user_id?: string | unknown;
   /**
-     * Resolution
-     *
-     * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.
-     */
+   * Bitrate Mode
+   *
+   * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
+   */
+  bitrate_mode?: 'standard' | 'high';
+  /**
+   * Duration
+   *
+   * Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.
+   */
+  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19' | '20' | '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '30';
+  /**
+   * Resolution
+   *
+   * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.
+   */
   resolution?: '480p' | '720p' | '1080p';
+  /**
+   * Prompt
+   *
+   * The text prompt used to generate the video.
+   */
+  prompt: string;
+  /**
+   * Generate Audio
+   *
+   * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
+   */
+  generate_audio?: boolean;
 };
 
 /**
@@ -885,10 +946,71 @@ export type Seedance25ReferenceToVideoInput = {
  */
 export type Seedance25ReferenceToVideoOutput = {
   /**
-     * Seed
-     *
-     * The seed used for generation.
-     */
+   * Seed
+   *
+   * The seed used for generation.
+   */
+  seed: number;
+  video: File;
+};
+
+/**
+ * Seedance2T2VInput
+ */
+export type Seedance25TextToVideoInput = {
+  /**
+   * Generate Audio
+   *
+   * Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.
+   */
+  generate_audio?: boolean;
+  /**
+   * End User Id
+   *
+   * The unique user ID of the end user.
+   */
+  end_user_id?: string | unknown;
+  /**
+   * Bitrate Mode
+   *
+   * Output bitrate mode. 'high' requests a higher-quality, larger-file encode from the model; 'standard' uses the default bitrate.
+   */
+  bitrate_mode?: 'standard' | 'high';
+  /**
+   * Duration
+   *
+   * Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.
+   */
+  duration?: 'auto' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11' | '12' | '13' | '14' | '15' | '16' | '17' | '18' | '19' | '20' | '21' | '22' | '23' | '24' | '25' | '26' | '27' | '28' | '29' | '30';
+  /**
+   * Resolution
+   *
+   * Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.
+   */
+  resolution?: '480p' | '720p' | '1080p';
+  /**
+   * Prompt
+   *
+   * The text prompt used to generate the video
+   */
+  prompt: string;
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.
+   */
+  aspect_ratio?: 'auto' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
+};
+
+/**
+ * Seedance2VideoOutput
+ */
+export type Seedance25TextToVideoOutput = {
+  /**
+   * Seed
+   *
+   * The seed used for generation.
+   */
   seed: number;
   video: File;
 };
@@ -898,41 +1020,41 @@ export type Seedance25ReferenceToVideoOutput = {
  */
 export type GeminiOmni11FlashReferenceToVideoInput = {
   /**
-     * Duration
-     *
-     * The duration of the generated video, in seconds.
-     */
-  duration?: number;
+   * Reference Video URLs
+   *
+   * URLs of up to three reference videos. Each video must be at most three seconds long.
+   */
+  reference_video_urls?: Array<string>;
   /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video.
-     */
-  aspect_ratio?: '16:9' | '9:16';
-  /**
-     * Resolution
-     *
-     * The resolution of the generated video.
-     */
+   * Resolution
+   *
+   * The resolution of the generated video.
+   */
   resolution?: '360p' | '720p' | '1080p' | '4k';
   /**
-     * Image URLs
-     *
-     * URLs of reference images to incorporate into the video.
-     */
+   * Duration
+   *
+   * The duration of the generated video, in seconds.
+   */
+  duration?: number;
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video.
+   */
+  aspect_ratio?: '16:9' | '9:16';
+  /**
+   * Image URLs
+   *
+   * URLs of reference images to incorporate into the video.
+   */
   image_urls?: Array<string>;
   /**
-     * Prompt
-     *
-     * The text prompt describing the video. Reference media is sent in list order before the prompt.
-     */
+   * Prompt
+   *
+   * The text prompt describing the video. Reference media is sent in list order before the prompt.
+   */
   prompt: string;
-  /**
-     * Reference Video URLs
-     *
-     * URLs of up to three reference videos. Each video must be at most three seconds long.
-     */
-  reference_video_urls?: Array<string>;
 };
 
 /**
@@ -943,75 +1065,112 @@ export type GeminiOmni11FlashReferenceToVideoOutput = {
 };
 
 /**
+ * Omni11FlashTextToVideoInput
+ */
+export type GeminiOmni11FlashInput = {
+  /**
+   * Duration
+   *
+   * The duration of the generated video, in seconds.
+   */
+  duration?: number;
+  /**
+   * Resolution
+   *
+   * The resolution of the generated video.
+   */
+  resolution?: '360p' | '720p' | '1080p' | '4k';
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video.
+   */
+  aspect_ratio?: '16:9' | '9:16';
+  /**
+   * Prompt
+   *
+   * The text prompt describing the video you want to generate.
+   */
+  prompt: string;
+};
+
+/**
+ * VideoOutput
+ */
+export type GeminiOmni11FlashOutput = {
+  video: File;
+};
+
+/**
  * TurboReferenceToVideoHailuo03Input
  */
 export type H3MaxReferenceToVideoInput = {
   /**
-     * Reference Video URLs
-     *
-     * URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.
-     */
-  reference_video_urls?: Array<string>;
-  /**
-     * Reference Audio URLs
-     *
-     * URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.
-     */
-  reference_audio_urls?: Array<string>;
-  /**
-     * Seed
-     *
-     * Random seed. A random seed is selected when omitted.
-     */
-  seed?: number | unknown;
-  /**
-     * Enable Safety Checker
-     *
-     * If set to true, the safety checker will be enabled.
-     */
-  enable_safety_checker?: boolean;
-  /**
-     * Aspect Ratio
-     *
-     * The aspect ratio of the generated video.
-     */
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video.
+   */
   aspect_ratio?: 'adaptive' | '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
   /**
-     * Duration
-     *
-     * The duration of the video in seconds.
-     */
-  duration?: number;
+   * Reference Video URLs
+   *
+   * URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.
+   */
+  reference_video_urls?: Array<string>;
   /**
-     * Sync Mode
-     *
-     * Return the generated video as base64 instead of a CDN URL.
-     */
-  sync_mode?: boolean;
-  /**
-     * Reference Image URLs
-     *
-     * URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.
-     */
-  reference_image_urls?: Array<string>;
-  /**
-     * Prompt
-     *
-     * Text prompt for video generation. Refer to reference assets by their modality and order in the reference lists: Image 1, Image 2, Video 1, Audio 1, and so on.
-     */
-  prompt: string;
-  /**
-     * Prompt Expansion Mode
-     *
-     * How much effort to spend rewriting the prompt before generation. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.
-     */
+   * Prompt Expansion Mode
+   *
+   * How much effort to spend rewriting the prompt before generation. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.
+   */
   prompt_expansion_mode: string;
   /**
-     * Resolution
-     *
-     * The native generation resolution of the video.
-     */
+   * Reference Audio URLs
+   *
+   * URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.
+   */
+  reference_audio_urls?: Array<string>;
+  /**
+   * Duration
+   *
+   * The duration of the video in seconds.
+   */
+  duration?: number;
+  /**
+   * Sync Mode
+   *
+   * Return the generated video as base64 instead of a CDN URL.
+   */
+  sync_mode?: boolean;
+  /**
+   * Resolution
+   *
+   * The native generation resolution of the video.
+   */
   resolution?: '480P' | '768P';
+  /**
+   * Prompt
+   *
+   * Text prompt for video generation. Refer to reference assets by their modality and order in the reference lists: Image 1, Image 2, Video 1, Audio 1, and so on.
+   */
+  prompt: string;
+  /**
+   * Reference Image URLs
+   *
+   * URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.
+   */
+  reference_image_urls?: Array<string>;
+  /**
+   * Enable Safety Checker
+   *
+   * If set to true, the safety checker will be enabled.
+   */
+  enable_safety_checker?: boolean;
+  /**
+   * Seed
+   *
+   * Random seed. A random seed is selected when omitted.
+   */
+  seed?: number | unknown;
 };
 
 /**
@@ -1019,23 +1178,98 @@ export type H3MaxReferenceToVideoInput = {
  */
 export type H3MaxReferenceToVideoOutput = {
   /**
-     * Expanded Prompt
-     *
-     * The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.
-     */
+   * Expanded Prompt
+   *
+   * The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.
+   */
   expanded_prompt?: string | unknown;
-  /**
-     * Seed
-     *
-     * Base seed for reproducing the generation.
-     */
-  seed: number;
   video: File;
   /**
-     * Timings
-     *
-     * Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.
-     */
+   * Timings
+   *
+   * Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.
+   */
+  timings?: {
+    [key: string]: number;
+  } | unknown;
+  /**
+   * Seed
+   *
+   * Base seed for reproducing the generation.
+   */
+  seed: number;
+};
+
+/**
+ * TurboTextToVideoHailuo03Input
+ */
+export type H3MaxTextToVideoInput = {
+  /**
+   * Aspect Ratio
+   *
+   * The aspect ratio of the generated video.
+   */
+  aspect_ratio?: '21:9' | '16:9' | '4:3' | '1:1' | '3:4' | '9:16';
+  /**
+   * Prompt Expansion Mode
+   *
+   * How much effort to spend rewriting the prompt before generation. 'balanced' returns in about a second. 'quality' spends up to ~30s on a richer prompt.
+   */
+  prompt_expansion_mode: string;
+  /**
+   * Duration
+   *
+   * The duration of the video in seconds.
+   */
+  duration?: number;
+  /**
+   * Sync Mode
+   *
+   * Return the generated video as base64 instead of a CDN URL.
+   */
+  sync_mode?: boolean;
+  /**
+   * Resolution
+   *
+   * The native generation resolution of the video.
+   */
+  resolution?: '480P' | '768P';
+  /**
+   * Prompt
+   *
+   * Text prompt for video generation
+   */
+  prompt: string;
+  /**
+   * Enable Safety Checker
+   *
+   * If set to true, the safety checker will be enabled.
+   */
+  enable_safety_checker?: boolean;
+  /**
+   * Seed
+   *
+   * Random seed. A random seed is selected when omitted.
+   */
+  seed?: number | unknown;
+};
+
+/**
+ * TurboTextToVideoHailuo03Output
+ */
+export type H3MaxTextToVideoOutput = {
+  /**
+   * Expanded Prompt
+   *
+   * The prompt after expansion, as sent to the model. Null when prompt expansion was disabled, left the prompt unchanged, or was performed internally by MiniMax's hosted API.
+   */
+  expanded_prompt?: string | unknown;
+  video: File;
+  /**
+   * Timings
+   *
+   * Timing breakdown in seconds. 'inference' is the DiT denoising time on the GPU backend. Null on routes that do not report backend timings.
+   */
   timings?: {
     [key: string]: number;
   } | unknown;
@@ -1045,14 +1279,14 @@ export type GetXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdStatusData =
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/xai/grok-imagine-video/v1.5/image-to-video/requests/{request_id}/status';
@@ -1060,8 +1294,8 @@ export type GetXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdStatusData =
 
 export type GetXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1071,8 +1305,8 @@ export type PutXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdCancelData =
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1081,12 +1315,12 @@ export type PutXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdCancelData =
 
 export type PutXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1102,8 +1336,8 @@ export type PostXaiGrokImagineVideoV15ImageToVideoData = {
 
 export type PostXaiGrokImagineVideoV15ImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1113,8 +1347,8 @@ export type GetXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1123,8 +1357,8 @@ export type GetXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdData = {
 
 export type GetXaiGrokImagineVideoV15ImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: GrokImagineVideoV15ImageToVideoOutput;
 };
 
@@ -1134,14 +1368,14 @@ export type GetFalAiLtx23ImageToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/fal-ai/ltx-2.3/image-to-video/requests/{request_id}/status';
@@ -1149,8 +1383,8 @@ export type GetFalAiLtx23ImageToVideoRequestsByRequestIdStatusData = {
 
 export type GetFalAiLtx23ImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1160,8 +1394,8 @@ export type PutFalAiLtx23ImageToVideoRequestsByRequestIdCancelData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1170,12 +1404,12 @@ export type PutFalAiLtx23ImageToVideoRequestsByRequestIdCancelData = {
 
 export type PutFalAiLtx23ImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1191,8 +1425,8 @@ export type PostFalAiLtx23ImageToVideoData = {
 
 export type PostFalAiLtx23ImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1202,8 +1436,8 @@ export type GetFalAiLtx23ImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1212,8 +1446,8 @@ export type GetFalAiLtx23ImageToVideoRequestsByRequestIdData = {
 
 export type GetFalAiLtx23ImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: Ltx23ImageToVideoOutput;
 };
 
@@ -1223,14 +1457,14 @@ export type GetFalAiVeo31ImageToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/fal-ai/veo3.1/image-to-video/requests/{request_id}/status';
@@ -1238,8 +1472,8 @@ export type GetFalAiVeo31ImageToVideoRequestsByRequestIdStatusData = {
 
 export type GetFalAiVeo31ImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1249,8 +1483,8 @@ export type PutFalAiVeo31ImageToVideoRequestsByRequestIdCancelData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1259,12 +1493,12 @@ export type PutFalAiVeo31ImageToVideoRequestsByRequestIdCancelData = {
 
 export type PutFalAiVeo31ImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1280,8 +1514,8 @@ export type PostFalAiVeo31ImageToVideoData = {
 
 export type PostFalAiVeo31ImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1291,8 +1525,8 @@ export type GetFalAiVeo31ImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1301,8 +1535,8 @@ export type GetFalAiVeo31ImageToVideoRequestsByRequestIdData = {
 
 export type GetFalAiVeo31ImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: Veo31ImageToVideoOutput;
 };
 
@@ -1312,14 +1546,14 @@ export type GetFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdStatusData =
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/fal-ai/gemini-omni-1.1-flash/image-to-video/requests/{request_id}/status';
@@ -1327,8 +1561,8 @@ export type GetFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdStatusData =
 
 export type GetFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1338,8 +1572,8 @@ export type PutFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdCancelData =
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1348,12 +1582,12 @@ export type PutFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdCancelData =
 
 export type PutFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1369,8 +1603,8 @@ export type PostFalAiGeminiOmni11FlashImageToVideoData = {
 
 export type PostFalAiGeminiOmni11FlashImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1380,8 +1614,8 @@ export type GetFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1390,8 +1624,8 @@ export type GetFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdData = {
 
 export type GetFalAiGeminiOmni11FlashImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: GeminiOmni11FlashImageToVideoOutput;
 };
 
@@ -1401,14 +1635,14 @@ export type GetFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/fal-ai/kling-video/v3/pro/image-to-video/requests/{request_id}/status';
@@ -1416,8 +1650,8 @@ export type GetFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdStatusData = {
 
 export type GetFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1427,8 +1661,8 @@ export type PutFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdCancelData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1437,12 +1671,12 @@ export type PutFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdCancelData = {
 
 export type PutFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1458,8 +1692,8 @@ export type PostFalAiKlingVideoV3ProImageToVideoData = {
 
 export type PostFalAiKlingVideoV3ProImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1469,8 +1703,8 @@ export type GetFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1479,8 +1713,8 @@ export type GetFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdData = {
 
 export type GetFalAiKlingVideoV3ProImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: KlingVideoV3ProImageToVideoOutput;
 };
 
@@ -1490,14 +1724,14 @@ export type GetFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdStatusData 
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/fal-ai/minimax/hailuo-2.3/pro/image-to-video/requests/{request_id}/status';
@@ -1505,8 +1739,8 @@ export type GetFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdStatusData 
 
 export type GetFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1516,8 +1750,8 @@ export type PutFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdCancelData 
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1526,12 +1760,12 @@ export type PutFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdCancelData 
 
 export type PutFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1547,8 +1781,8 @@ export type PostFalAiMinimaxHailuo23ProImageToVideoData = {
 
 export type PostFalAiMinimaxHailuo23ProImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1558,8 +1792,8 @@ export type GetFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1568,8 +1802,8 @@ export type GetFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdData = {
 
 export type GetFalAiMinimaxHailuo23ProImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: MinimaxHailuo23ProImageToVideoOutput;
 };
 
@@ -1579,14 +1813,14 @@ export type GetMinimaxH3MaxImageToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/minimax/h3-max/image-to-video/requests/{request_id}/status';
@@ -1594,8 +1828,8 @@ export type GetMinimaxH3MaxImageToVideoRequestsByRequestIdStatusData = {
 
 export type GetMinimaxH3MaxImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1605,8 +1839,8 @@ export type PutMinimaxH3MaxImageToVideoRequestsByRequestIdCancelData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1615,12 +1849,12 @@ export type PutMinimaxH3MaxImageToVideoRequestsByRequestIdCancelData = {
 
 export type PutMinimaxH3MaxImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1636,8 +1870,8 @@ export type PostMinimaxH3MaxImageToVideoData = {
 
 export type PostMinimaxH3MaxImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1647,8 +1881,8 @@ export type GetMinimaxH3MaxImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1657,8 +1891,8 @@ export type GetMinimaxH3MaxImageToVideoRequestsByRequestIdData = {
 
 export type GetMinimaxH3MaxImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: H3MaxImageToVideoOutput;
 };
 
@@ -1668,14 +1902,14 @@ export type GetBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdSta
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/bytedance/seedance-2.0/enterprise/v2/image-to-video/requests/{request_id}/status';
@@ -1683,8 +1917,8 @@ export type GetBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdSta
 
 export type GetBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1694,8 +1928,8 @@ export type PutBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdCan
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1704,12 +1938,12 @@ export type PutBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdCan
 
 export type PutBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1725,8 +1959,8 @@ export type PostBytedanceSeedance20EnterpriseV2ImageToVideoData = {
 
 export type PostBytedanceSeedance20EnterpriseV2ImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1736,8 +1970,8 @@ export type GetBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdDat
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1746,8 +1980,8 @@ export type GetBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdDat
 
 export type GetBytedanceSeedance20EnterpriseV2ImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: Seedance20EnterpriseV2ImageToVideoOutput;
 };
 
@@ -1757,14 +1991,14 @@ export type GetBytedanceSeedance25ImageToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/bytedance/seedance-2.5/image-to-video/requests/{request_id}/status';
@@ -1772,8 +2006,8 @@ export type GetBytedanceSeedance25ImageToVideoRequestsByRequestIdStatusData = {
 
 export type GetBytedanceSeedance25ImageToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1783,8 +2017,8 @@ export type PutBytedanceSeedance25ImageToVideoRequestsByRequestIdCancelData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1793,12 +2027,12 @@ export type PutBytedanceSeedance25ImageToVideoRequestsByRequestIdCancelData = {
 
 export type PutBytedanceSeedance25ImageToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1814,8 +2048,8 @@ export type PostBytedanceSeedance25ImageToVideoData = {
 
 export type PostBytedanceSeedance25ImageToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1825,8 +2059,8 @@ export type GetBytedanceSeedance25ImageToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1835,8 +2069,8 @@ export type GetBytedanceSeedance25ImageToVideoRequestsByRequestIdData = {
 
 export type GetBytedanceSeedance25ImageToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: Seedance25ImageToVideoOutput;
 };
 
@@ -1846,14 +2080,14 @@ export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestI
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/bytedance/seedance-2.0/enterprise/v2/reference-to-video/requests/{request_id}/status';
@@ -1861,8 +2095,8 @@ export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestI
 
 export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1872,8 +2106,8 @@ export type PutBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestI
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1882,12 +2116,12 @@ export type PutBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestI
 
 export type PutBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1903,8 +2137,8 @@ export type PostBytedanceSeedance20EnterpriseV2ReferenceToVideoData = {
 
 export type PostBytedanceSeedance20EnterpriseV2ReferenceToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1914,8 +2148,8 @@ export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestI
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1924,25 +2158,114 @@ export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestI
 
 export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: Seedance20EnterpriseV2ReferenceToVideoOutput;
 };
 
 export type GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdResponse = GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdResponses[keyof GetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdResponses];
 
-export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdStatusData = {
+export type GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
+    logs?: number;
+  };
+  url: '/bytedance/seedance-2.0/enterprise/v2/text-to-video/requests/{request_id}/status';
+};
+
+export type GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusResponse = GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusResponses[keyof GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusResponses];
+
+export type PutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/bytedance/seedance-2.0/enterprise/v2/text-to-video/requests/{request_id}/cancel';
+};
+
+export type PutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelResponses = {
+  /**
+   * The request was cancelled.
+   */
+  200: {
+    /**
+     * Whether the request was cancelled successfully.
+     */
+    success?: boolean;
+  };
+};
+
+export type PutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelResponse = PutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelResponses[keyof PutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelResponses];
+
+export type PostBytedanceSeedance20EnterpriseV2TextToVideoData = {
+  body: Seedance20EnterpriseV2TextToVideoInput;
+  path?: never;
+  query?: never;
+  url: '/bytedance/seedance-2.0/enterprise/v2/text-to-video';
+};
+
+export type PostBytedanceSeedance20EnterpriseV2TextToVideoResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type PostBytedanceSeedance20EnterpriseV2TextToVideoResponse = PostBytedanceSeedance20EnterpriseV2TextToVideoResponses[keyof PostBytedanceSeedance20EnterpriseV2TextToVideoResponses];
+
+export type GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/bytedance/seedance-2.0/enterprise/v2/text-to-video/requests/{request_id}';
+};
+
+export type GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdResponses = {
+  /**
+   * Result of the request.
+   */
+  200: Seedance20EnterpriseV2TextToVideoOutput;
+};
+
+export type GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdResponse = GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdResponses[keyof GetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdResponses];
+
+export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdStatusData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: {
+    /**
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/bytedance/seedance-2.5/reference-to-video/requests/{request_id}/status';
@@ -1950,8 +2273,8 @@ export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdStatusData 
 
 export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -1961,8 +2284,8 @@ export type PutBytedanceSeedance25ReferenceToVideoRequestsByRequestIdCancelData 
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -1971,12 +2294,12 @@ export type PutBytedanceSeedance25ReferenceToVideoRequestsByRequestIdCancelData 
 
 export type PutBytedanceSeedance25ReferenceToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -1992,8 +2315,8 @@ export type PostBytedanceSeedance25ReferenceToVideoData = {
 
 export type PostBytedanceSeedance25ReferenceToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -2003,8 +2326,8 @@ export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -2013,25 +2336,114 @@ export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdData = {
 
 export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: Seedance25ReferenceToVideoOutput;
 };
 
 export type GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdResponse = GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdResponses[keyof GetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdResponses];
 
-export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdStatusData = {
+export type GetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
+    logs?: number;
+  };
+  url: '/bytedance/seedance-2.5/text-to-video/requests/{request_id}/status';
+};
+
+export type GetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type GetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusResponse = GetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusResponses[keyof GetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusResponses];
+
+export type PutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/bytedance/seedance-2.5/text-to-video/requests/{request_id}/cancel';
+};
+
+export type PutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelResponses = {
+  /**
+   * The request was cancelled.
+   */
+  200: {
+    /**
+     * Whether the request was cancelled successfully.
+     */
+    success?: boolean;
+  };
+};
+
+export type PutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelResponse = PutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelResponses[keyof PutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelResponses];
+
+export type PostBytedanceSeedance25TextToVideoData = {
+  body: Seedance25TextToVideoInput;
+  path?: never;
+  query?: never;
+  url: '/bytedance/seedance-2.5/text-to-video';
+};
+
+export type PostBytedanceSeedance25TextToVideoResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type PostBytedanceSeedance25TextToVideoResponse = PostBytedanceSeedance25TextToVideoResponses[keyof PostBytedanceSeedance25TextToVideoResponses];
+
+export type GetBytedanceSeedance25TextToVideoRequestsByRequestIdData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/bytedance/seedance-2.5/text-to-video/requests/{request_id}';
+};
+
+export type GetBytedanceSeedance25TextToVideoRequestsByRequestIdResponses = {
+  /**
+   * Result of the request.
+   */
+  200: Seedance25TextToVideoOutput;
+};
+
+export type GetBytedanceSeedance25TextToVideoRequestsByRequestIdResponse = GetBytedanceSeedance25TextToVideoRequestsByRequestIdResponses[keyof GetBytedanceSeedance25TextToVideoRequestsByRequestIdResponses];
+
+export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdStatusData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: {
+    /**
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/fal-ai/gemini-omni-1.1-flash/reference-to-video/requests/{request_id}/status';
@@ -2039,8 +2451,8 @@ export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdStatusDa
 
 export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -2050,8 +2462,8 @@ export type PutFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdCancelDa
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -2060,12 +2472,12 @@ export type PutFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdCancelDa
 
 export type PutFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -2081,8 +2493,8 @@ export type PostFalAiGeminiOmni11FlashReferenceToVideoData = {
 
 export type PostFalAiGeminiOmni11FlashReferenceToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -2092,8 +2504,8 @@ export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -2102,25 +2514,114 @@ export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdData = {
 
 export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: GeminiOmni11FlashReferenceToVideoOutput;
 };
 
 export type GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdResponse = GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdResponses[keyof GetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdResponses];
 
-export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdStatusData = {
+export type GetFalAiGeminiOmni11FlashRequestsByRequestIdStatusData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: {
     /**
-         * Whether to include logs (`1`) in the response or not (`0`).
-         */
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
+    logs?: number;
+  };
+  url: '/fal-ai/gemini-omni-1.1-flash/requests/{request_id}/status';
+};
+
+export type GetFalAiGeminiOmni11FlashRequestsByRequestIdStatusResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type GetFalAiGeminiOmni11FlashRequestsByRequestIdStatusResponse = GetFalAiGeminiOmni11FlashRequestsByRequestIdStatusResponses[keyof GetFalAiGeminiOmni11FlashRequestsByRequestIdStatusResponses];
+
+export type PutFalAiGeminiOmni11FlashRequestsByRequestIdCancelData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/fal-ai/gemini-omni-1.1-flash/requests/{request_id}/cancel';
+};
+
+export type PutFalAiGeminiOmni11FlashRequestsByRequestIdCancelResponses = {
+  /**
+   * The request was cancelled.
+   */
+  200: {
+    /**
+     * Whether the request was cancelled successfully.
+     */
+    success?: boolean;
+  };
+};
+
+export type PutFalAiGeminiOmni11FlashRequestsByRequestIdCancelResponse = PutFalAiGeminiOmni11FlashRequestsByRequestIdCancelResponses[keyof PutFalAiGeminiOmni11FlashRequestsByRequestIdCancelResponses];
+
+export type PostFalAiGeminiOmni11FlashData = {
+  body: GeminiOmni11FlashInput;
+  path?: never;
+  query?: never;
+  url: '/fal-ai/gemini-omni-1.1-flash';
+};
+
+export type PostFalAiGeminiOmni11FlashResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type PostFalAiGeminiOmni11FlashResponse = PostFalAiGeminiOmni11FlashResponses[keyof PostFalAiGeminiOmni11FlashResponses];
+
+export type GetFalAiGeminiOmni11FlashRequestsByRequestIdData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/fal-ai/gemini-omni-1.1-flash/requests/{request_id}';
+};
+
+export type GetFalAiGeminiOmni11FlashRequestsByRequestIdResponses = {
+  /**
+   * Result of the request.
+   */
+  200: GeminiOmni11FlashOutput;
+};
+
+export type GetFalAiGeminiOmni11FlashRequestsByRequestIdResponse = GetFalAiGeminiOmni11FlashRequestsByRequestIdResponses[keyof GetFalAiGeminiOmni11FlashRequestsByRequestIdResponses];
+
+export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdStatusData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: {
+    /**
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
     logs?: number;
   };
   url: '/minimax/h3-max/reference-to-video/requests/{request_id}/status';
@@ -2128,8 +2629,8 @@ export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdStatusData = {
 
 export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdStatusResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -2139,8 +2640,8 @@ export type PutMinimaxH3MaxReferenceToVideoRequestsByRequestIdCancelData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -2149,12 +2650,12 @@ export type PutMinimaxH3MaxReferenceToVideoRequestsByRequestIdCancelData = {
 
 export type PutMinimaxH3MaxReferenceToVideoRequestsByRequestIdCancelResponses = {
   /**
-     * The request was cancelled.
-     */
+   * The request was cancelled.
+   */
   200: {
     /**
-         * Whether the request was cancelled successfully.
-         */
+     * Whether the request was cancelled successfully.
+     */
     success?: boolean;
   };
 };
@@ -2170,8 +2671,8 @@ export type PostMinimaxH3MaxReferenceToVideoData = {
 
 export type PostMinimaxH3MaxReferenceToVideoResponses = {
   /**
-     * The request status.
-     */
+   * The request status.
+   */
   200: QueueStatus;
 };
 
@@ -2181,8 +2682,8 @@ export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdData = {
   body?: never;
   path: {
     /**
-         * Request ID
-         */
+     * Request ID
+     */
     request_id: string;
   };
   query?: never;
@@ -2191,9 +2692,98 @@ export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdData = {
 
 export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdResponses = {
   /**
-     * Result of the request.
-     */
+   * Result of the request.
+   */
   200: H3MaxReferenceToVideoOutput;
 };
 
 export type GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdResponse = GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdResponses[keyof GetMinimaxH3MaxReferenceToVideoRequestsByRequestIdResponses];
+
+export type GetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: {
+    /**
+     * Whether to include logs (`1`) in the response or not (`0`).
+     */
+    logs?: number;
+  };
+  url: '/minimax/h3-max/text-to-video/requests/{request_id}/status';
+};
+
+export type GetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type GetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusResponse = GetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusResponses[keyof GetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusResponses];
+
+export type PutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/minimax/h3-max/text-to-video/requests/{request_id}/cancel';
+};
+
+export type PutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelResponses = {
+  /**
+   * The request was cancelled.
+   */
+  200: {
+    /**
+     * Whether the request was cancelled successfully.
+     */
+    success?: boolean;
+  };
+};
+
+export type PutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelResponse = PutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelResponses[keyof PutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelResponses];
+
+export type PostMinimaxH3MaxTextToVideoData = {
+  body: H3MaxTextToVideoInput;
+  path?: never;
+  query?: never;
+  url: '/minimax/h3-max/text-to-video';
+};
+
+export type PostMinimaxH3MaxTextToVideoResponses = {
+  /**
+   * The request status.
+   */
+  200: QueueStatus;
+};
+
+export type PostMinimaxH3MaxTextToVideoResponse = PostMinimaxH3MaxTextToVideoResponses[keyof PostMinimaxH3MaxTextToVideoResponses];
+
+export type GetMinimaxH3MaxTextToVideoRequestsByRequestIdData = {
+  body?: never;
+  path: {
+    /**
+     * Request ID
+     */
+    request_id: string;
+  };
+  query?: never;
+  url: '/minimax/h3-max/text-to-video/requests/{request_id}';
+};
+
+export type GetMinimaxH3MaxTextToVideoRequestsByRequestIdResponses = {
+  /**
+   * Result of the request.
+   */
+  200: H3MaxTextToVideoOutput;
+};
+
+export type GetMinimaxH3MaxTextToVideoRequestsByRequestIdResponse = GetMinimaxH3MaxTextToVideoRequestsByRequestIdResponses[keyof GetMinimaxH3MaxTextToVideoRequestsByRequestIdResponses];

--- a/src/lib/motion/generated/zod.gen.ts
+++ b/src/lib/motion/generated/zod.gen.ts
@@ -44,6 +44,9 @@ export const zGrokImagineVideoV15ImageToVideoInput = z.object({
     z.string(),
     z.string()
   ]),
+  duration: z.int().gte(1).lte(15).register(z.globalRegistry, {
+    description: 'Video duration in seconds.'
+  }).optional().default(6),
   resolution: z.enum([
     '480p',
     '720p',
@@ -51,9 +54,6 @@ export const zGrokImagineVideoV15ImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'Resolution of the output video.'
   }).optional().default('720p'),
-  duration: z.int().gte(1).lte(15).register(z.globalRegistry, {
-    description: 'Video duration in seconds.'
-  }).optional().default(6),
   prompt: z.string().max(4096).register(z.globalRegistry, {
     description: 'Text description of desired changes or motion in the video.'
   })
@@ -65,20 +65,28 @@ export const zGrokImagineVideoV15ImageToVideoInput = z.object({
  * VideoFile
  */
 export const zVideoFile = z.object({
+  file_size: z.union([
+    z.int(),
+    z.unknown()
+  ]).optional(),
   width: z.union([
     z.int(),
     z.unknown()
   ]).optional(),
-  num_frames: z.union([
-    z.int(),
+  file_name: z.union([
+    z.string(),
     z.unknown()
   ]).optional(),
   fps: z.union([
     z.number(),
     z.unknown()
   ]).optional(),
-  file_name: z.union([
-    z.string(),
+  num_frames: z.union([
+    z.int(),
+    z.unknown()
+  ]).optional(),
+  height: z.union([
+    z.int(),
     z.unknown()
   ]).optional(),
   url: z.string().register(z.globalRegistry, {
@@ -86,14 +94,6 @@ export const zVideoFile = z.object({
   }),
   content_type: z.union([
     z.string(),
-    z.unknown()
-  ]).optional(),
-  height: z.union([
-    z.int(),
-    z.unknown()
-  ]).optional(),
-  file_size: z.union([
-    z.int(),
     z.unknown()
   ]).optional(),
   duration: z.union([
@@ -113,17 +113,14 @@ export const zGrokImagineVideoV15ImageToVideoOutput = z.object({
  * LTXV23ImageToVideoRequest
  */
 export const zLtx23ImageToVideoInput = z.object({
-  resolution: z.enum([
-    '1080p',
-    '1440p',
-    '2160p'
-  ]).register(z.globalRegistry, {
-    description: 'The resolution of the generated video'
-  }).optional().default('1080p'),
   image_url: z.union([
     z.string(),
     z.string()
   ]),
+  end_image_url: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
   aspect_ratio: z.enum([
     'auto',
     '16:9',
@@ -131,10 +128,14 @@ export const zLtx23ImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The aspect ratio of the generated video. If \'auto\', the aspect ratio will be determined automatically based on the input image.'
   }).optional().default('auto'),
-  end_image_url: z.union([
-    z.string(),
-    z.unknown()
-  ]).optional(),
+  fps: z.union([
+    z.literal(24),
+    z.literal(25),
+    z.literal(48),
+    z.literal(50)
+  ]).register(z.globalRegistry, {
+    description: 'The frames per second of the generated video'
+  }).optional().default(25),
   duration: z.union([
     z.literal(6),
     z.literal(8),
@@ -148,14 +149,13 @@ export const zLtx23ImageToVideoInput = z.object({
   prompt: z.string().min(1).max(5000).register(z.globalRegistry, {
     description: 'The prompt to use for the generated video'
   }),
-  fps: z.union([
-    z.literal(24),
-    z.literal(25),
-    z.literal(48),
-    z.literal(50)
+  resolution: z.enum([
+    '1080p',
+    '1440p',
+    '2160p'
   ]).register(z.globalRegistry, {
-    description: 'The frames per second of the generated video'
-  }).optional().default(25)
+    description: 'The resolution of the generated video'
+  }).optional().default('1080p')
 });
 
 /**
@@ -172,6 +172,13 @@ export const zVeo31ImageToVideoInput = z.object({
   prompt: z.string().max(20000).register(z.globalRegistry, {
     description: 'The text prompt describing the video you want to generate'
   }),
+  aspect_ratio: z.enum([
+    'auto',
+    '16:9',
+    '9:16'
+  ]).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video. Only 16:9 and 9:16 are supported.'
+  }).optional().default('auto'),
   safety_tolerance: z.enum([
     '1',
     '2',
@@ -182,24 +189,9 @@ export const zVeo31ImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The safety tolerance level for content moderation. 1 is the most strict (blocks most content), 6 is the least strict.'
   }).optional().default('4'),
-  duration: z.enum([
-    '4s',
-    '6s',
-    '8s'
-  ]).register(z.globalRegistry, {
-    description: 'The duration of the generated video.'
-  }).optional().default('8s'),
-  aspect_ratio: z.enum([
-    'auto',
-    '16:9',
-    '9:16'
-  ]).register(z.globalRegistry, {
-    description: 'The aspect ratio of the generated video. Only 16:9 and 9:16 are supported.'
-  }).optional().default('auto'),
-  image_url: z.union([
-    z.string(),
-    z.string()
-  ]),
+  auto_fix: z.boolean().register(z.globalRegistry, {
+    description: 'Whether to automatically attempt to fix prompts that fail content policy or other validation checks by rewriting them.'
+  }).optional().default(false),
   negative_prompt: z.union([
     z.string(),
     z.unknown()
@@ -207,10 +199,10 @@ export const zVeo31ImageToVideoInput = z.object({
   generate_audio: z.boolean().register(z.globalRegistry, {
     description: 'Whether to generate audio for the video.'
   }).optional().default(true),
-  seed: z.union([
-    z.int(),
-    z.unknown()
-  ]).optional(),
+  image_url: z.union([
+    z.string(),
+    z.string()
+  ]),
   resolution: z.enum([
     '720p',
     '1080p',
@@ -218,9 +210,17 @@ export const zVeo31ImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The resolution of the generated video.'
   }).optional().default('720p'),
-  auto_fix: z.boolean().register(z.globalRegistry, {
-    description: 'Whether to automatically attempt to fix prompts that fail content policy or other validation checks by rewriting them.'
-  }).optional().default(false)
+  seed: z.union([
+    z.int(),
+    z.unknown()
+  ]).optional(),
+  duration: z.enum([
+    '4s',
+    '6s',
+    '8s'
+  ]).register(z.globalRegistry, {
+    description: 'The duration of the generated video.'
+  }).optional().default('8s')
 });
 
 /**
@@ -231,15 +231,15 @@ export const zFile = z.object({
     z.string(),
     z.unknown()
   ]).optional(),
+  content_type: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
   url: z.string().register(z.globalRegistry, {
     description: 'The URL where the file can be downloaded from.'
   }),
   file_size: z.union([
     z.int(),
-    z.unknown()
-  ]).optional(),
-  content_type: z.union([
-    z.string(),
     z.unknown()
   ]).optional()
 });
@@ -255,13 +255,9 @@ export const zVeo31ImageToVideoOutput = z.object({
  * Omni11FlashImageToVideoInput
  */
 export const zGeminiOmni11FlashImageToVideoInput = z.object({
-  aspect_ratio: z.enum(['16:9', '9:16']).register(z.globalRegistry, {
-    description: 'The aspect ratio of the generated video.'
-  }).optional().default('16:9'),
-  image_url: z.union([
-    z.string(),
-    z.string()
-  ]),
+  duration: z.int().gte(3).lte(10).register(z.globalRegistry, {
+    description: 'The duration of the generated video, in seconds.'
+  }).optional().default(8),
   resolution: z.enum([
     '360p',
     '720p',
@@ -270,16 +266,20 @@ export const zGeminiOmni11FlashImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The resolution of the generated video.'
   }).optional().default('720p'),
-  prompt: z.string().max(20000).register(z.globalRegistry, {
-    description: 'The text prompt describing how the first image should be animated or interpolated into the optional end image.'
-  }),
-  duration: z.int().gte(3).lte(10).register(z.globalRegistry, {
-    description: 'The duration of the generated video, in seconds.'
-  }).optional().default(8),
+  aspect_ratio: z.enum(['16:9', '9:16']).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video.'
+  }).optional().default('16:9'),
   end_image_url: z.union([
     z.string(),
     z.unknown()
-  ]).optional()
+  ]).optional(),
+  image_url: z.union([
+    z.string(),
+    z.string()
+  ]),
+  prompt: z.string().max(20000).register(z.globalRegistry, {
+    description: 'The text prompt describing how the first image should be animated or interpolated into the optional end image.'
+  })
 });
 
 /**
@@ -300,11 +300,7 @@ export const zKlingVideoV3ProImageToVideoOutput = z.object({
  * KlingV3ComboElementInput
  */
 export const zKlingV3ComboElementInput = z.object({
-  reference_image_urls: z.union([
-    z.array(z.string()),
-    z.unknown()
-  ]).optional(),
-  frontal_image_url: z.union([
+  voice_id: z.union([
     z.string(),
     z.unknown()
   ]).optional(),
@@ -312,7 +308,11 @@ export const zKlingV3ComboElementInput = z.object({
     z.string(),
     z.unknown()
   ]).optional(),
-  voice_id: z.union([
+  reference_image_urls: z.union([
+    z.array(z.string()),
+    z.unknown()
+  ]).optional(),
+  frontal_image_url: z.union([
     z.string(),
     z.unknown()
   ]).optional()
@@ -350,36 +350,17 @@ export const zKlingV3MultiPromptElement = z.object({
  * ImageToVideoV3ProRequest
  */
 export const zKlingVideoV3ProImageToVideoInput = z.object({
-  cfg_scale: z.number().gte(0).lte(1).register(z.globalRegistry, {
-    description: '\n            The CFG (Classifier Free Guidance) scale is a measure of how close you want\n            the model to stick to your prompt.\n        '
-  }).optional().default(0.5),
-  elements: z.union([
-    z.array(zKlingV3ComboElementInput),
+  prompt: z.union([
+    z.string().max(2500),
     z.unknown()
   ]).optional(),
   start_image_url: z.union([
     z.string(),
     z.string()
   ]),
-  end_image_url: z.union([
-    z.string(),
-    z.unknown()
-  ]).optional(),
-  prompt: z.union([
-    z.string().max(2500),
-    z.unknown()
-  ]).optional(),
   generate_audio: z.boolean().register(z.globalRegistry, {
     description: 'Whether to generate native audio for the video. Supports Chinese and English voice output. Other languages are automatically translated to English. For English speech, use lowercase letters; for acronyms or proper nouns, use uppercase.'
   }).optional().default(true),
-  multi_prompt: z.union([
-    z.array(zKlingV3MultiPromptElement),
-    z.unknown()
-  ]).optional(),
-  shot_type: z.enum(['customize', 'intelligent']).register(z.globalRegistry, {
-    description: 'The type of multi-shot video generation. \'intelligent\' lets the model automatically determine shot structure.'
-  }).optional().default('customize'),
-  negative_prompt: z.string().max(2500).optional().default('blur, distort, and low quality'),
   duration: z.enum([
     '3',
     '4',
@@ -396,7 +377,26 @@ export const zKlingVideoV3ProImageToVideoInput = z.object({
     '15'
   ]).register(z.globalRegistry, {
     description: 'The duration of the generated video in seconds'
-  }).optional().default('5')
+  }).optional().default('5'),
+  cfg_scale: z.number().gte(0).lte(1).register(z.globalRegistry, {
+    description: '\n            The CFG (Classifier Free Guidance) scale is a measure of how close you want\n            the model to stick to your prompt.\n        '
+  }).optional().default(0.5),
+  elements: z.union([
+    z.array(zKlingV3ComboElementInput),
+    z.unknown()
+  ]).optional(),
+  shot_type: z.enum(['customize', 'intelligent']).register(z.globalRegistry, {
+    description: 'The type of multi-shot video generation. \'intelligent\' lets the model automatically determine shot structure.'
+  }).optional().default('customize'),
+  multi_prompt: z.union([
+    z.array(zKlingV3MultiPromptElement),
+    z.unknown()
+  ]).optional(),
+  end_image_url: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
+  negative_prompt: z.string().max(2500).optional().default('blur, distort, and low quality')
 });
 
 /**
@@ -407,12 +407,12 @@ export const zMinimaxHailuo23ProImageToVideoInput = z.object({
     z.string(),
     z.string()
   ]),
-  prompt: z.string().min(1).max(2000).register(z.globalRegistry, {
-    description: 'Text prompt for video generation'
-  }),
   prompt_optimizer: z.boolean().register(z.globalRegistry, {
     description: 'Whether to use the model\'s prompt optimizer'
-  }).optional().default(true)
+  }).optional().default(true),
+  prompt: z.string().min(1).max(2000).register(z.globalRegistry, {
+    description: 'Text prompt for video generation'
+  })
 });
 
 /**
@@ -426,36 +426,36 @@ export const zMinimaxHailuo23ProImageToVideoOutput = z.object({
  * TurboImageToVideoHailuo03Input
  */
 export const zH3MaxImageToVideoInput = z.object({
+  prompt_expansion_mode: z.string().register(z.globalRegistry, {
+    description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.'
+  }).default('balanced'),
   end_image_url: z.union([
     z.string(),
     z.unknown()
   ]).optional(),
-  prompt: z.string().min(1).max(50000).register(z.globalRegistry, {
-    description: 'Text prompt for video generation'
-  }),
-  seed: z.union([
-    z.int(),
-    z.unknown()
-  ]).optional(),
-  enable_safety_checker: z.boolean().register(z.globalRegistry, {
-    description: 'If set to true, the safety checker will be enabled.'
-  }).optional().default(true),
   duration: z.int().gte(5).lte(15).register(z.globalRegistry, {
     description: 'The duration of the video in seconds.'
   }).optional().default(5),
   sync_mode: z.boolean().register(z.globalRegistry, {
     description: 'Return the generated video as base64 instead of a CDN URL.'
   }).optional().default(false),
+  resolution: z.enum(['480P', '768P']).register(z.globalRegistry, {
+    description: 'The native generation resolution of the video.'
+  }).optional().default('768P'),
+  prompt: z.string().min(1).max(50000).register(z.globalRegistry, {
+    description: 'Text prompt for video generation'
+  }),
   image_url: z.union([
     z.string(),
     z.unknown()
   ]).optional(),
-  prompt_expansion_mode: z.string().register(z.globalRegistry, {
-    description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.'
-  }).default('balanced'),
-  resolution: z.enum(['480P', '768P']).register(z.globalRegistry, {
-    description: 'The native generation resolution of the video.'
-  }).optional().default('768P')
+  enable_safety_checker: z.boolean().register(z.globalRegistry, {
+    description: 'If set to true, the safety checker will be enabled.'
+  }).optional().default(true),
+  seed: z.union([
+    z.int(),
+    z.unknown()
+  ]).optional()
 });
 
 /**
@@ -477,16 +477,17 @@ export const zH3MaxImageToVideoOutput = z.object({
  * Seedance2I2VInput
  */
 export const zSeedance20EnterpriseV2ImageToVideoInput = z.object({
-  end_image_url: z.union([
+  end_user_id: z.union([
     z.string(),
     z.unknown()
   ]).optional(),
   prompt: z.string().register(z.globalRegistry, {
     description: 'The text prompt describing the desired motion and action for the video.'
   }),
-  generate_audio: z.boolean().register(z.globalRegistry, {
-    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
-  }).optional().default(true),
+  end_image_url: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
   bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
     description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
   }).optional().default('standard'),
@@ -494,17 +495,17 @@ export const zSeedance20EnterpriseV2ImageToVideoInput = z.object({
     z.string(),
     z.string()
   ]),
-  aspect_ratio: z.enum([
-    'auto',
-    '21:9',
-    '16:9',
-    '4:3',
-    '1:1',
-    '3:4',
-    '9:16'
+  resolution: z.enum([
+    '480p',
+    '720p',
+    '1080p',
+    '4k'
   ]).register(z.globalRegistry, {
-    description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to infer from the input image.'
-  }).optional().default('auto'),
+    description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.'
+  }).optional().default('720p'),
+  generate_audio: z.boolean().register(z.globalRegistry, {
+    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+  }).optional().default(true),
   duration: z.enum([
     'auto',
     '4',
@@ -522,34 +523,37 @@ export const zSeedance20EnterpriseV2ImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.'
   }).optional().default('auto'),
-  resolution: z.enum([
-    '480p',
-    '720p',
-    '1080p',
-    '4k'
+  aspect_ratio: z.enum([
+    'auto',
+    '21:9',
+    '16:9',
+    '4:3',
+    '1:1',
+    '3:4',
+    '9:16'
   ]).register(z.globalRegistry, {
-    description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.'
-  }).optional().default('720p'),
-  end_user_id: z.union([
-    z.string(),
-    z.unknown()
-  ]).optional()
+    description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to infer from the input image.'
+  }).optional().default('auto')
 });
 
 /**
  * Seedance2VideoOutput
  */
 export const zSeedance20EnterpriseV2ImageToVideoOutput = z.object({
-  video: zFile,
   seed: z.int().register(z.globalRegistry, {
     description: 'The seed used for generation.'
-  })
+  }),
+  video: zFile
 });
 
 /**
  * Seedance2I2VInput
  */
 export const zSeedance25ImageToVideoInput = z.object({
+  image_url: z.union([
+    z.string(),
+    z.string()
+  ]),
   end_image_url: z.union([
     z.string(),
     z.unknown()
@@ -557,9 +561,13 @@ export const zSeedance25ImageToVideoInput = z.object({
   aspect_ratio: z.string().register(z.globalRegistry, {
     description: 'The aspect ratio of the generated video. Always "auto" for image-to-video'
   }).optional().default('auto'),
-  prompt: z.string().register(z.globalRegistry, {
-    description: 'The text prompt describing the desired motion and action for the video.'
-  }),
+  end_user_id: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
+  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
+    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+  }).optional().default('standard'),
   duration: z.enum([
     'auto',
     '4',
@@ -592,20 +600,12 @@ export const zSeedance25ImageToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.'
   }).optional().default('auto'),
-  image_url: z.union([
-    z.string(),
-    z.string()
-  ]),
-  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
-    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
-  }).optional().default('standard'),
   generate_audio: z.boolean().register(z.globalRegistry, {
     description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
   }).optional().default(true),
-  end_user_id: z.union([
-    z.string(),
-    z.unknown()
-  ]).optional(),
+  prompt: z.string().register(z.globalRegistry, {
+    description: 'The text prompt describing the desired motion and action for the video.'
+  }),
   resolution: z.enum([
     '480p',
     '720p',
@@ -629,6 +629,36 @@ export const zSeedance25ImageToVideoOutput = z.object({
  * Seedance2R2VInput
  */
 export const zSeedance20EnterpriseV2ReferenceToVideoInput = z.object({
+  end_user_id: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
+  prompt: z.string().register(z.globalRegistry, {
+    description: 'The text prompt used to generate the video.'
+  }),
+  audio_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
+    description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file. At least one reference image or video is required.'
+  }).optional(),
+  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
+    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+  }).optional().default('standard'),
+  video_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
+    description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.'
+  }).optional(),
+  resolution: z.enum([
+    '480p',
+    '720p',
+    '1080p',
+    '4k'
+  ]).register(z.globalRegistry, {
+    description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality, 4k for highest quality.'
+  }).optional().default('720p'),
+  image_urls: z.array(z.string()).max(9).register(z.globalRegistry, {
+    description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPEG, PNG, WebP. Max 30 MB per image. Up to 9 images. Total files across all modalities must not exceed 12.'
+  }).optional(),
+  generate_audio: z.boolean().register(z.globalRegistry, {
+    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+  }).optional().default(true),
   duration: z.enum([
     'auto',
     '4',
@@ -646,21 +676,6 @@ export const zSeedance20EnterpriseV2ReferenceToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.'
   }).optional().default('auto'),
-  audio_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
-    description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 3 files, combined duration must not exceed 15 seconds. Max 15 MB per file. At least one reference image or video is required.'
-  }).optional(),
-  prompt: z.string().register(z.globalRegistry, {
-    description: 'The text prompt used to generate the video.'
-  }),
-  generate_audio: z.boolean().register(z.globalRegistry, {
-    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
-  }).optional().default(true),
-  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
-    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
-  }).optional().default('standard'),
-  video_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
-    description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 3 videos, combined duration must be between 2 and 15 seconds, total size under 50 MB. Each video must be between ~480p (640x640) and ~720p (834x1112) in resolution.'
-  }).optional(),
   aspect_ratio: z.enum([
     'auto',
     '21:9',
@@ -671,10 +686,23 @@ export const zSeedance20EnterpriseV2ReferenceToVideoInput = z.object({
     '9:16'
   ]).register(z.globalRegistry, {
     description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.'
-  }).optional().default('auto'),
-  image_urls: z.array(z.string()).max(9).register(z.globalRegistry, {
-    description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPEG, PNG, WebP. Max 30 MB per image. Up to 9 images. Total files across all modalities must not exceed 12.'
-  }).optional(),
+  }).optional().default('auto')
+});
+
+/**
+ * Seedance2VideoOutput
+ */
+export const zSeedance20EnterpriseV2ReferenceToVideoOutput = z.object({
+  seed: z.int().register(z.globalRegistry, {
+    description: 'The seed used for generation.'
+  }),
+  video: zFile
+});
+
+/**
+ * Seedance2T2VInput
+ */
+export const zSeedance20EnterpriseV2TextToVideoInput = z.object({
   resolution: z.enum([
     '480p',
     '720p',
@@ -686,28 +714,65 @@ export const zSeedance20EnterpriseV2ReferenceToVideoInput = z.object({
   end_user_id: z.union([
     z.string(),
     z.unknown()
-  ]).optional()
+  ]).optional(),
+  generate_audio: z.boolean().register(z.globalRegistry, {
+    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+  }).optional().default(true),
+  duration: z.enum([
+    'auto',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '10',
+    '11',
+    '12',
+    '13',
+    '14',
+    '15'
+  ]).register(z.globalRegistry, {
+    description: 'Duration of the video in seconds. Supports 4 to 15 seconds, or auto to let the model decide based on the prompt.'
+  }).optional().default('auto'),
+  aspect_ratio: z.enum([
+    'auto',
+    '21:9',
+    '16:9',
+    '4:3',
+    '1:1',
+    '3:4',
+    '9:16'
+  ]).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.'
+  }).optional().default('auto'),
+  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
+    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+  }).optional().default('standard'),
+  prompt: z.string().register(z.globalRegistry, {
+    description: 'The text prompt used to generate the video'
+  })
 });
 
 /**
  * Seedance2VideoOutput
  */
-export const zSeedance20EnterpriseV2ReferenceToVideoOutput = z.object({
-  video: zFile,
+export const zSeedance20EnterpriseV2TextToVideoOutput = z.object({
   seed: z.int().register(z.globalRegistry, {
     description: 'The seed used for generation.'
-  })
+  }),
+  video: zFile
 });
 
 /**
  * Seedance2R2VInput
  */
 export const zSeedance25ReferenceToVideoInput = z.object({
-  prompt: z.string().register(z.globalRegistry, {
-    description: 'The text prompt used to generate the video.'
-  }),
   video_urls: z.array(z.string()).register(z.globalRegistry, {
     description: 'Reference videos to guide video generation. Refer to them in the prompt as @Video1, @Video2, etc. Supported formats: MP4, MOV. Up to 10 videos. Each video must be 1.8 to 30.2 seconds and no larger than 200 MB; combined duration must not exceed 30.2 seconds. Dimensions must be 300 to 6,000 pixels per side, aspect ratio 0.4 to 2.5, and frame rate 24 to 60 FPS.'
+  }).optional(),
+  audio_urls: z.array(z.string()).register(z.globalRegistry, {
+    description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. At least one reference image or video is required.'
   }).optional(),
   aspect_ratio: z.enum([
     'auto',
@@ -720,6 +785,16 @@ export const zSeedance25ReferenceToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.'
   }).optional().default('auto'),
+  image_urls: z.array(z.string()).register(z.globalRegistry, {
+    description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.'
+  }).optional(),
+  end_user_id: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
+  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
+    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+  }).optional().default('standard'),
   duration: z.enum([
     'auto',
     '4',
@@ -752,29 +827,19 @@ export const zSeedance25ReferenceToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.'
   }).optional().default('auto'),
-  audio_urls: z.array(z.string()).register(z.globalRegistry, {
-    description: 'Reference audio to guide video generation. Refer to them in the prompt as @Audio1, @Audio2, etc. Supported formats: MP3, WAV. Up to 10 files. Each file must be 1.8 to 30.2 seconds and no larger than 15 MB; combined duration must not exceed 30.2 seconds. At least one reference image or video is required.'
-  }).optional(),
-  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
-    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
-  }).optional().default('standard'),
-  image_urls: z.array(z.string()).register(z.globalRegistry, {
-    description: 'Reference images to guide video generation. Refer to them in the prompt as @Image1, @Image2, etc. Supported formats: JPG, PNG, WebP, BMP, TIFF, GIF, HEIC, HEIF. Max 30 MB per image. Up to 30 images. Total files across all modalities must not exceed 50.'
-  }).optional(),
-  generate_audio: z.boolean().register(z.globalRegistry, {
-    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
-  }).optional().default(true),
-  end_user_id: z.union([
-    z.string(),
-    z.unknown()
-  ]).optional(),
   resolution: z.enum([
     '480p',
     '720p',
     '1080p'
   ]).register(z.globalRegistry, {
     description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.'
-  }).optional().default('720p')
+  }).optional().default('720p'),
+  prompt: z.string().register(z.globalRegistry, {
+    description: 'The text prompt used to generate the video.'
+  }),
+  generate_audio: z.boolean().register(z.globalRegistry, {
+    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+  }).optional().default(true)
 });
 
 /**
@@ -788,15 +853,91 @@ export const zSeedance25ReferenceToVideoOutput = z.object({
 });
 
 /**
+ * Seedance2T2VInput
+ */
+export const zSeedance25TextToVideoInput = z.object({
+  generate_audio: z.boolean().register(z.globalRegistry, {
+    description: 'Whether to generate synchronized audio for the video, including sound effects, ambient sounds, and lip-synced speech. The cost of video generation is the same regardless of whether audio is generated or not.'
+  }).optional().default(true),
+  end_user_id: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
+  bitrate_mode: z.enum(['standard', 'high']).register(z.globalRegistry, {
+    description: 'Output bitrate mode. \'high\' requests a higher-quality, larger-file encode from the model; \'standard\' uses the default bitrate.'
+  }).optional().default('standard'),
+  duration: z.enum([
+    'auto',
+    '4',
+    '5',
+    '6',
+    '7',
+    '8',
+    '9',
+    '10',
+    '11',
+    '12',
+    '13',
+    '14',
+    '15',
+    '16',
+    '17',
+    '18',
+    '19',
+    '20',
+    '21',
+    '22',
+    '23',
+    '24',
+    '25',
+    '26',
+    '27',
+    '28',
+    '29',
+    '30'
+  ]).register(z.globalRegistry, {
+    description: 'Duration of the video in seconds. Supports 4 to 30 seconds, or auto to let the model decide based on the prompt.'
+  }).optional().default('auto'),
+  resolution: z.enum([
+    '480p',
+    '720p',
+    '1080p'
+  ]).register(z.globalRegistry, {
+    description: 'Video resolution - 480p for faster generation, 720p for balance, 1080p for high quality.'
+  }).optional().default('720p'),
+  prompt: z.string().register(z.globalRegistry, {
+    description: 'The text prompt used to generate the video'
+  }),
+  aspect_ratio: z.enum([
+    'auto',
+    '21:9',
+    '16:9',
+    '4:3',
+    '1:1',
+    '3:4',
+    '9:16'
+  ]).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video. Use 16:9 for landscape, 9:16 for portrait/vertical, 1:1 for square, 21:9 for ultrawide cinematic, or auto to let the model decide.'
+  }).optional().default('auto')
+});
+
+/**
+ * Seedance2VideoOutput
+ */
+export const zSeedance25TextToVideoOutput = z.object({
+  seed: z.int().register(z.globalRegistry, {
+    description: 'The seed used for generation.'
+  }),
+  video: zFile
+});
+
+/**
  * Omni11FlashReferenceToVideoInput
  */
 export const zGeminiOmni11FlashReferenceToVideoInput = z.object({
-  duration: z.int().gte(3).lte(10).register(z.globalRegistry, {
-    description: 'The duration of the generated video, in seconds.'
-  }).optional().default(8),
-  aspect_ratio: z.enum(['16:9', '9:16']).register(z.globalRegistry, {
-    description: 'The aspect ratio of the generated video.'
-  }).optional().default('16:9'),
+  reference_video_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
+    description: 'URLs of up to three reference videos. Each video must be at most three seconds long.'
+  }).optional(),
   resolution: z.enum([
     '360p',
     '720p',
@@ -805,15 +946,18 @@ export const zGeminiOmni11FlashReferenceToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The resolution of the generated video.'
   }).optional().default('720p'),
+  duration: z.int().gte(3).lte(10).register(z.globalRegistry, {
+    description: 'The duration of the generated video, in seconds.'
+  }).optional().default(8),
+  aspect_ratio: z.enum(['16:9', '9:16']).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video.'
+  }).optional().default('16:9'),
   image_urls: z.array(z.string()).max(10).register(z.globalRegistry, {
     description: 'URLs of reference images to incorporate into the video.'
   }).optional(),
   prompt: z.string().max(20000).register(z.globalRegistry, {
     description: 'The text prompt describing the video. Reference media is sent in list order before the prompt.'
-  }),
-  reference_video_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
-    description: 'URLs of up to three reference videos. Each video must be at most three seconds long.'
-  }).optional()
+  })
 });
 
 /**
@@ -824,22 +968,39 @@ export const zGeminiOmni11FlashReferenceToVideoOutput = z.object({
 });
 
 /**
+ * Omni11FlashTextToVideoInput
+ */
+export const zGeminiOmni11FlashInput = z.object({
+  duration: z.int().gte(3).lte(10).register(z.globalRegistry, {
+    description: 'The duration of the generated video, in seconds.'
+  }).optional().default(8),
+  resolution: z.enum([
+    '360p',
+    '720p',
+    '1080p',
+    '4k'
+  ]).register(z.globalRegistry, {
+    description: 'The resolution of the generated video.'
+  }).optional().default('720p'),
+  aspect_ratio: z.enum(['16:9', '9:16']).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video.'
+  }).optional().default('16:9'),
+  prompt: z.string().max(20000).register(z.globalRegistry, {
+    description: 'The text prompt describing the video you want to generate.'
+  })
+});
+
+/**
+ * VideoOutput
+ */
+export const zGeminiOmni11FlashOutput = z.object({
+  video: zFile
+});
+
+/**
  * TurboReferenceToVideoHailuo03Input
  */
 export const zH3MaxReferenceToVideoInput = z.object({
-  reference_video_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
-    description: 'URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.'
-  }).optional(),
-  reference_audio_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
-    description: 'URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.'
-  }).optional(),
-  seed: z.union([
-    z.int(),
-    z.unknown()
-  ]).optional(),
-  enable_safety_checker: z.boolean().register(z.globalRegistry, {
-    description: 'If set to true, the safety checker will be enabled.'
-  }).optional().default(true),
   aspect_ratio: z.enum([
     'adaptive',
     '21:9',
@@ -851,24 +1012,37 @@ export const zH3MaxReferenceToVideoInput = z.object({
   ]).register(z.globalRegistry, {
     description: 'The aspect ratio of the generated video.'
   }).optional().default('adaptive'),
+  reference_video_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
+    description: 'URLs of motion/reference video clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Video 1, Video 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.'
+  }).optional(),
+  prompt_expansion_mode: z.string().register(z.globalRegistry, {
+    description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.'
+  }).default('balanced'),
+  reference_audio_urls: z.array(z.string()).max(3).register(z.globalRegistry, {
+    description: 'URLs of reference audio clips (2-15 seconds each, combined duration at most 15 seconds), referenced in the prompt as Audio 1, Audio 2, and so on. Audio cannot be the only reference input; provide at least one reference image or video with it. Reference images, videos, and audio clips must add up to at most 12 files.'
+  }).optional(),
   duration: z.int().gte(5).lte(15).register(z.globalRegistry, {
     description: 'The duration of the video in seconds.'
   }).optional().default(5),
   sync_mode: z.boolean().register(z.globalRegistry, {
     description: 'Return the generated video as base64 instead of a CDN URL.'
   }).optional().default(false),
-  reference_image_urls: z.array(z.string()).max(9).register(z.globalRegistry, {
-    description: 'URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.'
-  }).optional(),
+  resolution: z.enum(['480P', '768P']).register(z.globalRegistry, {
+    description: 'The native generation resolution of the video.'
+  }).optional().default('768P'),
   prompt: z.string().min(1).max(50000).register(z.globalRegistry, {
     description: 'Text prompt for video generation. Refer to reference assets by their modality and order in the reference lists: Image 1, Image 2, Video 1, Audio 1, and so on.'
   }),
-  prompt_expansion_mode: z.string().register(z.globalRegistry, {
-    description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.'
-  }).default('balanced'),
-  resolution: z.enum(['480P', '768P']).register(z.globalRegistry, {
-    description: 'The native generation resolution of the video.'
-  }).optional().default('768P')
+  reference_image_urls: z.array(z.string()).max(9).register(z.globalRegistry, {
+    description: 'URLs of subject/style reference images, referenced in the prompt as Image 1, Image 2, and so on. Reference images, videos, and audio clips must add up to at most 12 files.'
+  }).optional(),
+  enable_safety_checker: z.boolean().register(z.globalRegistry, {
+    description: 'If set to true, the safety checker will be enabled.'
+  }).optional().default(true),
+  seed: z.union([
+    z.int(),
+    z.unknown()
+  ]).optional()
 });
 
 /**
@@ -879,9 +1053,62 @@ export const zH3MaxReferenceToVideoOutput = z.object({
     z.string(),
     z.unknown()
   ]).optional(),
+  video: zFile,
+  timings: z.union([
+    z.record(z.string(), z.number()),
+    z.unknown()
+  ]).optional(),
   seed: z.int().register(z.globalRegistry, {
     description: 'Base seed for reproducing the generation.'
+  })
+});
+
+/**
+ * TurboTextToVideoHailuo03Input
+ */
+export const zH3MaxTextToVideoInput = z.object({
+  aspect_ratio: z.enum([
+    '21:9',
+    '16:9',
+    '4:3',
+    '1:1',
+    '3:4',
+    '9:16'
+  ]).register(z.globalRegistry, {
+    description: 'The aspect ratio of the generated video.'
+  }).optional().default('16:9'),
+  prompt_expansion_mode: z.string().register(z.globalRegistry, {
+    description: 'How much effort to spend rewriting the prompt before generation. \'balanced\' returns in about a second. \'quality\' spends up to ~30s on a richer prompt.'
+  }).default('balanced'),
+  duration: z.int().gte(5).lte(15).register(z.globalRegistry, {
+    description: 'The duration of the video in seconds.'
+  }).optional().default(5),
+  sync_mode: z.boolean().register(z.globalRegistry, {
+    description: 'Return the generated video as base64 instead of a CDN URL.'
+  }).optional().default(false),
+  resolution: z.enum(['480P', '768P']).register(z.globalRegistry, {
+    description: 'The native generation resolution of the video.'
+  }).optional().default('768P'),
+  prompt: z.string().min(1).max(50000).register(z.globalRegistry, {
+    description: 'Text prompt for video generation'
   }),
+  enable_safety_checker: z.boolean().register(z.globalRegistry, {
+    description: 'If set to true, the safety checker will be enabled.'
+  }).optional().default(true),
+  seed: z.union([
+    z.int(),
+    z.unknown()
+  ]).optional()
+});
+
+/**
+ * TurboTextToVideoHailuo03Output
+ */
+export const zH3MaxTextToVideoOutput = z.object({
+  expanded_prompt: z.union([
+    z.string(),
+    z.unknown()
+  ]).optional(),
   video: zFile,
   timings: z.union([
     z.record(z.string(), z.number()),
@@ -1409,6 +1636,58 @@ export const zGetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByReques
  */
 export const zGetBytedanceSeedance20EnterpriseV2ReferenceToVideoRequestsByRequestIdResponse = zSeedance20EnterpriseV2ReferenceToVideoOutput;
 
+export const zGetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+export const zGetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusQuery = z.object({
+  logs: z.number().register(z.globalRegistry, {
+    description: 'Whether to include logs (`1`) in the response or not (`0`).'
+  }).optional()
+});
+
+/**
+ * The request status.
+ */
+export const zGetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdStatusResponse = zQueueStatus;
+
+export const zPutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * The request was cancelled.
+ */
+export const zPutBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdCancelResponse = z.object({
+  success: z.boolean().register(z.globalRegistry, {
+    description: 'Whether the request was cancelled successfully.'
+  }).optional()
+}).register(z.globalRegistry, {
+  description: 'The request was cancelled.'
+});
+
+export const zPostBytedanceSeedance20EnterpriseV2TextToVideoBody = zSeedance20EnterpriseV2TextToVideoInput;
+
+/**
+ * The request status.
+ */
+export const zPostBytedanceSeedance20EnterpriseV2TextToVideoResponse = zQueueStatus;
+
+export const zGetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * Result of the request.
+ */
+export const zGetBytedanceSeedance20EnterpriseV2TextToVideoRequestsByRequestIdResponse = zSeedance20EnterpriseV2TextToVideoOutput;
+
 export const zGetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdStatusPath = z.object({
   request_id: z.string().register(z.globalRegistry, {
     description: 'Request ID'
@@ -1460,6 +1739,58 @@ export const zGetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdPath = z.
  * Result of the request.
  */
 export const zGetBytedanceSeedance25ReferenceToVideoRequestsByRequestIdResponse = zSeedance25ReferenceToVideoOutput;
+
+export const zGetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+export const zGetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusQuery = z.object({
+  logs: z.number().register(z.globalRegistry, {
+    description: 'Whether to include logs (`1`) in the response or not (`0`).'
+  }).optional()
+});
+
+/**
+ * The request status.
+ */
+export const zGetBytedanceSeedance25TextToVideoRequestsByRequestIdStatusResponse = zQueueStatus;
+
+export const zPutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * The request was cancelled.
+ */
+export const zPutBytedanceSeedance25TextToVideoRequestsByRequestIdCancelResponse = z.object({
+  success: z.boolean().register(z.globalRegistry, {
+    description: 'Whether the request was cancelled successfully.'
+  }).optional()
+}).register(z.globalRegistry, {
+  description: 'The request was cancelled.'
+});
+
+export const zPostBytedanceSeedance25TextToVideoBody = zSeedance25TextToVideoInput;
+
+/**
+ * The request status.
+ */
+export const zPostBytedanceSeedance25TextToVideoResponse = zQueueStatus;
+
+export const zGetBytedanceSeedance25TextToVideoRequestsByRequestIdPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * Result of the request.
+ */
+export const zGetBytedanceSeedance25TextToVideoRequestsByRequestIdResponse = zSeedance25TextToVideoOutput;
 
 export const zGetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdStatusPath = z.object({
   request_id: z.string().register(z.globalRegistry, {
@@ -1513,6 +1844,58 @@ export const zGetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdPath =
  */
 export const zGetFalAiGeminiOmni11FlashReferenceToVideoRequestsByRequestIdResponse = zGeminiOmni11FlashReferenceToVideoOutput;
 
+export const zGetFalAiGeminiOmni11FlashRequestsByRequestIdStatusPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+export const zGetFalAiGeminiOmni11FlashRequestsByRequestIdStatusQuery = z.object({
+  logs: z.number().register(z.globalRegistry, {
+    description: 'Whether to include logs (`1`) in the response or not (`0`).'
+  }).optional()
+});
+
+/**
+ * The request status.
+ */
+export const zGetFalAiGeminiOmni11FlashRequestsByRequestIdStatusResponse = zQueueStatus;
+
+export const zPutFalAiGeminiOmni11FlashRequestsByRequestIdCancelPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * The request was cancelled.
+ */
+export const zPutFalAiGeminiOmni11FlashRequestsByRequestIdCancelResponse = z.object({
+  success: z.boolean().register(z.globalRegistry, {
+    description: 'Whether the request was cancelled successfully.'
+  }).optional()
+}).register(z.globalRegistry, {
+  description: 'The request was cancelled.'
+});
+
+export const zPostFalAiGeminiOmni11FlashBody = zGeminiOmni11FlashInput;
+
+/**
+ * The request status.
+ */
+export const zPostFalAiGeminiOmni11FlashResponse = zQueueStatus;
+
+export const zGetFalAiGeminiOmni11FlashRequestsByRequestIdPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * Result of the request.
+ */
+export const zGetFalAiGeminiOmni11FlashRequestsByRequestIdResponse = zGeminiOmni11FlashOutput;
+
 export const zGetMinimaxH3MaxReferenceToVideoRequestsByRequestIdStatusPath = z.object({
   request_id: z.string().register(z.globalRegistry, {
     description: 'Request ID'
@@ -1564,3 +1947,55 @@ export const zGetMinimaxH3MaxReferenceToVideoRequestsByRequestIdPath = z.object(
  * Result of the request.
  */
 export const zGetMinimaxH3MaxReferenceToVideoRequestsByRequestIdResponse = zH3MaxReferenceToVideoOutput;
+
+export const zGetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+export const zGetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusQuery = z.object({
+  logs: z.number().register(z.globalRegistry, {
+    description: 'Whether to include logs (`1`) in the response or not (`0`).'
+  }).optional()
+});
+
+/**
+ * The request status.
+ */
+export const zGetMinimaxH3MaxTextToVideoRequestsByRequestIdStatusResponse = zQueueStatus;
+
+export const zPutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * The request was cancelled.
+ */
+export const zPutMinimaxH3MaxTextToVideoRequestsByRequestIdCancelResponse = z.object({
+  success: z.boolean().register(z.globalRegistry, {
+    description: 'Whether the request was cancelled successfully.'
+  }).optional()
+}).register(z.globalRegistry, {
+  description: 'The request was cancelled.'
+});
+
+export const zPostMinimaxH3MaxTextToVideoBody = zH3MaxTextToVideoInput;
+
+/**
+ * The request status.
+ */
+export const zPostMinimaxH3MaxTextToVideoResponse = zQueueStatus;
+
+export const zGetMinimaxH3MaxTextToVideoRequestsByRequestIdPath = z.object({
+  request_id: z.string().register(z.globalRegistry, {
+    description: 'Request ID'
+  })
+});
+
+/**
+ * Result of the request.
+ */
+export const zGetMinimaxH3MaxTextToVideoRequestsByRequestIdResponse = zH3MaxTextToVideoOutput;

--- a/src/lib/motion/motion-generation.test.ts
+++ b/src/lib/motion/motion-generation.test.ts
@@ -848,6 +848,30 @@ describe('Motion Service', () => {
       expect(billing.recordFalUsage).toBe(false);
       expect(billing.endpointId).toBe('gemini-omni-1.1-flash');
     });
+
+    // The post-run charge re-resolves the row submit used, so the two must
+    // agree on all three fal routes (#873, #1521).
+    it.each([
+      [false, false, 'bytedance/seedance-2.5/image-to-video'],
+      [true, true, 'bytedance/seedance-2.5/reference-to-video'],
+      [false, true, 'bytedance/seedance-2.5/text-to-video'],
+    ] as const)(
+      'prices the fal row the shot hit (refs=%s, referenceOnly=%s)',
+      async (hasReferenceImages, referenceOnly, endpointId) => {
+        const billing = await motionCostFromUsage(
+          'fal',
+          {
+            promptTokens: 0,
+            completionTokens: 0,
+            totalTokens: 0,
+            unitsBilled: 5,
+          },
+          { modelKey: 'seedance_v2_5', hasReferenceImages, referenceOnly }
+        );
+        expect(billing.endpointId).toBe(endpointId);
+        expect(billing.recordFalUsage).toBe(true);
+      }
+    );
   });
 
   describe('resolveMotionVia', () => {

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -386,10 +386,10 @@ export async function submitMotionJob(
   );
 
   // Reference-only with nothing matched is not the mode — it is text-to-video
-  // at the reference-to-video price, with the character, set and continuity all
-  // reinvented for this one shot while every sibling shot binds its sheets.
-  // The request is still valid (the endpoint serves it), so this is a warning
-  // rather than a throw; without it the shot just comes back looking wrong and
+  // (the fal route submits to the t2v sibling, #1521), with the character, set
+  // and continuity all reinvented for this one shot while every sibling shot
+  // binds its sheets. The request is still valid, so this is a warning rather
+  // than a throw; without it the shot just comes back looking wrong and
   // nothing anywhere says why. Also emitted as an event: a server log is
   // nobody's dashboard, and the rate of this is the measure of how often
   // reference-only silently degrades to text-to-video.
@@ -681,10 +681,10 @@ export async function motionCostFromUsage(
     modelKey: ImageToVideoModel;
     hasReferenceImages: boolean;
     /**
-     * Reference-only shots route to the reference-to-video endpoint even with
-     * no matched sheets, so the charge must be priced against that endpoint —
-     * resolving without it would bill an image-to-video rate for a job that
-     * never ran there.
+     * Reference-only shots route to the reference-to-video endpoint (or its
+     * text-to-video sibling when no sheets matched, #1521), so the charge must
+     * be priced against that endpoint — resolving without it would bill an
+     * image-to-video rate for a job that never ran there.
      */
     referenceOnly?: boolean;
   }

--- a/src/lib/motion/motion-generation.ts
+++ b/src/lib/motion/motion-generation.ts
@@ -111,9 +111,10 @@ export type GenerateMotionOptions = {
   referenceImages?: ReferenceImageDescription[];
   /**
    * Reference-only mode: this shot has no start frame by design, not by
-   * failure. It forces the reference-to-video route (whose start frame is
-   * optional) even when the scene matched no sheets at all, and it is what
-   * keeps `@Image1` bound to a real reference instead of a nonexistent still.
+   * failure. It routes to the reference-to-video endpoint when the scene
+   * matched sheets and to the model's text-to-video sibling when it matched
+   * none (#1521 — fal r2v rejects an empty image list), and it is what keeps
+   * `@Image1` bound to a real reference instead of a nonexistent still.
    * `imageUrl` must be absent whenever this is true.
    */
   referenceOnly?: boolean;
@@ -396,12 +397,16 @@ export async function submitMotionJob(
   if (options.referenceOnly && !hasReferenceImages) {
     logger.warn(
       'Reference-only motion job has no matched reference sheets; submitting as text-to-video',
-      { modelKey, via: endpoint.via }
+      { modelKey, via: endpoint.via, endpointId: endpoint.endpointId }
     );
     getPostHogClient()?.capture({
       distinctId: 'system',
       event: 'reference_only_no_references',
-      properties: { model: modelKey, via: endpoint.via },
+      properties: {
+        model: modelKey,
+        via: endpoint.via,
+        endpointId: endpoint.endpointId,
+      },
     });
   }
 

--- a/src/lib/motion/reference-only-guards.test.ts
+++ b/src/lib/motion/reference-only-guards.test.ts
@@ -96,11 +96,33 @@ describe('estimateVideoCost', () => {
       unit: 'seconds',
       unitPrice: micros(2000),
     },
+    'bytedance/seedance-2.5/text-to-video': {
+      unit: 'seconds',
+      unitPrice: micros(3000),
+    },
   };
 
-  it('prices reference-to-video even with no matched sheets', () => {
-    // The shot routes to r2v regardless; resolving on hasReferenceImages alone
-    // priced the i2v row for a job that never runs there.
+  // Pinned to a row, not merely "different from i2v": any wrong route that
+  // happens to differ would pass an inequality.
+  const at = (endpointId: string) =>
+    Number(estimateFalCost(endpointId, { durationSeconds: 5 }, pricing));
+
+  it('prices reference-to-video when sheets matched', () => {
+    const withFlag = estimateVideoCost('seedance_v2_5', 5, {
+      pricing,
+      hasReferenceImages: true,
+      referenceOnly: true,
+    });
+    expect(Number(withFlag)).toBe(
+      at('bytedance/seedance-2.5/reference-to-video')
+    );
+    expect(Number(withFlag)).toBeGreaterThan(0);
+  });
+
+  it('prices text-to-video with no matched sheets, never image-to-video (#1521)', () => {
+    // The shot submits to the t2v sibling (fal r2v rejects an empty list);
+    // resolving on hasReferenceImages alone priced the i2v row for a job that
+    // never runs there.
     const withFlag = estimateVideoCost('seedance_v2_5', 5, {
       pricing,
       hasReferenceImages: false,
@@ -110,13 +132,7 @@ describe('estimateVideoCost', () => {
       pricing,
       hasReferenceImages: false,
     });
-    // Pinned to the r2v row, not merely "different from i2v": any wrong route
-    // that happens to differ would pass an inequality.
-    const at = (endpointId: string) =>
-      Number(estimateFalCost(endpointId, { durationSeconds: 5 }, pricing));
-    expect(Number(withFlag)).toBe(
-      at('bytedance/seedance-2.5/reference-to-video')
-    );
+    expect(Number(withFlag)).toBe(at('bytedance/seedance-2.5/text-to-video'));
     expect(Number(withoutFlag)).toBe(
       at('bytedance/seedance-2.5/image-to-video')
     );

--- a/src/lib/motion/reference-only-guards.test.ts
+++ b/src/lib/motion/reference-only-guards.test.ts
@@ -119,6 +119,16 @@ describe('estimateVideoCost', () => {
     expect(Number(withFlag)).toBeGreaterThan(0);
   });
 
+  it('quotes reference-to-video when the caller has not matched sheets yet', () => {
+    // Pre-flight gates (add-video-model, smart-retry, stale preview) run before
+    // any sheet is bound; omitting the flag must keep the conservative row.
+    const quote = estimateVideoCost('seedance_v2_5', 5, {
+      pricing,
+      referenceOnly: true,
+    });
+    expect(Number(quote)).toBe(at('bytedance/seedance-2.5/reference-to-video'));
+  });
+
   it('prices text-to-video with no matched sheets, never image-to-video (#1521)', () => {
     // The shot submits to the t2v sibling (fal r2v rejects an empty list);
     // resolving on hasReferenceImages alone priced the i2v row for a job that

--- a/src/lib/motion/resolve-motion-endpoint.test.ts
+++ b/src/lib/motion/resolve-motion-endpoint.test.ts
@@ -146,14 +146,31 @@ describe('resolveMotionEndpoint', () => {
 });
 
 describe('reference-only', () => {
-  it('routes Seedance to reference-to-video even with no matched refs', () => {
-    expect(resolveMotionEndpoint('seedance_v2_5', false, 'fal', true)).toEqual({
+  it('routes Seedance to reference-to-video when refs matched', () => {
+    expect(resolveMotionEndpoint('seedance_v2_5', true, 'fal', true)).toEqual({
       via: 'fal',
       endpointId: 'bytedance/seedance-2.5/reference-to-video',
       references: 'endpoint',
       referenceConfig: MOTION_REFERENCE_ENDPOINTS.seedance_v2_5,
     });
   });
+
+  // fal's reference-to-video endpoints 422 on an empty image list (#1521).
+  it.each([
+    ['seedance_v2', 'bytedance/seedance-2.0/enterprise/v2/text-to-video'],
+    ['seedance_v2_5', 'bytedance/seedance-2.5/text-to-video'],
+    ['minimax_h3_max', 'minimax/h3-max/text-to-video'],
+    ['gemini_omni_flash', 'fal-ai/gemini-omni-1.1-flash'],
+  ] as const)(
+    'routes %s to text-to-video with no matched refs',
+    (model, endpointId) => {
+      expect(resolveMotionEndpoint(model, false, 'fal', true)).toEqual({
+        via: 'fal',
+        endpointId,
+        references: 'text-to-video',
+      });
+    }
+  );
 
   it('refuses a model with no reference-to-video route', () => {
     expect(() =>

--- a/src/lib/motion/resolve-motion-endpoint.ts
+++ b/src/lib/motion/resolve-motion-endpoint.ts
@@ -13,13 +13,16 @@
  *   - `inline` — URLs on the same generations call (Kling `elements`, Grok
  *     Imagine 1.5 native `reference`/`character` prompt parts)
  *   - `none` — URLs are not sent; tokens become descriptions in the prompt
+ *   - `text-to-video` — nothing to send: a reference-only shot that matched no
+ *     sheets goes to the model's prompt-only sibling (#1521). Every fal
+ *     reference-to-video endpoint rejects an empty image list.
  *
  * `referenceOnly` is the mode where no start frame was ever rendered: the clip
  * is driven by the cast/element/location sheets and a self-describing prompt.
- * It forces the reference route even when a shot happens to have matched no
- * references at all (a two-hander in an unmatched location still has to reach
- * an endpoint whose start frame is optional), and it is what tells the request
- * builders not to reserve `@Image1` for a still that does not exist.
+ * It is what tells the request builders not to reserve `@Image1` for a still
+ * that does not exist, and when a shot happens to have matched no references
+ * at all it picks the text-to-video sibling rather than an endpoint that would
+ * reject the empty list.
  */
 
 import { NATIVE_GEMINI_VIDEO_MODEL } from '@/lib/ai/gemini-native';
@@ -47,6 +50,11 @@ export type MotionEndpointResolution =
       references: 'endpoint';
       /** Tag syntax + image cap for binding refs into the prompt. */
       referenceConfig: MotionReferenceEndpointConfig;
+    }
+  | {
+      via: 'fal';
+      endpointId: string;
+      references: 'text-to-video';
     };
 
 export function resolveMotionEndpoint(
@@ -101,6 +109,17 @@ export function resolveMotionEndpoint(
   }
   if (hasReferenceImages || referenceOnly) {
     const referenceConfig = getMotionReferenceEndpoint(modelKey);
+    if (referenceConfig && !hasReferenceImages) {
+      // Reference-only with nothing matched (an abstract piece, an unmatched
+      // location): the reference-to-video endpoint 422s on an empty image
+      // list, so the shot goes to the prompt-only sibling. Billing and the
+      // estimator resolve through here too, so they price the same row.
+      return {
+        via: 'fal',
+        endpointId: referenceConfig.textToVideoEndpointId,
+        references: 'text-to-video',
+      };
+    }
     if (referenceConfig) {
       return {
         via: 'fal',

--- a/src/lib/motion/resolve-motion-endpoint.ts
+++ b/src/lib/motion/resolve-motion-endpoint.ts
@@ -6,10 +6,13 @@
  * endpoint that takes an image list bound to per-model prompt tokens and has
  * no single start-frame `image_url` — see `MOTION_REFERENCE_ENDPOINTS`. When a
  * scene actually has references AND the model has such an endpoint, route there;
- * otherwise stay on the normal image-to-video endpoint.
+ * a reference-only scene with no references goes to that model's text-to-video
+ * sibling; otherwise stay on the normal image-to-video endpoint.
  *
- * `references` is how those images ride, if at all:
- *   - `endpoint` — dedicated reference-to-video endpoint (Seedance, H3 Max)
+ * `references` is the request shape — how the images ride, or that nothing
+ * rides at all:
+ *   - `endpoint` — dedicated reference-to-video endpoint (Seedance, H3 Max,
+ *     Omni Flash)
  *   - `inline` — URLs on the same generations call (Kling `elements`, Grok
  *     Imagine 1.5 native `reference`/`character` prompt parts)
  *   - `none` — URLs are not sent; tokens become descriptions in the prompt
@@ -36,6 +39,7 @@ import {
   type MotionReferenceEndpointConfig,
 } from '@/lib/ai/models';
 import type { MediaVia } from '@/lib/ai/via';
+import type { MotionEndpointId } from '@/lib/motion/endpoint-map';
 
 export type MotionEndpointResolution =
   | {
@@ -53,7 +57,7 @@ export type MotionEndpointResolution =
     }
   | {
       via: 'fal';
-      endpointId: string;
+      endpointId: MotionEndpointId;
       references: 'text-to-video';
     };
 
@@ -109,18 +113,18 @@ export function resolveMotionEndpoint(
   }
   if (hasReferenceImages || referenceOnly) {
     const referenceConfig = getMotionReferenceEndpoint(modelKey);
-    if (referenceConfig && !hasReferenceImages) {
-      // Reference-only with nothing matched (an abstract piece, an unmatched
-      // location): the reference-to-video endpoint 422s on an empty image
-      // list, so the shot goes to the prompt-only sibling. Billing and the
-      // estimator resolve through here too, so they price the same row.
-      return {
-        via: 'fal',
-        endpointId: referenceConfig.textToVideoEndpointId,
-        references: 'text-to-video',
-      };
-    }
     if (referenceConfig) {
+      if (!hasReferenceImages) {
+        // Reference-only with nothing matched (an abstract piece, an unmatched
+        // location): the reference-to-video endpoint 422s on an empty image
+        // list, so the shot goes to the prompt-only sibling. Billing and the
+        // estimator resolve through here too, so they price the same row.
+        return {
+          via: 'fal',
+          endpointId: referenceConfig.textToVideoEndpointId,
+          references: 'text-to-video',
+        };
+      }
       return {
         via: 'fal',
         endpointId: referenceConfig.endpointId,

--- a/src/lib/motion/resolve-motion-endpoint.ts
+++ b/src/lib/motion/resolve-motion-endpoint.ts
@@ -11,7 +11,10 @@
  *
  * `references` is the request shape — how the images ride, or that nothing
  * rides at all:
- *   - `endpoint` — dedicated reference-to-video endpoint (Seedance, H3 Max,
+ *  | {
+      via: 'fal';
+      endpointId: MotionEndpointId;
+      references: 'endpoint'; - `endpoint` — dedicated reference-to-video endpoint (Seedance, H3 Max,
  *     Omni Flash)
  *   - `inline` — URLs on the same generations call (Kling `elements`, Grok
  *     Imagine 1.5 native `reference`/`character` prompt parts)


### PR DESCRIPTION
Closes #1521

## Why

Every fal reference-to-video endpoint rejects an empty image list ("At least one reference image, video, or audio must be provided"). A reference-only shot whose scene bibles legitimately matched no cast, location or element sheets (a one-line abstract brief) therefore 422'd on Seedance 2.0 / 2.5, H3 Max and Omni Flash. The old comment in `buildMotionRequest` claimed the endpoint served the empty case as text-to-video. It does not.

## What

- `MotionReferenceEndpointConfig.textToVideoEndpointId` (required) names each model's prompt-only sibling. `bun motion:codegen` now pulls those schemas too; the generated files are regenerated (existing endpoints only reorder).
- `resolveMotionEndpoint` returns `references: 'text-to-video'` when reference-only has nothing matched. Submit, post-hoc billing and the estimator all resolve through it, so they price the same row.
- `buildMotionRequest` builds a prompt-only body on that branch. The reference branch now always sends the image list.
- `applyBytePlusRouteAliases` aliases the text-to-video id to the Ark rate alongside the reference id.
- The native Ark / xAI / Google builders are untouched (they already send plain text-to-video here). The prompt binding they share with the fal path is now typed on the two knobs it reads, `tag` and `maxImages`, instead of the full fal endpoint config.
- Docs and stale comments updated. No guard forcing a location into the bibles; an empty bible stays a valid outcome.

## Omni Flash on fal

Checked against the queue with a key (empty-body probes, rejected at validation, no charge):

- `fal-ai/gemini-omni-1.1-flash` is the text-to-video endpoint (the studio already uses it).
- `.../reference-to-video` and `.../image-to-video` are live.
- `.../text-to-video` does not exist ("Path /text-to-video not found").
- Only the fal.ai HTML pages and `llms.txt` 404. The OpenAPI specs still resolve. Not a rename.

## Tests

- `build-model-input.test.ts`: reference-only + empty references → text-to-video id, no image field, for all four models; H3 Max keeps its quality overrides on that route.
- `resolve-motion-endpoint.test.ts`: same four routings.
- `reference-only-guards.test.ts`: the estimator pins the text-to-video row with nothing matched and the reference-to-video row with a match.

https://claude.ai/code/session_01JyBnz9qBwB7swmafNQSWJk
