### PR TITLE
Top-up demo: toast on insufficient credits,  min, BYOK as a link

### DIFF
--- a/src/components/billing/add-credits-dialog.tsx
+++ b/src/components/billing/add-credits-dialog.tsx
@@ -46,6 +46,7 @@ import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
 import { BILLING_GATE_KEY } from '@/hooks/use-billing-gate';
 import { useAuthSession } from '@/lib/auth/session-query';
 import {
+  DEFAULT_TOPUP_AMOUNT_USD,
   formatPlatformFeePercent,
   MAX_TOPUP_AMOUNT_USD,
   MIN_TOPUP_AMOUNT_USD,
@@ -63,7 +64,7 @@ import { ulid } from 'ulid';
 const NEW_CARD = 'new-card';
 
 /** Amount the dialog opens on — matches the low-balance toast's "Add $10". */
-const DEFAULT_TOPUP_AMOUNT = String(MIN_TOPUP_AMOUNT_USD);
+const DEFAULT_TOPUP_AMOUNT = String(DEFAULT_TOPUP_AMOUNT_USD);
 
 function formatBrand(brand: string): string {
   return brand.charAt(0).toUpperCase() + brand.slice(1);

--- a/src/components/billing/billing-gate-dialog.tsx
+++ b/src/components/billing/billing-gate-dialog.tsx
@@ -1,11 +1,9 @@
 /**
  * Billing Gate Dialog
- * Promotes credits first (#1096): buy credits, or ask the founder for some,
- * with BYOK below — a fal.ai key alone covers everything, since LLM calls
- * route through fal's OpenRouter endpoint. Gift codes at the bottom.
+ * Promotes credits first (#1096): buy credits, or ask the founder for some.
+ * Gift codes and BYOK (Settings → API keys) are footer links.
  */
 
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -14,18 +12,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
-import { FalLogo } from '@/components/icons/fal-logo';
-import { saveApiKeyFn } from '@/functions/api-keys';
 import { requestFounderCreditsFn } from '@/functions/billing';
-import { getCurrentUserProfileFn } from '@/functions/user';
 import { openAddCreditsDialog } from '@/hooks/use-add-credits-dialog';
-import {
-  BILLING_GATE_KEY,
-  useBillingGateQuery,
-} from '@/hooks/use-billing-gate';
+import { useBillingGateQuery } from '@/hooks/use-billing-gate';
 import {
   closeBillingGate,
   getBillingGateReason,
@@ -34,15 +24,15 @@ import {
 } from '@/hooks/use-billing-gate-dialog';
 import { cn } from '@/shared/utils';
 import { usePostHog } from '@posthog/react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
   ArrowRight,
   Check,
   CreditCard,
-  ExternalLink,
   Gift,
   HeartHandshake,
+  Key,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
@@ -236,45 +226,6 @@ const AskFounderCard: React.FC = () => {
   );
 };
 
-const ConnectedBadge: React.FC = () => (
-  <Badge variant="default" className="gap-1 px-1.5 py-0 text-[10px]">
-    <Check className="size-2.5" />
-    Connected
-  </Badge>
-);
-
-type ProviderCardProps = {
-  logo: React.ReactNode;
-  title: string;
-  description: string;
-  connected: boolean;
-  children?: React.ReactNode;
-};
-
-const ProviderCard: React.FC<ProviderCardProps> = ({
-  logo,
-  title,
-  description,
-  connected,
-  children,
-}) => (
-  <div className="flex flex-col gap-2.5 rounded-xl border border-border/60 p-3.5">
-    <div className="flex items-center gap-3.5">
-      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground">
-        {logo}
-      </div>
-      <div className="flex-1 space-y-0.5">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{title}</span>
-          {connected && <ConnectedBadge />}
-        </div>
-        <p className="text-xs text-muted-foreground">{description}</p>
-      </div>
-    </div>
-    {!connected && children}
-  </div>
-);
-
 type BillingGateDialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -295,51 +246,11 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
   context = 'generation',
   reason = 'manual',
 }) => {
-  const queryClient = useQueryClient();
   const posthog = usePostHog();
-  const [falKeyInput, setFalKeyInput] = useState('');
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) posthog.capture('billing_gate_shown', { reason, context });
   }, [open, reason, context, posthog]);
