### PR TITLE
fix(#1570): forward selected resolution on retry, recast, studio fal, and motion estimates

### DIFF
--- a/src/motion/server/workflows/motion-workflow.test.ts
+++ b/src/motion/server/workflows/motion-workflow.test.ts
@@ -19,6 +19,7 @@ const mockSubmit = vi.fn();
 const mockPoll = vi.fn();
 const mockSoften = vi.fn();
 const mockDeductWorkflowCredits = vi.fn();
+const mockCalculateMotionMetadata = vi.fn(() => ({ cost: 0, duration: 5 }));
 const mockResolveMotionVia = vi.fn(
   async (): Promise<'fal' | 'google'> => 'fal'
 );
@@ -29,7 +30,7 @@ vi.doMock('@/motion/server/motion-generation', () => ({
   submitMotionJob: mockSubmit,
   pollMotionJob: mockPoll,
   canRenderReferenceOnly: async () => true,
-  calculateMotionMetadata: () => ({ cost: 0, duration: 5 }),
+  calculateMotionMetadata: mockCalculateMotionMetadata,
   motionCostFromUsage: () => ({
     cost: 0,
     unitsBilled: 0,
@@ -511,6 +512,23 @@ describe('MotionWorkflow onFailure observation', () => {
           hashAssetIdentity
         )
       )
+    );
+  });
+});
+
+describe('MotionWorkflow affordability estimate (#1570)', () => {
+  it('forwards the selected resolution into calculateMotionMetadata', async () => {
+    const { scopedDb } = makeScopedDb();
+
+    await makeWorkflow().runBody(
+      makeEvent({ resolution: '1080p' }),
+      makeStep(),
+      scopedDb
+    );
+
+    expect(mockCalculateMotionMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ resolution: '1080p' }),
+      expect.anything()
     );
   });
 });

--- a/src/motion/server/workflows/motion-workflow.ts
+++ b/src/motion/server/workflows/motion-workflow.ts
@@ -197,6 +197,7 @@ export class MotionWorkflow extends OpenStoryWorkflowEntrypoint<MotionWorkflowIn
             fps: input.fps,
             motionBucket: input.motionBucket,
             aspectRatio: input.aspectRatio,
+            resolution: input.resolution,
             generateAudio: input.generateAudio,
           },
           await getEffectiveFalPricing()

--- a/src/sequences/server/smart-retry.ts
+++ b/src/sequences/server/smart-retry.ts
@@ -343,6 +343,7 @@ export async function executeSmartRetry(context: SmartRetryContext) {
         prompt,
         model: imageModel,
         imageSize: aspectRatioToImageSize(sequence.aspectRatio),
+        resolution: sequence.resolution,
         numImages: 1,
         shotId: shot.id,
         // The anchor + the prompt version `prompt` came from, snapshotted here

--- a/src/sequences/smart-retry.test.ts
+++ b/src/sequences/smart-retry.test.ts
@@ -812,3 +812,26 @@ describe('executeSmartRetry — per-asset model selection (#1066)', () => {
     );
   });
 });
+
+describe('executeSmartRetry — resolution forwarding (#1570)', () => {
+  test('forwards the sequence resolution onto the still-generation workflow input', async () => {
+    resetMocks();
+    const shot = makeShot({
+      imageStatus: 'failed',
+      imagePrompt: 'A cinematic shot of the lab',
+    });
+    const { context } = makeContext(makeSequence({ resolution: '1080p' }), [
+      shot,
+    ]);
+
+    await executeSmartRetry(context);
+
+    expect(triggerWorkflowMock).toHaveBeenCalledWith(
+      '/image',
+      expect.objectContaining({
+        shotId: 'shot-1',
+        resolution: '1080p',
+      })
+    );
+  });
+});

