### PR TITLE
fix(#1594): disable Generate Image/Motion when the prompt is empty

### DIFF
--- a/src/motion/motion.fn.ts
+++ b/src/motion/motion.fn.ts
@@ -60,6 +60,7 @@ import {
   resolveMotionPrompt,
   resolveMotionPromptFromVersion,
 } from '@/motion/server/resolve-motion-prompt';
+import { requireGenerationPrompt } from '@/shots/generation-prompt';
 import {
   rendersReferenceOnly,
   shotPromptSequence,
@@ -135,6 +136,10 @@ export const generateShotMotionFn = createServerFn({ method: 'POST' })
     const userEditedPrompt = Boolean(data.prompt);
     const selectedMotion =
       await context.scopedDb.shotPromptVersions.getSelectedMotion(shot.id);
+    // Empty base prompt is empty even when assembly would append dialogue
+    // and audio direction. Refuse before credits so a stale tab matches
+    // the disabled button (#1594).
+    requireGenerationPrompt(data.prompt, selectedMotion?.text);
     // An edit replaces the version's `fullPrompt`; model assembly (dialogue
     // tags, audio direction, no-music) still goes on top — the same thing the
     // editor's optimised-prompt preview shows. So what fal receives (`prompt`)

--- a/src/motion/motion.fn.ts
+++ b/src/motion/motion.fn.ts
@@ -86,6 +86,12 @@ export const generateShotMotionFn = createServerFn({ method: 'POST' })
   .handler(async ({ data, context }) => {
     const { shot, frame, sequence, teamId } = context;
 
+    // Explicit empty/whitespace override is refused before still/model
+    // guards so a stale tab gets the same sentence as the disabled button.
+    if (data.prompt !== undefined) {
+      requireGenerationPrompt(data.prompt, undefined);
+    }
+
     // The still lives on the anchor frame's SELECTED version (#989/#1067).
     // Resolved as the whole row, not just the URL: the render manifest records
     // WHICH version the clip rendered from, and re-reading the pointer in the

--- a/src/shots/generation-prompt.test.ts
+++ b/src/shots/generation-prompt.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EMPTY_GENERATION_PROMPT_MESSAGE,
+  isBlankPrompt,
+  requireGenerationPrompt,
+} from './generation-prompt';
+
+describe('isBlankPrompt', () => {
+  it('treats missing, empty, and whitespace as empty', () => {
+    expect(isBlankPrompt(undefined)).toBe(true);
+    expect(isBlankPrompt(null)).toBe(true);
+    expect(isBlankPrompt('')).toBe(true);
+    expect(isBlankPrompt('   ')).toBe(true);
+    expect(isBlankPrompt('\n\t')).toBe(true);
+  });
+
+  it('treats any non-whitespace content as present', () => {
+    expect(isBlankPrompt('wide shot')).toBe(false);
+    expect(isBlankPrompt('  wide shot  ')).toBe(false);
+  });
+});
+
+describe('requireGenerationPrompt', () => {
+  it('refuses an empty or whitespace override even when a stored prompt exists', () => {
+    expect(() => requireGenerationPrompt('', 'stored prompt')).toThrow(
+      EMPTY_GENERATION_PROMPT_MESSAGE
+    );
+    expect(() => requireGenerationPrompt('  ', 'stored prompt')).toThrow(
+      EMPTY_GENERATION_PROMPT_MESSAGE
+    );
+  });
+
+  it('refuses when no override is sent and the stored prompt is empty', () => {
+    expect(() => requireGenerationPrompt(undefined, undefined)).toThrow(
+      EMPTY_GENERATION_PROMPT_MESSAGE
+    );
+    expect(() => requireGenerationPrompt(undefined, '')).toThrow(
+      EMPTY_GENERATION_PROMPT_MESSAGE
+    );
+    expect(() => requireGenerationPrompt(undefined, '  ')).toThrow(
+      EMPTY_GENERATION_PROMPT_MESSAGE
+    );
+  });
+
+  it('accepts a non-empty override or a non-empty stored prompt', () => {
+    expect(() => requireGenerationPrompt('wide shot', undefined)).not.toThrow();
+    expect(() => requireGenerationPrompt(undefined, 'wide shot')).not.toThrow();
+  });
+});

--- a/src/shots/generation-prompt.ts
+++ b/src/shots/generation-prompt.ts
@@ -15,9 +15,9 @@ export function isBlankPrompt(text: string | null | undefined): boolean {
 }
 
 /**
- * Resolve the prompt a generate click will render: an explicit override
+ * Assert a generate click has a base prompt. An explicit override
  * (including `''` / whitespace) wins; otherwise the stored selected prompt.
- * Throws before credits are reserved.
+ * Call before credits are reserved.
  */
 export function requireGenerationPrompt(
   override: string | undefined,

--- a/src/shots/generation-prompt.ts
+++ b/src/shots/generation-prompt.ts
@@ -1,0 +1,30 @@
+/**
+ * Empty-prompt gate for Generate Image / Generate Motion (#1594).
+ *
+ * The assembled motion trailer (dialogue, audio direction, reference lines)
+ * does not count: an empty *base* prompt is an empty prompt. Whitespace is
+ * empty. Shared by the scene-editor buttons and the server fns behind them
+ * so a stale tab gets the same answer as the UI.
+ */
+
+export const EMPTY_GENERATION_PROMPT_MESSAGE =
+  'Write or generate a prompt first.';
+
+export function isBlankPrompt(text: string | null | undefined): boolean {
+  return !text?.trim();
+}
+
+/**
+ * Resolve the prompt a generate click will render: an explicit override
+ * (including `''` / whitespace) wins; otherwise the stored selected prompt.
+ * Throws before credits are reserved.
+ */
+export function requireGenerationPrompt(
+  override: string | undefined,
+  stored: string | null | undefined
+): void {
+  const source = override !== undefined ? override : (stored ?? '');
+  if (isBlankPrompt(source)) {
+    throw new Error(EMPTY_GENERATION_PROMPT_MESSAGE);
+  }
+}

--- a/src/shots/server/shot-image-input.test.ts
+++ b/src/shots/server/shot-image-input.test.ts
@@ -21,8 +21,9 @@ import type { Frame, Shot } from '@/platform/server/db/schema';
 vi.doMock('@/billing/server/fal-pricing-live', () => ({
   getEffectiveFalPricing: async () => ({}),
 }));
+const requireCredits = vi.fn(async () => undefined);
 vi.doMock('@/billing/server/preflight', () => ({
-  requireCredits: async () => undefined,
+  requireCredits,
 }));
 
 // Dynamic import so the mocks above apply (vi.doMock is not hoisted).
@@ -181,5 +182,23 @@ describe('prepareShotImageWorkflowInput still reads what it does consume', () =>
     expect(getSelectedVariant).toHaveBeenCalledWith(FRAME_ID);
     expect(getLastFailed).toHaveBeenCalledWith(FRAME_ID);
     expect(input.model).toBe('seedream_v5');
+  });
+});
+
+describe('prepareShotImageWorkflowInput refuses a blank prompt before credits', () => {
+  it('throws on a whitespace-only override without reserving credits', async () => {
+    requireCredits.mockClear();
+    const { scopedDb } = makeScopedDb();
+
+    await expect(
+      prepareShotImageWorkflowInput({
+        ...baseArgs(scopedDb),
+        promptOverride: '   ',
+        promptVersionOverride: 'fpv_from_caller',
+        modelOverride: 'nano_banana_pro',
+      })
+    ).rejects.toThrow('Shot has no prompt or description to regenerate from');
+
+    expect(requireCredits).not.toHaveBeenCalled();
   });
 });

--- a/src/shots/server/shot-image-input.ts
+++ b/src/shots/server/shot-image-input.ts
@@ -157,7 +157,7 @@ export async function prepareShotImageWorkflowInput(args: {
     ? await scopedDb.framePromptVersions.getSelected(frame.id)
     : null;
   const prompt = promptOverride || selectedPrompt?.text || scriptExtract;
-  if (!prompt) {
+  if (!prompt.trim()) {
     throw new Error('Shot has no prompt or description to regenerate from');
   }
 

--- a/src/shots/ui/scene-script-prompts.stories.tsx
+++ b/src/shots/ui/scene-script-prompts.stories.tsx
@@ -2,6 +2,7 @@ import type { SceneWithScript } from './use-scenes';
 import { dbSceneId } from '@/shots/scene-id';
 import { frameFixture, frameVariantFixture } from '@/mocks/frame-fixtures';
 import { toShotView, type ShotView } from '@/shots/shot-view';
+import { UploadRightsGateStub } from '@/cast/ui/upload-rights-gate';
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
 import {
@@ -104,9 +105,11 @@ const meta: Meta<typeof SceneScriptPrompts> = {
   },
   decorators: [
     (Story) => (
-      <div className="w-[600px]">
-        <Story />
-      </div>
+      <UploadRightsGateStub>
+        <div className="w-[600px]">
+          <Story />
+        </div>
+      </UploadRightsGateStub>
     ),
   ],
 };
@@ -193,6 +196,13 @@ export const ImagePromptTab: Story = {
   },
 };
 
+export const EmptyImagePrompt: Story = {
+  args: {
+    shot: mockShot,
+    selectedTab: 'image-prompt',
+  },
+};
+
 export const MotionPromptTab: Story = {
   args: {
     shot: {
@@ -200,6 +210,29 @@ export const MotionPromptTab: Story = {
       motionPrompt: {
         fullPrompt:
           'Slow push in as Sarah types; her eyes flick to the silenced phone.',
+        dialogue: {
+          presence: true,
+          lines: [
+            {
+              character: 'SARAH',
+              line: 'This deadline is going to kill me.',
+              tone: '',
+            },
+          ],
+        },
+        audio: null,
+      },
+    },
+    selectedTab: 'motion-prompt',
+  },
+};
+
+export const EmptyMotionPrompt: Story = {
+  args: {
+    shot: {
+      ...mockShot,
+      motionPrompt: {
+        fullPrompt: '',
         dialogue: {
           presence: true,
           lines: [

--- a/src/shots/ui/scene-script-prompts.tsx
+++ b/src/shots/ui/scene-script-prompts.tsx
@@ -1746,16 +1746,19 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   ? 'Regenerate Image'
                   : 'Generate Image'}
             </Button>
-            {shot &&
-            !hasVisualPrompt &&
-            !isGenerating &&
-            !variantIsGenerating ? (
-              <p className="text-xs text-muted-foreground">
-                {EMPTY_GENERATION_PROMPT_MESSAGE}
-              </p>
-            ) : (
-              <ActionCost estimate={imageCostEstimate} />
-            )}
+            <p
+              className={
+                shot &&
+                !hasVisualPrompt &&
+                !isGenerating &&
+                !variantIsGenerating
+                  ? 'text-xs text-muted-foreground'
+                  : 'hidden'
+              }
+            >
+              {EMPTY_GENERATION_PROMPT_MESSAGE}
+            </p>
+            <ActionCost estimate={imageCostEstimate} />
           </div>
 
           {/* Manual still inject (#1108) — upload replaces the selected image;
@@ -2197,17 +2200,20 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   ? 'Regenerate Motion'
                   : 'Generate Motion'}
             </Button>
-            {shot &&
-            !hasMotionPrompt &&
-            !isGenerating &&
-            !isGeneratingMotion &&
-            !videoVariantIsGenerating ? (
-              <p className="text-xs text-muted-foreground">
-                {EMPTY_GENERATION_PROMPT_MESSAGE}
-              </p>
-            ) : (
-              <ActionCost estimate={motionCostEstimate} />
-            )}
+            <p
+              className={
+                shot &&
+                !hasMotionPrompt &&
+                !isGenerating &&
+                !isGeneratingMotion &&
+                !videoVariantIsGenerating
+                  ? 'text-xs text-muted-foreground'
+                  : 'hidden'
+              }
+            >
+              {EMPTY_GENERATION_PROMPT_MESSAGE}
+            </p>
+            <ActionCost estimate={motionCostEstimate} />
           </div>
 
           <AlertDialog

--- a/src/shots/ui/scene-script-prompts.tsx
+++ b/src/shots/ui/scene-script-prompts.tsx
@@ -21,6 +21,10 @@ import {
 import { Button } from '@/ui/shadcn/button';
 import { Checkbox } from '@/ui/shadcn/checkbox';
 import { setShotUseStartFrameFn } from '@/shots/shots.fn';
+import {
+  EMPTY_GENERATION_PROMPT_MESSAGE,
+  isBlankPrompt,
+} from '@/shots/generation-prompt';
 import { canUseStartFrame, usesStartFrame } from '@/shots/use-start-frame';
 import {
   Select,
@@ -859,6 +863,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
 
   const handleRegenerate = useCallback(async () => {
     if (!shot?.id || !shot.sequenceId) return;
+    if (isBlankPrompt(editedImagePrompt)) return;
 
     const promptOverride = editedImagePrompt || undefined;
 
@@ -944,6 +949,7 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
 
   const handleRegenerateMotion = useCallback(async () => {
     if (!shot?.id || !shot.sequenceId) return;
+    if (isBlankPrompt(editedMotionPrompt)) return;
 
     onRegenerateStart(shot.id, 'motion');
 
@@ -1255,6 +1261,10 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
   // the mode, so it is also right for a shot whose prompt generation failed.
   const visualPromptAction = imagePrompt?.trim() ? 'Regenerate' : 'Generate';
   const motionPromptAction = rawMotionPrompt.trim() ? 'Regenerate' : 'Generate';
+  // Generate Image / Generate Motion spend credits; an empty (or whitespace)
+  // base prompt has nothing to render. Generate Prompt above is the way out.
+  const hasVisualPrompt = !isBlankPrompt(editedImagePrompt);
+  const hasMotionPrompt = !isBlankPrompt(editedMotionPrompt);
 
   // Check if image is currently generating
   const isGenerating =
@@ -1722,7 +1732,9 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 }
                 void handleRegenerate();
               }}
-              disabled={isGenerating || variantIsGenerating || !shot}
+              disabled={
+                isGenerating || variantIsGenerating || !shot || !hasVisualPrompt
+              }
               className="w-full"
             >
               {(isGenerating || variantIsGenerating) && (
@@ -1734,7 +1746,16 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   ? 'Regenerate Image'
                   : 'Generate Image'}
             </Button>
-            <ActionCost estimate={imageCostEstimate} />
+            {shot &&
+            !hasVisualPrompt &&
+            !isGenerating &&
+            !variantIsGenerating ? (
+              <p className="text-xs text-muted-foreground">
+                {EMPTY_GENERATION_PROMPT_MESSAGE}
+              </p>
+            ) : (
+              <ActionCost estimate={imageCostEstimate} />
+            )}
           </div>
 
           {/* Manual still inject (#1108) — upload replaces the selected image;
@@ -2162,7 +2183,8 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                 isGeneratingMotion ||
                 videoVariantIsGenerating ||
                 unusableElementLines.length > 0 ||
-                !shot
+                !shot ||
+                !hasMotionPrompt
               }
               className="w-full"
             >
@@ -2175,7 +2197,17 @@ export const SceneScriptPrompts: React.FC<SceneScriptPromptsProps> = ({
                   ? 'Regenerate Motion'
                   : 'Generate Motion'}
             </Button>
-            <ActionCost estimate={motionCostEstimate} />
+            {shot &&
+            !hasMotionPrompt &&
+            !isGenerating &&
+            !isGeneratingMotion &&
+            !videoVariantIsGenerating ? (
+              <p className="text-xs text-muted-foreground">
+                {EMPTY_GENERATION_PROMPT_MESSAGE}
+              </p>
+            ) : (
+              <ActionCost estimate={motionCostEstimate} />
+            )}
           </div>
 
           <AlertDialog

--- a/src/stills/shot-image.fn.ts
+++ b/src/stills/shot-image.fn.ts
@@ -5,6 +5,7 @@ import {
   safeTextToImageModel,
 } from '@/models/models';
 import { resolveUpscaleModel } from '@/models/resolve-asset-models';
+import { requireGenerationPrompt } from '@/shots/generation-prompt';
 import { shotPromptSequence } from '@/shots/use-start-frame';
 import {
   estimateImageCost,
@@ -126,6 +127,16 @@ export const generateShotImageFn = createServerFn({ method: 'POST' })
       scene: resolvedScene,
       script,
     } = context;
+
+    // Refuse before credits: an empty/whitespace visual prompt has nothing
+    // to render. A missing override falls through to the stored selected
+    // prompt so a stale tab matches the button (#1594).
+    const storedVisualPrompt =
+      data.prompt === undefined
+        ? ((await context.scopedDb.framePromptVersions.getSelected(frame.id))
+            ?.text ?? null)
+        : undefined;
+    requireGenerationPrompt(data.prompt, storedVisualPrompt);
 
     // Auto-link any element/cast/location tags the user mentioned in their
     // edited prompt before computing reference attachment, so a freshly-


### PR DESCRIPTION
## Related Issue

Closes #1594

## Summary of Changes

Generate Image and Generate Motion no longer fire on an empty (or whitespace-only) base prompt.

- Scene editor buttons disable and show "Write or generate a prompt first." Generate Prompt stays available above.
- `generateShotImageFn` / `generateShotMotionFn` refuse the same way before credits are reserved, so a stale tab matches the UI.
- Assembled motion trailers (dialogue, audio direction, reference lines) do not count as a prompt.

## Risk Assessment

- [x] Low
- [ ] Medium
- [ ] High

## Additional Notes

Verified in Storybook: empty image/motion tabs disable the spend buttons; typing a prompt re-enables them; whitespace stays disabled; filled-prompt tabs stay enabled.