-
-  const { data: profile } = useQuery({
-    queryKey: ['currentUserProfile'],
-    queryFn: () => getCurrentUserProfileFn(),
-    staleTime: 5 * 60 * 1000,
-    enabled: open,
-  });
-  const teamId = profile?.teamId;
-
-  const saveFalKeyMutation = useMutation({
-    mutationFn: (apiKey: string) => {
-      if (!teamId) throw new Error('No team found');
-      return saveApiKeyFn({ data: { teamId, provider: 'fal', apiKey } });
-    },
-    onSuccess: () => {
-      setFalKeyInput('');
-      setError(null);
-      posthog.capture('api_key_saved', {
-        provider: 'fal',
-        source: 'billing_gate',
-      });
-      void queryClient.invalidateQueries({ queryKey: [...BILLING_GATE_KEY] });
-      void queryClient.invalidateQueries({ queryKey: ['apiKeys', teamId] });
-      void queryClient.invalidateQueries({
-        queryKey: ['apiKeyStatus', teamId],
-      });
-    },
-    onError: (err) => {
-      setError(err instanceof Error ? err.message : 'Failed to save key');
-    },
-  });
-
-  const handleSaveFalKey = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (!falKeyInput.trim()) return;
-    saveFalKeyMutation.mutate(falKeyInput.trim());
-  };
 
   const handleNav = () => {
     setReturnPath(returnTo);
@@ -368,7 +279,7 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
         </DialogHeader>
 
         <div className="flex flex-col gap-2 pt-1">
-          {stripeEnabled && (
+          {stripeEnabled ? (
             <>
               {/* Opens the add-credits modal on top of the gate (#1099) */}
               <OptionCard
@@ -380,70 +291,39 @@ export const BillingGateDialog: React.FC<BillingGateDialogProps> = ({
               />
 
               <AskFounderCard />
-
-              <div className="flex items-center gap-3 py-1">
-                <Separator className="flex-1" />
-                <span className="text-[11px] font-medium uppercase tracking-widest text-muted-foreground/50">
-                  or
-                </span>
-                <Separator className="flex-1" />
-              </div>
             </>
-          )}
-
-          <ProviderCard
-            logo={<FalLogo className="size-5" />}
-            title="fal.ai"
-            description="One key covers everything — images, video, audio, and script analysis."
-            connected={hasFalKey}
-          >
-            <form onSubmit={handleSaveFalKey} className="flex gap-2">
-              <Input
-                name="falKey"
-                type="password"
-                placeholder="fal_…"
-                value={falKeyInput}
-                onChange={(e) => setFalKeyInput(e.target.value)}
-                autoComplete="off"
-                spellCheck={false}
-                aria-label="fal.ai API key"
-                required
-              />
-              <Button
-                type="submit"
-                disabled={saveFalKeyMutation.isPending || !falKeyInput.trim()}
-              >
-                {saveFalKeyMutation.isPending ? 'Saving…' : 'Save'}
-              </Button>
-            </form>
-            <a
-              href="https://fal.ai/dashboard/keys"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-xs text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline"
-            >
-              Get a key from fal.ai
-              <ExternalLink className="size-3" />
-            </a>
-          </ProviderCard>
-
-          {error && (
-            <p role="alert" className="text-xs text-destructive">
-              {error}
-            </p>
+          ) : (
+            <OptionCard
+              to="/settings/api-keys"
+              icon={<Key className="size-4" />}
+              title="Use your own key"
+              description="Connect fal.ai — images, video, audio, and script analysis."
+              variant="primary"
+              onClick={handleNav}
+            />
           )}
         </div>
 
-        <div className="flex items-center justify-between pt-1">
-          <Link
-            to="/credits"
-            search={{ tab: 'gift-codes' }}
-            onClick={handleNav}
-            className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 transition-colors hover:text-muted-foreground"
-          >
-            <Gift className="size-3.5" />
-            Redeem a gift code
-          </Link>
+        <div className="flex items-center justify-between gap-3 pt-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <Link
+              to="/credits"
+              search={{ tab: 'gift-codes' }}
+              onClick={handleNav}
+              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 transition-colors hover:text-muted-foreground"
+            >
+              <Gift className="size-3.5" />
+              Redeem a gift code
+            </Link>
+            <Link
+              to="/settings/api-keys"
+              onClick={handleNav}
+              className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 transition-colors hover:text-muted-foreground"
+            >
+              <Key className="size-3.5" />
+              Use your own key
+            </Link>
+          </div>
           <Button
             variant="ghost"
             size="sm"

--- a/src/components/billing/low-balance-toast.ts
+++ b/src/components/billing/low-balance-toast.ts
@@ -8,7 +8,7 @@
  * it fires, the analytics, and what the buttons open.
  */
 
-import { MIN_TOPUP_AMOUNT_USD } from '@/lib/billing/constants';
+import { DEFAULT_TOPUP_AMOUNT_USD } from '@/lib/billing/constants';
 import type { CSSProperties } from 'react';
 import { toast } from 'sonner';
 
@@ -29,7 +29,7 @@ export function showLowBalanceToast({
   onOtherOptions,
 }: LowBalanceToastProps) {
   const action = {
-    label: `Add $${MIN_TOPUP_AMOUNT_USD}`,
+    label: `Add $${DEFAULT_TOPUP_AMOUNT_USD}`,
     onClick: onAddCredits,
   };
   const cancel = { label: 'Other options', onClick: onOtherOptions };
@@ -41,6 +41,7 @@ export function showLowBalanceToast({
 
   if (isZeroBalance) {
     toast.error('Your credit balance is $0', {
+      id: 'low-balance',
       description: 'Generation is off until you add credits.',
       action,
       cancel,
@@ -51,6 +52,7 @@ export function showLowBalanceToast({
   }
 
   toast.warning(`Balance is $${balanceUsd.toFixed(2)}`, {
+    id: 'low-balance',
     description: `Another short is about $${Math.round(runCostUsd)}.`,
     action,
     cancel,

--- a/src/components/models/model-detail-view.tsx
+++ b/src/components/models/model-detail-view.tsx
@@ -40,8 +40,6 @@ import {
   listGeneratedAssetsFn,
 } from '@/functions/model-assets';
 import { getModelDetailFn, getModelFamilyFn } from '@/functions/model-catalog';
-import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
-import { useFalBillingGate } from '@/hooks/use-billing-gate';
 import { isInsufficientCreditsError } from '@/shared/errors';
 import type { GeneratedAsset } from '@/lib/db/schema';
 import {
@@ -181,7 +179,6 @@ const ModelRunPanel: FC<{ detail: ModelDetail }> = ({ detail }) => {
   const { model, inputSchema } = detail;
   const queryClient = useQueryClient();
   const { requireAuth, isAuthenticated } = useAuthGate();
-  const { showGate: showBillingGate } = useFalBillingGate();
 
   const [values, setValues] = useState<Record<string, JsonValue>>(() =>
     seedFormValue(inputSchema)
@@ -206,12 +203,6 @@ const ModelRunPanel: FC<{ detail: ModelDetail }> = ({ detail }) => {
       void queryClient.invalidateQueries({
         queryKey: ['generated-assets', model.endpointId],
       });
-    },
-    onError: (error) => {
-      if (isInsufficientCreditsError(error)) {
-        showBillingGate('insufficient');
-        void queryClient.invalidateQueries({ queryKey: BILLING_BALANCE_KEY });
-      }
     },
   });
 

--- a/src/components/scenes/scene-script-prompts.tsx
+++ b/src/components/scenes/scene-script-prompts.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/functions/motion-functions';
 import { regenerateShotPromptFn } from '@/functions/prompt-variants';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
+import { notifyInsufficientCredits } from '@/hooks/notify-insufficient-credits';
 import { useFalBillingGate } from '@/hooks/use-billing-gate';
 import { useFalPricing } from '@/hooks/use-fal-pricing';
 import { segmentKeys } from '@/hooks/use-segments';
@@ -979,7 +980,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       invalidateContinuity();
     } catch (error) {
       if (isInsufficientCreditsError(error)) {
-        showFalGate();
+        notifyInsufficientCredits();
         void queryClient.invalidateQueries({
           queryKey: [...BILLING_BALANCE_KEY],
         });
@@ -1002,7 +1003,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     queryClient,
     invalidateContinuity,
     onRegenerateStart,
-    showFalGate,
   ]);
 
   const handleRegenerateMotion = useCallback(async () => {
@@ -1070,7 +1070,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
       invalidateContinuity();
     } catch (error) {
       if (isInsufficientCreditsError(error)) {
-        showFalGate();
+        notifyInsufficientCredits();
         void queryClient.invalidateQueries({
           queryKey: [...BILLING_BALANCE_KEY],
         });
@@ -1094,7 +1094,6 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
     queryClient,
     invalidateContinuity,
     onRegenerateStart,
-    showFalGate,
   ]);
 
   // The shot's selected motion prompt, projected from its version row (#713) —

--- a/src/components/scenes/scenes-view.tsx
+++ b/src/components/scenes/scenes-view.tsx
@@ -34,7 +34,7 @@ import { smartRetryFn } from '@/functions/smart-retry';
 import { useActiveImageModel } from '@/hooks/use-active-image-model';
 import { useActiveVideoModel } from '@/hooks/use-active-video-model';
 import { BILLING_BALANCE_KEY } from '@/hooks/use-billing-balance';
-import { useFalBillingGate } from '@/hooks/use-billing-gate';
+import { notifyInsufficientCredits } from '@/hooks/notify-insufficient-credits';
 import { useHorizontalSwipe } from '@/hooks/use-horizontal-swipe';
 import { useSceneSelection } from '@/hooks/use-scene-selection';
 import { useSequenceSegments } from '@/hooks/use-segments';
@@ -249,8 +249,6 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
 }) => {
   const queryClient = useQueryClient();
   const posthog = usePostHog();
-
-  const { showGate: showBillingGate } = useFalBillingGate();
 
   const {
     selection,
@@ -1235,7 +1233,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
       void queryClient.invalidateQueries({ queryKey: ['shots', sequenceId] });
     } catch (error) {
       if (isInsufficientCreditsError(error)) {
-        showBillingGate('insufficient');
+        notifyInsufficientCredits();
         void queryClient.invalidateQueries({
           queryKey: BILLING_BALANCE_KEY,
         });
@@ -1247,7 +1245,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
     } finally {
       setIsRetrying(false);
     }
-  }, [sequenceId, queryClient, showBillingGate]);
+  }, [sequenceId, queryClient]);
 
   // Handler for batch motion generation (server determines eligible shots)
   const handleBatchMotionGeneration = useCallback(
@@ -1332,7 +1330,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         }
 
         if (isInsufficientCreditsError(error)) {
-          showBillingGate('insufficient');
+          notifyInsufficientCredits();
           void queryClient.invalidateQueries({
             queryKey: BILLING_BALANCE_KEY,
           });
@@ -1341,14 +1339,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         }
       }
     },
-    [
-      sequenceId,
-      shots,
-      generateStartFrames,
-      queryClient,
-      posthog,
-      showBillingGate,
-    ]
+    [sequenceId, shots, generateStartFrames, queryClient, posthog]
   );
 
   const musicPromptsReady = !!(sequence?.musicPrompt && sequence.musicTags);
@@ -1397,10 +1388,10 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         });
       } catch (error) {
         // Continue reserves credits like any other run, so it hits the same
-        // gate as batch motion — show the gate, not a generic error toast.
+        // toast as batch motion — not a generic error.
         queryClient.setQueryData<Sequence>(key, previous);
         if (!isInsufficientCreditsError(error)) throw error;
-        showBillingGate('insufficient');
+        notifyInsufficientCredits();
         void queryClient.invalidateQueries({ queryKey: BILLING_BALANCE_KEY });
         return;
       }
@@ -1408,7 +1399,7 @@ export const ScenesView: React.FC<ScenesViewProps> = ({
         queryKey: sequenceKeys.detail(sequenceId),
       });
     },
-    [sequenceId, queryClient, showBillingGate]
+    [sequenceId, queryClient]
   );
 
   const handleGenerateMusic = useCallback(

--- a/src/components/studio/studio-composer.tsx
+++ b/src/components/studio/studio-composer.tsx
@@ -61,7 +61,6 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Switch } from '@/components/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { useFalBillingGate } from '@/hooks/use-billing-gate';
 import { useFalPricing } from '@/hooks/use-fal-pricing';
 import {
   useCreateStudioAssets,
@@ -89,7 +88,6 @@ import {
   DEFAULT_ASPECT_RATIO,
   type AspectRatio,
 } from '@/shared/constants/aspect-ratios';
-import { isInsufficientCreditsError } from '@/shared/errors';
 import { VoiceInputButton } from '@/components/voice/voice-input-button';
 import { useEditorDictation } from '@/hooks/use-dictation';
 import {
@@ -283,7 +281,6 @@ export function StudioComposer({
 }: StudioComposerProps) {
   const { requireAuth, isAuthenticated } = useAuthGate();
   const posthog = usePostHog();
-  const { showGate } = useFalBillingGate();
   const { pricing } = useFalPricing();
   const create = useCreateStudioAssets();
   const draft = useDraftStudioPrompt();
@@ -677,9 +674,6 @@ export function StudioComposer({
           setLastShuffled(next);
           options?.onDrafted?.(next);
         },
-        onError: (error) => {
-          if (isInsufficientCreditsError(error)) showGate();
-        },
       }
     );
   };
@@ -841,11 +835,7 @@ export function StudioComposer({
       return;
     }
     requireAuth(() => {
-      create.mutate(buildInput(), {
-        onError: (error) => {
-          if (isInsufficientCreditsError(error)) showGate();
-        },
-      });
+      create.mutate(buildInput());
     });
   };
 

--- a/src/hooks/notify-insufficient-credits.ts
+++ b/src/hooks/notify-insufficient-credits.ts
@@ -1,0 +1,19 @@
+/**
+ * Lightweight pub/sub so non-React callers (the query client's mutation
+ * cache) can fire the low-balance toast without importing it.
+ *
+ * `useLowBalanceWarning` is mounted in the app shell and owns the toast.
+ */
+
+const listeners = new Set<() => void>();
+
+export function notifyInsufficientCredits(): void {
+  for (const listener of listeners) listener();
+}
+
+export function subscribeInsufficientCredits(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/src/hooks/use-low-balance-warning.ts
+++ b/src/hooks/use-low-balance-warning.ts
@@ -1,11 +1,14 @@
 /**
  * Low Balance Warning Hook
- * Fires toast notifications when balance decreases and crosses threshold
+ * Fires toast notifications when balance decreases and crosses threshold,
+ * and when a generation is rejected for insufficient credits (preflight
+ * does not debit, so that path never looks like a balance drop).
  */
 
 import { usePostHog } from '@posthog/react';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { showLowBalanceToast } from '@/components/billing/low-balance-toast';
+import { subscribeInsufficientCredits } from './notify-insufficient-credits';
 import { openAddCreditsDialog } from './use-add-credits-dialog';
 import { openBillingGate } from './use-billing-gate-dialog';
 import { useBillingBalance } from './use-billing-balance';
@@ -19,6 +22,43 @@ export function useLowBalanceWarning() {
   const posthog = usePostHog();
   const prevBalanceRef = useRef<number | null>(null);
   const hasWarnedRef = useRef(false);
+
+  const fireToast = useCallback(
+    (source: 'balance_drop' | 'insufficient_credits') => {
+      const balanceUsd = balance ?? 0;
+      const zero = balance === null ? true : isZeroBalance;
+      const props = {
+        balance_usd: balanceUsd,
+        is_zero: zero,
+        source,
+      };
+      posthog.capture('low_balance_toast_shown', props);
+
+      const clicked = (choice: 'add_credits' | 'other_options') =>
+        posthog.capture('low_balance_toast_clicked', { ...props, choice });
+
+      showLowBalanceToast({
+        balanceUsd,
+        isZeroBalance: zero,
+        runCostUsd: typicalShortCostUsd(pricing),
+        onAddCredits: () => {
+          clicked('add_credits');
+          openAddCreditsDialog('low_balance_toast');
+        },
+        onOtherOptions: () => {
+          clicked('other_options');
+          openBillingGate(zero ? 'zero' : 'insufficient');
+        },
+      });
+    },
+    [balance, isZeroBalance, posthog, pricing]
+  );
+
+  useEffect(() => {
+    return subscribeInsufficientCredits(() => {
+      fireToast('insufficient_credits');
+    });
+  }, [fireToast]);
 
   useEffect(() => {
     if (balance === null) return;
@@ -41,31 +81,6 @@ export function useLowBalanceWarning() {
     if (!isZeroBalance && !isLowBalance) return;
 
     hasWarnedRef.current = true;
-    const props = { balance_usd: balance, is_zero: isZeroBalance };
-    posthog.capture('low_balance_toast_shown', props);
-
-    const clicked = (choice: 'add_credits' | 'other_options') =>
-      posthog.capture('low_balance_toast_clicked', { ...props, choice });
-
-    showLowBalanceToast({
-      balanceUsd: balance,
-      isZeroBalance,
-      runCostUsd: typicalShortCostUsd(pricing),
-      onAddCredits: () => {
-        clicked('add_credits');
-        openAddCreditsDialog('low_balance_toast');
-      },
-      onOtherOptions: () => {
-        clicked('other_options');
-        openBillingGate(isZeroBalance ? 'zero' : 'manual');
-      },
-    });
-  }, [
-    balance,
-    isLowBalance,
-    isZeroBalance,
-    lowBalanceThreshold,
-    posthog,
-    pricing,
-  ]);
+    fireToast('balance_drop');
+  }, [balance, fireToast, isLowBalance, isZeroBalance, lowBalanceThreshold]);
 }

--- a/src/hooks/use-sequences.ts
+++ b/src/hooks/use-sequences.ts
@@ -19,6 +19,7 @@ import type { CreateSequenceInput } from '@/lib/schemas/sequence.schemas';
 import { UNTITLED_SEQUENCE_TITLE } from '@/lib/sequences/untitled-sequence-title';
 import type { Sequence } from '@/types/database';
 import { useAuthSession } from '@/lib/auth/session-query';
+import { isInsufficientCreditsError } from '@/shared/errors';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePostHog } from '@posthog/react';
 import { toast } from 'sonner';
@@ -213,8 +214,10 @@ export function useCreateSequence() {
         });
     },
     // A silent failure here is what produced 9 identical resubmissions in
-    // #1259 — always tell the user why nothing happened.
+    // #1259 — always tell the user why nothing happened. Insufficient
+    // credits is the global mutation handler's job (low-balance toast).
     onError: (error) => {
+      if (isInsufficientCreditsError(error)) return;
       toast.error(error.message || 'Generation failed to start.');
     },
   });

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -21,14 +21,10 @@ export const PLATFORM_FEE_PERCENT = 0.07;
 /**
  * Free credit granted to every new team on signup, in USD.
  *
- * Must cover a typical first short with product defaults: Enhance 30s target
- * (~6 shots × 5s), stills + motion + music (Turbo: Nano Banana 2 Lite /
- * H3 Max / ElevenLabs). Guarded by the signup-grant test in
- * constants.test.ts. Preflight uses fal historical typicalUnitsPerCall
- * (not raw unitPrice alone). Raised from $10 when motion+music became the
- * default aha path (#1140).
+ * Demo branch (`topup-demo`): $10. Product default on main is $20 (covers a
+ * typical first 30s short with motion and music — #1140).
  */