--- a/src/shots/server/workflows/regenerate-shots-workflow.test.ts
+++ b/src/shots/server/workflows/regenerate-shots-workflow.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Pins that recast image children receive the sequence resolution (#1570).
+ * Variant regen already forwards it; the still-generation child was the miss.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkflowScopedDb } from '@/platform/server/db/scoped-workflow';
+import type {
+  ImageWorkflowInput,
+  RegenerateShotsWorkflowInput,
+} from '@/platform/server/workflow/types';
+import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+
+const spawnAndAwaitChild =
+  vi.fn<
+    (
+      step: unknown,
+      args: { childId: string; childPayload: ImageWorkflowInput }
+    ) => Promise<unknown>
+  >();
+vi.doMock('@/platform/server/workflow/await-child', () => ({
+  spawnAndAwaitChild,
+}));
+
+vi.doMock('@/platform/server/workflow/client', () => ({
+  triggerWorkflow: vi.fn(async () => 'wf_variant'),
+}));
+
+vi.doMock('@/platform/realtime', () => ({
+  getGenerationChannel: () => ({ emit: vi.fn(async () => {}) }),
+}));
+
+const { RegenerateShotsWorkflow } = await import('./regenerate-shots-workflow');
+
+class Probe extends RegenerateShotsWorkflow {
+  runBody(
+    event: Readonly<WorkflowEvent<RegenerateShotsWorkflowInput>>,
+    step: WorkflowStep,
+    scopedDb: WorkflowScopedDb
+  ) {
+    return this.runImpl(event, step, scopedDb);
+  }
+}
+
+function makeWorkflow(): Probe {
+  type Ctor = ConstructorParameters<typeof Probe>;
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- runImpl never reads ctx
+  const ctx = undefined as unknown as Ctor[0];
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- only IMAGE_WORKFLOW is read, and the spawn is mocked
+  const env = { IMAGE_WORKFLOW: {} } as unknown as Ctor[1];
+  return new Probe(ctx, env);
+}
+
+function makeStep(): WorkflowStep {
+  // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- runImpl only uses `do`
+  return {
+    do: vi.fn((_name: string, fn: () => Promise<unknown>) => fn()),
+  } as unknown as WorkflowStep;
+}
+
+function makeEvent(): Readonly<WorkflowEvent<RegenerateShotsWorkflowInput>> {
+  return {
+    payload: {
+      userId: 'u1',
+      teamId: 't1',
+      sequenceId: 'seq_1',
+      shotIds: ['shot-1'],
+      triggerKind: 'character',
+      triggerId: 'char-1',
+      imageModel: 'nano_banana_2',
+      aspectRatio: '16:9',
+      resolution: '1080p',
+      snapshotInputHash: '',
+      shotSnapshots: [
+        {
+          shotId: 'shot-1',
+          frameId: 'frame-1',
+          imagePrompt: 'Jack at the docks',
+          characterSheetHashes: [],
+          locationSheetHashes: [],
+          elementReferenceHashes: [],
+          characterRefs: [],
+          locationRefs: [],
+          snapshotInputHash: 'hash-1',
+        },
+      ],
+    },
+    instanceId: 'regen_run_1',
+    workflowName: 'regenerate-shots',
+    timestamp: new Date(0),
+  };
+}
+
+// oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- stub covering only the surface runImpl touches
+const SCOPED_DB = {
+  liveRead: {
+    compliance: { listEnforcementFor: async () => ({}) },
+  },
+} as unknown as WorkflowScopedDb;
+
+describe('RegenerateShotsWorkflow resolution forwarding (#1570)', () => {
+  beforeEach(() => {
+    spawnAndAwaitChild.mockReset();
+    spawnAndAwaitChild.mockResolvedValue({
+      imageUrl: 'https://cdn/shot-1.jpg',
+    });
+  });
+
+  it('forwards the selected resolution onto each image child payload', async () => {
+    await makeWorkflow().runBody(makeEvent(), makeStep(), SCOPED_DB);
+
+    expect(spawnAndAwaitChild).toHaveBeenCalledTimes(1);
+    expect(spawnAndAwaitChild.mock.calls[0]?.[1].childPayload).toMatchObject({
+      shotId: 'shot-1',
+      resolution: '1080p',
+    });
+  });
+});

--- a/src/shots/server/workflows/regenerate-shots-workflow.ts
+++ b/src/shots/server/workflows/regenerate-shots-workflow.ts
@@ -147,6 +147,7 @@ export class RegenerateShotsWorkflow extends OpenStoryWorkflowEntrypoint<Regener
           prompt: snapshot.imagePrompt,
           model: imageModel,
           imageSize: aspectRatioToImageSize(aspectRatio),
