### PR TITLE
fix(#1575): don't 401 the Generate estimate; show ~x.xx logged out

### DIFF
--- a/src/billing/pricing.fn.ts
+++ b/src/billing/pricing.fn.ts
@@ -1,5 +1,4 @@
 import { getEnv } from '#env';
-import { authWithTeamMiddleware } from '@/platform/middleware.fn';
 import { isBytePlusConfigured } from '@/models/server/byteplus-config';
 import {
   getEffectiveFalPricing,
@@ -112,11 +111,10 @@ const estimateDraftGenerationInputSchema = z.object({
 });
 
 /**
- * Live Generate-dialog estimate. Catalog rates only, no secrets, but every
- * debounced composer edit lands here, so it is gated like the create fn.
+ * Live Generate-dialog estimate. Catalog rates only, no secrets — public so
+ * the anonymous composer can show ~$x.xx. Create stays authed.
  */
 export const estimateDraftGenerationFn = createServerFn({ method: 'POST' })
-  .middleware([authWithTeamMiddleware])
   .validator(zodValidator(estimateDraftGenerationInputSchema))
   .handler(async ({ data }) => {
     if (!data.script.trim()) return { estimateMicros: null };

--- a/src/billing/pricing.fn.ts
+++ b/src/billing/pricing.fn.ts
@@ -1,4 +1,5 @@
 import { getEnv } from '#env';
+import { authWithTeamMiddleware } from '@/platform/middleware.fn';
 import { isBytePlusConfigured } from '@/models/server/byteplus-config';
 import {
   getEffectiveFalPricing,
@@ -111,10 +112,11 @@ const estimateDraftGenerationInputSchema = z.object({
 });
 
 /**
- * Live Generate-dialog estimate. Catalog rates only, no secrets — public so
- * the anonymous composer can show ~$x.xx. Create stays authed.
+ * Live Generate-dialog estimate. Catalog rates only, no secrets, but every
+ * debounced composer edit lands here, so it is gated like the create fn.
  */
 export const estimateDraftGenerationFn = createServerFn({ method: 'POST' })
+  .middleware([authWithTeamMiddleware])
   .validator(zodValidator(estimateDraftGenerationInputSchema))
   .handler(async ({ data }) => {
     if (!data.script.trim()) return { estimateMicros: null };

--- a/src/billing/ui/action-cost.tsx
+++ b/src/billing/ui/action-cost.tsx
@@ -6,6 +6,9 @@
  * - there is no estimate (null/undefined) — never invent a number here
  * - estimate is still loading and no value yet
  *
+ * Logged out: the amount slot is the glyph `~$x.xx`, not a calculated
+ * figure. The estimate fn is authed; we do not call it (#1575).
+ *
  * Callers should pass an honest single-action estimate (`estimateImageCost` /
  * video / audio → null when unknown). Storyboard totals from
  * `estimateStoryboardCost` may still embed gate floors for unpriced
@@ -24,6 +27,7 @@ import {
   microsToUsd,
   type Microdollars,
 } from '@/billing/money';
+import { useAuthSession } from '@/platform/ui/auth/session-query';
 import { cn } from '@/ui/utils';
 import { AlertTriangle } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -49,6 +53,7 @@ export function ActionCost({
   prefix,
 }: ActionCostProps) {
   const { showCosts } = useShowCosts();
+  const { data: session } = useAuthSession();
   const { balance } = useBillingBalance();
   const { data: gate } = useBillingGateQuery();
 
@@ -65,6 +70,21 @@ export function ActionCost({
         {prefix}
       </span>
     ) : null;
+  }
+  if (!session) {
+    return (
+      <span
+        className={cn(
+          justify,
+          'min-h-4 tabular-nums text-muted-foreground',
+          className
+        )}
+        aria-label="Estimated cost shown after sign in"
+      >
+        {prefix}
+        <span>~$x.xx</span>
+      </span>
+    );
   }
   // The estimate arrives client-side after the pricing query, so an empty
   // line is reserved until then — otherwise every button it sits under jumps.

--- a/src/sequences/ui/use-draft-generation-estimate.test.ts
+++ b/src/sequences/ui/use-draft-generation-estimate.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Draft estimate is public (catalog rates, no secrets) so the anonymous
+ * composer can show ~$x.xx. It must still not fire on an empty script.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const estimateDraftGenerationFn = vi.fn();
+vi.doMock('@/billing/pricing.fn', () => ({ estimateDraftGenerationFn }));
+
+type QueryOpts = { enabled?: boolean };
+let lastQuery: QueryOpts = {};
+vi.doMock('@tanstack/react-query', () => ({
+  useQuery: (options: QueryOpts) => {
+    lastQuery = options;
+    return { data: undefined };
+  },
+}));
+
+vi.doMock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    useState: <T>(init: T) => [init, vi.fn()] as [T, (value: T) => void],
+    useEffect: () => undefined,
+  };
+});
+
+const { useDraftGenerationEstimate } =
+  await import('./use-draft-generation-estimate');
+
+const INPUT = {
+  script: 'INT. LAUNDROMAT - NIGHT',
+  imageModels: ['nano_banana_2_lite'],
+  videoModels: ['minimax_h3_max'],
+  audioModels: ['lyria_2'],
+  aspectRatio: '9:16' as const,
+  stopAt: 'motion' as const,
+  generateStartFrames: false,
+};
+
+describe('useDraftGenerationEstimate', () => {
+  it('fires with a script even without a session', () => {
+    lastQuery = {};
+    useDraftGenerationEstimate(INPUT);
+    expect(lastQuery.enabled).toBe(true);
+  });
+
+  it('stays off when the script is empty', () => {
+    lastQuery = {};
+    useDraftGenerationEstimate({ ...INPUT, script: '   ' });
+    expect(lastQuery.enabled).toBe(false);
+  });
+});

--- a/src/sequences/ui/use-draft-generation-estimate.test.ts
+++ b/src/sequences/ui/use-draft-generation-estimate.test.ts
@@ -1,12 +1,18 @@
 /**
- * Draft estimate is public (catalog rates, no secrets) so the anonymous
- * composer can show ~$x.xx. It must still not fire on an empty script.
+ * The composer is anonymous-browsable; `estimateDraftGenerationFn` is not.
+ * Firing it logged-out 401s at error level on every debounced keystroke
+ * (same class as useSequences, #1333 / #1575).
  */
 
 import { describe, expect, it, vi } from 'vitest';
 
 const estimateDraftGenerationFn = vi.fn();
 vi.doMock('@/billing/pricing.fn', () => ({ estimateDraftGenerationFn }));
+
+const sessionRef: { current: unknown } = { current: null };
+vi.doMock('@/platform/ui/auth/session-query', () => ({
+  useAuthSession: () => ({ data: sessionRef.current }),
+}));
 
 type QueryOpts = { enabled?: boolean };
 let lastQuery: QueryOpts = {};
@@ -40,13 +46,22 @@ const INPUT = {
 };
 
 describe('useDraftGenerationEstimate', () => {
-  it('fires with a script even without a session', () => {
+  it('does not fire the authed fn without a session', () => {
+    sessionRef.current = null;
+    lastQuery = {};
+    useDraftGenerationEstimate(INPUT);
+    expect(lastQuery.enabled).toBe(false);
+  });
+
+  it('fires once there is a session and a script', () => {
+    sessionRef.current = { user: { id: 'u1' } };
     lastQuery = {};
     useDraftGenerationEstimate(INPUT);
     expect(lastQuery.enabled).toBe(true);
   });
 
-  it('stays off when the script is empty', () => {
+  it('stays off when the script is empty even with a session', () => {
+    sessionRef.current = { user: { id: 'u1' } };
     lastQuery = {};
     useDraftGenerationEstimate({ ...INPUT, script: '   ' });
     expect(lastQuery.enabled).toBe(false);

--- a/src/sequences/ui/use-draft-generation-estimate.ts
+++ b/src/sequences/ui/use-draft-generation-estimate.ts
@@ -2,6 +2,7 @@ import { estimateDraftGenerationFn } from '@/billing/pricing.fn';
 import { micros, type Microdollars } from '@/billing/money';
 import type { AspectRatio } from '@/models/aspect-ratios';
 import type { Resolution } from '@/models/resolutions';
+import { useAuthSession } from '@/platform/ui/auth/session-query';
 import type { GenerationStage } from '@/sequences/pipeline';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
@@ -21,6 +22,10 @@ export type DraftGenerationEstimateInput = {
 export function useDraftGenerationEstimate(
   input: DraftGenerationEstimateInput | null
 ): Microdollars | null | undefined {
+  // Composer is anonymous-browsable; the fn is not. Don't fire (and
+  // error-log AUTHENTICATION_ERROR) without a session — same gate as
+  // useSequences (#1333, #1575).
+  const { data: session } = useAuthSession();
   const [debouncedScript, setDebouncedScript] = useState(input?.script ?? '');
   useEffect(() => {
     const timeout = window.setTimeout(
@@ -30,7 +35,7 @@ export function useDraftGenerationEstimate(
     return () => window.clearTimeout(timeout);
   }, [input?.script]);
 
-  const enabled = Boolean(input && debouncedScript.trim());
+  const enabled = Boolean(session && input && debouncedScript.trim());
   const { data } = useQuery({
     queryKey: [
       'draft-generation-estimate',


### PR DESCRIPTION
## Related Issue

Closes #1575

## Summary of Changes

Logged-out Generate was POSTing authed `estimateDraftGenerationFn` on every debounce. Each call 401'd at **error** and nothing rendered in the cost slot.

1. Do not fire the query without a session (same gate as `useSequences`, #1333). The fn stays authed.
2. The amount slot is the glyph `~$x.xx` — not a calculated rate, not a client estimator.

Signed-in Generate still shows the real `~$amount`.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

Client-only. No server-fn auth change.

## Additional Notes

Earlier commits on this PR tried dropping auth so a real number could render logged out. Wrong. This is a placeholder, not a price.