-const SIGNUP_GRANT_USD = 20;
+const SIGNUP_GRANT_USD = 10;
 
 /** Free credit granted to every new team on signup, in microdollars */
 export const SIGNUP_GRANT_MICROS: Microdollars = usdToMicros(SIGNUP_GRANT_USD);

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -42,7 +42,13 @@ export const SIGNUP_GRANT_MICROS: Microdollars = usdToMicros(SIGNUP_GRANT_USD);
 export const TYPICAL_SHORT_COST_USD = 13;
 
 /** Minimum top-up amount in USD */
-export const MIN_TOPUP_AMOUNT_USD = 10;
+export const MIN_TOPUP_AMOUNT_USD = 5;
+
+/**
+ * Amount the add-credits dialog and low-balance toast open on.
+ * Higher than the floor so a one-click top-up still funds a typical short.
+ */
+export const DEFAULT_TOPUP_AMOUNT_USD = 10;
 
 /** Minimum top-up amount in microdollars */
 export const MIN_TOPUP_AMOUNT_MICROS: Microdollars =

--- a/src/lib/billing/film-cost-examples.ts
+++ b/src/lib/billing/film-cost-examples.ts
@@ -58,7 +58,7 @@ type FilmCostExample = {
 
 export type FilmCostExamples = {
   examples: FilmCostExample[];
-  /** e.g. "$20.00" — from SIGNUP_GRANT_MICROS. */
+  /** e.g. "$10.00" — from SIGNUP_GRANT_MICROS. */
   welcomeCredits: string;
   imageModelName: string;
   videoModelName: string;

--- a/src/lib/db/seed-model-pricing.ts
+++ b/src/lib/db/seed-model-pricing.ts
@@ -15,7 +15,7 @@ import {
 } from '@/lib/ai/fal-typical-units';
 import { usdToMicros } from '@/lib/billing/money';
 import { modelPricing } from '@/lib/db/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import type { SeedDb } from './seed-system-templates';
 
 type SeedPrice = {
@@ -157,19 +157,69 @@ export const LOCAL_FAL_PRICING_SEED: Record<string, SeedPrice> = {
 /** D1 100-bind cap; 10 columns × 9 rows. */
 const INSERT_CHUNK = 9;
 
+/** fal's $1/unit catalog stub — no typical, no observed. ActionCost hides. */
+function isCatalogStub(row: {
+  unit: string;
+  unitPriceMicros: number;
+  typicalUnitsPerCall: number | null;
+  observedSampleCount: number;
+}): boolean {
+  return (
+    row.unit === 'units' &&
+    row.unitPriceMicros === 1_000_000 &&
+    row.typicalUnitsPerCall == null &&
+    row.observedSampleCount === 0
+  );
+}
+
 /**
  * Insert seed rows for fal endpoints that have no `model_pricing` row yet.
- * Does not overwrite a live refresh.
+ * Also replaces fal $1/unit catalog stubs for seeded endpoints — a live
+ * `refresh-fal-pricing` snapshot writes those stubs and would otherwise
+ * hide Generate's cost on Turbo (Lite). Never overwrites a real rate.
  */
 export async function ensureLocalModelPricingSeeded(
   db: SeedDb,
   log: (message: string) => void = () => {}
 ): Promise<number> {
   const existing = await db
-    .select({ endpointId: modelPricing.endpointId })
+    .select({
+      endpointId: modelPricing.endpointId,
+      unit: modelPricing.unit,
+      unitPriceMicros: modelPricing.unitPriceMicros,
+      typicalUnitsPerCall: modelPricing.typicalUnitsPerCall,
+      observedSampleCount: modelPricing.observedSampleCount,
+    })
     .from(modelPricing)
     .where(eq(modelPricing.provider, 'fal'));
-  const have = new Set(existing.map((row) => row.endpointId));
+
+  const stubIds = [
+    ...new Set(
+      existing
+        .filter(
+          (row) =>
+            isCatalogStub(row) && row.endpointId in LOCAL_FAL_PRICING_SEED
+        )
+        .map((row) => row.endpointId)
+    ),
+  ];
+  if (stubIds.length > 0) {
+    await db
+      .delete(modelPricing)
+      .where(
+        and(
+          eq(modelPricing.provider, 'fal'),
+          inArray(modelPricing.endpointId, stubIds)
+        )
+      );
+    log(
+      `💰 Replaced ${stubIds.length} catalog-stub model_pricing row(s) with local seed rates`
+    );
+  }
+
+  const have = new Set(
+    existing.map((row) => row.endpointId).filter((id) => !stubIds.includes(id))
+  );
 
   const now = new Date();
   const rows = Object.entries(LOCAL_FAL_PRICING_SEED)

--- a/src/shared/query-client.ts
+++ b/src/shared/query-client.ts
@@ -1,4 +1,4 @@
-import { openBillingGate } from '@/hooks/use-billing-gate-dialog';
+import { notifyInsufficientCredits } from '@/hooks/notify-insufficient-credits';
 import { isAuthError, isInsufficientCreditsError } from '@/shared/errors';
 import { MutationCache, QueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -31,10 +31,11 @@ export function makeQueryClient() {
         logger.error('[MUTATION ERROR]', {
           data: error instanceof Error ? error.message : error,
         });
-        // Out of credits is a billing problem, not an error toast — open the
-        // globally-mounted gate dialog instead (#1099).
+        // Out of credits is a billing problem, not an error toast — the
+        // low-balance toast carries the top-up offer; "Other options" opens
+        // the gate.
         if (isInsufficientCreditsError(error)) {
-          openBillingGate('insufficient');
+          notifyInsufficientCredits();
           return;
         }
         // Mutations that render their own inline error opt out, so a failure


### PR DESCRIPTION
## Related Issue

Demo branch (`topup-demo`) — not tied to a numbered issue.

## Summary of Changes

- Out-of-credits Generate shows the low-balance toast (`Add $10` / Other options) instead of the billing-setup modal plus a red error toast. Preflight does not debit, so the toast now also fires on `INSUFFICIENT_CREDITS`.
- Minimum top-up is $5; the dialog and toast still default to $10.
- Fal BYOK is no longer an inline form on the billing gate — it is a footer link next to gift-code redeem (`/settings/api-keys`).
- Local `model_pricing` seed replaces fal $1/unit catalog stubs so Turbo Generate shows an estimate after a live pricing refresh.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Demo-only UX and local seed behavior. Server checkout still enforces the $5 floor.

## Test plan

- [ ] With a low balance, click Generate — expect the Add $10 toast, not “Set up billing to continue”.
- [ ] Toast “Add $10” opens checkout prefilled at $10; typing $5 succeeds.
- [ ] Billing gate footer has “Redeem a gift code” and “Use your own key”.
- [ ] Turbo Generate shows a `~$` estimate after local seed (Lite is no longer a silent stub).

## Additional Notes

Welcome grant is still $20. Local D1 balance for `tom+7sep2` was set to $1 outside this PR.