### PR TITLE
feat(#1537): accept Alipay and WeChat Pay at checkout

### DIFF
--- a/src/components/billing/add-credits-dialog.tsx
+++ b/src/components/billing/add-credits-dialog.tsx
@@ -3,9 +3,9 @@
  * OpenAI-style "Add to credit balance" modal — the in-app purchase surface.
  * (Credits also arrive via gift codes, the signup grant, founder grants, and
  * auto-top-up.) A saved card is charged in place; "+ Add payment method" (or
- * having no saved card) falls back to Stripe Checkout, which saves the card
- * for next time. Globally mounted in AppLayout, opened via
- * openAddCreditsDialog().
+ * having no saved card) falls back to Stripe Checkout — card, Alipay or WeChat
+ * Pay (#1537); a card is saved for next time. Globally mounted in AppLayout,
+ * opened via openAddCreditsDialog().
  */
 
 import { Button } from '@/components/ui/button';
@@ -63,7 +63,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { ulid } from 'ulid';
 
-/** Sentinel Select value for "pay with a new card at checkout". */
+/** Sentinel Select value for "pay at checkout" — new card, Alipay or WeChat Pay (#1537). */
 const NEW_CARD = 'new-card';
 
 /** Amount the dialog opens on — matches the low-balance toast's "Add $10". */
@@ -285,7 +285,10 @@ export function AddCreditsDialog() {
                   value: pm.id,
                   label: `${formatBrand(pm.brand)} •••• ${pm.last4}`,
                 })),
-                { value: NEW_CARD, label: 'New card at checkout' },
+                {
+                  value: NEW_CARD,
+                  label: 'Card, Alipay or WeChat Pay at checkout',
+                },
               ]}
               onValueChange={(value) => {
                 if (value == null) return;
@@ -305,7 +308,7 @@ export function AddCreditsDialog() {
                 ))}
                 <SelectItem value={NEW_CARD}>
                   <Plus className="size-4 text-muted-foreground" />
-                  New card at checkout
+                  Card, Alipay or WeChat Pay at checkout
                 </SelectItem>
               </SelectContent>
             </Select>

--- a/src/lib/billing/__tests__/checkout.test.ts
+++ b/src/lib/billing/__tests__/checkout.test.ts
@@ -26,6 +26,7 @@ vi.doMock('@/lib/observability/product-events', () => ({
 }));
 
 const {
+  chargeFingerprint,
   createCheckoutSession,
   createSetupCheckoutSession,
   grantWelcomeIfTeamHasCard,
@@ -93,6 +94,32 @@ describe('createCheckoutSession', () => {
         stripe_payment_intent_id: 'pi_1',
         surface: 'sidebar_pill',
       }),
+    });
+  });
+
+  it('lets the Dashboard pick payment methods and saves only cards (#1537)', async () => {
+    create.mockResolvedValue({
+      id: 'cs_2',
+      url: 'https://x',
+      payment_intent: 'pi_2',
+    });
+    await createCheckoutSession({
+      scopedDb: makeScopedDb(),
+      teamId: 'team_1',
+      amountUsd: 10,
+      userId: 'user_1',
+      userEmail: 'test@example.com',
+      successUrl: 'https://app/success',
+      cancelUrl: 'https://app/cancel',
+    });
+    const session = create.mock.calls.at(-1)?.[0];
+    // A hard-coded list would 400 the whole checkout when a wallet is off.
+    expect(session.payment_method_types).toBeUndefined();
+    // Session-level setup_future_usage hides single-use wallets.
+    expect(session.payment_intent_data.setup_future_usage).toBeUndefined();
+    expect(session.payment_method_options).toEqual({
+      card: { setup_future_usage: 'off_session' },
+      wechat_pay: { client: 'web' },
     });
   });
 
@@ -193,5 +220,34 @@ describe('grantWelcomeIfTeamHasCard', () => {
       hasSignupGrant: false,
     });
     expect(addCredits).not.toHaveBeenCalled();
+  });
+});
+
+describe('chargeFingerprint', () => {
+  const charge = (payment_method_details: unknown) =>
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- test double
+    ({ payment_method_details }) as unknown as import('stripe').Stripe.Charge;
+
+  it('reads the card, Alipay or WeChat Pay account fingerprint', () => {
+    expect(
+      chargeFingerprint(charge({ type: 'card', card: { fingerprint: 'fp_c' } }))
+    ).toBe('fp_c');
+    expect(
+      chargeFingerprint(
+        charge({ type: 'alipay', alipay: { fingerprint: 'fp_a' } })
+      )
+    ).toBe('fp_a');
+    expect(
+      chargeFingerprint(
+        charge({ type: 'wechat_pay', wechat_pay: { fingerprint: 'fp_w' } })
+      )
+    ).toBe('fp_w');
+  });
+
+  it('is null for a method Stripe does not fingerprint', () => {
+    expect(
+      chargeFingerprint(charge({ type: 'link', link: { country: 'AU' } }))
+    ).toBeNull();
+    expect(chargeFingerprint(charge(null))).toBeNull();
   });
 });

