### PR TITLE
feat(#1529): turn off free signup credits

### DIFF
--- a/src/components/billing/welcome-credits-dialog.tsx
+++ b/src/components/billing/welcome-credits-dialog.tsx
@@ -105,6 +105,11 @@ export const WelcomeCreditsProvider: React.FC<{ children: ReactNode }> = ({
 
   useEffect(() => {
     if (!user) return;
+    // Free credits off (#1529): nothing to announce.
+    if (SIGNUP_GRANT_MICROS <= 0) {
+      setSettled(true);
+      return;
+    }
     // Wait until balance query settles (success or error). Don't use isFetched
     // alone — while the query is disabled it stays false forever.
     if (!balanceReady && !balanceFailed) return;

--- a/src/components/layout/credit-balance-pill.tsx
+++ b/src/components/layout/credit-balance-pill.tsx
@@ -56,6 +56,8 @@ export const CreditBalancePill: React.FC = () => {
   useBillingBalanceRealtime(teamId, !isSignedOut && isSignedInVisible);
 
   if (isSignedOut) {
+    // Free credits off (#1529): nothing to preview.
+    if (SIGNUP_GRANT_MICROS <= 0) return null;
     return (
       <SidebarMenu>
         <SidebarMenuItem>

--- a/src/lib/auth/config.ts
+++ b/src/lib/auth/config.ts
@@ -316,14 +316,17 @@ export function createAuth(db: ReturnType<typeof getDb> = getDb()) {
             });
 
             // Grant every new team a one-time welcome credit (#1047; preflight fixed in #1062).
-            await createBillingMethods(db, team.id, user.id).addCredits(
-              SIGNUP_GRANT_MICROS,
-              {
-                type: 'credit_adjustment',
-                description: `Welcome credit: ${microsToDisplayUsd(SIGNUP_GRANT_MICROS)}`,
-                metadata: { signupGrant: true },
-              }
-            );
+            // Off when the grant is 0 (#1529) — no $0 ledger row.
+            if (SIGNUP_GRANT_MICROS > 0) {
+              await createBillingMethods(db, team.id, user.id).addCredits(
+                SIGNUP_GRANT_MICROS,
+                {
+                  type: 'credit_adjustment',
+                  description: `Welcome credit: ${microsToDisplayUsd(SIGNUP_GRANT_MICROS)}`,
+                  metadata: { signupGrant: true },
+                }
+              );
+            }
 
             // First-time account only — drives #product-alerts via PostHog (#1088).
             // personProperties set email/name on the PostHog person so Slack

--- a/src/lib/billing/__tests__/constants.test.ts
+++ b/src/lib/billing/__tests__/constants.test.ts
@@ -67,24 +67,28 @@ describe('billing constants', () => {
    * #1062 / #1140: new users must finish a first short on welcome credits with
    * product defaults — Enhance 30s target, stills + motion + music on.
    * If this fails, raise SIGNUP_GRANT_USD or re-check default model pricing.
+   * Skipped while free credits are off (#1529).
    */
-  it('signup grant covers a default 30s stills+motion+music pre-flight estimate', () => {
-    const defaultShortCost = estimateStoryboardCost({
-      imageModel: TURBO_DEFAULT_IMAGE,
-      aspectRatio: DEFAULT_ASPECT_RATIO,
-      estimatedSceneCount: WELCOME_SHORT_SCENE_COUNT,
-      autoGenerateMotion: true,
-      videoModels: [TURBO_DEFAULT_VIDEO],
-      videoDurationSeconds: WELCOME_SHORT_SHOT_DURATION_S,
-      autoGenerateMusic: true,
-      audioModels: [TURBO_DEFAULT_AUDIO],
-      audioDurationSeconds: WELCOME_SHORT_TARGET_S,
-      pricing: FAL_PRICING,
-    });
+  it.skipIf(SIGNUP_GRANT_MICROS <= 0)(
+    'signup grant covers a default 30s stills+motion+music pre-flight estimate',
+    () => {
+      const defaultShortCost = estimateStoryboardCost({
+        imageModel: TURBO_DEFAULT_IMAGE,
+        aspectRatio: DEFAULT_ASPECT_RATIO,
+        estimatedSceneCount: WELCOME_SHORT_SCENE_COUNT,
+        autoGenerateMotion: true,
+        videoModels: [TURBO_DEFAULT_VIDEO],
+        videoDurationSeconds: WELCOME_SHORT_SHOT_DURATION_S,
+        autoGenerateMusic: true,
+        audioModels: [TURBO_DEFAULT_AUDIO],
+        audioDurationSeconds: WELCOME_SHORT_TARGET_S,
+        pricing: FAL_PRICING,
+      });
 
-    expect(
-      SIGNUP_GRANT_MICROS,
-      `SIGNUP_GRANT ($${microsToUsd(SIGNUP_GRANT_MICROS)}) must be ≥ default short estimate ($${microsToUsd(defaultShortCost).toFixed(2)}; ${TURBO_DEFAULT_IMAGE} + ${TURBO_DEFAULT_VIDEO} + ${TURBO_DEFAULT_AUDIO})`
-    ).toBeGreaterThanOrEqual(defaultShortCost);
-  });
+      expect(
+        SIGNUP_GRANT_MICROS,
+        `SIGNUP_GRANT ($${microsToUsd(SIGNUP_GRANT_MICROS)}) must be ≥ default short estimate ($${microsToUsd(defaultShortCost).toFixed(2)}; ${TURBO_DEFAULT_IMAGE} + ${TURBO_DEFAULT_VIDEO} + ${TURBO_DEFAULT_AUDIO})`
+      ).toBeGreaterThanOrEqual(defaultShortCost);
+    }
+  );
 });

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -21,10 +21,10 @@ export const PLATFORM_FEE_PERCENT = 0.07;
 /**
  * Free credit granted to every new team on signup, in USD.
  *
- * Demo branch (`topup-demo`): $10. Product default on main is $20 (covers a
- * typical first 30s short with motion and music — #1140).
+ * 0 = free credits are off (#1529): no ledger row on signup, and the welcome
+ * dialog / signed-out pill / pricing blurb all hide. Was $10.
  */
-const SIGNUP_GRANT_USD = 10;
+const SIGNUP_GRANT_USD = 0;
 
 /** Free credit granted to every new team on signup, in microdollars */
 export const SIGNUP_GRANT_MICROS: Microdollars = usdToMicros(SIGNUP_GRANT_USD);

--- a/src/lib/billing/film-cost-examples.test.ts
+++ b/src/lib/billing/film-cost-examples.test.ts
@@ -48,18 +48,22 @@ describe('buildFilmCostExamples', () => {
     expect(motion.breakdown.some((line) => /6 × 5s/i.test(line))).toBe(true);
   });
 
-  it('keeps the full stills+motion+music tier within the welcome grant under fixture pricing', () => {
-    const result = buildFilmCostExamples(FAL_PRICING);
-    expect(result).not.toBeNull();
-    if (!result) return;
+  // Skipped while free credits are off (#1529).
+  it.skipIf(SIGNUP_GRANT_MICROS <= 0)(
+    'keeps the full stills+motion+music tier within the welcome grant under fixture pricing',
+    () => {
+      const result = buildFilmCostExamples(FAL_PRICING);
+      expect(result).not.toBeNull();
+      if (!result) return;
 
-    const full = result.examples.find((e) => e.id === 'with-motion-music');
-    expect(full).toBeDefined();
-    if (!full) return;
+      const full = result.examples.find((e) => e.id === 'with-motion-music');
+      expect(full).toBeDefined();
+      if (!full) return;
 
-    expect(
-      full.costMicros,
-      `with-motion-music ($${microsToUsd(full.costMicros).toFixed(2)} with ${TURBO_DEFAULT_IMAGE}) should fit in welcome grant ($${microsToUsd(SIGNUP_GRANT_MICROS)})`
-    ).toBeLessThanOrEqual(SIGNUP_GRANT_MICROS);
-  });
+      expect(
+        full.costMicros,
+        `with-motion-music ($${microsToUsd(full.costMicros).toFixed(2)} with ${TURBO_DEFAULT_IMAGE}) should fit in welcome grant ($${microsToUsd(SIGNUP_GRANT_MICROS)})`
+      ).toBeLessThanOrEqual(SIGNUP_GRANT_MICROS);
+    }
+  );
 });

--- a/src/lib/billing/film-cost-examples.ts
+++ b/src/lib/billing/film-cost-examples.ts
@@ -58,8 +58,8 @@ type FilmCostExample = {
 
 export type FilmCostExamples = {
   examples: FilmCostExample[];
-  /** e.g. "$10.00" — from SIGNUP_GRANT_MICROS. */
-  welcomeCredits: string;
+  /** e.g. "$10.00" — from SIGNUP_GRANT_MICROS; null when free credits are off (#1529). */
+  welcomeCredits: string | null;
   imageModelName: string;
   videoModelName: string;
   audioModelName: string;
@@ -140,7 +140,8 @@ export function buildFilmCostExamples(
   const locationSheets = estimateLocationSheetCount(TYPICAL_SCENE_COUNT);
 
   return {
-    welcomeCredits: microsToDisplayUsd(SIGNUP_GRANT_MICROS),
+    welcomeCredits:
+      SIGNUP_GRANT_MICROS > 0 ? microsToDisplayUsd(SIGNUP_GRANT_MICROS) : null,
     imageModelName: imageName,
     videoModelName: videoName,
     audioModelName: audioName,

--- a/src/routes/_app/pricing.tsx
+++ b/src/routes/_app/pricing.tsx
@@ -55,7 +55,7 @@ function PricingPage() {
         <p className="mt-3 text-base leading-relaxed text-muted-foreground">
           Pay providers as you go. We show an estimate under each action before
           you spend.
-          {filmCosts ? (
+          {filmCosts?.welcomeCredits ? (
             <>
               {' '}
               New accounts start with{' '}


### PR DESCRIPTION
Closes #1529

Temporary: `SIGNUP_GRANT_USD` is now 0. With a zero grant:
- no welcome credit ledger row on signup
- welcome-credits dialog never opens
- signed-out sidebar pill hides
- pricing page drops the "New accounts start with $X free" sentence

Grant-coverage unit tests skip while the grant is off. Re-enable by setting the constant back to $10.

https://claude.ai/code/session_012iUnrm5UJBxMcptLwHS5qA