### PR TITLE
Support page to see user images and videos

### DIFF
--- a/e2e/tests/studio.spec.ts
+++ b/e2e/tests/studio.spec.ts
@@ -75,6 +75,28 @@ test.describe('Images and Videos studio', () => {
     await expect(page).toHaveURL(/\/images/);
   });
 
+  test('remembered support mode does not break a non-admin list', async ({
+    page,
+  }) => {
+    await page.goto('/images');
+    await page.evaluate(() => {
+      localStorage.setItem(
+        'openstory:studio-list:v1',
+        JSON.stringify({
+          search: '',
+          supportMode: true,
+          hideInternal: false,
+        })
+      );
+    });
+    await page.goto('/images');
+
+    await expect(
+      page.getByRole('button', { name: 'Generate image' })
+    ).toBeVisible({ timeout: HYDRATION_TIMEOUT });
+    await expect(page.getByText('Failed to load')).toHaveCount(0);
+  });
+
   test('empty-prompt Generate offers a random prompt (#1393)', async ({
     page,
   }) => {

--- a/src/platform/admin-support.fn.ts
+++ b/src/platform/admin-support.fn.ts
@@ -25,3 +25,21 @@ export const getAdminShotsFn = createServerFn({ method: 'GET' })
   .handler(async ({ context, data }) => {
     return context.adminScopedDb.admin.getShotsForSequence(data.sequenceId);
   });
+
+export const getAllAdminStudioAssetsFn = createServerFn({ method: 'GET' })
+  .middleware([systemAdminMiddleware])
+  .validator(
+    zodValidator(
+      z.object({
+        activity: z.enum(['image', 'video']).optional(),
+        search: z.string().max(200).optional(),
+        favoritesOnly: z.boolean().optional(),
+        order: z.enum(['newest', 'oldest']).optional(),
+        limit: z.number().int().min(1).max(100).optional(),
+        cursor: ulidSchema.optional(),
+      })
+    )
+  )
+  .handler(async ({ context, data }) => {
+    return context.adminScopedDb.admin.getAllStudioAssets(data);
+  });

--- a/src/platform/server/db/scoped/admin.test.ts
+++ b/src/platform/server/db/scoped/admin.test.ts
@@ -1,9 +1,10 @@
 /**
- * Support-mode lookup (`createAdminMethods.getAllSequences`): resolves a person
- * through TEAM MEMBERSHIP, so a customer's sequences stay reachable by their
- * email even when `sequences.created_by` is NULL — the state the #612-class
- * table-rebuild left 174 prod rows in. Guards against regressing back to a
- * creator-only filter that strands those rows.
+ * Support-mode lookup (`createAdminMethods.getAllSequences` /
+ * `getAllStudioAssets`): resolves a person through TEAM MEMBERSHIP, so a
+ * customer's work stays reachable by their email even when a creator column
+ * is missing — the state the #612-class table-rebuild left 174 prod sequences
+ * in. Studio `userId` is required, but lookup still goes through membership
+ * so a teammate's stills/clips show up under the customer's email (#1568).
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
@@ -12,6 +13,7 @@ import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 import { generateId } from '@/platform/id';
 import {
+  generatedAssets,
   sequences,
   styles,
   teamMembers,
@@ -40,6 +42,7 @@ const styleConfig = {
 // teams excluded".
 const ids = {
   tannerUser: '',
+  tannerTeammate: '',
   tannerTeam: '',
   tannerStyle: '',
   liveSeq: '',
@@ -48,9 +51,15 @@ const ids = {
   otherTeam: '',
   otherStyle: '',
   otherSeq: '',
+  tannerImage: '',
+  tannerTeammateImage: '',
+  tannerVideo: '',
+  tannerCatalog: '',
+  otherImage: '',
 };
 
 async function seed() {
+  await db.delete(generatedAssets);
   await db.delete(sequences);
   await db.delete(styles);
   await db.delete(teamMembers);
@@ -58,15 +67,26 @@ async function seed() {
   await db.delete(user);
 
   ids.tannerUser = generateId();
+  ids.tannerTeammate = generateId();
   ids.tannerTeam = generateId();
   ids.otherUser = generateId();
   ids.otherTeam = generateId();
   ids.liveSeq = generateId();
   ids.archivedSeq = generateId();
   ids.otherSeq = generateId();
+  ids.tannerImage = generateId();
+  ids.tannerTeammateImage = generateId();
+  ids.tannerVideo = generateId();
+  ids.tannerCatalog = generateId();
+  ids.otherImage = generateId();
 
   await db.insert(user).values([
     { id: ids.tannerUser, name: 'Tanner Linsley', email: 'tanner@example.com' },
+    {
+      id: ids.tannerTeammate,
+      name: 'Teammate',
+      email: 'teammate@example.com',
+    },
     { id: ids.otherUser, name: 'Someone Else', email: 'other@example.com' },
   ]);
   await db.insert(teams).values([
@@ -75,6 +95,7 @@ async function seed() {
   ]);
   await db.insert(teamMembers).values([
     { teamId: ids.tannerTeam, userId: ids.tannerUser, role: 'owner' },
+    { teamId: ids.tannerTeam, userId: ids.tannerTeammate, role: 'member' },
     { teamId: ids.otherTeam, userId: ids.otherUser, role: 'owner' },
   ]);
   const [tannerStyle, otherStyle] = await db
@@ -111,6 +132,69 @@ async function seed() {
       teamId: ids.otherTeam,
       title: 'Unrelated',
       styleId: ids.otherStyle,
+      status: 'completed',
+    },
+  ]);
+
+  await db.insert(generatedAssets).values([
+    {
+      id: ids.tannerImage,
+      teamId: ids.tannerTeam,
+      userId: ids.tannerUser,
+      provider: 'fal',
+      endpointId: 'fal-ai/flux-1/dev',
+      activity: 'image',
+      modelName: 'FLUX.1 [dev]',
+      source: 'studio',
+      input: { prompt: 'a red fox' },
+      status: 'completed',
+    },
+    {
+      id: ids.tannerTeammateImage,
+      teamId: ids.tannerTeam,
+      userId: ids.tannerTeammate,
+      provider: 'fal',
+      endpointId: 'fal-ai/flux-1/dev',
+      activity: 'image',
+      modelName: 'FLUX.1 [dev]',
+      source: 'studio',
+      input: { prompt: 'a blue heron' },
+      status: 'completed',
+    },
+    {
+      id: ids.tannerVideo,
+      teamId: ids.tannerTeam,
+      userId: ids.tannerUser,
+      provider: 'fal',
+      endpointId: 'fal-ai/kling-video',
+      activity: 'video',
+      modelName: 'Kling',
+      source: 'studio',
+      input: { prompt: 'fox runs' },
+      status: 'completed',
+    },
+    {
+      id: ids.tannerCatalog,
+      teamId: ids.tannerTeam,
+      userId: ids.tannerUser,
+      provider: 'fal',
+      endpointId: 'fal-ai/flux-1/dev',
+      activity: 'image',
+      modelName: 'FLUX.1 [dev]',
+      source: 'catalog',
+      input: { prompt: 'catalog only' },
+      status: 'completed',
+    },
+    {
+      id: ids.otherImage,
+      teamId: ids.otherTeam,
+      userId: ids.otherUser,
+      provider: 'fal',
+      endpointId: 'fal-ai/flux-1/dev',
+      activity: 'image',
+      modelName: 'FLUX.1 [dev]',
+      source: 'studio',
+      input: { prompt: 'unrelated still' },
       status: 'completed',
     },
   ]);
@@ -154,5 +238,81 @@ describe('createAdminMethods.getAllSequences', () => {
     const admin = createAdminMethods(db);
     const rows = await admin.getAllSequences({ search: 'hidden divide' });
     expect(rows.map((r) => r.id)).toEqual([ids.liveSeq]);
+  });
+});
+
+describe('createAdminMethods.getAllStudioAssets', () => {
+  it('lists every studio asset across teams when unfiltered', async () => {
+    const admin = createAdminMethods(db);
+    const { assets, nextCursor } = await admin.getAllStudioAssets();
+
+    expect(assets.map((a) => a.id).sort()).toEqual(
+      [
+        ids.tannerImage,
+        ids.tannerTeammateImage,
+        ids.tannerVideo,
+        ids.otherImage,
+      ].sort()
+    );
+    expect(nextCursor).toBeNull();
+    expect(assets.some((a) => a.id === ids.tannerCatalog)).toBe(false);
+  });
+
+  it("finds a team's studio stills by a member email, including a teammate's", async () => {
+    const admin = createAdminMethods(db);
+    const { assets } = await admin.getAllStudioAssets({
+      activity: 'image',
+      search: 'tanner@example.com',
+    });
+
+    expect(assets.map((a) => a.id).sort()).toEqual(
+      [ids.tannerImage, ids.tannerTeammateImage].sort()
+    );
+    expect(assets.find((a) => a.id === ids.tannerImage)?.creatorEmail).toBe(
+      'tanner@example.com'
+    );
+    expect(
+      assets.find((a) => a.id === ids.tannerTeammateImage)?.creatorEmail
+    ).toBe('teammate@example.com');
+  });
+
+  it('excludes catalog runs, other teams, and the other activity', async () => {
+    const admin = createAdminMethods(db);
+    const { assets } = await admin.getAllStudioAssets({
+      activity: 'video',
+      search: 'tanner',
+    });
+
+    expect(assets.map((a) => a.id)).toEqual([ids.tannerVideo]);
+  });
+
+  it('matches a snapshotted prompt', async () => {
+    const admin = createAdminMethods(db);
+    const { assets } = await admin.getAllStudioAssets({
+      search: 'blue heron',
+    });
+    expect(assets.map((a) => a.id)).toEqual([ids.tannerTeammateImage]);
+  });
+
+  it('paginates newest-first with a keyset cursor', async () => {
+    const admin = createAdminMethods(db);
+    // Insert order of studio rows (catalog is skipped by the query).
+    const newestFirst = [
+      ids.otherImage,
+      ids.tannerVideo,
+      ids.tannerTeammateImage,
+      ids.tannerImage,
+    ];
+
+    const page1 = await admin.getAllStudioAssets({ limit: 2 });
+    expect(page1.assets.map((a) => a.id)).toEqual(newestFirst.slice(0, 2));
+    expect(page1.nextCursor).toBe(newestFirst[1]);
+
+    const page2 = await admin.getAllStudioAssets({
+      limit: 2,
+      cursor: page1.nextCursor ?? undefined,
+    });
+    expect(page2.assets.map((a) => a.id)).toEqual(newestFirst.slice(2));
+    expect(page2.nextCursor).toBeNull();
   });
 });

--- a/src/platform/server/db/scoped/admin.ts
+++ b/src/platform/server/db/scoped/admin.ts
@@ -265,7 +265,6 @@ export function createAdminMethods(db: Database) {
     const memberUser = alias(user, 'member_user');
     const searchClause = trimmed
       ? or(
-          like(sql`lower(${generatedAssets.modelName})`, `%${trimmed}%`),
           like(sql`lower(${generatedAssets.input})`, `%${trimmed}%`),
           exists(
             db

--- a/src/platform/server/db/scoped/admin.ts
+++ b/src/platform/server/db/scoped/admin.ts
@@ -21,11 +21,29 @@ import {
 } from '@/platform/server/db/schema/gift-tokens';
 import type { GiftToken } from '@/platform/server/db/schema/gift-tokens';
 import { sequences } from '@/platform/server/db/schema/sequences';
-import type { Sequence } from '@/platform/server/db/schema';
+import {
+  generatedAssets,
+  type GeneratedAsset,
+  type Sequence,
+} from '@/platform/server/db/schema';
 import type { ShotView } from '@/shots/shot-view';
 import { teamMembers, teams } from '@/platform/server/db/schema/teams';
 import { ValidationError } from '@/platform/errors';
-import { and, count, desc, eq, exists, like, not, or, sql } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  exists,
+  gt,
+  like,
+  lt,
+  not,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import { alias } from 'drizzle-orm/sqlite-core';
 
 // Ambiguity-free alphabet (no 0/O/1/I) -- 32 chars -> 32^6 ~ 1B combinations.
@@ -216,6 +234,101 @@ export function createAdminMethods(db: Database) {
     return assembleShotViews(db, rows);
   }
 
+  // ---- Support: cross-team studio images/videos (#1568) ----
+
+  type StudioAssetWithCreator = GeneratedAsset & {
+    creatorName: string | null;
+    creatorEmail: string | null;
+  };
+
+  async function getAllStudioAssets(opts?: {
+    activity?: GeneratedAsset['activity'];
+    search?: string;
+    favoritesOnly?: boolean;
+    order?: 'newest' | 'oldest';
+    limit?: number;
+    cursor?: string;
+  }): Promise<{
+    assets: StudioAssetWithCreator[];
+    nextCursor: string | null;
+  }> {
+    const {
+      activity,
+      search,
+      favoritesOnly,
+      order = 'newest',
+      limit = 40,
+      cursor,
+    } = opts ?? {};
+
+    const trimmed = search?.trim().toLowerCase();
+    const memberUser = alias(user, 'member_user');
+    const searchClause = trimmed
+      ? or(
+          like(sql`lower(${generatedAssets.modelName})`, `%${trimmed}%`),
+          like(sql`lower(${generatedAssets.input})`, `%${trimmed}%`),
+          exists(
+            db
+              .select({ one: sql`1` })
+              .from(teamMembers)
+              .innerJoin(memberUser, eq(memberUser.id, teamMembers.userId))
+              .where(
+                and(
+                  eq(teamMembers.teamId, generatedAssets.teamId),
+                  or(
+                    like(sql`lower(${memberUser.name})`, `%${trimmed}%`),
+                    like(sql`lower(${memberUser.email})`, `%${trimmed}%`)
+                  )
+                )
+              )
+          )
+        )
+      : undefined;
+
+    const conditions: SQL[] = [eq(generatedAssets.source, 'studio')];
+    if (activity) {
+      conditions.push(eq(generatedAssets.activity, activity));
+    }
+    if (favoritesOnly) {
+      conditions.push(eq(generatedAssets.isFavorite, true));
+    }
+    if (cursor) {
+      conditions.push(
+        order === 'oldest'
+          ? gt(generatedAssets.id, cursor)
+          : lt(generatedAssets.id, cursor)
+      );
+    }
+    if (searchClause) {
+      conditions.push(searchClause);
+    }
+
+    const rows = await db
+      .select({
+        asset: generatedAssets,
+        creatorName: user.name,
+        creatorEmail: user.email,
+      })
+      .from(generatedAssets)
+      .leftJoin(user, eq(generatedAssets.userId, user.id))
+      .where(and(...conditions))
+      .orderBy(
+        order === 'oldest' ? asc(generatedAssets.id) : desc(generatedAssets.id)
+      )
+      .limit(limit + 1);
+
+    const page = rows.slice(0, limit);
+    const last = page[page.length - 1];
+    return {
+      assets: page.map(({ asset, creatorName, creatorEmail }) => ({
+        ...asset,
+        creatorName,
+        creatorEmail,
+      })),
+      nextCursor: rows.length > limit && last ? last.asset.id : null,
+    };
+  }
+
   // ---- User activity reporting ----
 
   async function listUserActivity(): Promise<UserActivityRow[]> {
@@ -293,6 +406,7 @@ export function createAdminMethods(db: Database) {
     listGiftTokens,
     getAllSequences,
     getShotsForSequence,
+    getAllStudioAssets,
     listUserActivity,
   };
 }

--- a/src/routes/_app/admin/usage.tsx
+++ b/src/routes/_app/admin/usage.tsx
@@ -380,15 +380,33 @@ const UserRow: React.FC<{ row: UserActivityRow }> = ({ row }) => {
         {microsToDisplayUsd(micros(row.currentBalanceMicros))}
       </td>
       <td className="px-4 py-3">
-        <Link
-          to="/sequences"
-          search={{ user: row.email }}
-          className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-          aria-label={`Open support view for ${row.email}`}
-        >
-          <LifeBuoy className="h-4 w-4" />
-          Support
-        </Link>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <Link
+            to="/sequences"
+            search={{ user: row.email }}
+            className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+            aria-label={`Open sequence support view for ${row.email}`}
+          >
+            <LifeBuoy className="h-4 w-4" />
+            Sequences
+          </Link>
+          <Link
+            to="/images"
+            search={{ user: row.email }}
+            className="text-sm text-primary hover:underline"
+            aria-label={`Open image support view for ${row.email}`}
+          >
+            Images
+          </Link>
+          <Link
+            to="/videos"
+            search={{ user: row.email }}
+            className="text-sm text-primary hover:underline"
+            aria-label={`Open video support view for ${row.email}`}
+          >
+            Videos
+          </Link>
+        </div>
       </td>
     </tr>
   );
@@ -410,6 +428,8 @@ const CSV_COLUMNS = [
   'creditsGiftedUsd',
   'currentBalanceUsd',
   'supportUrl',
+  'imagesSupportUrl',
+  'videosSupportUrl',
 ] as const;
 
 function csvEscape(value: string | number | null): string {
@@ -428,7 +448,10 @@ function toCsv(rows: UserActivityRow[], origin: string): string {
       row.avgAnalysisDurationMs === null
         ? null
         : Math.round(row.avgAnalysisDurationMs / 1000);
-    const supportUrl = `${origin}/sequences?user=${encodeURIComponent(row.email)}`;
+    const encoded = encodeURIComponent(row.email);
+    const supportUrl = `${origin}/sequences?user=${encoded}`;
+    const imagesSupportUrl = `${origin}/images?user=${encoded}`;
+    const videosSupportUrl = `${origin}/videos?user=${encoded}`;
     const values: Array<string | number | null> = [
       row.userId,
       row.name,
@@ -445,6 +468,8 @@ function toCsv(rows: UserActivityRow[], origin: string): string {
       microsToUsd(micros(row.creditsGiftedMicros)).toFixed(2),
       microsToUsd(micros(row.currentBalanceMicros)).toFixed(2),
       supportUrl,
+      imagesSupportUrl,
+      videosSupportUrl,
     ];
     return values.map(csvEscape).join(',');
   });

--- a/src/routes/_app/images/index.tsx
+++ b/src/routes/_app/images/index.tsx
@@ -1,20 +1,21 @@
 import { StudioView } from '@/studio/ui/studio-view';
+import { studioListSearchSchema } from '@/studio/ui/list-prefs';
 import { createFileRoute } from '@tanstack/react-router';
-import { studioSortSchema } from '@/studio/schema';
-import { z } from 'zod';
-
-const searchParamsSchema = z.object({
-  sort: studioSortSchema.optional(),
-  favorites: z.boolean().optional(),
-});
 
 export const Route = createFileRoute('/_app/images/')({
-  validateSearch: searchParamsSchema,
+  validateSearch: studioListSearchSchema,
   component: ImagesPage,
   staticData: { breadcrumb: 'Images' },
 });
 
 function ImagesPage() {
-  const { sort = 'newest', favorites = false } = Route.useSearch();
-  return <StudioView activity="image" sort={sort} favorites={favorites} />;
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  return (
+    <StudioView
+      activity="image"
+      search={search}
+      navigate={(opts) => navigate(opts)}
+    />
+  );
 }

--- a/src/routes/_app/studio/index.tsx
+++ b/src/routes/_app/studio/index.tsx
@@ -1,11 +1,9 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { studioSortSchema } from '@/studio/schema';
+import { studioListSearchSchema } from '@/studio/ui/list-prefs';
 import { z } from 'zod';
 
-const searchParamsSchema = z.object({
+const searchParamsSchema = studioListSearchSchema.extend({
   kind: z.enum(['all', 'image', 'video']).optional(),
-  sort: studioSortSchema.optional(),
-  favorites: z.boolean().optional(),
 });
 
 export const Route = createFileRoute('/_app/studio/')({
@@ -16,6 +14,10 @@ export const Route = createFileRoute('/_app/studio/')({
       search: {
         sort: search.sort,
         favorites: search.favorites,
+        user: search.user,
+        q: search.q,
+        support: search.support,
+        hideInternal: search.hideInternal,
       },
     });
   },

--- a/src/routes/_app/videos/index.tsx
+++ b/src/routes/_app/videos/index.tsx
@@ -1,20 +1,21 @@
 import { StudioView } from '@/studio/ui/studio-view';
+import { studioListSearchSchema } from '@/studio/ui/list-prefs';
 import { createFileRoute } from '@tanstack/react-router';
-import { studioSortSchema } from '@/studio/schema';
-import { z } from 'zod';
-
-const searchParamsSchema = z.object({
-  sort: studioSortSchema.optional(),
-  favorites: z.boolean().optional(),
-});
 
 export const Route = createFileRoute('/_app/videos/')({
-  validateSearch: searchParamsSchema,
+  validateSearch: studioListSearchSchema,
   component: VideosPage,
   staticData: { breadcrumb: 'Videos' },
 });
 
 function VideosPage() {
-  const { sort = 'newest', favorites = false } = Route.useSearch();
-  return <StudioView activity="video" sort={sort} favorites={favorites} />;
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  return (
+    <StudioView
+      activity="video"
+      search={search}
+      navigate={(opts) => navigate(opts)}
+    />
+  );
 }

--- a/src/studio/ui/list-prefs.test.ts
+++ b/src/studio/ui/list-prefs.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Images / Videos list prefs (#1568): URL search is the live snapshot;
+ * localStorage restores support mode on a bare /images or /videos visit.
+ * `sort` / `favorites` never turn on this browser's support mode.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mem = new Map<string, string>();
+const localStorageMock = {
+  getItem: (k: string) => mem.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    mem.set(k, v);
+  },
+  removeItem: (k: string) => {
+    mem.delete(k);
+  },
+};
+
+const storedPrefs = {
+  search: 'ada@example.com',
+  supportMode: true,
+  hideInternal: true,
+};
+
+describe('studio list prefs', () => {
+  beforeEach(() => {
+    mem.clear();
+    vi.stubGlobal('window', { localStorage: localStorageMock });
+    vi.stubGlobal('localStorage', localStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads empty URL search as the default list prefs', async () => {
+    const { prefsFromSearch, DEFAULT_STUDIO_LIST_PREFS } =
+      await import('./list-prefs');
+
+    expect(prefsFromSearch({})).toEqual(DEFAULT_STUDIO_LIST_PREFS);
+  });
+
+  it('takes search from q, and user over q, forcing support on for the deep link', async () => {
+    const { prefsFromSearch } = await import('./list-prefs');
+
+    expect(prefsFromSearch({ q: 'fox' })).toMatchObject({
+      search: 'fox',
+      supportMode: false,
+    });
+    expect(
+      prefsFromSearch({
+        user: 'ada@example.com',
+        q: 'ignored',
+        support: false,
+        hideInternal: true,
+        sort: 'oldest',
+        favorites: true,
+      })
+    ).toEqual({
+      search: 'ada@example.com',
+      supportMode: true,
+      hideInternal: false,
+      sort: 'oldest',
+      favorites: true,
+    });
+  });
+
+  it('treats support params as a complete URL snapshot, not sort or favorites', async () => {
+    const { searchSpecifiesSupportPrefs } = await import('./list-prefs');
+
+    expect(searchSpecifiesSupportPrefs({})).toBe(false);
+    expect(searchSpecifiesSupportPrefs({ sort: 'oldest' })).toBe(false);
+    expect(searchSpecifiesSupportPrefs({ favorites: true })).toBe(false);
+    expect(searchSpecifiesSupportPrefs({ q: 'x' })).toBe(true);
+    expect(searchSpecifiesSupportPrefs({ support: true })).toBe(true);
+    expect(searchSpecifiesSupportPrefs({ user: 'ada@example.com' })).toBe(true);
+  });
+
+  it('restores stored support prefs onto a bare visit, keeping URL sort', async () => {
+    const { resolveStudioListPrefs } = await import('./list-prefs');
+
+    expect(resolveStudioListPrefs({}, storedPrefs)).toEqual({
+      search: 'ada@example.com',
+      supportMode: true,
+      hideInternal: true,
+      sort: 'newest',
+      favorites: false,
+    });
+    expect(resolveStudioListPrefs({ sort: 'oldest' }, storedPrefs)).toEqual({
+      search: 'ada@example.com',
+      supportMode: true,
+      hideInternal: true,
+      sort: 'oldest',
+      favorites: false,
+    });
+    expect(resolveStudioListPrefs({}, null)).toEqual({
+      search: '',
+      supportMode: false,
+      hideInternal: false,
+      sort: 'newest',
+      favorites: false,
+    });
+  });
+
+  it('does not blend a support URL with stored search', async () => {
+    const { resolveStudioListPrefs } = await import('./list-prefs');
+
+    expect(resolveStudioListPrefs({ q: 'shared' }, storedPrefs)).toEqual({
+      search: 'shared',
+      supportMode: false,
+      hideInternal: false,
+      sort: 'newest',
+      favorites: false,
+    });
+    expect(
+      resolveStudioListPrefs({ user: 'ada@example.com' }, storedPrefs)
+    ).toMatchObject({
+      search: 'ada@example.com',
+      supportMode: true,
+      hideInternal: false,
+    });
+  });
+
+  it('omits default prefs from the URL so /images stays canonical', async () => {
+    const { prefsToSearch, DEFAULT_STUDIO_LIST_PREFS } =
+      await import('./list-prefs');
+
+    expect(prefsToSearch(DEFAULT_STUDIO_LIST_PREFS)).toEqual({});
+    expect(
+      prefsToSearch({
+        search: 'fox',
+        supportMode: true,
+        hideInternal: true,
+        sort: 'oldest',
+        favorites: true,
+      })
+    ).toEqual({
+      q: 'fox',
+      support: true,
+      hideInternal: true,
+      sort: 'oldest',
+      favorites: true,
+    });
+  });
+
+  it('keeps the admin user param only while search still matches and support is on', async () => {
+    const { prefsToSearch } = await import('./list-prefs');
+    const user = 'ada@example.com';
+
+    expect(
+      prefsToSearch(
+        {
+          search: user,
+          supportMode: true,
+          hideInternal: false,
+          sort: 'newest',
+          favorites: false,
+        },
+        user
+      )
+    ).toEqual({ user });
+
+    expect(
+      prefsToSearch(
+        {
+          search: 'other',
+          supportMode: true,
+          hideInternal: false,
+          sort: 'newest',
+          favorites: false,
+        },
+        user
+      )
+    ).toEqual({ q: 'other', support: true });
+
+    expect(
+      prefsToSearch(
+        {
+          search: user,
+          supportMode: false,
+          hideInternal: false,
+          sort: 'newest',
+          favorites: false,
+        },
+        user
+      )
+    ).toEqual({ q: user });
+  });
+
+  it('round-trips support prefs through localStorage and rejects garbage', async () => {
+    const { loadStudioListPrefs, saveStudioListPrefs, STUDIO_LIST_PREFS_KEY } =
+      await import('./list-prefs');
+
+    expect(loadStudioListPrefs()).toBeNull();
+    saveStudioListPrefs({
+      search: storedPrefs.search,
+      supportMode: true,
+      hideInternal: true,
+      sort: 'oldest',
+      favorites: true,
+    });
+    expect(loadStudioListPrefs()).toEqual(storedPrefs);
+
+    localStorage.setItem(STUDIO_LIST_PREFS_KEY, '{not json');
+    expect(loadStudioListPrefs()).toBeNull();
+  });
+});

--- a/src/studio/ui/list-prefs.ts
+++ b/src/studio/ui/list-prefs.ts
@@ -1,0 +1,149 @@
+/**
+ * Images / Videos list toolbar prefs (#1568).
+ *
+ * Live state lives in the /images and /videos search params (shareable).
+ * localStorage is the memory for a bare visit (sidebar / breadcrumb) so
+ * support mode survives leaving the page — same contract as sequences.
+ *
+ * `sort` and `favorites` stay on the URL only; they are not stored, so a
+ * remembered Support overlay does not clobber Newest/Oldest.
+ *
+ * No `.default()` on the search schema: a default rewrites the bare path
+ * with a 307, which sours the sitemap entry (#814).
+ */
+import { studioSortSchema, type StudioSort } from '@/studio/schema';
+import { z } from 'zod';
+
+export const STUDIO_LIST_PREFS_KEY = 'openstory:studio-list:v1';
+
+export const studioListSearchSchema = z.object({
+  user: z.string().email().optional(),
+  q: z.string().optional(),
+  support: z.boolean().optional(),
+  hideInternal: z.boolean().optional(),
+  sort: studioSortSchema.optional(),
+  favorites: z.boolean().optional(),
+});
+
+export type StudioListSearch = z.infer<typeof studioListSearchSchema>;
+
+export type StudioListPrefs = {
+  search: string;
+  supportMode: boolean;
+  hideInternal: boolean;
+  sort: StudioSort;
+  favorites: boolean;
+};
+
+export const DEFAULT_STUDIO_LIST_PREFS: StudioListPrefs = {
+  search: '',
+  supportMode: false,
+  hideInternal: false,
+  sort: 'newest',
+  favorites: false,
+};
+
+const storedPrefsSchema = z.object({
+  search: z.string().catch(''),
+  supportMode: z.boolean().catch(false),
+  hideInternal: z.boolean().catch(false),
+});
+
+type StoredStudioListPrefs = z.infer<typeof storedPrefsSchema>;
+
+export function searchSpecifiesSupportPrefs(search: StudioListSearch): boolean {
+  return (
+    search.user != null ||
+    search.q != null ||
+    search.support != null ||
+    search.hideInternal != null
+  );
+}
+
+export function prefsFromSearch(search: StudioListSearch): StudioListPrefs {
+  return {
+    search: search.user ?? search.q ?? '',
+    supportMode: Boolean(search.user) || Boolean(search.support),
+    hideInternal: search.user ? false : Boolean(search.hideInternal),
+    sort: search.sort ?? 'newest',
+    favorites: Boolean(search.favorites),
+  };
+}
+
+export function resolveStudioListPrefs(
+  search: StudioListSearch,
+  stored: StoredStudioListPrefs | null
+): StudioListPrefs {
+  const fromUrl = prefsFromSearch(search);
+  if (searchSpecifiesSupportPrefs(search)) {
+    return fromUrl;
+  }
+  return {
+    ...fromUrl,
+    search: stored?.search ?? '',
+    supportMode: stored?.supportMode ?? false,
+    hideInternal: stored?.hideInternal ?? false,
+  };
+}
+
+export function isDefaultStudioListPrefs(prefs: StudioListPrefs): boolean {
+  return (
+    prefs.search === '' &&
+    !prefs.supportMode &&
+    !prefs.hideInternal &&
+    prefs.sort === 'newest' &&
+    !prefs.favorites
+  );
+}
+
+export function prefsToSearch(
+  prefs: StudioListPrefs,
+  currentUser?: string
+): StudioListSearch {
+  const search: StudioListSearch = {};
+  const keepUser =
+    Boolean(currentUser) && prefs.supportMode && prefs.search === currentUser;
+
+  if (keepUser && currentUser) {
+    search.user = currentUser;
+  } else if (prefs.search) {
+    search.q = prefs.search;
+  }
+
+  if (prefs.supportMode && !search.user) search.support = true;
+  if (prefs.hideInternal && prefs.supportMode && !search.user) {
+    search.hideInternal = true;
+  }
+  if (prefs.sort !== 'newest') search.sort = prefs.sort;
+  if (prefs.favorites) search.favorites = true;
+  return search;
+}
+
+export function loadStudioListPrefs(): StoredStudioListPrefs | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(STUDIO_LIST_PREFS_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    const result = storedPrefsSchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveStudioListPrefs(prefs: StudioListPrefs): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(
+      STUDIO_LIST_PREFS_KEY,
+      JSON.stringify({
+        search: prefs.search,
+        supportMode: prefs.supportMode,
+        hideInternal: prefs.hideInternal,
+      })
+    );
+  } catch {
+    // private mode / quota
+  }
+}

--- a/src/studio/ui/list-prefs.ts
+++ b/src/studio/ui/list-prefs.ts
@@ -86,16 +86,6 @@ export function resolveStudioListPrefs(
   };
 }
 