+          resolution,
           numImages: 1,
           referenceImages,
         };

--- a/src/studio/server/studio-video-generation.test.ts
+++ b/src/studio/server/studio-video-generation.test.ts
@@ -126,6 +126,56 @@ describe('submitStudioVideoJob', () => {
     );
   });
 
+  it('forwards selected resolution on fal text-to-video (#1570)', async () => {
+    mockGenerateVideo.mockResolvedValue({
+      jobId: 't2v-1080',
+      model: 'bytedance/seedance-2.5/text-to-video',
+    });
+
+    await submitStudioVideoJob({
+      arkAssets: registeredAssets,
+      prompt: 'A red fox turns toward camera',
+      model: 'seedance_v2_5',
+      duration: 5,
+      aspectRatio: '9:16',
+      resolution: '1080p',
+    });
+
+    expect(mockGenerateVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelOptions: expect.objectContaining({
+          resolution: '1080p',
+        }),
+      })
+    );
+  });
+
+  it('forwards selected resolution on fal frames (#1570)', async () => {
+    mockGenerateVideo.mockResolvedValue({
+      jobId: 'i2v-1080',
+      model: 'bytedance/seedance-2.0/enterprise/v2/image-to-video',
+    });
+
+    await submitStudioVideoJob({
+      arkAssets: registeredAssets,
+      prompt: 'Camera pushes in',
+      model: 'seedance_v2',
+      mode: 'frames',
+      startImageUrl: 'https://example.com/start.jpg',
+      duration: 5,
+      aspectRatio: '16:9',
+      resolution: '1080p',
+    });
+
+    expect(mockGenerateVideo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelOptions: expect.objectContaining({
+          resolution: '1080p',
+        }),
+      })
+    );
+  });
+
   it('submits H3 Max reference mode to r2v with Image N tags', async () => {
     mockGenerateVideo.mockResolvedValue({
       jobId: 'h3-r2v',

--- a/src/studio/server/studio-video-generation.ts
+++ b/src/studio/server/studio-video-generation.ts
@@ -210,6 +210,7 @@ async function buildStudioImageModeInput(
     (url): url is string => Boolean(url)
   );
   const urls = await ensureExternallyFetchableUrls(stored, falApiKey);
+  const resolution = studioVideoResolution(modelKey, options.resolution);
   const { prompt, ...modelOptions } = transform.parse({
     prompt: options.prompt,
     duration: options.duration,
@@ -219,6 +220,7 @@ async function buildStudioImageModeInput(
     ...(options.generateAudio !== undefined && {
       generate_audio: options.generateAudio,
     }),
+    ...(resolution && { resolution }),
   });
   return {
     endpointId,
@@ -263,6 +265,7 @@ async function submitFalStudioVideoJob(
     model: modelKey,
     duration: options.duration,
     aspectRatio: options.aspectRatio,
+    resolution: options.resolution,
     generateAudio: options.generateAudio,
   });
   const key = await resolveFalKey(options.scopedDb);


### PR DESCRIPTION
## Related Issue

Closes #1570

## Summary of Changes

Five call sites still dropped the selected resolution after #1449 / #1451. Each now forwards the chosen tier and lets the existing model-specific resolver apply its supported-resolution fallback:

1. **Smart-retry stills** — `ImageWorkflowInput` gets `sequence.resolution`
2. **Recast image children** — `RegenerateShotsWorkflow` child payload gets the already-available `resolution`
3. **Studio fal text-to-video** — `buildStudioVideoInput` gets `options.resolution`
4. **Studio fal frames** — `transform.parse` gets the mapped token from `studioVideoResolution`
5. **Motion affordability** — `calculateMotionMetadata` gets `input.resolution`, matching submit

Regression tests capture the child payloads, transformed fal inputs, and affordability input at those seams.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

No schema or fallback-policy changes. Reference-mode Studio already forwarded resolution; this fills the remaining gaps.

## Additional Notes

Not verified with a live fal/BytePlus render. Coverage is source-wiring + unit tests at the five boundaries.