### PR TITLE
Restore welcome grant to $20

### DIFF
--- a/src/components/billing/welcome-credits-dialog.tsx
+++ b/src/components/billing/welcome-credits-dialog.tsx
@@ -1,7 +1,7 @@
 /**
  * Welcome Credits Dialog (#1096, #1516)
  *
- * - **claim**: Stripe on, welcome grant unpaid. Add a card (Stripe Checkout setup,
+ * - **claim**: Stripe on, $20 unpaid. Add a card (Stripe Checkout setup,
  *   no charge) to unlock it.
  * - **gift**: unused signup grant and Stripe off (e2e / self-host).
  *

--- a/src/lib/billing/constants.ts
+++ b/src/lib/billing/constants.ts
@@ -50,7 +50,7 @@ export const PLATFORM_FEE_PERCENT = 0.07;
  * H3 Max / ElevenLabs). Guarded by the signup-grant test in
  * constants.test.ts.
  */
-const SIGNUP_GRANT_USD = 10;
+const SIGNUP_GRANT_USD = 20;
 
 export const SIGNUP_GRANT_MICROS: Microdollars = usdToMicros(SIGNUP_GRANT_USD);
 

--- a/src/lib/billing/film-cost-examples.ts
+++ b/src/lib/billing/film-cost-examples.ts
@@ -58,7 +58,7 @@ type FilmCostExample = {
 
 export type FilmCostExamples = {
   examples: FilmCostExample[];
-  /** e.g. "$10.00" — from SIGNUP_GRANT_MICROS; null when free credits are off (#1529). */
+  /** e.g. "$20.00" — from SIGNUP_GRANT_MICROS; null when free credits are off (#1529). */
   welcomeCredits: string | null;
   imageModelName: string;
   videoModelName: string;

--- a/src/lib/billing/signup-grant-gate.test.ts
+++ b/src/lib/billing/signup-grant-gate.test.ts
@@ -15,7 +15,7 @@ describe('grantsWelcomeCreditsOnSignup', () => {
     expect(grantsWelcomeCreditsOnSignup()).toBe(true);
   });
 
-  it('does not credit at team create when Stripe is configured', () => {
+  it('does not credit $20 at team create when Stripe is configured', () => {
     env.E2E_TEST = undefined;
     env.STRIPE_SECRET_KEY = 'sk_test_x';
     expect(grantsWelcomeCreditsOnSignup()).toBe(false);

--- a/src/lib/db/scoped/billing.ts
+++ b/src/lib/db/scoped/billing.ts
@@ -294,7 +294,7 @@ function createBillingReadMethods(db: Database, teamId: string) {
     return existing;
   }
 
-  /** True if this team already received the welcome grant.
+  /** True if this team already received the $20 welcome grant.
    *  Match idempotency key OR metadata.signupGrant: pre-#1516 rows have
    *  no key, so the key alone would miss them and double-pay. */
   async function hasSignupGrant(): Promise<boolean> {


### PR DESCRIPTION
Fixes #1532

Revert the welcome grant from $10 back to $20 (`SIGNUP_GRANT_USD`). Dialog copy, comments, and the signup-grant gate test follow the constant. UI surfaces (welcome dialog, credit pill, pricing page) already format `SIGNUP_GRANT_MICROS`, so they pick up $20 without extra copy.

## Test plan
- [x] `bun run test src/lib/billing` (162 passed)
- [x] `bun typecheck`
- [ ] Confirm welcome dialog / signed-out pill show **$20.00** after deploy