-export function isDefaultStudioListPrefs(prefs: StudioListPrefs): boolean {
-  return (
-    prefs.search === '' &&
-    !prefs.supportMode &&
-    !prefs.hideInternal &&
-    prefs.sort === 'newest' &&
-    !prefs.favorites
-  );
-}
-
 export function prefsToSearch(
   prefs: StudioListPrefs,
   currentUser?: string

--- a/src/studio/ui/studio-gallery.tsx
+++ b/src/studio/ui/studio-gallery.tsx
@@ -56,13 +56,11 @@ export type StudioGalleryAsset = GeneratedAsset & {
 function StudioCard({
   asset,
   onOpen,
-  readOnly,
-  showCreator,
+  supportMode,
 }: {
   asset: StudioGalleryAsset;
   onOpen: () => void;
-  readOnly: boolean;
-  showCreator: boolean;
+  supportMode: boolean;
 }) {
   const favorite = useToggleStudioFavorite();
   const primary = studioPrimaryOutput(asset);
@@ -129,7 +127,7 @@ function StudioCard({
           </div>
         )}
       </button>
-      {!readOnly && (
+      {!supportMode && (
         <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-end p-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
           <Button
             type="button"
@@ -152,7 +150,7 @@ function StudioCard({
           </Button>
         </div>
       )}
-      {showCreator && (asset.creatorName || asset.creatorEmail) && (
+      {supportMode && (asset.creatorName || asset.creatorEmail) && (
         <p className="pointer-events-none absolute inset-x-0 top-0 truncate bg-background/80 px-2 py-1 text-xs text-muted-foreground">
           <span>
             {asset.creatorName && asset.creatorEmail
@@ -240,8 +238,7 @@ export function StudioGallery({
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
-  readOnly = false,
-  showCreator = false,
+  supportMode = false,
 }: {
   assets: StudioGalleryAsset[];
   isLoading: boolean;
@@ -250,14 +247,13 @@ export function StudioGallery({
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
-  readOnly?: boolean;
-  showCreator?: boolean;
+  supportMode?: boolean;
 }) {
   const [openId, setOpenId] = useState<string | null>(null);
   const remove = useDeleteStudioAsset();
   const openAsset = assets.find((asset) => asset.id === openId);
   const pendingCreates = useStudioPendingCreates(activity);
-  const pending = readOnly
+  const pending = supportMode
     ? []
     : pendingCreates.flatMap((input, index) =>
         Array.from({ length: input.count }, (_, i) => ({
@@ -284,7 +280,7 @@ export function StudioGallery({
       <EmptyState
         icon={<Images className="h-12 w-12" />}
         title={
-          readOnly
+          supportMode
             ? activity === 'video'
               ? 'No matching videos'
               : 'No matching images'
@@ -293,7 +289,7 @@ export function StudioGallery({
               : 'Sign in to generate'
         }
         description={
-          readOnly
+          supportMode
             ? activity === 'video'
               ? 'No clips match this search across any users.'
               : 'No stills match this search across any users.'
@@ -320,8 +316,7 @@ export function StudioGallery({
             <StudioCard
               asset={asset}
               onOpen={() => setOpenId(asset.id)}
-              readOnly={readOnly}
-              showCreator={showCreator}
+              supportMode={supportMode}
             />
           </div>
         ))}
@@ -356,7 +351,7 @@ export function StudioGallery({
                   {[
                     openAsset.modelName,
                     studioAspectRatio(openAsset),
-                    showCreator
+                    supportMode
                       ? [openAsset.creatorName, openAsset.creatorEmail]
                           .filter(Boolean)
                           .join(' · ')
@@ -384,7 +379,7 @@ export function StudioGallery({
                     </Button>
                   );
                 })()}
-                {!readOnly &&
+                {!supportMode &&
                   openAsset.status !== 'queued' &&
                   openAsset.status !== 'running' && (
                     <AlertDialog>

--- a/src/studio/ui/studio-gallery.tsx
+++ b/src/studio/ui/studio-gallery.tsx
@@ -48,12 +48,21 @@ function useNow(active: boolean) {
   return active ? now : null;
 }
 
+export type StudioGalleryAsset = GeneratedAsset & {
+  creatorName?: string | null;
+  creatorEmail?: string | null;
+};
+
 function StudioCard({
   asset,
   onOpen,
+  readOnly,
+  showCreator,
 }: {
-  asset: GeneratedAsset;
+  asset: StudioGalleryAsset;
   onOpen: () => void;
+  readOnly: boolean;
+  showCreator: boolean;
 }) {
   const favorite = useToggleStudioFavorite();
   const primary = studioPrimaryOutput(asset);
@@ -120,27 +129,38 @@ function StudioCard({
           </div>
         )}
       </button>
-      <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-end p-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-        <Button
-          type="button"
-          size="icon"
-          variant="secondary"
-          className="pointer-events-auto"
-          aria-label={asset.isFavorite ? 'Remove from favorites' : 'Favorite'}
-          aria-pressed={asset.isFavorite}
-          onClick={() =>
-            favorite.mutate({
-              id: asset.id,
-              isFavorite: !asset.isFavorite,
-            })
-          }
-        >
-          <Star
-            className={cn(asset.isFavorite && 'fill-current')}
-            aria-hidden="true"
-          />
-        </Button>
-      </div>
+      {!readOnly && (
+        <div className="pointer-events-none absolute inset-x-0 top-0 flex justify-end p-2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
+          <Button
+            type="button"
+            size="icon"
+            variant="secondary"
+            className="pointer-events-auto"
+            aria-label={asset.isFavorite ? 'Remove from favorites' : 'Favorite'}
+            aria-pressed={asset.isFavorite}
+            onClick={() =>
+              favorite.mutate({
+                id: asset.id,
+                isFavorite: !asset.isFavorite,
+              })
+            }
+          >
+            <Star
+              className={cn(asset.isFavorite && 'fill-current')}
+              aria-hidden="true"
+            />
+          </Button>
+        </div>
+      )}
+      {showCreator && (asset.creatorName || asset.creatorEmail) && (
+        <p className="pointer-events-none absolute inset-x-0 top-0 truncate bg-background/80 px-2 py-1 text-xs text-muted-foreground">
+          <span>
+            {asset.creatorName && asset.creatorEmail
+              ? `${asset.creatorName} · ${asset.creatorEmail}`
+              : (asset.creatorName ?? asset.creatorEmail)}
+          </span>
+        </p>
+      )}
       {inFlight && (
         <p
           aria-live="polite"
@@ -220,24 +240,31 @@ export function StudioGallery({
   hasNextPage,
   isFetchingNextPage,
   onLoadMore,
+  readOnly = false,
+  showCreator = false,
 }: {
-  assets: GeneratedAsset[];
+  assets: StudioGalleryAsset[];
   isLoading: boolean;
   isAuthenticated: boolean;
   activity: 'image' | 'video';
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   onLoadMore: () => void;
+  readOnly?: boolean;
+  showCreator?: boolean;
 }) {
   const [openId, setOpenId] = useState<string | null>(null);
   const remove = useDeleteStudioAsset();
   const openAsset = assets.find((asset) => asset.id === openId);
-  const pending = useStudioPendingCreates(activity).flatMap((input, index) =>
-    Array.from({ length: input.count }, (_, i) => ({
-      key: `pending-${index}-${i}`,
-      aspectRatio: input.aspectRatio,
-    }))
-  );
+  const pendingCreates = useStudioPendingCreates(activity);
+  const pending = readOnly
+    ? []
+    : pendingCreates.flatMap((input, index) =>
+        Array.from({ length: input.count }, (_, i) => ({
+          key: `pending-${index}-${i}`,
+          aspectRatio: input.aspectRatio,
+        }))
+      );
 
   if (isLoading) {
     return (
@@ -256,13 +283,25 @@ export function StudioGallery({
     return (
       <EmptyState
         icon={<Images className="h-12 w-12" />}
-        title={isAuthenticated ? 'Nothing here yet' : 'Sign in to generate'}
-        description={
-          isAuthenticated
+        title={
+          readOnly
             ? activity === 'video'
-              ? 'Your clips land here. Start with a prompt below.'
-              : 'Your stills land here. Start with a prompt below.'
-            : 'Browse the composer, then sign in to generate and keep a library.'
+              ? 'No matching videos'
+              : 'No matching images'
+            : isAuthenticated
+              ? 'Nothing here yet'
+              : 'Sign in to generate'
+        }
+        description={
+          readOnly
+            ? activity === 'video'
+              ? 'No clips match this search across any users.'
+              : 'No stills match this search across any users.'
+            : isAuthenticated
+              ? activity === 'video'
+                ? 'Your clips land here. Start with a prompt below.'
+                : 'Your stills land here. Start with a prompt below.'
+              : 'Browse the composer, then sign in to generate and keep a library.'
         }
       />
     );
@@ -278,7 +317,12 @@ export function StudioGallery({
         ))}
         {assets.map((asset) => (
           <div key={asset.id} className="mb-4 break-inside-avoid">
-            <StudioCard asset={asset} onOpen={() => setOpenId(asset.id)} />
+            <StudioCard
+              asset={asset}
+              onOpen={() => setOpenId(asset.id)}
+              readOnly={readOnly}
+              showCreator={showCreator}
+            />
           </div>
         ))}
       </div>
@@ -309,7 +353,17 @@ export function StudioGallery({
                   {studioPrompt(openAsset) || 'Generated asset'}
                 </DialogTitle>
                 <DialogDescription>
-                  {openAsset.modelName} · {studioAspectRatio(openAsset)}
+                  {[
+                    openAsset.modelName,
+                    studioAspectRatio(openAsset),
+                    showCreator
+                      ? [openAsset.creatorName, openAsset.creatorEmail]
+                          .filter(Boolean)
+                          .join(' · ')
+                      : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
                 </DialogDescription>
               </DialogHeader>
               <StudioViewer asset={openAsset} />
@@ -330,7 +384,8 @@ export function StudioGallery({
                     </Button>
                   );
                 })()}
-                {openAsset.status !== 'queued' &&
+                {!readOnly &&
+                  openAsset.status !== 'queued' &&
                   openAsset.status !== 'running' && (
                     <AlertDialog>
                       <AlertDialogTrigger asChild>

--- a/src/studio/ui/studio-view.tsx
+++ b/src/studio/ui/studio-view.tsx
@@ -12,7 +12,6 @@ import { useIsomorphicLayoutEffect } from '@/ui/use-isomorphic-layout-effect';
 import { useAdminStudioAssets, useStudioAssets } from './use-studio-assets';
 import { studioPrompt } from './outputs';
 import {
-  isDefaultStudioListPrefs,
   loadStudioListPrefs,
   prefsFromSearch,
   prefsToSearch,
@@ -50,8 +49,8 @@ function useStudioListPrefs(
     }
 
     const resolved = resolveStudioListPrefs(search, loadStudioListPrefs());
-    if (isDefaultStudioListPrefs(resolved)) return;
     const nextSearch = prefsToSearch(resolved, search.user);
+    if (Object.keys(nextSearch).length === 0) return;
     saveStudioListPrefs(resolved);
     void navigate({ search: nextSearch, replace: true });
   }, [navigate, search]);
@@ -174,8 +173,7 @@ export function StudioView({ activity, search, navigate }: StudioViewProps) {
             hasNextPage={query.hasNextPage}
             isFetchingNextPage={query.isFetchingNextPage}
             onLoadMore={() => void query.fetchNextPage()}
-            readOnly={supportMode}
-            showCreator={supportMode}
+            supportMode={supportMode}
           />
         </PageContainer>
       </div>

--- a/src/studio/ui/studio-view.tsx
+++ b/src/studio/ui/studio-view.tsx
@@ -1,34 +1,144 @@
 import { StudioComposer } from './studio-composer';
-import { StudioGallery } from './studio-gallery';
+import { StudioGallery, type StudioGalleryAsset } from './studio-gallery';
+import { isSystemAdminFn } from '@/billing/gift-tokens.fn';
 import { useAuthGate } from '@/platform/ui/auth/auth-gate-provider';
 import { Button } from '@/ui/shadcn/button';
+import { Input } from '@/ui/shadcn/input';
+import { Label } from '@/ui/shadcn/label';
+import { Switch } from '@/ui/shadcn/switch';
 import { PageContainer } from '@/ui/layout/page-container';
 import { PageIntro } from '@/ui/typography/page-intro';
-import { useStudioAssets } from './use-studio-assets';
+import { useIsomorphicLayoutEffect } from '@/ui/use-isomorphic-layout-effect';
+import { useAdminStudioAssets, useStudioAssets } from './use-studio-assets';
 import { studioPrompt } from './outputs';
-import type { StudioActivity, StudioSort } from '@/studio/schema';
+import {
+  isDefaultStudioListPrefs,
+  loadStudioListPrefs,
+  prefsFromSearch,
+  prefsToSearch,
+  resolveStudioListPrefs,
+  saveStudioListPrefs,
+  searchSpecifiesSupportPrefs,
+  type StudioListPrefs,
+  type StudioListSearch,
+} from './list-prefs';
+import type { StudioActivity } from '@/studio/schema';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
-import { Star } from 'lucide-react';
+import { ShieldCheck, Star } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type StudioListNavigate = (opts: {
+  search: StudioListSearch;
+  replace: boolean;
+}) => unknown;
+
+function useStudioListPrefs(
+  search: StudioListSearch,
+  navigate: StudioListNavigate
+) {
+  const restored = useRef(false);
+  const prefs = prefsFromSearch(search);
+
+  useIsomorphicLayoutEffect(() => {
+    if (restored.current) return;
+    restored.current = true;
+
+    if (searchSpecifiesSupportPrefs(search)) {
+      saveStudioListPrefs(prefsFromSearch(search));
+      return;
+    }
+
+    const resolved = resolveStudioListPrefs(search, loadStudioListPrefs());
+    if (isDefaultStudioListPrefs(resolved)) return;
+    const nextSearch = prefsToSearch(resolved, search.user);
+    saveStudioListPrefs(resolved);
+    void navigate({ search: nextSearch, replace: true });
+  }, [navigate, search]);
+
+  const setPrefs = useCallback(
+    (next: StudioListPrefs) => {
+      saveStudioListPrefs(next);
+      void navigate({
+        search: prefsToSearch(next, search.user),
+        replace: true,
+      });
+    },
+    [navigate, search.user]
+  );
+
+  return { prefs, setPrefs };
+}
 
 type StudioViewProps = {
   activity: StudioActivity;
-  sort: StudioSort;
-  favorites: boolean;
+  search: StudioListSearch;
+  navigate: StudioListNavigate;
 };
 
-export function StudioView({ activity, sort, favorites }: StudioViewProps) {
+export function StudioView({ activity, search, navigate }: StudioViewProps) {
   const { isAuthenticated } = useAuthGate();
-  const query = useStudioAssets({
-    activity,
-    favoritesOnly: favorites || undefined,
-    order: sort,
+  const { prefs, setPrefs } = useStudioListPrefs(search, navigate);
+  const to = activity === 'video' ? '/videos' : '/images';
+
+  const { data: adminStatus, isLoading: adminStatusLoading } = useQuery({
+    queryKey: ['system-admin-status'],
+    queryFn: () => isSystemAdminFn(),
+    staleTime: 5 * 60 * 1000,
+    enabled: isAuthenticated,
   });
 
-  const assets = query.data?.pages.flatMap((page) => page.assets) ?? [];
+  const isAdmin = adminStatus?.isAdmin ?? false;
+  const internalDomains = useMemo(
+    () => adminStatus?.internalDomains ?? [],
+    [adminStatus?.internalDomains]
+  );
+  // Admin query is gated on isAdmin so a remembered `support=true` cannot 403
+  // a non-admin. Stay in the loading skeleton until that check resolves.
+  const supportMode = isAdmin && prefs.supportMode;
+  const hideInternal = supportMode && prefs.hideInternal;
+  const effectiveHideInternal =
+    hideInternal && !search.user && internalDomains.length > 0;
+
+  const ownQuery = useStudioAssets(
+    {
+      activity,
+      favoritesOnly: prefs.favorites || undefined,
+      order: prefs.sort,
+    },
+    !supportMode
+  );
+  const adminQuery = useAdminStudioAssets(
+    {
+      activity,
+      favoritesOnly: prefs.favorites || undefined,
+      order: prefs.sort,
+      search: supportMode ? prefs.search : undefined,
+    },
+    supportMode
+  );
+
+  const query = supportMode ? adminQuery : ownQuery;
+  const assets = useMemo(() => {
+    const rows: StudioGalleryAsset[] =
+      query.data?.pages.flatMap((page) => page.assets) ?? [];
+    if (!effectiveHideInternal) return rows;
+    const suffixes = internalDomains.map((d) => `@${d.toLowerCase()}`);
+    return rows.filter((asset) => {
+      const email = asset.creatorEmail;
+      if (!email) return true;
+      const lowered = email.toLowerCase();
+      return !suffixes.some((suffix) => lowered.endsWith(suffix));
+    });
+  }, [query.data, effectiveHideInternal, internalDomains]);
+
   const generatingPrompts = assets
     .filter((a) => a.status === 'queued' || a.status === 'running')
     .map(studioPrompt);
-  const to = activity === 'video' ? '/videos' : '/images';
+
+  const isLoading =
+    (prefs.supportMode && adminStatusLoading) ||
+    (query.isPending && (supportMode || isAuthenticated));
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -37,89 +147,179 @@ export function StudioView({ activity, sort, favorites }: StudioViewProps) {
           title={activity === 'video' ? 'Videos' : 'Images'}
           maxWidth="wide"
         >
-          {activity === 'video'
-            ? 'Make or edit short clips with any video model.'
-            : 'Make or edit images with any image model.'}
+          {supportMode
+            ? activity === 'video'
+              ? 'Every clip users have generated.'
+              : 'Every still users have generated.'
+            : activity === 'video'
+              ? 'Make or edit short clips with any video model.'
+              : 'Make or edit images with any image model.'}
         </PageIntro>
         <PageContainer maxWidth="wide" padding="none" className="pb-8">
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              asChild
-              size="sm"
-              variant={favorites ? 'default' : 'outline'}
-            >
-              <Link
-                to={to}
-                search={{
-                  sort: sort === 'newest' ? undefined : sort,
-                  favorites: favorites ? undefined : true,
-                }}
-              >
-                <Star className="size-4" aria-hidden="true" />
-                Favorites
-              </Link>
-            </Button>
-            <div className="ml-auto flex items-center gap-2">
-              <Button
-                asChild
-                size="sm"
-                variant={sort === 'newest' ? 'default' : 'outline'}
-              >
-                <Link
-                  to={to}
-                  search={{
-                    sort: undefined,
-                    favorites: favorites ? true : undefined,
-                  }}
-                >
-                  Newest
-                </Link>
-              </Button>
-              <Button
-                asChild
-                size="sm"
-                variant={sort === 'oldest' ? 'default' : 'outline'}
-              >
-                <Link
-                  to={to}
-                  search={{
-                    sort: 'oldest',
-                    favorites: favorites ? true : undefined,
-                  }}
-                >
-                  Oldest
-                </Link>
-              </Button>
-            </div>
-          </div>
+          <StudioToolbar
+            to={to}
+            prefs={prefs}
+            setPrefs={setPrefs}
+            currentUser={search.user}
+            isAdmin={isAdmin}
+            hideInternalAvailable={internalDomains.length > 0}
+            hideInternalLocked={Boolean(search.user)}
+          />
 
           <StudioGallery
             assets={assets}
-            isLoading={query.isPending && isAuthenticated}
+            isLoading={isLoading}
             isAuthenticated={isAuthenticated}
             activity={activity}
             hasNextPage={query.hasNextPage}
             isFetchingNextPage={query.isFetchingNextPage}
             onLoadMore={() => void query.fetchNextPage()}
+            readOnly={supportMode}
+            showCreator={supportMode}
           />
         </PageContainer>
       </div>
 
-      {/* #1474: grow with the prompt, but never more than half the column. */}
-      <div
-        className="flex min-h-0 max-h-[50%] shrink-0 flex-col overflow-hidden border-t bg-background/80 backdrop-blur-md"
-        data-testid="studio-composer-pane"
-      >
-        <PageContainer
-          maxWidth="wide"
-          padding="compact"
-          className="flex min-h-0 flex-col overflow-hidden py-4"
+      {!supportMode && (
+        <div
+          className="flex min-h-0 max-h-[50%] shrink-0 flex-col overflow-hidden border-t bg-background/80 backdrop-blur-md"
+          data-testid="studio-composer-pane"
         >
-          <StudioComposer
-            activity={activity}
-            generatingPrompts={generatingPrompts}
+          <PageContainer
+            maxWidth="wide"
+            padding="compact"
+            className="flex min-h-0 flex-col overflow-hidden py-4"
+          >
+            <StudioComposer
+              activity={activity}
+              generatingPrompts={generatingPrompts}
+            />
+          </PageContainer>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StudioToolbar({
+  to,
+  prefs,
+  setPrefs,
+  currentUser,
+  isAdmin,
+  hideInternalAvailable,
+  hideInternalLocked,
+}: {
+  to: '/images' | '/videos';
+  prefs: StudioListPrefs;
+  setPrefs: (prefs: StudioListPrefs) => void;
+  currentUser?: string;
+  isAdmin: boolean;
+  hideInternalAvailable: boolean;
+  hideInternalLocked: boolean;
+}) {
+  const [searchDraft, setSearchDraft] = useState(prefs.search);
+  const prefsRef = useRef(prefs);
+  const setPrefsRef = useRef(setPrefs);
+  useEffect(() => {
+    prefsRef.current = prefs;
+    setPrefsRef.current = setPrefs;
+  });
+  useEffect(() => {
+    setSearchDraft(prefs.search);
+  }, [prefs.search]);
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (searchDraft === prefsRef.current.search) return;
+      setPrefsRef.current({ ...prefsRef.current, search: searchDraft });
+    }, 250);
+    return () => clearTimeout(t);
+  }, [searchDraft]);
+
+  const linkSearch = (next: Partial<StudioListPrefs>) =>
+    prefsToSearch({ ...prefs, ...next }, currentUser);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {isAdmin && prefs.supportMode && (
+          <Input
+            placeholder="Search name, email, prompt…"
+            value={searchDraft}
+            onChange={(event) => setSearchDraft(event.target.value)}
+            className="h-8 w-56"
+            aria-label="Search studio assets"
           />
-        </PageContainer>
+        )}
+        <Button
+          asChild
+          size="sm"
+          variant={prefs.favorites ? 'default' : 'outline'}
+        >
+          <Link to={to} search={linkSearch({ favorites: !prefs.favorites })}>
+            <Star className="size-4" aria-hidden="true" />
+            Favorites
+          </Link>
+        </Button>
+        <div className="ml-auto flex flex-wrap items-center gap-2">
+          <Button
+            asChild
+            size="sm"
+            variant={prefs.sort === 'newest' ? 'default' : 'outline'}
+          >
+            <Link to={to} search={linkSearch({ sort: 'newest' })}>
+              Newest
+            </Link>
+          </Button>
+          <Button
+            asChild
+            size="sm"
+            variant={prefs.sort === 'oldest' ? 'default' : 'outline'}
+          >
+            <Link to={to} search={linkSearch({ sort: 'oldest' })}>
+              Oldest
+            </Link>
+          </Button>
+          {isAdmin && (
+            <div className="flex items-center gap-4">
+              {prefs.supportMode && hideInternalAvailable && (
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="studio-hide-internal" className="text-sm">
+                    Hide internal
+                  </Label>
+                  <Switch
+                    id="studio-hide-internal"
+                    checked={prefs.hideInternal}
+                    disabled={hideInternalLocked}
+                    onCheckedChange={(value) =>
+                      setPrefs({ ...prefs, hideInternal: value })
+                    }
+                  />
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <ShieldCheck
+                  className="h-4 w-4 text-muted-foreground"
+                  aria-hidden="true"
+                />
+                <Label htmlFor="studio-support-mode" className="text-sm">
+                  Support
+                </Label>
+                <Switch
+                  id="studio-support-mode"
+                  checked={prefs.supportMode}
+                  onCheckedChange={(value) =>
+                    setPrefs({
+                      ...prefs,
+                      supportMode: value,
+                      hideInternal: value ? prefs.hideInternal : false,
+                    })
+                  }
+                />
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/studio/ui/use-studio-assets.ts
+++ b/src/studio/ui/use-studio-assets.ts
@@ -1,4 +1,5 @@
 import { useAuthGate } from '@/platform/ui/auth/auth-gate-provider';
+import { getAllAdminStudioAssetsFn } from '@/platform/admin-support.fn';
 import {
   createStudioAssetsFn,
   deleteStudioAssetFn,
@@ -32,14 +33,20 @@ const studioAssetKeys = {
     [...studioAssetKeys.all, 'list', filters] as const,
 };
 
+const adminStudioAssetKeys = {
+  all: ['admin-support', 'studio-assets'] as const,
+  list: (filters: StudioAssetFilters & { search?: string }) =>
+    [...adminStudioAssetKeys.all, 'list', filters] as const,
+};
+
 const PAGE_SIZE = 40;
 
-export function useStudioAssets(filters: StudioAssetFilters) {
+export function useStudioAssets(filters: StudioAssetFilters, enabled = true) {
   const { isAuthenticated } = useAuthGate();
 
   return useInfiniteQuery({
     queryKey: studioAssetKeys.list(filters),
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && enabled,
     initialPageParam: undefined as string | undefined,
     queryFn: ({ pageParam }) =>
       listStudioAssetsFn({
@@ -62,6 +69,36 @@ export function useStudioAssets(filters: StudioAssetFilters) {
       );
       return inFlight ? 2000 : false;
     },
+  });
+}
+
+/** Cross-team studio gallery for support mode. Gated by the caller on isAdmin. */
+export function useAdminStudioAssets(
+  filters: StudioAssetFilters & { search?: string },
+  enabled: boolean
+) {
+  const trimmedSearch = filters.search?.trim() || undefined;
+
+  return useInfiniteQuery({
+    queryKey: adminStudioAssetKeys.list({
+      ...filters,
+      search: trimmedSearch,
+    }),
+    enabled,
+    initialPageParam: undefined as string | undefined,
+    queryFn: ({ pageParam }) =>
+      getAllAdminStudioAssetsFn({
+        data: {
+          activity: filters.activity,
+          favoritesOnly: filters.favoritesOnly,
+          order: filters.order,
+          search: trimmedSearch,
+          limit: PAGE_SIZE,
+          cursor: pageParam,
+        },
+      }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    staleTime: 60_000,
   });
 }
 


### PR DESCRIPTION
Fixes #1568

Admins can now browse **every team's studio stills and clips** the same way they already browse sequences.

## How to use
1. Open `/admin/usage` and hit **Images** or **Videos** on a user row (`/images?user=ada@example.com`)
2. Or go to `/images` / `/videos` and flip **Support** — that is the big cross-user list
3. Search by name, email, or prompt. Hide-internal works like sequences. Composer / favorite / delete are off so you cannot mutate another team.

Lookup is by **team membership**, not only the creator column, matching `getAllSequences`. Catalog `/models` runs stay out of this gallery.

## Verification
- `getAllStudioAssets` tests: unfiltered list, member-email finds teammate work, catalog excluded, prompt match, keyset pagination
- List-prefs tests: `?user=` forces support, sort/favorites do not blend stored support
- Non-admin e2e: remembered `supportMode: true` does not 403 `/images`