--- a/src/lib/billing/checkout.ts
+++ b/src/lib/billing/checkout.ts
@@ -36,6 +36,22 @@ async function cardFingerprint(paymentMethodId: string): Promise<string> {
   return fingerprint;
 }
 
+/**
+ * Account fingerprint of whatever paid a charge — card, Alipay or WeChat Pay
+ * (#1537). Stripe stamps one on each so the welcome grant's one-per-account
+ * rule holds for wallets too. `null` for a method Stripe does not fingerprint
+ * (e.g. Link), which cannot claim the grant.
+ */
+export function chargeFingerprint(charge: Stripe.Charge): string | null {
+  const details = charge.payment_method_details;
+  return (
+    details?.card?.fingerprint ??
+    details?.alipay?.fingerprint ??
+    details?.wechat_pay?.fingerprint ??
+    null
+  );
+}
+
 type CreateCheckoutParams = {
   scopedDb: ScopedDb;
   teamId: string;
@@ -126,12 +142,17 @@ export async function createCheckoutSession(
   const session = await stripe.checkout.sessions.create({
     mode: 'payment',
     customer: customerId,
-    payment_method_types: ['card'],
-    // Save the payment method for auto-top-up
-    payment_intent_data: {
-      setup_future_usage: 'off_session',
-      metadata,
+    // No `payment_method_types`: Stripe shows what is enabled in the Dashboard
+    // (card, Alipay, WeChat Pay — #1537) and only when eligible for the
+    // currency, so a wallet that is off or unavailable can never break
+    // checkout. Alipay / WeChat Pay are single-use, so the card is the only
+    // method saved for auto-top-up — a session-level `setup_future_usage`
+    // would hide the wallets.
+    payment_method_options: {
+      card: { setup_future_usage: 'off_session' },
+      wechat_pay: { client: 'web' },
     },
+    payment_intent_data: { metadata },
     line_items: [
       {
         price_data: {

--- a/src/routes/api/billing/webhook.ts
+++ b/src/routes/api/billing/webhook.ts
@@ -5,8 +5,10 @@
 
 import { stripeWebhookMiddleware } from '@/functions/stripe-webhook-middleware';
 import {
+  chargeFingerprint,
   fulfillSavedCard,
   grantWelcomeCreditsForPaymentMethod,
+  grantWelcomeCreditsForTeam,
   SAVE_CARD_METADATA_TYPE,
   type WelcomeGrantSource,
 } from '@/lib/billing/checkout';
@@ -100,17 +102,25 @@ export const Route = createFileRoute('/api/billing/webhook')({
                 expand: ['latest_charge'],
               });
               const charge = pi.latest_charge;
-              const receiptUrl =
-                charge && typeof charge === 'object'
-                  ? (charge.receipt_url ?? undefined)
-                  : undefined;
-              const purchasePaymentMethodId = stripeObjectId(pi.payment_method);
-              if (!purchasePaymentMethodId) {
-                throw new Error('checkout session missing payment method');
+              if (!charge || typeof charge !== 'object') {
+                throw new Error('checkout session missing charge');
               }
+              const receiptUrl = charge.receipt_url ?? undefined;
 
-              // Default PM / decline-cooldown — not required for the welcome grant.
-              if (customerId) {
+              // Default PM / decline-cooldown — not required for the welcome
+              // grant. Only a card is reusable: Alipay / WeChat Pay are
+              // single-use (#1537), so they are never attached and never
+              // become the auto-top-up method.
+              if (
+                customerId &&
+                charge.payment_method_details?.type === 'card'
+              ) {
+                const purchasePaymentMethodId = stripeObjectId(
+                  pi.payment_method
+                );
+                if (!purchasePaymentMethodId) {
+                  throw new Error('checkout session missing payment method');
+                }
                 try {
                   await stripe.customers.update(customerId, {
                     invoice_settings: {
@@ -160,12 +170,25 @@ export const Route = createFileRoute('/api/billing/webhook')({
               if (!teamId || !userId) {
                 throw new Error('credit_top_up missing teamId or userId');
               }
-              await grantWelcomeFromPaymentMethod({
-                scopedDb,
-                teamId,
-                userId,
-                paymentMethodId: purchasePaymentMethodId,
-              });
+              const fingerprint = chargeFingerprint(charge);
+              if (!fingerprint) {
+                // Nothing to key the one-per-account rule on; the team can
+                // still claim by saving a card.
+                logger.info('welcome grant skipped: no payment fingerprint', {
+                  teamId,
+                  paymentMethodType: charge.payment_method_details?.type,
+                });
+                break;
+              }
+              await grantWelcomeOrThrow(scopedDb, teamId, () =>
+                grantWelcomeCreditsForTeam({
+                  scopedDb,
+                  teamId,
+                  userId,
+                  source: 'purchase',
+                  cardFingerprint: fingerprint,
+                })
+              );
               break;
             }
 
@@ -257,12 +280,15 @@ export const Route = createFileRoute('/api/billing/webhook')({
               if (!pmId) {
                 throw new Error('credit_top_up_direct missing payment method');
               }
-              await grantWelcomeFromPaymentMethod({
-                scopedDb,
-                teamId,
-                userId,
-                paymentMethodId: pmId,
-              });
+              await grantWelcomeOrThrow(scopedDb, teamId, () =>
+                grantWelcomeCreditsForPaymentMethod({
+                  scopedDb,
+                  teamId,
+                  userId,
+                  paymentMethodId: pmId,
+                  source: 'purchase',
+                })
+              );
               break;
             }
 
@@ -300,25 +326,19 @@ function stripeObjectId(
  * Purchase/setup webhooks 200 on already-claimed so Stripe stops. Anything
  * else that leaves this team without a grant must 400 so Stripe retries.
  */
-async function grantWelcomeFromPaymentMethod(opts: {
-  scopedDb: ScopedDb;
-  teamId: string;
-  userId: string;
-  paymentMethodId: string;
-}): Promise<void> {
+async function grantWelcomeOrThrow(
+  scopedDb: ScopedDb,
+  teamId: string,
+  grant: () => Promise<{ granted: boolean }>
+): Promise<void> {
   try {
-    const { granted } = await grantWelcomeCreditsForPaymentMethod({
-      ...opts,
-      source: 'purchase',
-    });
+    const { granted } = await grant();
     if (granted || SIGNUP_GRANT_MICROS <= 0) return;
-    if (await opts.scopedDb.billing.hasSignupGrant()) return;
+    if (await scopedDb.billing.hasSignupGrant()) return;
     throw new Error('Welcome grant did not land');
   } catch (err) {
     if (isWelcomeCardAlreadyClaimedError(err)) {
-      logger.info('welcome grant skipped: card already claimed', {
-        teamId: opts.teamId,
-      });
+      logger.info('welcome grant skipped: card already claimed', { teamId });
       return;
     }
     throw err;


### PR DESCRIPTION
Closes #1537

## What

- **Checkout no longer pins `payment_method_types: ['card']`.** Stripe Checkout shows whatever is enabled in the Dashboard and eligible for USD (card, Alipay, WeChat Pay), so an unavailable wallet can never 400 the session. Card saving for auto top-up moves to `payment_method_options.card.setup_future_usage` (a session-level `setup_future_usage` hides single-use wallets). WeChat Pay gets its required `client: 'web'`.
- **Webhook** keys the welcome grant on the charge's account fingerprint (card / Alipay / WeChat Pay all carry one) instead of retrieving a card PaymentMethod, which would have 400'd every wallet purchase and made Stripe retry for days. Only a card is set as the customer's default / auto-top-up method; wallets are single-use.
- **Dialog copy:** "New card at checkout" → "Card, Alipay or WeChat Pay at checkout".

The save-card (welcome credits, `mode: 'setup'`) flow stays card-only: Stripe doesn't support Alipay or WeChat Pay in setup mode.

## To enable

Stripe Dashboard → Settings → Payment methods → turn on **Alipay** and **WeChat Pay** (test and live separately). No config change in the app.

⚠️ The account is AU and we charge USD. Stripe's docs list USD Alipay only for US/UK/CA/HK/SG/GI accounts (AU → AUD). WeChat Pay lists USD for AU. If Alipay doesn't appear at checkout after enabling, it needs a Stripe support request. Test mode accepted both.

## Tests

- `checkout.test.ts`: session omits `payment_method_types`, saves card via `payment_method_options`, WeChat client set; `chargeFingerprint` reads card/Alipay/WeChat and is null for Link.

https://claude.ai/code/session_015g7UvJhiB5GSs7duwPPe7D