### PR TITLE
Stable server-function ids across file moves (#1549)

### DIFF
--- a/src/platform/server-fn-id.test.ts
+++ b/src/platform/server-fn-id.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { createServerFnIdGenerator } from './server-fn-id';
+
+describe('createServerFnIdGenerator', () => {
+  it('gives the same id after a file move', () => {
+    const generate = createServerFnIdGenerator();
+    const before = generate({
+      filename: 'src/old/place.fn.ts',
+      functionName: 'listSequencesFn_createServerFn_handler',
+    });
+    const after = createServerFnIdGenerator()({
+      filename: 'src/new/place.fn.ts',
+      functionName: 'listSequencesFn_createServerFn_handler',
+    });
+    expect(after).toBe(before);
+  });
+
+  it('gives different ids to different function names', () => {
+    const generate = createServerFnIdGenerator();
+    expect(
+      generate({
+        filename: 'a.fn.ts',
+        functionName: 'aFn_createServerFn_handler',
+      })
+    ).not.toBe(
+      generate({
+        filename: 'a.fn.ts',
+        functionName: 'bFn_createServerFn_handler',
+      })
+    );
+  });
+
+  it('is stable when the same file is compiled twice (client + ssr)', () => {
+    const generate = createServerFnIdGenerator();
+    const opts = {
+      filename: 'a.fn.ts',
+      functionName: 'aFn_createServerFn_handler',
+    };
+    expect(generate(opts)).toBe(generate(opts));
+  });
+
+  it('throws when two files share a function name', () => {
+    const generate = createServerFnIdGenerator();
+    generate({
+      filename: 'a.fn.ts',
+      functionName: 'dupFn_createServerFn_handler',
+    });
+    expect(() =>
+      generate({
+        filename: 'b.fn.ts',
+        functionName: 'dupFn_createServerFn_handler',
+      })
+    ).toThrow(/Duplicate server function name "dupFn_createServerFn_handler"/);
+  });
+});

--- a/src/platform/server-fn-id.ts
+++ b/src/platform/server-fn-id.ts
@@ -1,0 +1,42 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Stable server-function ids across file moves (#1549).
+ *
+ * TanStack Start's default production id is
+ * `sha256("<relative filename>--<functionName>")`, so moving a file changes
+ * the id of every server function in it. #1536 moved ~1,500 files and every
+ * open browser tab from before the deploy then called `GET /_serverFn/<id>`
+ * for ids that no longer existed — ~50 bare `HTTPError` 500s in an hour.
+ *
+ * Seeding on the function name alone makes a move a no-op; only renaming the
+ * variable moves the id, which is a real API change. The name is still hashed
+ * so the id stays compact and doesn't leak source layout.
+ *
+ * Wired via `tanstackStart({ serverFns: { generateFunctionId } })` in
+ * vite.config.ts. Dev is unaffected — dev ids are base64 of file + export and
+ * the hook is only consulted for builds.
+ */
+export function createServerFnIdGenerator(): (opts: {
+  filename: string;
+  functionName: string;
+}) => string {
+  // id -> the file that first produced it. Two different files with the same
+  // function name would otherwise get silently deduplicated by the compiler
+  // (it appends `_1`), whose ordering isn't stable — a build failure is safer.
+  const owners = new Map<string, string>();
+
+  return ({ filename, functionName }) => {
+    const id = createHash('sha256').update(functionName).digest('hex');
+    const owner = owners.get(id);
+    if (owner !== undefined && owner !== filename) {
+      throw new Error(
+        `Duplicate server function name "${functionName}" in ${owner} and ${filename}. ` +
+          'Server function ids are seeded on the variable name alone (#1549), ' +
+          'so the name must be unique across the codebase — rename one of them.'
+      );
+    }
+    owners.set(id, filename);
+    return id;
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { devtools } from '@tanstack/devtools-vite';
 import viteReact from '@vitejs/plugin-react';
 import { worktreeAuthCookiePrefix } from './src/platform/auth/cookie-prefix.ts';
+import { createServerFnIdGenerator } from './src/platform/server-fn-id.ts';
 
 const isDev = process.env.NODE_ENV !== 'production';
 // Per-worktree auth cookie name (#1288). Set on process.env so Vite's usual
@@ -232,6 +233,11 @@ export default defineConfig({
       srcDirectory: 'src',
       router: {
         routesDirectory: 'routes',
+      },
+      serverFns: {
+        // Seed production ids on the function name only, so moving a file
+        // doesn't 500 every tab open across the deploy (#1549).
+        generateFunctionId: createServerFnIdGenerator(),
       },
     }),
     viteReact(),


### PR DESCRIPTION
Closes #1549.

## Problem

In a production build TanStack Start makes each server-function id `sha256("<relative filename>--<functionName>")`. #1536 moved ~1,500 files, so every id changed — every browser tab open across the deploy called `GET /_serverFn/<id>` for ids that no longer existed and got `{"status":500,"unhandled":true,"message":"HTTPError"}`. ~50 of those in the hour after the 03:42 UTC deploy.

## Fix

`serverFns.generateFunctionId` on `tanstackStart()` now seeds the id on the function name alone. Still sha256 (compact, doesn't leak source layout), just without the filename. A file move keeps the id; only renaming the variable moves it, which is a real API change.

The generator keeps a `Map<id, filename>` and throws at build time if two different files produce the same id. Without it the compiler silently dedupes with an unstable `_1` suffix — a build failure is safer than a mis-route. All 259 server functions have unique variable names today.

Dev is unaffected: dev ids are base64 of file + export, and the hook is only consulted for builds.

## Verification

- `src/platform/server-fn-id.test.ts` — same name from two paths → same id; different names → different ids; repeat call (client + ssr passes) → same id; same name from two files → throws.
- Built `dist/client` before and after moving `src/platform/user.fn.ts` to `src/platform/moved/user.fn.ts`: all 259 ids byte-identical. Spot-checked that `getCurrentUserProfileFn`'s id equals `sha256("getCurrentUserProfileFn_createServerFn_handler")`.

## Out of scope

Returning 404 (rather than the masked 500) for an unknown id and reloading the client once when that happens — TanStack is converging on that upstream (TanStack/router#7363, TanStack/router#8246).

https://claude.ai/code/session_018Ggq6LYXJ79HxFYR62ok7a